### PR TITLE
Match glyphsLib/ufo2ft defaults for underline thickness/position

### DIFF
--- a/fontbe/src/post.rs
+++ b/fontbe/src/post.rs
@@ -1,5 +1,6 @@
 //! Generates a [post](https://learn.microsoft.com/en-us/typography/opentype/spec/post) table.
 
+use font_types::FWord;
 use fontdrasil::orchestration::Work;
 use write_fonts::tables::post::Post;
 
@@ -21,7 +22,9 @@ impl Work<Context, Error> for PostWork {
         // TODO optionally drop glyph names with format 3.0.
         // TODO a more serious post
         let static_metadata = context.ir.get_final_static_metadata();
-        let post = Post::new_v2(static_metadata.glyph_order.iter().map(|g| g.as_str()));
+        let mut post = Post::new_v2(static_metadata.glyph_order.iter().map(|g| g.as_str()));
+        post.underline_position = FWord::new(static_metadata.misc.underline_position.0 as i16);
+        post.underline_thickness = FWord::new(static_metadata.misc.underline_thickness.0 as i16);
         context.set_post(post);
         Ok(())
     }

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -78,6 +78,9 @@ pub struct MiscMetadata {
 
     /// See <https://learn.microsoft.com/en-us/typography/opentype/spec/os2#achvendid>
     pub vendor_id: Tag,
+
+    pub underline_thickness: OrderedFloat<f32>,
+    pub underline_position: OrderedFloat<f32>,
 }
 
 impl StaticMetadata {
@@ -141,6 +144,8 @@ impl StaticMetadata {
             misc: MiscMetadata {
                 selection_flags: Default::default(),
                 vendor_id: DEFAULT_VENDOR_ID_TAG,
+                underline_thickness: 0.0.into(),
+                underline_position: 0.0.into(),
             },
         })
     }

--- a/fontir/src/serde.rs
+++ b/fontir/src/serde.rs
@@ -99,6 +99,8 @@ impl From<StaticMetadata> for StaticMetadataSerdeRepr {
 pub struct MiscSerdeRepr {
     pub selection_flags: u16,
     pub vendor_id: Tag,
+    pub underline_thickness: f32,
+    pub underline_position: f32,
 }
 
 impl From<MiscSerdeRepr> for MiscMetadata {
@@ -106,6 +108,8 @@ impl From<MiscSerdeRepr> for MiscMetadata {
         MiscMetadata {
             selection_flags: SelectionFlags::from_bits_truncate(from.selection_flags),
             vendor_id: from.vendor_id,
+            underline_thickness: from.underline_thickness.into(),
+            underline_position: from.underline_position.into(),
         }
     }
 }
@@ -115,6 +119,8 @@ impl From<MiscMetadata> for MiscSerdeRepr {
         MiscSerdeRepr {
             selection_flags: from.selection_flags.bits(),
             vendor_id: from.vendor_id,
+            underline_thickness: from.underline_thickness.into(),
+            underline_position: from.underline_position.into(),
         }
     }
 }

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -338,6 +338,10 @@ impl Work<Context, WorkError> for StaticMetadataWork {
             static_metadata.misc.vendor_id =
                 Tag::from_str(vendor_id).map_err(WorkError::InvalidTag)?;
         }
+        // <https://github.com/googlefonts/glyphsLib/blob/main/Lib/glyphsLib/builder/custom_params.py#L1116-L1125>
+        static_metadata.misc.underline_thickness = 50.0.into();
+        static_metadata.misc.underline_position = (-100.0).into();
+
         context.set_init_static_metadata(static_metadata);
         Ok(())
     }
@@ -1059,6 +1063,20 @@ mod tests {
         assert_eq!(
             Tag::new(b"RODS"),
             context.get_init_static_metadata().misc.vendor_id
+        );
+    }
+
+    #[test]
+    fn default_underline_settings() {
+        let (_, context) = build_static_metadata(glyphs3_dir().join("Oswald-O.glyphs"));
+        let static_metadata = context.get_init_static_metadata();
+        assert_eq!(
+            (1000, 50.0, -100.0),
+            (
+                static_metadata.units_per_em,
+                static_metadata.misc.underline_thickness.0,
+                static_metadata.misc.underline_position.0
+            )
         );
     }
 }

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -672,6 +672,18 @@ impl Work<Context, WorkError> for StaticMetadataWork {
                 Tag::from_str(vendor_id).map_err(WorkError::InvalidTag)?;
         }
 
+        // <https://github.com/googlefonts/ufo2ft/blob/main/Lib/ufo2ft/fontInfoData.py#L313-L322>
+        static_metadata.misc.underline_thickness = font_info_at_default
+            .postscript_underline_thickness
+            .map(|v| v as f32)
+            .unwrap_or(0.05 * units_per_em as f32)
+            .into();
+        static_metadata.misc.underline_position = font_info_at_default
+            .postscript_underline_position
+            .map(|v| v as f32)
+            .unwrap_or(-0.075 * units_per_em as f32)
+            .into();
+
         context.set_init_static_metadata(static_metadata);
         Ok(())
     }
@@ -1220,6 +1232,20 @@ mod tests {
                 (UserCoord::new(700.0), NormalizedCoord::new(1.0)),
             ],
             metric_locations
+        );
+    }
+
+    #[test]
+    fn default_underline_settings() {
+        let (_, context) = build_static_metadata("wght_var.designspace");
+        let static_metadata = &context.get_init_static_metadata();
+        assert_eq!(
+            (1000, 50.0, -75.0),
+            (
+                static_metadata.units_per_em,
+                static_metadata.misc.underline_thickness.0,
+                static_metadata.misc.underline_position.0
+            )
         );
     }
 }


### PR DESCRIPTION
Oswald post matches after:

```
  Only fontmake produced 'GDEF', 'GPOS', 'HVAR', 'STAT'
  DIFF 'GSUB', build/default/fontc.GSUB.ttx build/default/fontmake.GSUB.ttx
  Identical 'GlyphOrder'
  Identical 'OS_2'
  Identical 'avar'
  Identical 'cmap'
  Identical 'fvar'
  DIFF 'glyf', build/default/fontc.glyf.ttx build/default/fontmake.glyf.ttx
  DIFF 'gvar', build/default/fontc.gvar.ttx build/default/fontmake.gvar.ttx
  DIFF 'head', build/default/fontc.head.ttx build/default/fontmake.head.ttx
  DIFF 'hhea', build/default/fontc.hhea.ttx build/default/fontmake.hhea.ttx
  Identical 'hmtx'
  Identical 'loca'
  DIFF 'maxp', build/default/fontc.maxp.ttx build/default/fontmake.maxp.ttx
  Identical 'name'
  Identical 'post'
```