### PR TITLE
This updates to new versions of fontations + fea-rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,11 @@ env_logger = "0.10.0"
 
 parking_lot = "0.12.1"
 
-fea-rs = "= 0.4.0"
-font-types = { version = "0.1.6", features = ["serde"] }
-read-fonts = "0.2.0"
-write-fonts = "0.4.0"
-skrifa = "0.1.0"
+fea-rs = "= 0.5.0"
+font-types = { version = "0.1.8", features = ["serde"] }
+read-fonts = "0.3.0"
+write-fonts = "0.5.0"
+skrifa = "0.2.0"
 
 bitflags = "2.0"
 chrono = "0.4.24"

--- a/fontbe/src/error.rs
+++ b/fontbe/src/error.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Display, io};
 
-use fea_rs::compile::error::{BinaryCompilationError, CompilerError};
+use fea_rs::compile::error::CompilerError;
 use font_types::Tag;
 use fontdrasil::types::GlyphName;
 use fontir::variations::DeltaError;
@@ -12,8 +12,6 @@ use write_fonts::tables::{glyf::BadKurbo, gvar::GvarInputError, variations::IupE
 pub enum Error {
     #[error("IO failure")]
     IoError(#[from] io::Error),
-    #[error("Fea binary assembly failure")]
-    FeaAssembleError(#[from] BinaryCompilationError),
     #[error("Fea compilation failure")]
     FeaCompileError(#[from] CompilerError),
     #[error("'{0}' {1}")]


### PR DESCRIPTION
The only major change here is that fea-rs now just passes us the tables we want, so we no longer need to compile and then reparse them. (This also means we can remove one of our error variants, since fea-rs no longer generates binary)

JMM