### PR TITLE
Make Oswald 'name' match fontmake

### DIFF
--- a/fontbe/src/fvar.rs
+++ b/fontbe/src/fvar.rs
@@ -32,6 +32,9 @@ fn generate_fvar(static_metadata: &StaticMetadata) -> Option<Fvar> {
     let reverse_names: HashMap<_, _> = static_metadata
         .names
         .iter()
+        // To match fontmake we should use the font-specific name range and not reuse
+        // a well-known name, even if the name matches.
+        .filter(|(key, _)| key.name_id.to_u16() > 255)
         .map(|(key, name)| (name, key.name_id))
         .collect();
 

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -1781,4 +1781,18 @@ mod tests {
             "Should set bit 1, Latin-1 Supplement and bit 38, Math Operators",
         );
     }
+
+    #[test]
+    fn captures_vendor_id() {
+        let temp_dir = tempdir().unwrap();
+        let build_dir = temp_dir.path();
+        compile(Args::for_test(build_dir, "glyphs3/TheBestNames.glyphs"));
+
+        let font_file = build_dir.join("font.ttf");
+        assert!(font_file.exists());
+        let buf = fs::read(font_file).unwrap();
+        let font = FontRef::new(&buf).unwrap();
+        let os2 = font.os2().unwrap();
+        assert_eq!(Tag::new(b"RODS"), os2.ach_vend_id());
+    }
 }

--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -1608,6 +1608,10 @@ impl Font {
     pub fn default_master(&self) -> &FontMaster {
         &self.masters[self.default_master_idx]
     }
+
+    pub fn vendor_id(&self) -> Option<&String> {
+        self.names.get("vendorID")
+    }
 }
 
 /// Convert [kurbo::Point] to this for eq and hash/

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -12,6 +12,7 @@ use fontir::{
     error::{Error, WorkError},
     ir::{
         Features, GlobalMetric, GlobalMetrics, NameBuilder, NameKey, NamedInstance, StaticMetadata,
+        DEFAULT_VENDOR_ID,
     },
     orchestration::{Context, IrWork},
     source::{Input, Source},
@@ -578,7 +579,11 @@ fn names(font_info: &norad::FontInfo) -> HashMap<NameKey, String> {
     );
 
     // After our first pass at getting values, apply fallbacks
-    builder.apply_default_fallbacks();
+    let vendor = font_info
+        .open_type_os2_vendor_id
+        .as_deref()
+        .unwrap_or(DEFAULT_VENDOR_ID);
+    builder.apply_default_fallbacks(vendor);
 
     // Name's that don't get individual fields
     if let Some(name_records) = font_info.open_type_name_records.as_ref() {
@@ -1074,7 +1079,7 @@ mod tests {
                 ),
                 (
                     NameKey::new_bmp_only(NameId::UNIQUE_ID),
-                    String::from("0.000;NONE;NewFontRegular")
+                    String::from("0.000;NONE;NewFont-Regular")
                 ),
                 (
                     NameKey::new_bmp_only(NameId::FULL_NAME),
@@ -1086,15 +1091,7 @@ mod tests {
                 ),
                 (
                     NameKey::new_bmp_only(NameId::POSTSCRIPT_NAME),
-                    String::from("NewFontRegular")
-                ),
-                (
-                    NameKey::new_bmp_only(NameId::TYPOGRAPHIC_FAMILY_NAME),
-                    String::from("New Font")
-                ),
-                (
-                    NameKey::new_bmp_only(NameId::TYPOGRAPHIC_SUBFAMILY_NAME),
-                    String::from("Regular")
+                    String::from("NewFont-Regular")
                 ),
             ],
             names


### PR DESCRIPTION
ttx_diff in default mode:

```shell
  Only fontmake produced 'GDEF', 'GPOS', 'HVAR', 'STAT'
  DIFF 'GSUB', build/default/fontc.GSUB.ttx build/default/fontmake.GSUB.ttx
  Identical 'GlyphOrder'
  Identical 'OS_2'
  Identical 'avar'
  Identical 'cmap'
  Identical 'fvar'
  DIFF 'glyf', build/default/fontc.glyf.ttx build/default/fontmake.glyf.ttx
  DIFF 'gvar', build/default/fontc.gvar.ttx build/default/fontmake.gvar.ttx
  DIFF 'head', build/default/fontc.head.ttx build/default/fontmake.head.ttx
  DIFF 'hhea', build/default/fontc.hhea.ttx build/default/fontmake.hhea.ttx
  Identical 'hmtx'
  Identical 'loca'
  DIFF 'maxp', build/default/fontc.maxp.ttx build/default/fontmake.maxp.ttx
  Identical 'name'
  DIFF 'post', build/default/fontc.post.ttx build/default/fontmake.post.ttx
```

Note that I modified ttx_diff.py to eliminate unwanted diffs due to https://github.com/googlefonts/fontmake/issues/1003