### PR TITLE
Set more of head correctly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,11 @@ parking_lot = "0.12.1"
 fea-rs = "= 0.5.0"
 font-types = { version = "0.1.8", features = ["serde"] }
 read-fonts = "0.3.0"
-write-fonts = "0.5.0"
+write-fonts = "0.5.1"
 skrifa = "0.2.0"
 
 bitflags = "2.0"
-chrono = "0.4.24"
+chrono = { version = "0.4.24", features = ["serde"] }
 filetime = "0.2.18"
 indexmap = "1.9.2"
 kurbo = { version = "0.9.4", features = ["serde"] }

--- a/fontc/Cargo.toml
+++ b/fontc/Cargo.toml
@@ -48,3 +48,4 @@ read-fonts.workspace = true
 pretty_assertions.workspace = true
 skrifa.workspace = true
 kurbo.workspace = true
+chrono.workspace = true

--- a/fontc/src/workload.rs
+++ b/fontc/src/workload.rs
@@ -298,7 +298,7 @@ impl Workload {
             log::debug!("Exec {:?}", id);
             job.work
                 .exec(context)
-                .unwrap_or_else(|_| panic!("{id:?} should have succeeded"));
+                .unwrap_or_else(|e| panic!("{id:?} failed: {e:?}"));
             assert!(
                 self.success.insert(id.clone()),
                 "We just did {id:?} a second time?"

--- a/fontir/Cargo.toml
+++ b/fontir/Cargo.toml
@@ -31,6 +31,8 @@ parking_lot.workspace = true
 font-types.workspace = true
 write-fonts.workspace = true  # for pens
 
+chrono.workspace = true
+
 # unique to me!
 blake3 = "1.3.3"
 

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -6,6 +6,7 @@ use crate::{
     serde::{GlobalMetricsSerdeRepr, GlyphSerdeRepr, MiscSerdeRepr, StaticMetadataSerdeRepr},
     variations::VariationModel,
 };
+use chrono::{DateTime, Utc};
 use font_types::NameId;
 use font_types::Tag;
 use fontdrasil::types::GlyphName;
@@ -81,6 +82,17 @@ pub struct MiscMetadata {
 
     pub underline_thickness: OrderedFloat<f32>,
     pub underline_position: OrderedFloat<f32>,
+
+    /// UFO appears to allow negative major versions.
+    ///
+    /// See <https://unifiedfontobject.org/versions/ufo3/fontinfo.plist/#generic-identification-information>
+    pub version_major: i32,
+    pub version_minor: u32,
+
+    pub head_flags: u16,
+    pub lowest_rec_ppm: u16,
+
+    pub created: Option<DateTime<Utc>>,
 }
 
 impl StaticMetadata {
@@ -146,6 +158,14 @@ impl StaticMetadata {
                 vendor_id: DEFAULT_VENDOR_ID_TAG,
                 underline_thickness: 0.0.into(),
                 underline_position: 0.0.into(),
+                // https://github.com/googlefonts/ufo2ft/blob/0d2688cd847d003b41104534d16973f72ef26c40/Lib/ufo2ft/fontInfoData.py#L353-L354
+                version_major: 0,
+                version_minor: 0,
+                // <https://github.com/googlefonts/ufo2ft/blob/0d2688cd847d003b41104534d16973f72ef26c40/Lib/ufo2ft/fontInfoData.py#L364>
+                lowest_rec_ppm: 6,
+                // <https://github.com/googlefonts/ufo2ft/blob/0d2688cd847d003b41104534d16973f72ef26c40/Lib/ufo2ft/fontInfoData.py#L365>
+                head_flags: 3,
+                created: None,
             },
         })
     }

--- a/fontir/src/serde.rs
+++ b/fontir/src/serde.rs
@@ -3,6 +3,7 @@ use std::{
     path::PathBuf,
 };
 
+use chrono::{DateTime, Utc};
 use filetime::FileTime;
 use font_types::Tag;
 use ordered_float::OrderedFloat;
@@ -101,6 +102,11 @@ pub struct MiscSerdeRepr {
     pub vendor_id: Tag,
     pub underline_thickness: f32,
     pub underline_position: f32,
+    pub version_major: i32,
+    pub version_minor: u32,
+    pub head_flags: u16,
+    pub lowest_rec_ppm: u16,
+    pub created: Option<DateTime<Utc>>,
 }
 
 impl From<MiscSerdeRepr> for MiscMetadata {
@@ -110,6 +116,11 @@ impl From<MiscSerdeRepr> for MiscMetadata {
             vendor_id: from.vendor_id,
             underline_thickness: from.underline_thickness.into(),
             underline_position: from.underline_position.into(),
+            version_major: from.version_major,
+            version_minor: from.version_minor,
+            head_flags: from.head_flags,
+            lowest_rec_ppm: from.lowest_rec_ppm,
+            created: from.created,
         }
     }
 }
