### PR TITLE
Update to write-fonts 0.6.2 to get updated reverse pen

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ parking_lot = "0.12.1"
 fea-rs = "= 0.6.0"
 font-types = { version = "0.2.0", features = ["serde"] }
 read-fonts = "0.4.0"
-write-fonts = "0.6.1"
+write-fonts = "0.6.2"
 skrifa = "0.3.0"
 
 bitflags = "2.0"


### PR DESCRIPTION
After this diff is:

```shell
$ python resources/scripts/ttx_diff.py ../OswaldFont/sources/Oswald.glyphs --compare default
Compare default in build/default
  (cd build/default && cargo run -p fontc -- --source /usr/local/google/home/rsheeter/oss/OswaldFont/sources/Oswald.glyphs --build-dir . > fontc.log 2>&1)
  (cd build/default && ttx -o font.ttx font.ttf > ttx.log 2>&1)
  (cd build/default && fontmake -o variable --output-dir Oswald.glyphs --drop-implied-oncurves --no-production-names --keep-direction /usr/local/google/home/rsheeter/oss/OswaldFont/sources/Oswald.glyphs > fontmake.log 2>&1)
  (cd build/default/Oswald.glyphs && ttx -o Oswald-VF.ttx Oswald-VF.ttf > ttx.log 2>&1)
TTX FILES
  fontc     build/default/fontc.ttx
  fontmake  build/default/fontmake.ttx
COMPARISON
  Only fontmake produced 'GDEF', 'GPOS', 'HVAR'
  DIFF 'GSUB', build/default/fontc.GSUB.ttx build/default/fontmake.GSUB.ttx
  Identical 'GlyphOrder'
  Identical 'OS_2'
  Identical 'STAT'
  Identical 'avar'
  Identical 'cmap'
  Identical 'fvar'
  Identical 'glyf'
  DIFF 'gvar', build/default/fontc.gvar.ttx build/default/fontmake.gvar.ttx
  Identical 'head'
  Identical 'hhea'
  Identical 'hmtx'
  Identical 'loca'
  Identical 'maxp'
  Identical 'name'
  Identical 'post'
```

The `Identical 'glyf'` is great to finally see :)

JMM