### PR TITLE
Write a rudimentary STAT

### DIFF
--- a/fontbe/src/font.rs
+++ b/fontbe/src/font.rs
@@ -6,7 +6,7 @@ use read_fonts::{
     tables::{
         avar::Avar, cmap::Cmap, fvar::Fvar, glyf::Glyf, gpos::Gpos, gsub::Gsub, gvar::Gvar,
         head::Head, hhea::Hhea, hmtx::Hmtx, loca::Loca, maxp::Maxp, name::Name, os2::Os2,
-        post::Post,
+        post::Post, stat::Stat,
     },
     types::Tag,
     TopLevelTable,
@@ -45,6 +45,7 @@ const TABLES_TO_MERGE: &[(WorkId, Tag, TableType)] = &[
     (WorkId::Name, Name::TAG, TableType::Static),
     (WorkId::Os2, Os2::TAG, TableType::Static),
     (WorkId::Post, Post::TAG, TableType::Static),
+    (WorkId::Stat, Stat::TAG, TableType::Variable),
 ];
 
 fn has(context: &Context, id: WorkId) -> bool {
@@ -64,6 +65,7 @@ fn has(context: &Context, id: WorkId) -> bool {
         WorkId::Name => context.has_name(),
         WorkId::Os2 => context.has_os2(),
         WorkId::Post => context.has_post(),
+        WorkId::Stat => context.has_stat(),
         _ => false,
     }
 }
@@ -85,6 +87,7 @@ fn bytes_for(context: &Context, id: WorkId) -> Result<Vec<u8>, Error> {
         WorkId::Name => to_bytes(&*context.get_name()),
         WorkId::Os2 => to_bytes(&*context.get_os2()),
         WorkId::Post => to_bytes(&*context.get_post()),
+        WorkId::Stat => to_bytes(&*context.get_stat()),
         _ => panic!("Missing a match for {id:?}"),
     };
     Ok(bytes)

--- a/fontbe/src/lib.rs
+++ b/fontbe/src/lib.rs
@@ -13,5 +13,6 @@ pub mod orchestration;
 pub mod os2;
 pub mod paths;
 pub mod post;
+pub mod stat;
 #[cfg(test)]
 mod test_util;

--- a/fontbe/src/orchestration.rs
+++ b/fontbe/src/orchestration.rs
@@ -34,6 +34,7 @@ use write_fonts::{
         name::Name,
         os2::Os2,
         post::Post,
+        stat::Stat,
         variations::Tuple,
     },
     validate::Validate,
@@ -60,6 +61,7 @@ pub enum WorkId {
     Features,
     Avar,
     Cmap,
+    Font,
     Fvar,
     Glyf,
     GlyfFragment(GlyphName),
@@ -76,7 +78,7 @@ pub enum WorkId {
     Name,
     Os2,
     Post,
-    Font,
+    Stat,
 }
 
 // Identifies work of any type, FE, BE, ... future optimization passes, w/e.
@@ -368,6 +370,7 @@ pub struct Context {
     head: ContextItem<Head>,
     hhea: ContextItem<Hhea>,
     hmtx: ContextItem<Bytes>,
+    stat: ContextItem<Stat>,
     font: ContextItem<Bytes>,
 }
 
@@ -395,6 +398,7 @@ impl Context {
             head: self.head.clone(),
             hhea: self.hhea.clone(),
             hmtx: self.hmtx.clone(),
+            stat: self.stat.clone(),
             font: self.font.clone(),
         }
     }
@@ -422,6 +426,7 @@ impl Context {
             head: Arc::from(RwLock::new(None)),
             hhea: Arc::from(RwLock::new(None)),
             hmtx: Arc::from(RwLock::new(None)),
+            stat: Arc::from(RwLock::new(None)),
             font: Arc::from(RwLock::new(None)),
         }
     }
@@ -591,6 +596,7 @@ impl Context {
     context_accessors! { get_hhea, set_hhea, has_hhea, hhea, Hhea, WorkId::Hhea, from_file, to_bytes }
     context_accessors! { get_gpos, set_gpos, has_gpos, gpos, Gpos, WorkId::Gpos, from_file, to_bytes }
     context_accessors! { get_gsub, set_gsub, has_gsub, gsub, Gsub, WorkId::Gsub, from_file, to_bytes }
+    context_accessors! { get_stat, set_stat, has_stat, stat, Stat, WorkId::Stat, from_file, to_bytes }
 
     // Accessors where value is raw bytes
     context_accessors! { get_gvar, set_gvar, has_gvar, gvar, Bytes, WorkId::Gvar, raw_from_file, raw_to_bytes }

--- a/fontbe/src/paths.rs
+++ b/fontbe/src/paths.rs
@@ -66,6 +66,7 @@ impl Paths {
             WorkId::Name => self.build_dir.join("name.table"),
             WorkId::Os2 => self.build_dir.join("os2.table"),
             WorkId::Post => self.build_dir.join("post.table"),
+            WorkId::Stat => self.build_dir.join("stat.table"),
             WorkId::Font => self.build_dir.join("font.ttf"),
         }
     }

