### PR TITLE
Take the default master as authoritative in designspace kerning

### DIFF
--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -19,7 +19,7 @@ use log::{trace, warn};
 use ordered_float::OrderedFloat;
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     fmt::Debug,
     path::PathBuf,
 };
@@ -109,7 +109,7 @@ type KernValues = BTreeMap<NormalizedLocation, OrderedFloat<f32>>;
 #[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq, Eq)]
 #[serde(from = "KerningSerdeRepr", into = "KerningSerdeRepr")]
 pub struct Kerning {
-    pub groups: HashMap<GroupName, HashSet<GlyphName>>,
+    pub groups: HashMap<GroupName, BTreeSet<GlyphName>>,
     /// An adjustment to the space *between* two glyphs in logical order.
     ///
     /// Maps (side1, side2) => a mapping location:adjustment.

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -15,7 +15,7 @@ use glyphs_reader::{Font, InstanceType};
 use indexmap::IndexSet;
 use log::{debug, trace, warn};
 use read_fonts::tables::os2::SelectionFlags;
-use std::collections::HashSet;
+use std::collections::{BTreeSet, HashSet};
 use std::str::FromStr;
 use std::sync::Arc;
 use std::{collections::HashMap, path::PathBuf};
@@ -501,7 +501,7 @@ struct KerningWork {
 /// See <https://github.com/googlefonts/glyphsLib/blob/42bc1db912fd4b66f130fb3bdc63a0c1e774eb38/Lib/glyphsLib/builder/kerning.py#L53-L72>
 fn kern_participant(
     glyph_order: &IndexSet<GlyphName>,
-    groups: &HashMap<GlyphName, HashSet<GlyphName>>,
+    groups: &HashMap<GlyphName, BTreeSet<GlyphName>>,
     side: KernSide,
     raw_side: &str,
 ) -> Option<KernParticipant> {

--- a/resources/testdata/WghtVar-Bold.ufo/groups.plist
+++ b/resources/testdata/WghtVar-Bold.ufo/groups.plist
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <!-- deliberately different name than default master. Same glyphs so it should be renamed. -->
+    <key>public.kern1.the_WrOng_name</key>
+    <array>
+      <string>bar</string>
+      <string>plus</string>
+    </array>
+  </dict>
+</plist>

--- a/resources/testdata/WghtVar-Regular.ufo/groups.plist
+++ b/resources/testdata/WghtVar-Regular.ufo/groups.plist
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>public.kern1.correct_name</key>
+    <array>
+      <string>bar</string>
+      <string>plus</string>
+    </array>
+  </dict>
+</plist>


### PR DESCRIPTION
Based on discussion on https://github.com/googlefonts/ufo2ft/pull/635, treat the group names in the default master as authorititive. Remap alternate names for the same {glyphs} in other masters. Ignore all groups from non-default masters that do not identify a set of glyphs given a name in the default.