### PR TITLE
require write-fonts 0.6.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ parking_lot = "0.12.1"
 fea-rs = "= 0.6.0"
 font-types = { version = "0.2.0", features = ["serde"] }
 read-fonts = "0.4.0"
-write-fonts = "0.6.0"
+write-fonts = "0.6.1"
 skrifa = "0.3.0"
 
 bitflags = "2.0"
@@ -44,5 +44,5 @@ members = [
     "glyphs-reader",
     "glyphs2fontir",
     "ufo2fontir",
-    "fontc",    
+    "fontc",
 ]

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -1184,7 +1184,7 @@ mod tests {
             panic!("Expected 'O' to be a simple glyph, got {:?}", uppercase_o);
         };
         assert_eq!(2, glyph.number_of_contours());
-        assert_eq!(36, glyph.num_points());
+        assert_eq!(35, glyph.num_points());
         assert_eq!(
             [48, -9, 491, 817],
             [glyph.x_min(), glyph.y_min(), glyph.x_max(), glyph.y_max()]


### PR DESCRIPTION
fixes a bug when computing implied oncurves, and also prunes more implied oncurves (by testing midpoints either before or after rounding the float coordinates to integer)

After this, compiling Oswald.glyphs with fontc gives identical maxp and the glyf table diff is the following:

```diff
--- build/default/fontc.glyf.ttx        2023-06-08 16:53:37.677358984 +0100
+++ build/default/fontmake.glyf.ttx     2023-06-08 16:53:37.677358984 +0100
@@ -10285,7 +10285,6 @@
       </contour>
       <contour>
         <pt x="219" y="-9" on="1"/>
-        <pt x="219" y="-9" on="1"/>
         <pt x="290" y="-9" on="0"/>
         <pt x="382" y="51" on="0"/>
         <pt x="430" y="157" on="0"/>
@@ -10331,7 +10330,6 @@
         <pt x="25" y="124" on="0"/>
         <pt x="75" y="37" on="0"/>
         <pt x="163" y="-9" on="0"/>
-        <pt x="219" y="-9" on="1"/>
       </contour>
       <instructions/>
     </TTGlyph>
@@ -13250,7 +13248,7 @@
     </TTGlyph>

     <TTGlyph name="quotesinglbase" xMin="30" yMin="-133" xMax="148" yMax="132">
-      <component glyphName="quoteright" x="0" y="-678" flags="0x4"/>
+      <component glyphName="quoteright" x="0" y="-678" flags="0x204"/>
     </TTGlyph>

     <TTGlyph name="quotesingle" xMin="20" yMin="562" xMax="117" yMax="810">
```

the extra points are due to https://github.com/googlefonts/fontations/issues/370, whereas the different component flag has something to do with USE_MY_METRICS which I'll investigate separately