@@ -121,6 +132,11 @@ impl From<MiscMetadata> for MiscSerdeRepr {
             vendor_id: from.vendor_id,
             underline_thickness: from.underline_thickness.into(),
             underline_position: from.underline_position.into(),
+            version_major: from.version_major,
+            version_minor: from.version_minor,
+            head_flags: from.head_flags,
+            lowest_rec_ppm: from.lowest_rec_ppm,
+            created: from.created,
         }
     }
 }

--- a/glyphs-reader/Cargo.toml
+++ b/glyphs-reader/Cargo.toml
@@ -19,5 +19,7 @@ env_logger.workspace = true
 
 regex.workspace = true
 
+chrono.workspace = true
+
 [dev-dependencies]
 pretty_assertions.workspace = true

--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -61,6 +61,7 @@ pub struct Font {
     pub instances: Vec<Instance>,
     pub version_major: i32,
     pub version_minor: u32,
+    pub date: Option<String>,
 }
 
 #[derive(Debug, PartialEq, Eq, Hash)]
@@ -99,6 +100,7 @@ struct RawFont {
     pub units_per_em: Option<i64>,
     pub metrics: Option<Vec<RawMetric>>,
     pub family_name: String,
+    pub date: Option<String>,
     pub copyright: Option<String>,
     pub designer: Option<String>,
     pub designerURL: Option<String>,
@@ -1581,6 +1583,7 @@ impl TryFrom<RawFont> for Font {
             instances,
             version_major: from.versionMajor.unwrap_or_default() as i32,
             version_minor: from.versionMinor.unwrap_or_default() as u32,
+            date: from.date,
         })
     }
 }

--- a/glyphs2fontir/Cargo.toml
+++ b/glyphs2fontir/Cargo.toml
@@ -28,6 +28,8 @@ quick-xml.workspace = true
 font-types.workspace = true
 read-fonts.workspace = true
 
+chrono.workspace = true
+
 [dev-dependencies]
 diff.workspace = true
 ansi_term.workspace = true

--- a/resources/scripts/ttx_diff.py
+++ b/resources/scripts/ttx_diff.py
@@ -157,8 +157,12 @@ def name_id_to_name(ttx, xpath, attr):
         el.attrib[attr] = id_to_name[el.attrib[attr]]
 
 
-def find_table(ttx, tag):
-    el = ttx.xpath(f"/ttFont/{tag}")
+def find_table(ttx, table):
+    return select_one(ttx, f"/ttFont/{tag}")
+
+
+def select_one(ttx, xpath):
+    el = ttx.xpath(xpath)
     assert len(el) == 1, f"Wanted 1 name element, got {len(el)}"
     return el[0]
 
@@ -173,6 +177,11 @@ def drop_weird_names(ttx):
         drop.getparent().remove(drop)
 
 
+def erase_modified(ttx):
+    el = select_one(ttx, "//head/modified")
+    del el.attrib["value"]
+
+
 def reduce_diff_noise(fontc, fontmake):
     for ttx in (fontc, fontmake):
         # different name ids with the same value is fine
@@ -180,6 +189,9 @@ def reduce_diff_noise(fontc, fontmake):
 
         # deal with https://github.com/googlefonts/fontmake/issues/1003
         drop_weird_names(ttx)
+
+        # it's not at all helpful to see modified off by a second or two in a diff
+        erase_modified(ttx)
 
 
 def main(argv):

--- a/resources/testdata/WghtVar-Regular.ufo/fontinfo.plist
+++ b/resources/testdata/WghtVar-Regular.ufo/fontinfo.plist
@@ -8,5 +8,7 @@
     <real>799</real>
     <key>familyName</key>
     <string>Wght Var</string>
+    <key>openTypeHeadCreated</key>
+    <string>2023/05/05 15:11:55</string>
   </dict>
 </plist>

--- a/resources/testdata/glyphs3/Dated.glyphs
+++ b/resources/testdata/glyphs3/Dated.glyphs
@@ -1,0 +1,22 @@
+{
+.formatVersion = 3;
+familyName = Dated;
+date = "2023-05-05 15:11:55 +0000";
+fontMaster = (
+{
+id = m01;
+}
+);
+glyphs = (
+{
+glyphname = space;
+layers = (
+{
+layerId = m01;
+width = 200;
+}
+);
+}
+);
+unitsPerEm = 1000;
+}

--- a/ufo2fontir/Cargo.toml
+++ b/ufo2fontir/Cargo.toml
@@ -30,6 +30,8 @@ ordered-float.workspace = true
 indexmap.workspace = true
 quick-xml.workspace = true
 
+chrono.workspace = true
+
 # unique to me!
 norad = "0.10.0"
 plist = { version =  "1.3.1", features = ["serde"] }


### PR DESCRIPTION
Specifically:

* lowest rec ppm
* flags
* font revision
* created/modified

Fixes #233. Fixes #249.

Requires https://github.com/googlefonts/fontations/pull/469 which is in write-fonts 0.5.1.

The only Oswald head diff I'm left with is checksum. https://github.com/googlefonts/fontations/issues/466 requests fontations set checksum adjustment. It won't match until all tables do ofc.