### PR TITLE
Improve handling of fea-rs output

### DIFF
--- a/fontbe/src/paths.rs
+++ b/fontbe/src/paths.rs
@@ -47,11 +47,13 @@ impl Paths {
 
     pub fn target_file(&self, id: &WorkId) -> PathBuf {
         match id {
-            WorkId::Features => self.build_dir.join("features.ttf"),
+            WorkId::Features => self.build_dir.join("features.marker"),
             WorkId::GlyfFragment(name) => self.glyph_glyf_file(name.as_str()),
             WorkId::GvarFragment(name) => self.glyph_gvar_file(name.as_str()),
             WorkId::Avar => self.build_dir.join("avar.table"),
             WorkId::Glyf => self.build_dir.join("glyf.table"),
+            WorkId::Gsub => self.build_dir.join("gsub.table"),
+            WorkId::Gpos => self.build_dir.join("gpos.table"),
             WorkId::Gvar => self.build_dir.join("gvar.table"),
             WorkId::Loca => self.build_dir.join("loca.table"),
             WorkId::LocaFormat => self.build_dir.join("loca.format"),

--- a/fontc/src/args.rs
+++ b/fontc/src/args.rs
@@ -56,16 +56,22 @@ impl Args {
     /// Manually create args for testing
     #[cfg(test)]
     pub fn for_test(build_dir: &std::path::Path, source: &str) -> Args {
-        fn testdata_dir() -> PathBuf {
-            let path = PathBuf::from("../resources/testdata")
-                .canonicalize()
-                .unwrap();
-            assert!(path.is_dir(), "{path:#?} isn't a dir");
-            path
-        }
+        // cargo test seems to run in the project directory
+        // VSCode test seems to run in the workspace directory
+        // probe for the file we want in hopes of finding it regardless
+        let potential_paths = vec!["./resources/testdata", "../resources/testdata"];
+        let source = potential_paths
+            .iter()
+            .map(PathBuf::from)
+            .find(|pb| pb.exists())
+            .unwrap()
+            .join(source)
+            .canonicalize()
+            .unwrap();
+
         Args {
             glyph_name_filter: None,
-            source: testdata_dir().join(source),
+            source,
             emit_ir: true,
             emit_debug: false,
             build_dir: build_dir.to_path_buf(),

--- a/fontdrasil/src/orchestration.rs
+++ b/fontdrasil/src/orchestration.rs
@@ -18,7 +18,7 @@ pub enum Access<I> {
     All,
     /// Access to one specific resource is permitted
     One(I),
-    /// Access to two specific resource is permitted
+    /// Access to multiple resources is permitted
     Set(HashSet<I>),
     /// A closure is used to determine access
     Custom(Arc<dyn Fn(&I) -> bool + Send + Sync>),

--- a/resources/testdata/Static-Regular.ufo/features.fea
+++ b/resources/testdata/Static-Regular.ufo/features.fea
@@ -4,3 +4,7 @@ languagesystem latn dflt;
 feature kern {
     position bar plus -100;
 } kern;
+
+feature liga {
+    substitute bar bar by plus;
+} liga;


### PR DESCRIPTION
Split the single feature font from fea-rs into pieces and include those pieces in the final font instead of running fea-rs and then just abandoning the results if it succeeded.

This reveals that for Oswald GSUB doesn't match and we aren't ending up with a GPOS at all; filed #308.