--- a/fontbe/src/stat.rs
+++ b/fontbe/src/stat.rs
@@ -1,0 +1,62 @@
+//! Generates a [stat](https://learn.microsoft.com/en-us/typography/opentype/spec/stat) table.
+
+use std::collections::HashMap;
+
+use font_types::NameId;
+use fontdrasil::orchestration::Work;
+use log::trace;
+use write_fonts::tables::stat::{AxisRecord, Stat};
+
+use crate::{
+    error::Error,
+    orchestration::{BeWork, Context},
+};
+
+struct StatWork {}
+
+pub fn create_stat_work() -> Box<BeWork> {
+    Box::new(StatWork {})
+}
+
+impl Work<Context, Error> for StatWork {
+    /// Generate [stat](https://learn.microsoft.com/en-us/typography/opentype/spec/stat)
+    ///
+    /// See <https://github.com/fonttools/fonttools/blob/main/Lib/fontTools/otlLib/builder.py#L2688-L2810>
+    /// Note that we support only a very simple STAT at time of writing.
+    fn exec(&self, context: &Context) -> Result<(), Error> {
+        let static_metadata = context.ir.get_init_static_metadata();
+
+        // Guard clause: don't produce fvar for a static font
+        if static_metadata.variable_axes.is_empty() {
+            trace!("Skip stat; this is not a variable font");
+            return Ok(());
+        }
+
+        let reverse_names: HashMap<_, _> = static_metadata
+            .names
+            .iter()
+            // To match fontmake we should use the font-specific name range and not reuse
+            // a well-known name, even if the name matches.
+            .filter(|(key, _)| key.name_id.to_u16() > 255)
+            .map(|(key, name)| (name, key.name_id))
+            .collect();
+
+        context.set_stat(Stat {
+            design_axes: static_metadata
+                .variable_axes
+                .iter()
+                .enumerate()
+                .map(|(idx, a)| AxisRecord {
+                    axis_tag: a.tag,
+                    axis_name_id: *reverse_names.get(&a.name).unwrap(),
+                    axis_ordering: idx as u16,
+                })
+                .collect::<Vec<_>>()
+                .into(),
+            elided_fallback_name_id: Some(NameId::SUBFAMILY_NAME),
+            ..Default::default()
+        });
+
+        Ok(())
+    }
+}

--- a/fontc/src/change_detector.rs
+++ b/fontc/src/change_detector.rs
@@ -134,6 +134,11 @@ impl ChangeDetector {
             || !self.be_paths.target_file(&BeWorkIdentifier::Avar).is_file()
     }
 
+    pub fn stat_be_change(&self) -> bool {
+        self.final_static_metadata_ir_change()
+            || !self.be_paths.target_file(&BeWorkIdentifier::Stat).is_file()
+    }
+
     pub fn fvar_be_change(&self) -> bool {
         self.final_static_metadata_ir_change()
             || !self.be_paths.target_file(&BeWorkIdentifier::Fvar).is_file()


### PR DESCRIPTION
ttx_diff claims we match Oswald. Not cheating at all to massage the results right?

```shell
  Only fontmake produced 'GDEF', 'GPOS', 'HVAR'
  DIFF 'GSUB', build/default/fontc.GSUB.ttx build/default/fontmake.GSUB.ttx
  Identical 'GlyphOrder'
  Identical 'OS_2'
  Identical 'STAT'
  Identical 'avar'
  Identical 'cmap'
  Identical 'fvar'
  DIFF 'glyf', build/default/fontc.glyf.ttx build/default/fontmake.glyf.ttx
  DIFF 'gvar', build/default/fontc.gvar.ttx build/default/fontmake.gvar.ttx
  Identical 'head'
  Identical 'hhea'
  Identical 'hmtx'
  Identical 'loca'
  DIFF 'maxp', build/default/fontc.maxp.ttx build/default/fontmake.maxp.ttx
  Identical 'name'
  Identical 'post'

```