### PR TITLE
ttx_diff.py: pass --drop-implied-oncurves fontmake option to reduce glyf diff

### DIFF
--- a/resources/scripts/ttx_diff.py
+++ b/resources/scripts/ttx_diff.py
@@ -114,6 +114,7 @@ def build_fontmake(source: Path, build_dir: Path, compare: str):
         "variable",
         "--output-dir",
         str(source.name),
+        "--drop-implied-oncurves",
         # TODO we shouldn't need these flags
         "--no-production-names",
         "--keep-direction",


### PR DESCRIPTION
Requires [fontmake 3.6.0](https://github.com/googlefonts/fontmake/releases/tag/v3.6.0) just released