### PR TITLE
Add example .glyphs kern and ability to read it

### DIFF
--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -90,6 +90,7 @@ impl GlyphsIrSource {
             version_major: Default::default(),
             version_minor: Default::default(),
             date: None,
+            kerning_ltr: Default::default(),
         };
         state.track_memory("/font_master".to_string(), &font)?;
         Ok(state)
@@ -117,6 +118,7 @@ impl GlyphsIrSource {
             version_major: Default::default(),
             version_minor: Default::default(),
             date: None,
+            kerning_ltr: font.kerning_ltr.clone(),
         };
         state.track_memory("/font_master".to_string(), &font)?;
         Ok(state)

--- a/resources/testdata/glyphs2/WghtVar.glyphs
+++ b/resources/testdata/glyphs2/WghtVar.glyphs
@@ -2,7 +2,7 @@
 .appVersion = "3151";
 DisplayStrings = (
 "-",
-"!"
+"!!--"
 );
 copyright = "Copy!";
 customParameters = (
@@ -84,7 +84,7 @@ unicode = 0020;
 },
 {
 glyphname = exclam;
-lastChange = "2022-12-01 05:10:49 +0000";
+lastChange = "2023-06-05 23:22:51 +0000";
 layers = (
 {
 layerId = m01;
@@ -139,7 +139,7 @@ unicode = 0021;
 },
 {
 glyphname = hyphen;
-lastChange = "2022-12-01 04:57:39 +0000";
+lastChange = "2023-06-05 23:23:03 +0000";
 layers = (
 {
 layerId = m01;
@@ -208,6 +208,25 @@ width = 600;
 unicode = 003D;
 }
 );
+kerning = {
+m01 = {
+exclam = {
+exclam = -360;
+hyphen = 20;
+};
+hyphen = {
+hyphen = -150;
+};
+};
+"E09E0C54-128D-4FEA-B209-1B70BEFE300B" = {
+exclam = {
+exclam = -100;
+};
+hyphen = {
+hyphen = -50;
+};
+};
+};
 unitsPerEm = 1000;
 versionMajor = 42;
 versionMinor = 42;

--- a/resources/testdata/glyphs3/WghtVar.glyphs
+++ b/resources/testdata/glyphs3/WghtVar.glyphs
@@ -3,7 +3,7 @@
 .formatVersion = 3;
 DisplayStrings = (
 "-",
-"!"
+"!!--"
 );
 axes = (
 {
@@ -93,7 +93,7 @@ unicode = 32;
 },
 {
 glyphname = exclam;
-lastChange = "2022-12-01 05:10:49 +0000";
+lastChange = "2023-06-05 23:22:51 +0000";
 layers = (
 {
 layerId = m01;
@@ -148,7 +148,7 @@ unicode = 33;
 },
 {
 glyphname = hyphen;
-lastChange = "2022-12-01 04:57:39 +0000";
+lastChange = "2023-06-05 23:23:03 +0000";
 layers = (
 {
 layerId = m01;
@@ -218,6 +218,25 @@ width = 600;
 unicode = 61;
 }
 );
+kerningLTR = {
+m01 = {
+exclam = {
+exclam = -360;
+hyphen = 20;
+};
+hyphen = {
+hyphen = -150;
+};
+};
+"E09E0C54-128D-4FEA-B209-1B70BEFE300B" = {
+exclam = {
+exclam = -100;
+};
+hyphen = {
+hyphen = -50;
+};
+};
+};
 metrics = (
 {
 type = ascender;


### PR DESCRIPTION
Tiptoing toward #308

The existing test to confirm reading glyphs2 wghtvar == read glyphs3 wghtvar verifies the field rename works as intended.