### PR TITLE
Model kerning in IR and capture it for .glyphs and .designspace

### DIFF
--- a/fontc/src/change_detector.rs
+++ b/fontc/src/change_detector.rs
@@ -129,6 +129,15 @@ impl ChangeDetector {
                 .is_file()
     }
 
+    pub fn kerning_ir_change(&self) -> bool {
+        self.final_static_metadata_ir_change()
+            || self.current_inputs.features != self.prev_inputs.features
+            || !self
+                .ir_paths
+                .target_file(&FeWorkIdentifier::Kerning)
+                .is_file()
+    }
+
     pub fn avar_be_change(&self) -> bool {
         self.final_static_metadata_ir_change()
             || !self.be_paths.target_file(&BeWorkIdentifier::Avar).is_file()

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -256,6 +256,34 @@ fn add_feature_be_job(
     Ok(())
 }
 
+fn add_kerning_ir_job(
+    change_detector: &mut ChangeDetector,
+    workload: &mut Workload,
+) -> Result<(), Error> {
+    if change_detector.kerning_ir_change() {
+        let mut dependencies = HashSet::new();
+        dependencies.insert(FeWorkIdentifier::FinalizeStaticMetadata.into());
+
+        let id: AnyWorkId = FeWorkIdentifier::Kerning.into();
+        let write_access = Access::one(id.clone());
+        workload.insert(
+            id,
+            Job {
+                work: change_detector
+                    .ir_source()
+                    .create_kerning_ir_work(change_detector.current_inputs())?
+                    .into(),
+                dependencies,
+                read_access: ReadAccess::Dependencies,
+                write_access,
+            },
+        );
+    } else {
+        workload.mark_success(FeWorkIdentifier::Kerning);
+    }
+    Ok(())
+}
+
 fn add_glyph_ir_jobs(
     change_detector: &mut ChangeDetector,
     workload: &mut Workload,
@@ -743,6 +771,7 @@ pub fn create_workload(change_detector: &mut ChangeDetector) -> Result<Workload,
     add_init_static_metadata_ir_job(change_detector, &mut workload)?;
     add_global_metric_ir_job(change_detector, &mut workload)?;
     add_feature_ir_job(change_detector, &mut workload)?;
+    add_kerning_ir_job(change_detector, &mut workload)?;
     add_glyph_ir_jobs(change_detector, &mut workload)?;
     add_finalize_static_metadata_ir_job(change_detector, &mut workload)?;
 
@@ -796,7 +825,7 @@ mod tests {
     };
     use fontdrasil::types::GlyphName;
     use fontir::{
-        ir,
+        ir::{self, KernParticipant},
         orchestration::{Context as FeContext, WorkId as FeWorkIdentifier},
     };
     use indexmap::IndexSet;
@@ -948,6 +977,7 @@ mod tests {
         add_finalize_static_metadata_ir_job(&mut change_detector, &mut workload).unwrap();
         add_glyph_ir_jobs(&mut change_detector, &mut workload).unwrap();
         add_feature_ir_job(&mut change_detector, &mut workload).unwrap();
+        add_kerning_ir_job(&mut change_detector, &mut workload).unwrap();
         add_feature_be_job(&mut change_detector, &mut workload).unwrap();
 
         add_glyf_loca_be_job(&mut change_detector, &mut workload).unwrap();
@@ -1005,6 +1035,7 @@ mod tests {
                 FeWorkIdentifier::Glyph("plus".into()).into(),
                 FeWorkIdentifier::FinalizeStaticMetadata.into(),
                 FeWorkIdentifier::Features.into(),
+                FeWorkIdentifier::Kerning.into(),
                 BeWorkIdentifier::Features.into(),
                 BeWorkIdentifier::Avar.into(),
                 BeWorkIdentifier::Cmap.into(),
@@ -1186,6 +1217,7 @@ mod tests {
         assert_eq!(
             vec![
                 AnyWorkId::Fe(FeWorkIdentifier::Features),
+                AnyWorkId::Fe(FeWorkIdentifier::Kerning),
                 BeWorkIdentifier::Features.into(),
                 BeWorkIdentifier::Font.into(),
                 BeWorkIdentifier::Gpos.into(),
@@ -2032,5 +2064,107 @@ mod tests {
                     .collect::<Vec<_>>(),
             )
         );
+    }
+
+    fn assert_simple_kerning(source: &str) {
+        let temp_dir = tempdir().unwrap();
+        let build_dir = temp_dir.path();
+        let result = compile(Args::for_test(build_dir, source));
+
+        let kerning = result.fe_context.get_kerning();
+
+        let mut groups: Vec<_> = kerning
+            .groups
+            .iter()
+            .map(|(name, entries)| {
+                let mut entries: Vec<_> = entries.iter().map(|e| e.as_str()).collect();
+                entries.sort();
+                (name.as_str(), entries)
+            })
+            .collect();
+        groups.sort();
+
+        let mut kerns: Vec<_> = kerning
+            .kerns
+            .iter()
+            .map(|((side1, side2), values)| {
+                (
+                    side1,
+                    side2,
+                    values
+                        .iter()
+                        .map(|(loc, val)| {
+                            assert_eq!(loc.axis_names().count(), 1, "Should be only weight");
+                            let (axis, pos) = loc.iter().next().unwrap();
+                            (format!("{axis} {}", pos.to_f32()), val.0)
+                        })
+                        .collect::<Vec<_>>(),
+                )
+            })
+            .collect();
+        kerns.sort_by_key(|(side1, side2, _)| (*side1, *side2));
+
+        assert_eq!(
+            (groups, kerns),
+            (
+                vec![
+                    ("public.kern1.bracketleft_R", vec!["bracketleft"],),
+                    ("public.kern1.bracketright_R", vec!["bracketright"],),
+                    ("public.kern2.bracketleft_L", vec!["bracketleft"],),
+                    ("public.kern2.bracketright_L", vec!["bracketright"],),
+                ],
+                vec![
+                    (
+                        &KernParticipant::Glyph("bracketleft".into()),
+                        &KernParticipant::Glyph("bracketright".into()),
+                        vec![
+                            ("Weight 0".to_string(), -300.0),
+                            ("Weight 1".to_string(), -150.0)
+                        ],
+                    ),
+                    (
+                        &KernParticipant::Glyph("exclam".into()),
+                        &KernParticipant::Glyph("exclam".into()),
+                        vec![
+                            ("Weight 0".to_string(), -360.0),
+                            ("Weight 1".to_string(), -100.0)
+                        ],
+                    ),
+                    (
+                        &KernParticipant::Glyph("exclam".into()),
+                        &KernParticipant::Glyph("hyphen".into()),
+                        vec![("Weight 0".to_string(), 20.0),],
+                    ),
+                    (
+                        &KernParticipant::Glyph("exclam".into()),
+                        &KernParticipant::Group("public.kern2.bracketright_L".into()),
+                        vec![("Weight 0".to_string(), -160.0),],
+                    ),
+                    (
+                        &KernParticipant::Glyph("hyphen".into()),
+                        &KernParticipant::Glyph("hyphen".into()),
+                        vec![
+                            ("Weight 0".to_string(), -150.0),
+                            ("Weight 1".to_string(), -50.0)
+                        ],
+                    ),
+                    (
+                        &KernParticipant::Group("public.kern1.bracketleft_R".into()),
+                        &KernParticipant::Glyph("exclam".into()),
+                        vec![("Weight 0".to_string(), -165.0),],
+                    ),
+                ],
+            ),
+        );
+    }
+
+    #[test]
+    fn kerning_from_glyphs() {
+        assert_simple_kerning("glyphs3/WghtVar.glyphs");
+    }
+
+    #[test]
+    fn kerning_from_ufo() {
+        assert_simple_kerning("designspace_from_glyphs/WghtVar.designspace");
     }
 }

--- a/fontdrasil/src/types.rs
+++ b/fontdrasil/src/types.rs
@@ -49,3 +49,5 @@ impl Display for GlyphName {
         f.write_str(self.as_str())
     }
 }
+
+pub type GroupName = GlyphName;

--- a/fontir/src/error.rs
+++ b/fontir/src/error.rs
@@ -132,6 +132,8 @@ pub enum WorkError {
     AxisMustMapMin(Tag),
     #[error("Axis '{0}' must map max if it maps anything")]
     AxisMustMapMax(Tag),
+    #[error("No kerning group or glyph for name {0:?}")]
+    InvalidKernSide(String),
 }
 
 /// An async work error, hence one that must be Send

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -3,20 +3,23 @@
 use crate::{
     coords::{CoordConverter, NormalizedCoord, NormalizedLocation, UserCoord, UserLocation},
     error::{PathConversionError, VariationModelError, WorkError},
-    serde::{GlobalMetricsSerdeRepr, GlyphSerdeRepr, MiscSerdeRepr, StaticMetadataSerdeRepr},
+    serde::{
+        GlobalMetricsSerdeRepr, GlyphSerdeRepr, KerningSerdeRepr, MiscSerdeRepr,
+        StaticMetadataSerdeRepr,
+    },
     variations::VariationModel,
 };
 use chrono::{DateTime, Utc};
 use font_types::NameId;
 use font_types::Tag;
-use fontdrasil::types::GlyphName;
+use fontdrasil::types::{GlyphName, GroupName};
 use indexmap::IndexSet;
 use kurbo::{Affine, BezPath, PathEl, Point};
 use log::{trace, warn};
 use ordered_float::OrderedFloat;
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     fmt::Debug,
     path::PathBuf,
 };
@@ -93,6 +96,38 @@ pub struct MiscMetadata {
     pub lowest_rec_ppm: u16,
 
     pub created: Option<DateTime<Utc>>,
+}
+
+/// In logical (reading) order
+type KernPair = (KernParticipant, KernParticipant);
+type KernValues = BTreeMap<NormalizedLocation, OrderedFloat<f32>>;
+
+/// IR representation of kerning.
+///
+/// In UFO terms, roughly [groups.plist](https://unifiedfontobject.org/versions/ufo3/groups.plist/)
+/// and [kerning.plist](https://unifiedfontobject.org/versions/ufo3/kerning.plist/) combined.
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq, Eq)]
+#[serde(from = "KerningSerdeRepr", into = "KerningSerdeRepr")]
+pub struct Kerning {
+    pub groups: HashMap<GroupName, HashSet<GlyphName>>,
+    /// An adjustment to the space *between* two glyphs in logical order.
+    ///
+    /// Maps (side1, side2) => a mapping location:adjustment.
+    ///
+    /// Used for both LTR and RTL. The BE application differs but the concept
+    /// is the same.
+    pub kerns: HashMap<KernPair, KernValues>,
+}
+
+/// A participant in kerning, one of the entries in a kerning pair.
+///
+/// Concretely, a glyph or a group of glyphs.
+///
+/// <https://unifiedfontobject.org/versions/ufo3/kerning.plist/#kerning-pair-types>
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum KernParticipant {
+    Glyph(GlyphName),
+    Group(GroupName),
 }
 
 impl StaticMetadata {

--- a/fontir/src/orchestration.rs
+++ b/fontir/src/orchestration.rs
@@ -106,6 +106,7 @@ pub enum WorkId {
     /// BE glyphs so the glyph order may change.
     FinalizeStaticMetadata,
     Features,
+    Kerning,
 }
 
 pub type IrWork = dyn Work<Context, WorkError> + Send;
@@ -133,6 +134,7 @@ pub struct Context {
     global_metrics: ContextItem<ir::GlobalMetrics>,
     glyph_ir: Arc<RwLock<HashMap<GlyphName, Arc<ir::Glyph>>>>,
     feature_ir: ContextItem<ir::Features>,
+    kerning: ContextItem<ir::Kerning>,
 }
 
 pub fn set_cached<T>(lock: &Arc<RwLock<Option<Arc<T>>>>, value: T) {
@@ -152,6 +154,7 @@ impl Context {
             global_metrics: self.global_metrics.clone(),
             glyph_ir: self.glyph_ir.clone(),
             feature_ir: self.feature_ir.clone(),
+            kerning: self.kerning.clone(),
         }
     }
 
@@ -166,6 +169,7 @@ impl Context {
             global_metrics: Arc::from(RwLock::new(None)),
             glyph_ir: Arc::from(RwLock::new(HashMap::new())),
             feature_ir: Arc::from(RwLock::new(None)),
+            kerning: Arc::from(RwLock::new(None)),
         }
     }
 
