### PR TITLE
Use the real sort order for 'name'

### DIFF
--- a/fontbe/src/name.rs
+++ b/fontbe/src/name.rs
@@ -22,7 +22,7 @@ impl Work<Context, Error> for NameWork {
     fn exec(&self, context: &Context) -> Result<(), Error> {
         let static_metadata = context.ir.get_init_static_metadata();
 
-        let name_records = static_metadata
+        let mut name_records = static_metadata
             .names
             .iter()
             .map(|(key, value)| NameRecord {
@@ -32,9 +32,20 @@ impl Work<Context, Error> for NameWork {
                 language_id: key.lang_id,
                 string: OffsetMarker::new(value.clone()),
             })
-            .collect();
+            .collect::<Vec<_>>();
 
-        context.set_name(Name::new(name_records));
+        // https://learn.microsoft.com/en-us/typography/opentype/spec/name#name-records
+        // first by platform ID, then by platform-specific ID, then by language ID, and then by name ID
+        name_records.sort_by_key(|nr| {
+            (
+                nr.platform_id,
+                nr.encoding_id,
+                nr.language_id,
+                nr.name_id.to_u16(),
+            )
+        });
+
+        context.set_name(Name::new(name_records.into_iter().collect()));
         Ok(())
     }
 }

--- a/resources/scripts/ttx_diff.py
+++ b/resources/scripts/ttx_diff.py
@@ -163,22 +163,6 @@ def find_table(ttx, tag):
     return el[0]
 
 
-def sort_name(ttx):
-    name = find_table(ttx, "name")
-    records = sorted(
-        list(name),
-        key=lambda el: (
-            int(el.attrib["nameID"]),
-            el.attrib["platformID"],
-            el.attrib["platEncID"],
-            el.attrib["langID"],
-        ),
-    )
-    name.clear()
-    for record in records:
-        name.append(record)
-
-
 def drop_weird_names(ttx):
     drops = list(
         ttx.xpath(
@@ -193,9 +177,6 @@ def reduce_diff_noise(fontc, fontmake):
     for ttx in (fontc, fontmake):
         # different name ids with the same value is fine
         name_id_to_name(ttx, "//NamedInstance", "subfamilyNameID")
-
-        # different order of records is fine
-        sort_name(ttx)
 
         # deal with https://github.com/googlefonts/fontmake/issues/1003
         drop_weird_names(ttx)


### PR DESCRIPTION
As noted in https://github.com/googlefonts/fontc/pull/314#pullrequestreview-1455005475, apparently I invented a sort order for 'name'. Turns out the spec says something else; do that instead.