### PR TITLE
Resolve fea includes for UFO against dir containing .ufo

### DIFF
--- a/fontbe/src/error.rs
+++ b/fontbe/src/error.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Display, io};
+use std::{fmt::Display, io, path::PathBuf};
 
 use fea_rs::compile::error::CompilerError;
 use font_types::Tag;
@@ -50,6 +50,8 @@ pub enum Error {
     IupError(GlyphName, IupError),
     #[error("Unable to interpret bytes as {0}")]
     InvalidTableBytes(Tag),
+    #[error("Missing directory:{0}")]
+    MissingDirectory(PathBuf),
 }
 
 #[derive(Debug)]

--- a/fontbe/src/features.rs
+++ b/fontbe/src/features.rs
@@ -73,19 +73,26 @@ impl FeatureWork {
     }
 
     fn compile(&self, features: &Features, glyph_order: GlyphMap) -> Result<Compilation, Error> {
-        let root_path = if let Features::File(file) = features {
-            OsString::from(file)
-        } else {
-            OsString::new()
+        let compiler = match features {
+            Features::File {
+                fea_file,
+                include_dir,
+            } => {
+                let mut compiler = Compiler::new(OsString::from(fea_file), &glyph_order);
+                if let Some(include_dir) = include_dir {
+                    compiler = compiler.with_project_root(include_dir)
+                }
+                compiler
+            }
+            Features::Memory(fea_content) => {
+                let root = OsString::new();
+                Compiler::new(root.clone(), &glyph_order).with_resolver(InMemoryResolver {
+                    content_path: root,
+                    content: Arc::from(fea_content.as_str()),
+                })
+            }
+            Features::Empty => panic!("compile isn't supposed to be called for Empty"),
         };
-        let mut compiler = Compiler::new(root_path.clone(), &glyph_order);
-        if let Features::Memory(fea_content) = features {
-            let resolver = InMemoryResolver {
-                content_path: root_path,
-                content: Arc::from(fea_content.as_str()),
-            };
-            compiler = compiler.with_resolver(resolver);
-        }
         compiler.compile().map_err(Error::FeaCompileError)
     }
 }