@@ -234,6 +238,7 @@ impl Context {
     context_accessors! { get_final_static_metadata, set_final_static_metadata, has_final_static_metadata, final_static_metadata, ir::StaticMetadata, WorkId::FinalizeStaticMetadata, restore, nop }
     context_accessors! { get_global_metrics, set_global_metrics, has_global_metrics, global_metrics, ir::GlobalMetrics, WorkId::GlobalMetrics, restore, nop }
     context_accessors! { get_features, set_features, has_feature_ir, feature_ir, ir::Features, WorkId::Features, restore, nop }
+    context_accessors! { get_kerning, set_kerning, has_kerning, kerning, ir::Kerning, WorkId::Kerning, restore, nop }
 }
 
 fn nop<T>(v: &T) -> &T {

--- a/fontir/src/paths.rs
+++ b/fontir/src/paths.rs
@@ -49,6 +49,7 @@ impl Paths {
             WorkId::Glyph(name) => self.glyph_ir_file(name.as_str()),
             WorkId::GlyphIrDelete => self.build_dir.join("delete.yml"),
             WorkId::Features => self.build_dir.join("features.yml"),
+            WorkId::Kerning => self.build_dir.join("kerning.yml"),
         }
     }
 }

--- a/fontir/src/serde.rs
+++ b/fontir/src/serde.rs
@@ -13,8 +13,8 @@ use write_fonts::tables::os2::SelectionFlags;
 use crate::{
     coords::{CoordConverter, DesignCoord, NormalizedLocation, UserCoord},
     ir::{
-        Axis, GlobalMetric, GlobalMetrics, Glyph, GlyphBuilder, GlyphInstance, MiscMetadata,
-        NameKey, NamedInstance, StaticMetadata,
+        Axis, GlobalMetric, GlobalMetrics, Glyph, GlyphBuilder, GlyphInstance, KernParticipant,
+        Kerning, MiscMetadata, NameKey, NamedInstance, StaticMetadata,
     },
     stateset::{FileState, MemoryState, State, StateIdentifier, StateSet},
 };
