### PR TITLE
Improve hhea enough to match for Oswald

### DIFF
--- a/fontbe/src/metrics_and_limits.rs
+++ b/fontbe/src/metrics_and_limits.rs
@@ -143,8 +143,10 @@ impl Work<Context, Error> for MetricAndLimitWork {
         let min_right_side_bearing = min_right_side_bearing.into();
         let x_max_extent = glyph_limits.x_max_extent.unwrap_or_default().into();
         let hhea = Hhea {
-            ascender: FWord::new(default_metrics.ascender.into_inner().ot_round()),
-            descender: FWord::new(default_metrics.descender.into_inner().ot_round()),
+            ascender: FWord::new(default_metrics.hhea_ascender.into_inner().ot_round()),
+            descender: FWord::new(default_metrics.hhea_descender.into_inner().ot_round()),
+            line_gap: FWord::new(default_metrics.hhea_line_gap.into_inner().ot_round()),
+            caret_slope_rise: default_metrics.caret_slope_rise.into_inner().ot_round(),
             advance_width_max: glyph_limits.advance_width_max.into(),
             min_left_side_bearing,
             min_right_side_bearing,

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -243,10 +243,11 @@ impl GlobalMetrics {
         set(GlobalMetric::Os2TypoAscender, ascender + typo_line_gap);
         set(GlobalMetric::Os2TypoDescender, descender);
 
-        // https://github.com/googlefonts/ufo2ft/blob/main/Lib/ufo2ft/fontInfoData.py#L126-L130
+        // https://github.com/googlefonts/ufo2ft/blob/0d2688cd847d003b41104534d16973f72ef26c40/Lib/ufo2ft/fontInfoData.py#L126-L130
         set(GlobalMetric::HheaAscender, ascender + typo_line_gap);
         set(GlobalMetric::HheaDescender, descender);
-        set(GlobalMetric::HheaLineGap, typo_line_gap);
+        // https://github.com/googlefonts/ufo2ft/blob/0d2688cd847d003b41104534d16973f72ef26c40/Lib/ufo2ft/fontInfoData.py#L366
+        set(GlobalMetric::HheaLineGap, 0.0);
 
         // https://github.com/googlefonts/ufo2ft/blob/0d2688cd847d003b41104534d16973f72ef26c40/Lib/ufo2ft/fontInfoData.py#L241-L254
         set(GlobalMetric::Os2WinAscent, ascender);
@@ -261,7 +262,7 @@ impl GlobalMetrics {
         let italic_angle = 0.0;
         set(GlobalMetric::ItalicAngle, italic_angle);
 
-        // https://github.com/googlefonts/ufo2ft/blob/main/Lib/ufo2ft/fontInfoData.py#L133-L150
+        // https://github.com/googlefonts/ufo2ft/blob/0d2688cd847d003b41104534d16973f72ef26c40/Lib/ufo2ft/fontInfoData.py#L133-L150
         set(GlobalMetric::CaretSlopeRise, 1.0);
 
         // https://github.com/googlefonts/ufo2ft/blob/0d2688cd847d003b41104534d16973f72ef26c40/Lib/ufo2ft/outlineCompiler.py#L575-L616

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -179,12 +179,16 @@ pub struct GlobalMetrics(
 pub enum GlobalMetric {
     Ascender,
     Descender,
+    HheaAscender,
+    HheaDescender,
+    HheaLineGap,
     Os2TypoAscender,
     Os2TypoDescender,
     Os2TypoLineGap,
     Os2WinAscent,
     Os2WinDescent,
     CapHeight,
+    CaretSlopeRise,
     XHeight,
     ItalicAngle,
     YSubscriptXSize,
@@ -239,6 +243,11 @@ impl GlobalMetrics {
         set(GlobalMetric::Os2TypoAscender, ascender + typo_line_gap);
         set(GlobalMetric::Os2TypoDescender, descender);
 
+        // https://github.com/googlefonts/ufo2ft/blob/main/Lib/ufo2ft/fontInfoData.py#L126-L130
+        set(GlobalMetric::HheaAscender, ascender + typo_line_gap);
+        set(GlobalMetric::HheaDescender, descender);
+        set(GlobalMetric::HheaLineGap, typo_line_gap);
+
         // https://github.com/googlefonts/ufo2ft/blob/0d2688cd847d003b41104534d16973f72ef26c40/Lib/ufo2ft/fontInfoData.py#L241-L254
         set(GlobalMetric::Os2WinAscent, ascender);
         set(GlobalMetric::Os2WinDescent, descender);
@@ -251,6 +260,9 @@ impl GlobalMetrics {
         // https://github.com/googlefonts/ufo2ft/blob/0d2688cd847d003b41104534d16973f72ef26c40/Lib/ufo2ft/fontInfoData.py#L360
         let italic_angle = 0.0;
         set(GlobalMetric::ItalicAngle, italic_angle);
+
+        // https://github.com/googlefonts/ufo2ft/blob/main/Lib/ufo2ft/fontInfoData.py#L133-L150
+        set(GlobalMetric::CaretSlopeRise, 1.0);
 
         // https://github.com/googlefonts/ufo2ft/blob/0d2688cd847d003b41104534d16973f72ef26c40/Lib/ufo2ft/outlineCompiler.py#L575-L616
         let y_subscript_x_size = units_per_em as f32 * 0.65;
@@ -324,6 +336,7 @@ impl GlobalMetrics {
             pos: pos.clone(),
             ascender: self.get(GlobalMetric::Ascender, pos),
             descender: self.get(GlobalMetric::Descender, pos),
+            caret_slope_rise: self.get(GlobalMetric::CaretSlopeRise, pos),
             cap_height: self.get(GlobalMetric::CapHeight, pos),
             x_height: self.get(GlobalMetric::XHeight, pos),
             italic_angle: self.get(GlobalMetric::ItalicAngle, pos),
@@ -342,6 +355,9 @@ impl GlobalMetrics {
             os2_typo_line_gap: self.get(GlobalMetric::Os2TypoLineGap, pos),
             os2_win_ascent: self.get(GlobalMetric::Os2WinAscent, pos),
             os2_win_descent: self.get(GlobalMetric::Os2WinDescent, pos),
+            hhea_ascender: self.get(GlobalMetric::HheaAscender, pos),
+            hhea_descender: self.get(GlobalMetric::HheaDescender, pos),
+            hhea_line_gap: self.get(GlobalMetric::HheaLineGap, pos),
         }
     }
 
@@ -358,6 +374,7 @@ pub struct GlobalMetricsInstance {
     pub pos: NormalizedLocation,
     pub ascender: OrderedFloat<f32>,
     pub descender: OrderedFloat<f32>,
+    pub caret_slope_rise: OrderedFloat<f32>,
     pub cap_height: OrderedFloat<f32>,
     pub x_height: OrderedFloat<f32>,
     pub italic_angle: OrderedFloat<f32>,
@@ -376,6 +393,9 @@ pub struct GlobalMetricsInstance {
     pub os2_typo_line_gap: OrderedFloat<f32>,
     pub os2_win_ascent: OrderedFloat<f32>,
     pub os2_win_descent: OrderedFloat<f32>,
+    pub hhea_ascender: OrderedFloat<f32>,
+    pub hhea_descender: OrderedFloat<f32>,
+    pub hhea_line_gap: OrderedFloat<f32>,
 }
 
 /// Helps accumulate 'name' values.

--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -277,6 +277,9 @@ pub struct FontMaster {
     pub typo_line_gap: Option<i64>,
     pub win_ascent: Option<i64>,
     pub win_descent: Option<i64>,
+    pub hhea_ascender: Option<i64>,
+    pub hhea_descender: Option<i64>,
+    pub hhea_line_gap: Option<i64>,
 }
 
 impl FontMaster {
@@ -1556,6 +1559,9 @@ impl TryFrom<RawFont> for Font {
                 typo_line_gap: custom_param_int(&m.other_stuff, "typoLineGap"),
                 win_ascent: custom_param_int(&m.other_stuff, "winAscent"),
                 win_descent: custom_param_int(&m.other_stuff, "winDescent"),
+                hhea_ascender: custom_param_int(&m.other_stuff, "hheaAscender"),
+                hhea_descender: custom_param_int(&m.other_stuff, "hheaDescender"),
+                hhea_line_gap: custom_param_int(&m.other_stuff, "hheaLineGap"),
             })
             .collect();
 

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -1069,7 +1069,7 @@ mod tests {
                 os2_win_descent: (-200.0).into(),
                 hhea_ascender: 1000.0.into(),
                 hhea_descender: (-200.0).into(),
-                hhea_line_gap: 200.0.into(),
+                hhea_line_gap: 0.0.into(),
                 ..Default::default()
             },
             default_metrics

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -401,6 +401,21 @@ impl Work<Context, WorkError> for GlobalMetricWork {
                 pos.clone(),
                 master.win_descent.map(|v| v as f64),
             );
+            metrics.set_if_some(
+                GlobalMetric::HheaAscender,
+                pos.clone(),
+                master.hhea_ascender.map(|v| v as f64),
+            );
+            metrics.set_if_some(
+                GlobalMetric::HheaDescender,
+                pos.clone(),
+                master.hhea_descender.map(|v| v as f64),
+            );
+            metrics.set_if_some(
+                GlobalMetric::HheaLineGap,
+                pos.clone(),
+                master.hhea_line_gap.map(|v| v as f64),
+            );
         }
 
         context.set_global_metrics(metrics);
@@ -1036,6 +1051,7 @@ mod tests {
                 pos: static_metadata.default_location().clone(),
                 ascender: 737.0.into(),
                 descender: (-42.0).into(),
+                caret_slope_rise: 1.0.into(),
                 cap_height: 702.0.into(),
                 x_height: 501.0.into(),
                 y_subscript_x_size: 650.0.into(),
@@ -1051,6 +1067,9 @@ mod tests {
                 os2_typo_line_gap: 200.0.into(),
                 os2_win_ascent: 800.0.into(),
                 os2_win_descent: (-200.0).into(),
+                hhea_ascender: 1000.0.into(),
+                hhea_descender: (-200.0).into(),
+                hhea_line_gap: 200.0.into(),
                 ..Default::default()
             },
             default_metrics

--- a/resources/testdata/FontInfo-Regular.ufo/fontinfo.plist
+++ b/resources/testdata/FontInfo-Regular.ufo/fontinfo.plist
@@ -28,5 +28,11 @@
     <integer>1325</integer>
     <key>openTypeOS2WinDescent</key>
     <integer>377</integer>
+    <key>openTypeHheaAscender</key>
+    <integer>1194</integer>
+    <key>openTypeHheaDescender</key>
+    <integer>-290</integer>
+    <key>openTypeHheaLineGap</key>
+    <integer>43</integer>
   </dict>
 </plist>

--- a/resources/testdata/glyphs2/WghtVar_OS2.glyphs
+++ b/resources/testdata/glyphs2/WghtVar_OS2.glyphs
@@ -63,6 +63,18 @@ value = 1325;
 {
 name = winDescent;
 value = 377;
+},
+{
+name = hheaAscender;
+value = 1194;
+},
+{
+name = hheaDescender;
+value = -290;
+},
+{
+name = hheaLineGap;
+value = 43;
 }
 );
 descender = -42;

--- a/resources/testdata/glyphs3/WghtVar_OS2.glyphs
+++ b/resources/testdata/glyphs3/WghtVar_OS2.glyphs
@@ -38,6 +38,18 @@ value = 1325;
 {
 name = winDescent;
 value = 377;
+},
+{
+name = hheaAscender;
+value = 1194;
+},
+{
+name = hheaDescender;
+value = -290;
+},
+{
+name = hheaLineGap;
+value = 43;
 }
 );
 id = m01;

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -730,6 +730,11 @@ impl Work<Context, WorkError> for GlobalMetricsWork {
 
             metrics.set_if_some(GlobalMetric::Ascender, pos.clone(), font_info.ascender);
             metrics.set_if_some(GlobalMetric::Descender, pos.clone(), font_info.descender);
+            metrics.set_if_some(
+                GlobalMetric::CaretSlopeRise,
+                pos.clone(),
+                font_info.open_type_hhea_caret_slope_rise.map(|v| v as f64),
+            );
             metrics.set_if_some(GlobalMetric::CapHeight, pos.clone(), font_info.cap_height);
             metrics.set_if_some(GlobalMetric::XHeight, pos.clone(), font_info.x_height);
             metrics.set_if_some(
@@ -756,6 +761,21 @@ impl Work<Context, WorkError> for GlobalMetricsWork {
                 GlobalMetric::Os2WinDescent,
                 pos.clone(),
                 font_info.open_type_os2_win_descent.map(|v| v as f64),
+            );
+            metrics.set_if_some(
+                GlobalMetric::HheaAscender,
+                pos.clone(),
+                font_info.open_type_hhea_ascender.map(|v| v as f64),
+            );
+            metrics.set_if_some(
+                GlobalMetric::HheaDescender,
+                pos.clone(),
+                font_info.open_type_hhea_descender.map(|v| v as f64),
+            );
+            metrics.set_if_some(
+                GlobalMetric::HheaLineGap,
+                pos.clone(),
+                font_info.open_type_hhea_line_gap.map(|v| v as f64),
             );
         }
 
@@ -1163,6 +1183,7 @@ mod tests {
                 pos: static_metadata.default_location().clone(),
                 ascender: 737.0.into(),
                 descender: (-42.0).into(),
+                caret_slope_rise: 1.0.into(),
                 cap_height: 702.0.into(),
                 x_height: 501.0.into(),
                 y_subscript_x_size: 650.0.into(),
@@ -1178,6 +1199,9 @@ mod tests {
                 os2_typo_line_gap: 42.0.into(),
                 os2_win_ascent: 1325.0.into(),
                 os2_win_descent: 377.0.into(),
+                hhea_ascender: 1194.0.into(),
+                hhea_descender: (-290.0).into(),
+                hhea_line_gap: 43.0.into(),
                 ..Default::default()
             },
             default_metrics


### PR DESCRIPTION
Note that I have punted italic slope rise into #318 

ttx_diff of Oswald after shows matching hhea:

```
  Only fontmake produced 'GDEF', 'GPOS', 'HVAR', 'STAT'
  DIFF 'GSUB', build/default/fontc.GSUB.ttx build/default/fontmake.GSUB.ttx
  Identical 'GlyphOrder'
  Identical 'OS_2'
  Identical 'avar'
  Identical 'cmap'
  Identical 'fvar'
  DIFF 'glyf', build/default/fontc.glyf.ttx build/default/fontmake.glyf.ttx
  DIFF 'gvar', build/default/fontc.gvar.ttx build/default/fontmake.gvar.ttx
  DIFF 'head', build/default/fontc.head.ttx build/default/fontmake.head.ttx
  Identical 'hhea'
  Identical 'hmtx'
  Identical 'loca'
  DIFF 'maxp', build/default/fontc.maxp.ttx build/default/fontmake.maxp.ttx
  Identical 'name'
  Identical 'post'
``