--- a/fontc/src/args.rs
+++ b/fontc/src/args.rs
@@ -56,18 +56,9 @@ impl Args {
     /// Manually create args for testing
     #[cfg(test)]
     pub fn for_test(build_dir: &std::path::Path, source: &str) -> Args {
-        // cargo test seems to run in the project directory
-        // VSCode test seems to run in the workspace directory
-        // probe for the file we want in hopes of finding it regardless
-        let potential_paths = vec!["./resources/testdata", "../resources/testdata"];
-        let source = potential_paths
-            .iter()
-            .map(PathBuf::from)
-            .find(|pb| pb.exists())
-            .unwrap()
-            .join(source)
-            .canonicalize()
-            .unwrap();
+        use crate::testdata_dir;
+
+        let source = testdata_dir().join(source).canonicalize().unwrap();
 
         Args {
             glyph_name_filter: None,

--- a/fontir/src/error.rs
+++ b/fontir/src/error.rs
@@ -75,6 +75,8 @@ pub enum WorkError {
     NoGlyphIdForName(String),
     #[error("No Glyph for name {0:?}")]
     NoGlyphForName(GlyphName),
+    #[error("Directory expected {0}: {1}")]
+    DirectoryExpected(String, PathBuf),
     #[error("File expected: {0:?}")]
     FileExpected(PathBuf),
     #[error("Expected to match: {0:?}, {1:?}")]

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 use std::{
     collections::{HashMap, HashSet},
     fmt::Debug,
-    path::{Path, PathBuf},
+    path::PathBuf,
 };
 use write_fonts::tables::os2::SelectionFlags;
 
@@ -675,7 +675,10 @@ pub struct NamedInstance {
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub enum Features {
     Empty,
-    File(PathBuf),
+    File {
+        fea_file: PathBuf,
+        include_dir: Option<PathBuf>,
+    },
     Memory(String),
 }
 
@@ -683,8 +686,11 @@ impl Features {
     pub fn empty() -> Features {
         Features::Empty
     }
-    pub fn from_file(file: &Path) -> Features {
-        Features::File(file.to_path_buf())
+    pub fn from_file(fea_file: PathBuf, include_dir: Option<PathBuf>) -> Features {
+        Features::File {
+            fea_file,
+            include_dir,
+        }
     }
     pub fn from_string(fea_content: String) -> Features {
         Features::Memory(fea_content)

--- a/resources/testdata/fea_include.designspace
+++ b/resources/testdata/fea_include.designspace
@@ -1,0 +1,35 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Derived from Noto Sans Adlam -->
+<designspace format="4.1">
+  <axes>
+    <axis tag="wght" name="Weight" minimum="400" maximum="700" default="400"/>
+  </axes>
+  <sources>
+    <source filename="fea_include_ufo/FeaInc-Regular.ufo" name="Fea Inc Regular" familyname="Fea Inc" stylename="Regular">
+      <lib copy="1"/>
+      <groups copy="1"/>
+      <features copy="1"/>
+      <info copy="1"/>
+      <location>
+        <dimension name="Weight" xvalue="400"/>
+      </location>
+    </source>
+    <source filename="fea_include_ufo/FeaInc-Bold.ufo" name="Fea Inc Bold" familyname="Fea Inc" stylename="Bold">
+      <location>
+        <dimension name="Weight" xvalue="700"/>
+      </location>
+    </source>
+  </sources>
+  <instances>
+    <instance name="Fea Inc Regular" familyname="Fea Inc" stylename="Regular" filename="instance_ufos/FeaInc-Regular.ufo" stylemapfamilyname="Fea Inc" stylemapstylename="regular">
+      <location>
+        <dimension name="Weight" xvalue="400"/>
+      </location>
+    </instance>
+    <instance name="Fea Inc Bold" familyname="Fea Inc" stylename="Bold" filename="instance_ufos/FeaInc-Bold.ufo" stylemapfamilyname="Fea Inc" stylemapstylename="bold">
+      <location>
+        <dimension name="Weight" xvalue="700"/>
+      </location>      
+    </instance>
+  </instances>
+</designspace>

--- a/resources/testdata/fea_include_ufo/FeaInc-Bold.ufo/features.fea
+++ b/resources/testdata/fea_include_ufo/FeaInc-Bold.ufo/features.fea
@@ -5,4 +5,4 @@ feature kern {
     position bar plus -100;
 } kern;
 
-include(static.fea)
+include(common.fea)

--- a/resources/testdata/fea_include_ufo/FeaInc-Bold.ufo/fontinfo.plist
+++ b/resources/testdata/fea_include_ufo/FeaInc-Bold.ufo/fontinfo.plist
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+  </dict>
+</plist>

--- a/resources/testdata/fea_include_ufo/FeaInc-Bold.ufo/glyphs/bar.glif
+++ b/resources/testdata/fea_include_ufo/FeaInc-Bold.ufo/glyphs/bar.glif
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="bar" format="2">
+  <advance width="551"/>
+  <unicode hex="007C"/>
+  <outline>
+    <contour>
+      <point x="222" y="-227" type="line"/>
+      <point x="329" y="-227" type="line"/>
+      <point x="329" y="757" type="line"/>
+      <point x="222" y="757" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/resources/testdata/fea_include_ufo/FeaInc-Bold.ufo/glyphs/contents.plist
+++ b/resources/testdata/fea_include_ufo/FeaInc-Bold.ufo/glyphs/contents.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>bar</key>
+    <string>bar.glif</string>
+    <key>plus</key>
+    <string>plus.glif</string>
+  </dict>
+</plist>

--- a/resources/testdata/fea_include_ufo/FeaInc-Bold.ufo/glyphs/plus.glif
+++ b/resources/testdata/fea_include_ufo/FeaInc-Bold.ufo/glyphs/plus.glif
@@ -1,0 +1,21 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="plus" format="2">
+  <advance width="572"/>
+  <unicode hex="002B"/>
+  <outline>
+    <contour>
+      <point x="232" y="111" type="line"/>
+      <point x="339" y="111" type="line"/>
+      <point x="339" y="299" type="line"/>
+      <point x="528" y="299" type="line"/>
+      <point x="528" y="406" type="line"/>
+      <point x="339" y="406" type="line"/>
+      <point x="339" y="596" type="line"/>
+      <point x="232" y="596" type="line"/>
+      <point x="232" y="406" type="line"/>
+      <point x="43" y="406" type="line"/>
+      <point x="43" y="299" type="line"/>
+      <point x="232" y="299" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/resources/testdata/fea_include_ufo/FeaInc-Bold.ufo/layercontents.plist
+++ b/resources/testdata/fea_include_ufo/FeaInc-Bold.ufo/layercontents.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <array>
+    <array>
+      <string>public.default</string>
+      <string>glyphs</string>
+    </array>
+  </array>
+</plist>

--- a/resources/testdata/fea_include_ufo/FeaInc-Bold.ufo/metainfo.plist
+++ b/resources/testdata/fea_include_ufo/FeaInc-Bold.ufo/metainfo.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>creator</key>
+    <string>com.github.fonttools.ufoLib</string>
+    <key>formatVersion</key>
+    <integer>3</integer>
+  </dict>
+</plist>

--- a/resources/testdata/fea_include_ufo/FeaInc-Regular.ufo/features.fea
+++ b/resources/testdata/fea_include_ufo/FeaInc-Regular.ufo/features.fea
@@ -5,4 +5,4 @@ feature kern {
     position bar plus -100;
 } kern;
 
-include(static.fea)
+include(common.fea)

--- a/resources/testdata/fea_include_ufo/FeaInc-Regular.ufo/fontinfo.plist
+++ b/resources/testdata/fea_include_ufo/FeaInc-Regular.ufo/fontinfo.plist
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+  </dict>
+</plist>

--- a/resources/testdata/fea_include_ufo/FeaInc-Regular.ufo/glyphs/bar.glif
+++ b/resources/testdata/fea_include_ufo/FeaInc-Regular.ufo/glyphs/bar.glif
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="bar" format="2">
+  <advance width="517"/>
+  <unicode hex="007C"/>
+  <outline>
+    <contour>
+      <point x="222" y="-241" type="line"/>
+      <point x="295" y="-241" type="line"/>
+      <point x="295" y="760" type="line"/>
+      <point x="222" y="760" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/resources/testdata/fea_include_ufo/FeaInc-Regular.ufo/glyphs/contents.plist
+++ b/resources/testdata/fea_include_ufo/FeaInc-Regular.ufo/glyphs/contents.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>bar</key>
+    <string>bar.glif</string>
+    <key>plus</key>
+    <string>plus.glif</string>
+  </dict>
+</plist>

--- a/resources/testdata/fea_include_ufo/FeaInc-Regular.ufo/glyphs/plus.glif
+++ b/resources/testdata/fea_include_ufo/FeaInc-Regular.ufo/glyphs/plus.glif
@@ -1,0 +1,21 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="plus" format="2">
+  <advance width="557"/>
+  <unicode hex="002B"/>
+  <outline>
+    <contour>
+      <point x="242" y="111" type="line"/>
+      <point x="314" y="111" type="line"/>
+      <point x="314" y="317" type="line"/>
+      <point x="513" y="317" type="line"/>
+      <point x="513" y="388" type="line"/>
+      <point x="314" y="388" type="line"/>
+      <point x="314" y="595" type="line"/>
+      <point x="242" y="595" type="line"/>
+      <point x="242" y="388" type="line"/>
+      <point x="43" y="388" type="line"/>
+      <point x="43" y="317" type="line"/>
+      <point x="242" y="317" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/resources/testdata/fea_include_ufo/FeaInc-Regular.ufo/layercontents.plist
+++ b/resources/testdata/fea_include_ufo/FeaInc-Regular.ufo/layercontents.plist
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <array>
+    <array>
+      <string>public.default</string>
+      <string>glyphs</string>
+    </array>
+    <array>
+      <string>{600}</string>
+      <string>glyphs.{600}</string>
+    </array>
+  </array>
+</plist>

--- a/resources/testdata/fea_include_ufo/FeaInc-Regular.ufo/lib.plist
+++ b/resources/testdata/fea_include_ufo/FeaInc-Regular.ufo/lib.plist
@@ -1,0 +1,9 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>public.glyphOrder</key>
+    <array>
+    </array>
+  </dict>
+</plist>

--- a/resources/testdata/fea_include_ufo/FeaInc-Regular.ufo/metainfo.plist
+++ b/resources/testdata/fea_include_ufo/FeaInc-Regular.ufo/metainfo.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>creator</key>
+    <string>com.github.fonttools.ufoLib</string>
+    <key>formatVersion</key>
+    <integer>3</integer>
+  </dict>
+</plist>

--- a/resources/testdata/fea_include_ufo/common.fea
+++ b/resources/testdata/fea_include_ufo/common.fea
@@ -1,0 +1,3 @@
+feature liga {
+    substitute bar bar by plus;
+} liga;

--- a/resources/testdata/static.fea
+++ b/resources/testdata/static.fea
@@ -1,0 +1,3 @@
+feature liga {
+    substitute bar bar by plus;
+} liga;


### PR DESCRIPTION
First crack at resolving includes. For the purposes of incremental compilation all fea files in the .designspace dir will be considered for feature file change. An include pointed outside the .designspace dir won't be detected as changed when attempting incremental compile.

Fixes #296. After this change I can compile https://github.com/madig/FirerSans w/o error. I make no claim that the font will actually _work_ ofc.