@@ -91,6 +91,88 @@ impl From<StaticMetadata> for StaticMetadataSerdeRepr {
                 .glyph_order
                 .into_iter()
                 .map(|n| n.as_str().to_string())
+                .collect(),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct KerningSerdeRepr {
+    pub groups: Vec<KerningGroupSerdeRepr>,
+    pub kerns: Vec<KernSerdeRepr>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct KerningGroupSerdeRepr {
+    name: String,
+    glyphs: Vec<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct KernSerdeRepr {
+    side1: KernParticipant,
+    side2: KernParticipant,
+    values: Vec<(NormalizedLocation, f32)>,
+}
+
+impl From<Kerning> for KerningSerdeRepr {
+    fn from(from: Kerning) -> Self {
+        KerningSerdeRepr {
+            groups: from
+                .groups
+                .into_iter()
+                .map(|(name, glyphs)| {
+                    let name = name.to_string();
+                    let mut glyphs: Vec<_> = glyphs.iter().map(|g| g.to_string()).collect();
+                    glyphs.sort();
+                    KerningGroupSerdeRepr { name, glyphs }
+                })
+                .collect(),
+            kerns: from
+                .kerns
+                .into_iter()
+                .map(|((side1, side2), values)| {
+                    let mut values: Vec<_> = values
+                        .into_iter()
+                        .map(|(pos, adjustment)| (pos, adjustment.0))
+                        .collect();
+                    values.sort_by_key(|(pos, _)| pos.clone());
+                    KernSerdeRepr {
+                        side1,
+                        side2,
+                        values,
+                    }
+                })
+                .collect(),
+        }
+    }
+}
+
+impl From<KerningSerdeRepr> for Kerning {
+    fn from(from: KerningSerdeRepr) -> Self {
+        Kerning {
+            groups: from
+                .groups
+                .into_iter()
+                .map(|g| {
+                    (
+                        g.name.into(),
+                        g.glyphs.into_iter().map(|n| n.into()).collect(),
+                    )
+                })
+                .collect(),
+            kerns: from
+                .kerns
+                .into_iter()
+                .map(|k| {
+                    (
+                        (k.side1, k.side2),
+                        k.values
+                            .into_iter()
+                            .map(|(pos, value)| (pos, value.into()))
+                            .collect(),
+                    )
+                })
                 .collect(),
         }
     }

--- a/fontir/src/source.rs
+++ b/fontir/src/source.rs
@@ -69,6 +69,11 @@ pub trait Source {
     ///
     /// When run work should update [Context] with [crate::ir::Features].
     fn create_feature_ir_work(&self, input: &Input) -> Result<Box<IrWork>, Error>;
+
+    /// Create a function that could be called to generate or identify kerning.
+    ///
+    /// When run work should update [Context] with [crate::ir::Kerning].
+    fn create_kerning_ir_work(&self, input: &Input) -> Result<Box<IrWork>, Error>;
 }
 
 /// The files (in future non-file sources?) that drive various parts of IR

--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -2242,13 +2242,17 @@ mod tests {
         assert_eq!(
             (
                 vec![
-                    ("bracketleft", Some("brackets"), Some("brackets")),
-                    ("bracketright", Some("brackets"), Some("brackets")),
+                    ("bracketleft", Some("bracketleft_L"), Some("bracketleft_R")),
+                    (
+                        "bracketright",
+                        Some("bracketright_L"),
+                        Some("bracketright_R")
+                    ),
                 ],
                 vec![
-                    ("@MMK_L_brackets", "exclam", -165),
+                    ("@MMK_L_bracketleft_R", "exclam", -165),
                     ("bracketleft", "bracketright", -300),
-                    ("exclam", "@MMK_R_brackets", -160),
+                    ("exclam", "@MMK_R_bracketright_L", -160),
                     ("exclam", "exclam", -360),
                     ("exclam", "hyphen", 20),
                     ("hyphen", "hyphen", -150),

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -1,12 +1,12 @@
 use chrono::{TimeZone, Utc};
 use font_types::{NameId, Tag};
 use fontdrasil::orchestration::Work;
-use fontdrasil::types::GlyphName;
+use fontdrasil::types::{GlyphName, GroupName};
 use fontir::coords::NormalizedCoord;
 use fontir::error::{Error, WorkError};
 use fontir::ir::{
-    self, GlobalMetric, GlobalMetrics, GlyphInstance, NameBuilder, NameKey, NamedInstance,
-    StaticMetadata, DEFAULT_VENDOR_ID,
+    self, GlobalMetric, GlobalMetrics, GlyphInstance, KernParticipant, Kerning, NameBuilder,
+    NameKey, NamedInstance, StaticMetadata, DEFAULT_VENDOR_ID,
 };
 use fontir::orchestration::{Context, IrWork};
 use fontir::source::{Input, Source};
@@ -220,6 +220,16 @@ impl Source for GlyphsIrSource {
         let cache = self.cache.as_ref().unwrap();
 
         Ok(Box::new(FeatureWork {
+            font_info: cache.font_info.clone(),
+        }))
+    }
+
+    fn create_kerning_ir_work(&self, input: &Input) -> Result<Box<IrWork>, Error> {
+        self.check_static_metadata(&input.static_metadata)?;
+
+        let cache = self.cache.as_ref().unwrap();
+
+        Ok(Box::new(KerningWork {
             font_info: cache.font_info.clone(),
         }))
     }
@@ -454,6 +464,150 @@ impl Work<Context, WorkError> for FeatureWork {
         let font = &font_info.font;
 
         context.set_features(to_ir_features(&font.features)?);
+        Ok(())
+    }
+}
+
+/// What side of the kern is this, in logical order
+enum KernSide {
+    Side1,
+    Side2,
+}
+
+impl KernSide {
+    fn class_prefix(&self) -> &'static str {
+        match self {
+            KernSide::Side1 => "@MMK_L_",
+            KernSide::Side2 => "@MMK_R_",
+        }
+    }
+
+    fn group_prefix(&self) -> &'static str {
+        match self {
+            KernSide::Side1 => "public.kern1.",
+            KernSide::Side2 => "public.kern2.",
+        }
+    }
+}
+
+fn is_kerning_class(name: &str) -> bool {
+    name.starts_with("@MMK_")
+}
+
+struct KerningWork {
+    font_info: Arc<FontInfo>,
+}
+
+/// See <https://github.com/googlefonts/glyphsLib/blob/42bc1db912fd4b66f130fb3bdc63a0c1e774eb38/Lib/glyphsLib/builder/kerning.py#L53-L72>
+fn kern_participant(
+    glyph_order: &IndexSet<GlyphName>,
+    groups: &HashMap<GlyphName, HashSet<GlyphName>>,
+    side: KernSide,
+    raw_side: &str,
+) -> Option<KernParticipant> {
+    if is_kerning_class(raw_side) {
+        if raw_side.starts_with(side.class_prefix()) {
+            let group_name = format!(
+                "{}{}",
+                side.group_prefix(),
+                raw_side.strip_prefix(side.class_prefix()).unwrap()
+            );
+            let group = GroupName::from(&group_name);
+            if groups.contains_key(&group) {
+                Some(KernParticipant::Group(group))
+            } else {
+                warn!("Invalid kern side: {raw_side}, no group {group_name}");
+                None
+            }
+        } else {
+            warn!(
+                "Invalid kern side: {raw_side}, should have prefix {}",
+                side.class_prefix()
+            );
+            None
+        }
+    } else {
+        let name = GlyphName::from(raw_side);
+        if glyph_order.contains(&name) {
+            Some(KernParticipant::Glyph(name))
+        } else {
+            warn!("Invalid kern side: {raw_side}, no such glyph");
+            None
+        }
+    }
+}
+
+impl Work<Context, WorkError> for KerningWork {
+    fn exec(&self, context: &Context) -> Result<(), WorkError> {
+        trace!("Generate IR for kerning");
+        let static_metadata = context.get_final_static_metadata();
+        let glyph_order = &static_metadata.glyph_order;
+        let font_info = self.font_info.as_ref();
+        let font = &font_info.font;
+
+        let master_positions: HashMap<_, _> = font
+            .masters
+            .iter()
+            .map(|m| (&m.id, font_info.locations.get(&m.axes_values).unwrap()))
+            .collect();
+
+        let mut kerning = Kerning::default();
+
+        // If glyph uses a group for either side it goes in that group
+        font.glyphs
+            .iter()
+            .flat_map(|(glyph_name, glyph)| {
+                glyph
+                    .right_kern
+                    .iter()
+                    .map(|group| (KernSide::Side1, group))
+                    .chain(glyph.left_kern.iter().map(|group| (KernSide::Side2, group)))
+                    .map(|(side, group_name)| {
+                        (
+                            GroupName::from(format!("{}{}", side.group_prefix(), group_name)),
+                            GlyphName::from(glyph_name.as_str()),
+                        )
+                    })
+            })
+            .for_each(|(group_name, glyph_name)| {
+                kerning
+                    .groups
+                    .entry(group_name)
+                    .or_default()
+                    .insert(glyph_name);
+            });
+
+        font.kerning_ltr
+            .iter()
+            .filter_map(|(master_id, kerns)| match master_positions.get(master_id) {
+                Some(pos) => Some((pos, kerns)),
+                None => {
+                    warn!("Kerning is present for non-existent master {master_id}");
+                    None
+                }
+            })
+            .flat_map(|(master_pos, kerns)| {
+                kerns.iter().map(|((side1, side2), adjustment)| {
+                    ((side1, side2), ((*master_pos).clone(), *adjustment))
+                })
+            })
+            .filter_map(|((side1, side2), pos_adjust)| {
+                let side1 = kern_participant(glyph_order, &kerning.groups, KernSide::Side1, side1);
+                let side2 = kern_participant(glyph_order, &kerning.groups, KernSide::Side2, side2);
+                let (Some(side1), Some(side2)) = (side1, side2) else {
+                    return None
+                };
+                Some(((side1, side2), pos_adjust))
+            })
+            .for_each(|(participants, (pos, value))| {
+                kerning
+                    .kerns
+                    .entry(participants)
+                    .or_default()
+                    .insert(pos, (value as f32).into());
+            });
+
+        context.set_kerning(kerning);
         Ok(())
     }
 }

--- a/resources/testdata/designspace_from_glyphs/README.md
+++ b/resources/testdata/designspace_from_glyphs/README.md
@@ -2,5 +2,7 @@ Created by converting .glyphs files using fontmake, e.g.:
 
 ```shell
 $ fontmake -o=ufo resources/testdata/glyphs3/WghtVar.glyphs
+$ rm -rf resources/testdata/designspace_from_glyphs/*
 $ mv master_ufo/* resources/testdata/designspace_from_glyphs/
+$ rm -rf master_ufo/
 ```

--- a/resources/testdata/designspace_from_glyphs/WghtVar-Bold.ufo/groups.plist
+++ b/resources/testdata/designspace_from_glyphs/WghtVar-Bold.ufo/groups.plist
@@ -2,14 +2,20 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
   <dict>
-    <key>public.kern1.brackets</key>
+    <key>public.kern1.bracketleft_R</key>
     <array>
       <string>bracketleft</string>
+    </array>
+    <key>public.kern1.bracketright_R</key>
+    <array>
       <string>bracketright</string>
     </array>
-    <key>public.kern2.brackets</key>
+    <key>public.kern2.bracketleft_L</key>
     <array>
       <string>bracketleft</string>
+    </array>
+    <key>public.kern2.bracketright_L</key>
+    <array>
       <string>bracketright</string>
     </array>
   </dict>

--- a/resources/testdata/designspace_from_glyphs/WghtVar-Regular.ufo/groups.plist
+++ b/resources/testdata/designspace_from_glyphs/WghtVar-Regular.ufo/groups.plist
@@ -2,14 +2,20 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
   <dict>
-    <key>public.kern1.brackets</key>
+    <key>public.kern1.bracketleft_R</key>
     <array>
       <string>bracketleft</string>
+    </array>
+    <key>public.kern1.bracketright_R</key>
+    <array>
       <string>bracketright</string>
     </array>
-    <key>public.kern2.brackets</key>
+    <key>public.kern2.bracketleft_L</key>
     <array>
       <string>bracketleft</string>
+    </array>
+    <key>public.kern2.bracketright_L</key>
+    <array>
       <string>bracketright</string>
     </array>
   </dict>

--- a/resources/testdata/designspace_from_glyphs/WghtVar-Regular.ufo/kerning.plist
+++ b/resources/testdata/designspace_from_glyphs/WghtVar-Regular.ufo/kerning.plist
@@ -13,7 +13,7 @@
       <integer>-360</integer>
       <key>hyphen</key>
       <integer>20</integer>
-      <key>public.kern2.brackets</key>
+      <key>public.kern2.bracketright_L</key>
       <integer>-160</integer>
     </dict>
     <key>hyphen</key>
@@ -21,7 +21,7 @@
       <key>hyphen</key>
       <integer>-150</integer>
     </dict>
-    <key>public.kern1.brackets</key>
+    <key>public.kern1.bracketleft_R</key>
     <dict>
       <key>exclam</key>
       <integer>-165</integer>

--- a/resources/testdata/glyphs2/WghtVar.glyphs
+++ b/resources/testdata/glyphs2/WghtVar.glyphs
@@ -216,8 +216,8 @@ nodes = (
 width = 600;
 }
 );
-leftKerningGroup = brackets;
-rightKerningGroup = brackets;
+leftKerningGroup = bracketleft_L;
+rightKerningGroup = bracketleft_R;
 unicode = 005B;
 },
 {
@@ -263,8 +263,8 @@ nodes = (
 width = 600;
 }
 );
-leftKerningGroup = brackets;
-rightKerningGroup = brackets;
+leftKerningGroup = bracketright_L;
+rightKerningGroup = bracketright_R;
 unicode = 005D;
 },
 {
@@ -303,19 +303,19 @@ unicode = 003D;
 );
 kerning = {
 m01 = {
+"@MMK_L_bracketleft_R" = {
+exclam = -165;
+};
 bracketleft = {
 bracketright = -300;
 };
 exclam = {
-"@MMK_R_brackets" = -160;
+"@MMK_R_bracketright_L" = -160;
 exclam = -360;
 hyphen = 20;
 };
 hyphen = {
 hyphen = -150;
-};
-"@MMK_L_brackets" = {
-exclam = -165;
 };
 };
 "E09E0C54-128D-4FEA-B209-1B70BEFE300B" = {

--- a/resources/testdata/glyphs3/WghtVar.glyphs
+++ b/resources/testdata/glyphs3/WghtVar.glyphs
@@ -184,8 +184,8 @@ unicode = 45;
 },
 {
 glyphname = bracketleft;
-kernLeft = brackets;
-kernRight = brackets;
+kernLeft = bracketleft_L;
+kernRight = bracketleft_R;
 lastChange = "2023-06-07 22:37:02 +0000";
 layers = (
 {
@@ -231,8 +231,8 @@ unicode = 91;
 },
 {
 glyphname = bracketright;
-kernLeft = brackets;
-kernRight = brackets;
+kernLeft = bracketright_L;
+kernRight = bracketright_R;
 lastChange = "2023-06-07 22:35:47 +0000";
 layers = (
 {
@@ -313,19 +313,19 @@ unicode = 61;
 );
 kerningLTR = {
 m01 = {
+"@MMK_L_bracketleft_R" = {
+exclam = -165;
+};
 bracketleft = {
 bracketright = -300;
 };
 exclam = {
-"@MMK_R_brackets" = -160;
+"@MMK_R_bracketright_L" = -160;
 exclam = -360;
 hyphen = 20;
 };
 hyphen = {
 hyphen = -150;
-};
-"@MMK_L_brackets" = {
-exclam = -165;
 };
 };
 "E09E0C54-128D-4FEA-B209-1B70BEFE300B" = {


### PR DESCRIPTION
Intent is to output variable features we compile with fea-rs. IR model is meant to accomodate glyphs and designspace. Most interesting part should be `fontir/src/ir.rs` which has the IR changes, esp. `struct Kerning` which holds a variable-first representation of kerning.

left/right KerningGroup all the things. Or kern left/right ... it's all very confusing.

https://gist.github.com/rsheeter/4c8e7822d276f871eef974f8c1975ace shows an example of kerning IR (for Oswald).

Step toward #308. I want to leave filling in the blanks and aligning kerning groups to a subsequent PR.