### PR TITLE
[on hold] generate kerning and allow sparseness in a dangerous and incorrect manner

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,8 @@ env_logger = "0.10.0"
 
 parking_lot = "0.12.1"
 
-fea-rs = "= 0.8.0"
+#fea-rs = "= 0.8.0"
+fea-rs = { git="https://github.com/cmyr/fea-rs.git", branch="var-metric-draft" }
 font-types = { version = "0.3.0", features = ["serde"] }
 read-fonts = "0.6.0"
 write-fonts = "0.8.0"

--- a/fontbe/src/features.rs
+++ b/fontbe/src/features.rs
@@ -1,6 +1,9 @@
 //! Feature binary compilation.
 
 use std::{
+    cell::RefCell,
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
+    error::Error as StdError,
     ffi::{OsStr, OsString},
     fmt::Display,
     fs,
@@ -8,14 +11,22 @@ use std::{
 };
 
 use fea_rs::{
-    compile::Compilation,
+    compile::{Compilation, VariationInfo},
     parse::{SourceLoadError, SourceResolver},
     Compiler, GlyphMap, GlyphName as FeaRsGlyphName,
 };
-use fontir::{ir::Features, orchestration::Flags};
-use log::{debug, error, warn};
+use font_types::{F2Dot14, Fixed, Tag};
+use fontir::{
+    coords::{CoordConverter, NormalizedLocation, UserCoord, UserLocation},
+    ir::{Axis, Features, KernParticipant, Kerning, StaticMetadata},
+    orchestration::Flags,
+    variations::{ModelConstraints, VariationModel},
+};
+use indexmap::IndexSet;
+use log::{debug, error, trace, warn};
 
-use fontdrasil::orchestration::Work;
+use fontdrasil::{orchestration::Work, types::GlyphName};
+use write_fonts::{tables::variations::RegionAxisCoordinates, OtRound};
 
 use crate::{
     error::Error,
@@ -67,12 +78,183 @@ impl Display for NotSupportedError {
     }
 }
 
+// TODO: ask Colin if we need to be threadsafe
+struct FeaVariationInfo<'a> {
+    fea_rs_axes: HashMap<Tag, (&'a CoordConverter, fea_rs::compile::AxisInfo)>,
+    axes: HashMap<Tag, &'a Axis>,
+    static_metadata: &'a StaticMetadata,
+    /// fea coords, unlike glyphs, use locations we don't know until quite late.
+    ///
+    /// We have to establish a new, somewhat expensive, model for each unique combination of
+    /// locations we observe. We also use different `ModelConstraints` than glyf: we don't require
+    /// the effect at the default location to be zero.
+    ///
+    /// Cache the models because they are expensive and current sources seem prone to producing many
+    /// conditionsets that use the same normalized locations.
+    models: RefCell<HashMap<BTreeSet<NormalizedLocation>, VariationModel>>,
+}
+
+impl<'a> FeaVariationInfo<'a> {
+    fn new(static_metadata: &'a StaticMetadata) -> FeaVariationInfo<'a> {
+        FeaVariationInfo {
+            fea_rs_axes: static_metadata
+                .variable_axes
+                .iter()
+                .enumerate()
+                .map(|(i, a)| {
+                    (
+                        a.tag,
+                        (
+                            &a.converter,
+                            fea_rs::compile::AxisInfo {
+                                index: i as u16,
+                                default_value: a.default.into(),
+                                min_value: a.min.into(),
+                                max_value: a.max.into(),
+                            },
+                        ),
+                    )
+                })
+                .collect(),
+            axes: static_metadata
+                .variable_axes
+                .iter()
+                .map(|a| (a.tag, a))
+                .collect(),
+            static_metadata,
+            models: RefCell::new(Default::default()),
+        }
+    }
+}
+
+impl<'a> VariationInfo for FeaVariationInfo<'a> {
+    fn axis_info(&self, axis_tag: font_types::Tag) -> Option<fea_rs::compile::AxisInfo> {
+        self.fea_rs_axes.get(&axis_tag).map(|a| a.1)
+    }
+
+    fn normalize_coordinate(
+        &self,
+        axis_tag: font_types::Tag,
+        value: font_types::Fixed,
+    ) -> font_types::F2Dot14 {
+        let converter = &self
+            .axes
+            .get(&axis_tag)
+            .expect("Unsupported axis")
+            .converter;
+        let user_coord = UserCoord::new(value.to_f64() as f32);
+        F2Dot14::from_f32(user_coord.to_normalized(converter).to_f32())
+    }
+
+    fn resolve_variable_metric(
+        &self,
+        values: &HashMap<BTreeMap<Tag, Fixed>, i16>,
+    ) -> Result<
+        (
+            i16,
+            Vec<(write_fonts::tables::variations::VariationRegion, i16)>,
+        ),
+        Box<(dyn StdError + 'static)>,
+    > {
+        // WARNING: this will fail if the fea location isn't also a glyph location. In time we may wish to fix that.
+
+        // Compute deltas using f64 as 1d point and delta, then ship them home as i16
+        let point_seqs: HashMap<_, _> = values
+            .iter()
+            .map(|(pos, value)| {
+                let user = UserLocation::from_iter(
+                    pos.iter()
+                        .map(|(tag, value)| (*tag, UserCoord::new(value.to_f64() as f32))),
+                );
+                (user.to_normalized(&self.axes), vec![*value as f64])
+            })
+            .collect();
+
+        // What is this error handling of which you speak?
+        // TODO: error handling
+        let var_model_key: BTreeSet<_> = point_seqs.iter().map(|(pos, _)| pos).cloned().collect();
+        let mut var_model_cache = self.models.borrow_mut();
+        let var_model = var_model_cache
+            .entry(var_model_key.clone())
+            .or_insert_with(|| {
+                let axes: Vec<Axis> = values
+                    .keys()
+                    .flat_map(|k| k.keys())
+                    .map(|tag| (*self.axes.get(tag).unwrap()).clone())
+                    .collect();
+                VariationModel::new(
+                    var_model_key.into_iter().collect(),
+                    axes,
+                    ModelConstraints::None,
+                )
+                .unwrap()
+            });
+
+        // Only 1 value per region for our input
+        // TODO is that actually guaranteed?
+        let deltas: Vec<_> = var_model
+            .deltas(&point_seqs)?
+            .into_iter()
+            .map(|(region, values)| {
+                assert!(values.len() == 1, "{} values?!", values.len());
+                (region, values[0])
+            })
+            .collect();
+
+        // Compute the default on the unrounded deltas
+        let default_value = deltas
+            .iter()
+            .filter_map(|(region, value)| {
+                let scaler = region.scalar_at(&var_model.default).into_inner();
+                eprintln!("{region:?} default scaler {scaler} value {value}");
+                match scaler {
+                    scaler if scaler == 0.0 => None,
+                    scaler => Some(scaler * *value as f32),
+                }
+            })
+            .sum::<f32>()
+            .ot_round();
+
+        // Produce the desired delta type
+        let deltas = deltas
+            .into_iter()
+            .map(|(region, value)| {
+                (
+                    write_fonts::tables::variations::VariationRegion {
+                        region_axes: region
+                            .iter()
+                            .zip(self.static_metadata.axes.iter())
+                            .map(|((tag, tent), expected_axis)| {
+                                assert_eq!(*tag, expected_axis.tag);
+                                RegionAxisCoordinates {
+                                    start_coord: F2Dot14::from_f32(tent.min.to_f32()),
+                                    peak_coord: F2Dot14::from_f32(tent.peak.to_f32()),
+                                    end_coord: F2Dot14::from_f32(tent.max.to_f32()),
+                                }
+                            })
+                            .collect(),
+                    },
+                    value.ot_round(),
+                )
+            })
+            .collect();
+
+        Ok((default_value, deltas))
+    }
+}
+
 impl FeatureWork {
     pub fn create() -> Box<BeWork> {
         Box::new(FeatureWork {})
     }
 
-    fn compile(&self, features: &Features, glyph_order: GlyphMap) -> Result<Compilation, Error> {
+    fn compile(
+        &self,
+        static_metadata: &StaticMetadata,
+        features: &Features,
+        glyph_order: GlyphMap,
+    ) -> Result<Compilation, Error> {
+        let var_info = FeaVariationInfo::new(static_metadata);
         let compiler = match features {
             Features::File {
                 fea_file,
@@ -84,21 +266,30 @@ impl FeatureWork {
                 }
                 compiler
             }
-            Features::Memory(fea_content) => {
+            Features::Memory {
+                fea_content,
+                include_dir,
+            } => {
                 let root = OsString::new();
-                Compiler::new(root.clone(), &glyph_order).with_resolver(InMemoryResolver {
-                    content_path: root,
-                    content: Arc::from(fea_content.as_str()),
-                })
+                let mut compiler =
+                    Compiler::new(root.clone(), &glyph_order).with_resolver(InMemoryResolver {
+                        content_path: root,
+                        content: Arc::from(fea_content.as_str()),
+                    });
+                if let Some(include_dir) = include_dir {
+                    compiler = compiler.with_project_root(include_dir)
+                }
+                compiler
             }
             Features::Empty => panic!("compile isn't supposed to be called for Empty"),
-        };
+        }
+        .with_variable_info(&var_info);
         compiler.compile().map_err(Error::FeaCompileError)
     }
 }
 
 fn write_debug_fea(context: &Context, is_error: bool, why: &str, fea_content: &str) {
-    let debug_file = context.debug_dir().join("glyphs.fea");
+    let debug_file = context.debug_dir().join("features.fea");
     match fs::write(&debug_file, fea_content) {
         Ok(..) => {
             if is_error {
@@ -111,22 +302,167 @@ fn write_debug_fea(context: &Context, is_error: bool, why: &str, fea_content: &s
     };
 }
 
+fn create_glyphmap(glyph_order: &IndexSet<GlyphName>) -> GlyphMap {
+    if glyph_order.is_empty() {
+        warn!("Glyph order is empty; feature compile improbable");
+    }
+    glyph_order
+        .iter()
+        .map(|n| Into::<FeaRsGlyphName>::into(n.as_str()))
+        .collect()
+}
+
+fn push_identifier(fea: &mut String, identifier: &KernParticipant) {
+    match identifier {
+        KernParticipant::Glyph(name) => fea.push_str(name.as_str()),
+        KernParticipant::Group(name) => {
+            fea.push_str("@");
+            fea.push_str(name.as_str());
+        }
+    }
+}
+
+/// Create a single variable fea describing the kerning for the entire variation space.
+///
+/// No merge baby! - [context](https://github.com/fonttools/fonttools/issues/3168#issuecomment-1608787520)
+///
+/// To match existing behavior, all kerns must have values for all locations for which any kerning is specified.
+/// See <https://github.com/fonttools/fonttools/issues/3168#issuecomment-1603631080> for more.
+/// Missing values are populated using the https://unifiedfontobject.org/versions/ufo3/kerning.plist/#kerning-value-lookup-algorithm.
+/// In future it is likely sparse kerning - blanks filled by interpolation - will be permitted.
+///
+/// * See <https://github.com/fonttools/fonttools/issues/3168> wrt sparse kerning.
+/// * See <https://github.com/adobe-type-tools/afdko/pull/1350> wrt variable fea.
+fn create_kerning_fea(kerning: &Kerning) -> Result<String, Error> {
+    // Every kern must be defined at these locations. For human readability lets order things consistently.
+    let kerned_locations: HashSet<_> = kerning.kerns.values().flat_map(|v| v.keys()).collect();
+    let mut kerned_locations: Vec<_> = kerned_locations.into_iter().collect();
+    kerned_locations.sort();
+
+    if log::log_enabled!(log::Level::Trace) {
+        trace!(
+            "The following {} locations have kerning:",
+            kerned_locations.len()
+        );
+        for pos in kerned_locations.iter() {
+            trace!("  {pos:?}");
+        }
+    }
+
+    // For any kern that is incompletely specified fill in the missing values using UFO kerning lookup
+    // Not 100% sure if this is correct for .glyphs but lets start there
+    // Generate variable format kerning per https://github.com/adobe-type-tools/afdko/pull/1350
+    // Use design values per discussion on https://github.com/harfbuzz/boring-expansion-spec/issues/94
+    let mut fea = String::new();
+    fea.reserve(8192); // TODO is this a good value?
+    fea.push_str("\n\n# fontc generated kerning\n\n");
+
+    if kerning.is_empty() {
+        return Ok(fea);
+    }
+
+    // TODO eliminate singleton groups, e.g. @public.kern1.Je-cy = [Je-cy];
+
+    // 1) Generate classes (http://adobe-type-tools.github.io/afdko/OpenTypeFeatureFileSpecification.html#2.g.ii)
+    // @classname = [glyph1 glyph2 glyph3];
+    for (name, members) in kerning.groups.iter() {
+        fea.push_str("@");
+        fea.push_str(name.as_str());
+        fea.push_str(" = [");
+        for member in members {
+            fea.push_str(member.as_str());
+            fea.push_str(" ");
+        }
+        fea.remove(fea.len() - 1);
+        fea.push_str("];\n");
+    }
+    fea.push_str("\n\n");
+
+    // 2) Generate pairpos (http://adobe-type-tools.github.io/afdko/OpenTypeFeatureFileSpecification.html#6.b)
+    // it's likely that many kerns use the same location string, might as well remember the string edition
+    let mut pos_strings = HashMap::new();
+    fea.push_str("feature kern {\n");
+    for ((participant1, participant2), values) in kerning.kerns.iter() {
+        fea.push_str("  pos ");
+        push_identifier(&mut fea, participant1);
+        fea.push_str(" ");
+        push_identifier(&mut fea, participant2);
+
+        // See https://github.com/adobe-type-tools/afdko/pull/1350#issuecomment-845219109 for syntax
+        // <value>n for normalized, per https://github.com/harfbuzz/boring-expansion-spec/issues/94#issuecomment-1608007111
+        fea.push_str(" (");
+        for location in kerned_locations.iter() {
+            let pos_str = pos_strings.entry(location).or_insert_with(|| {
+                location
+                    .iter()
+                    .map(|(tag, value)| format!("{tag}={}n", value.into_inner()))
+                    .collect::<Vec<_>>()
+                    .join(",")
+            });
+
+            // TODO can we skip some values by dropping where value == interpolated value?
+            let value = values
+                .get(location)
+                .map(|f| f.into_inner())
+                // TODO: kerning lookup
+                .unwrap_or_else(|| 0.0);
+
+            fea.push_str(&pos_str);
+            fea.push_str(":");
+            fea.push_str(&format!("{} ", value));
+        }
+        fea.remove(fea.len() - 1);
+        fea.push_str(");\n");
+    }
+    fea.push_str("} kern;\n");
+
+    Ok(fea)
+}
+
+fn integrate_kerning(features: &Features, kern_fea: String) -> Result<Features, Error> {
+    // TODO: insert at proper spot, there's a magic marker that might be present
+    match features {
+        Features::Empty => Ok(Features::Memory {
+            fea_content: kern_fea,
+            include_dir: None,
+        }),
+        Features::Memory {
+            fea_content,
+            include_dir,
+        } => Ok(Features::Memory {
+            fea_content: format!("{fea_content}{kern_fea}"),
+            include_dir: include_dir.clone(),
+        }),
+        Features::File {
+            fea_file,
+            include_dir,
+        } => {
+            let fea_content = fs::read_to_string(fea_file).map_err(Error::IoError)?;
+            Ok(Features::Memory {
+                fea_content: format!("{fea_content}{kern_fea}"),
+                include_dir: include_dir.clone(),
+            })
+        }
+    }
+}
+
 impl Work<Context, Error> for FeatureWork {
     fn exec(&self, context: &Context) -> Result<(), Error> {
-        let features = context.ir.get_features();
-        if !matches!(*features, Features::Empty) {
-            let glyph_order = &context.ir.get_final_static_metadata().glyph_order;
-            if glyph_order.is_empty() {
-                warn!("Glyph order is empty; feature compile improbable");
-            }
-            let glyph_map = glyph_order
-                .iter()
-                .map(|n| Into::<FeaRsGlyphName>::into(n.as_str()))
-                .collect();
+        let static_metadata = context.ir.get_final_static_metadata();
 
-            let result = self.compile(&features, glyph_map);
+        let kerning = context.ir.get_kerning();
+        let features = if !kerning.is_empty() {
+            let kern_fea = create_kerning_fea(&kerning)?;
+            integrate_kerning(&context.ir.get_features(), kern_fea)?
+        } else {
+            (*context.ir.get_features()).clone()
+        };
+
+        if !matches!(features, Features::Empty) {
+            let glyph_map = create_glyphmap(&static_metadata.glyph_order);
+            let result = self.compile(&static_metadata, &features, glyph_map);
             if result.is_err() || context.flags.contains(Flags::EMIT_DEBUG) {
-                if let Features::Memory(fea_content) = &*features {
+                if let Features::Memory { fea_content, .. } = &features {
                     write_debug_fea(context, result.is_err(), "compile failed", fea_content);
                 }
             }
@@ -146,10 +482,84 @@ impl Work<Context, Error> for FeatureWork {
         } else {
             debug!("No fea file, dull compile");
         }
+
         // Enables the assumption that if the file exists features were compiled
         if context.flags.contains(Flags::EMIT_IR) {
             fs::write(context.paths.target_file(&WorkId::Features), "1").map_err(Error::IoError)?;
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{BTreeMap, HashMap, HashSet};
+
+    use fea_rs::compile::VariationInfo;
+    use font_types::{Fixed, Tag};
+    use fontir::{
+        coords::{CoordConverter, DesignCoord, NormalizedCoord, NormalizedLocation, UserCoord},
+        ir::{Axis, StaticMetadata},
+    };
+
+    use super::FeaVariationInfo;
+
+    fn single_axis_norm_loc(tag: Tag, value: f32) -> NormalizedLocation {
+        let mut loc = NormalizedLocation::new();
+        loc.insert(tag, NormalizedCoord::new(value));
+        loc
+    }
+
+    fn weight_variable_static_metadata(min: f32, def: f32, max: f32) -> StaticMetadata {
+        let wght = Tag::new(b"wght");
+        let min_wght_user = UserCoord::new(min);
+        let def_wght_user = UserCoord::new(def);
+        let max_wght_user = UserCoord::new(max);
+        let min_wght = single_axis_norm_loc(wght, -1.0);
+        let def_wght = single_axis_norm_loc(wght, 0.0);
+        let max_wght = single_axis_norm_loc(wght, 1.0);
+        StaticMetadata::new(
+            1024,
+            Default::default(),
+            vec![Axis {
+                name: "Weight".to_string(),
+                tag: Tag::new(b"wght"),
+                min: min_wght_user,
+                default: def_wght_user,
+                max: max_wght_user,
+                hidden: false,
+                converter: CoordConverter::new(
+                    vec![
+                        // the design values don't really matter
+                        (min_wght_user, DesignCoord::new(0.0)),
+                        (def_wght_user, DesignCoord::new(1.0)),
+                        (max_wght_user, DesignCoord::new(2.0)),
+                    ],
+                    1,
+                ),
+            }],
+            Default::default(),
+            Default::default(),
+            HashSet::from([min_wght, def_wght, max_wght]),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn compute_kern_at_default() {
+        let wght = Tag::new(b"wght");
+        let static_metadata = weight_variable_static_metadata(300.0, 400.0, 700.0);
+        let var_info = FeaVariationInfo::new(&static_metadata);
+
+        // Find me the default value despite that not being one of the input locations
+
+        //HashMap<BTreeMap<Tag, Fixed>, i16>
+        let (default, _) = var_info
+            .resolve_variable_metric(&HashMap::from([
+                (BTreeMap::from([(wght, Fixed::from_f64(300.0))]), 10),
+                (BTreeMap::from([(wght, Fixed::from_f64(700.0))]), 20),
+            ]))
+            .unwrap();
+        assert_eq!(default, 15);
     }
 }

--- a/fontbe/src/glyphs.rs
+++ b/fontbe/src/glyphs.rs
@@ -229,7 +229,7 @@ impl Work<Context, Error> for GlyphWork {
         trace!("BE glyph work for '{}'", self.glyph_name);
 
         let static_metadata = context.ir.get_final_static_metadata();
-        let var_model = &static_metadata.variation_model;
+        let var_model = &static_metadata.glyph_model;
         let default_location = static_metadata.default_location();
         let ir_glyph = &*context.ir.get_glyph_ir(&self.glyph_name);
         let glyph: CheckedGlyph = ir_glyph.try_into()?;

--- a/fontbe/src/orchestration.rs
+++ b/fontbe/src/orchestration.rs
@@ -659,7 +659,7 @@ mod tests {
     use font_types::Tag;
     use fontir::{
         coords::NormalizedCoord,
-        variations::{Tent, VariationRegion},
+        variations::{ModelConstraints, Tent, VariationRegion},
     };
     use tempfile::tempdir;
 
@@ -711,6 +711,7 @@ mod tests {
                 NormalizedCoord::new(0.0),
                 NormalizedCoord::new(1.0),
                 NormalizedCoord::new(1.0),
+                ModelConstraints::ZeroAtDefault,
             ),
         );
         region

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -239,6 +239,7 @@ fn add_feature_be_job(
                 dependencies: HashSet::from([
                     FeWorkIdentifier::FinalizeStaticMetadata.into(),
                     FeWorkIdentifier::Features.into(),
+                    FeWorkIdentifier::Kerning.into(),
                 ]),
                 read_access: ReadAccess::Dependencies,
                 write_access,

--- a/fontir/src/coords.rs
+++ b/fontir/src/coords.rs
@@ -277,6 +277,26 @@ impl<T: Copy> Location<T> {
     }
 }
 
+impl UserLocation {
+    pub fn to_normalized(&self, axes: &HashMap<Tag, &Axis>) -> NormalizedLocation {
+        Location::<NormalizedCoord>(
+            self.0
+                .iter()
+                .map(|(tag, dc)| (*tag, dc.to_normalized(&axes.get(tag).unwrap().converter)))
+                .collect(),
+        )
+    }
+
+    pub fn to_design(&self, axes: &HashMap<Tag, &Axis>) -> DesignLocation {
+        Location::<DesignCoord>(
+            self.0
+                .iter()
+                .map(|(tag, coord)| (*tag, coord.to_design(&axes.get(tag).unwrap().converter)))
+                .collect(),
+        )
+    }
+}
+
 impl DesignLocation {
     pub fn to_normalized(&self, axes: &HashMap<Tag, &Axis>) -> NormalizedLocation {
         Location::<NormalizedCoord>(

--- a/fontir/src/serde.rs
+++ b/fontir/src/serde.rs
@@ -79,7 +79,7 @@ impl From<StaticMetadataSerdeRepr> for StaticMetadata {
 
 impl From<StaticMetadata> for StaticMetadataSerdeRepr {
     fn from(from: StaticMetadata) -> Self {
-        let glyph_locations = from.variation_model.locations().cloned().collect();
+        let glyph_locations = from.glyph_model.locations().cloned().collect();
         StaticMetadataSerdeRepr {
             units_per_em: from.units_per_em,
             axes: from.axes,

--- a/glyphs2fontir/src/toir.rs
+++ b/glyphs2fontir/src/toir.rs
@@ -113,7 +113,10 @@ pub(crate) fn to_ir_features(features: &[FeatureSnippet]) -> Result<ir::Features
     // TODO: token expansion
     // TODO: implement notes and labels
     let fea_snippets: Vec<String> = features.iter().map(|f| f.as_str().to_string()).collect();
-    Ok(ir::Features::Memory(fea_snippets.join("\n\n")))
+    Ok(ir::Features::Memory {
+        fea_content: fea_snippets.join("\n\n"),
+        include_dir: None,
+    })
 }
 
 fn design_location(axes: &[ir::Axis], axes_values: &[OrderedFloat<f64>]) -> DesignLocation {

--- a/resources/testdata/glyphs2/KernImplicitAxes.glyphs
+++ b/resources/testdata/glyphs2/KernImplicitAxes.glyphs
@@ -1,0 +1,79 @@
+{
+familyName = WghtVar;
+fontMaster = (
+{
+alignmentZones = (
+"{737, 16}",
+"{0, -16}",
+"{-42, -16}"
+);
+ascender = 737;
+capHeight = 702;
+descender = -42;
+id = m01;
+weightValue = 400;
+xHeight = 501;
+},
+{
+ascender = 800;
+capHeight = 700;
+descender = -200;
+id = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+weight = Bold;
+weightValue = 700;
+xHeight = 500;
+}
+);
+glyphs = (
+{
+glyphname = hyphen;
+lastChange = "2023-06-05 23:23:03 +0000";
+layers = (
+{
+layerId = m01;
+paths = (
+{
+closed = 1;
+nodes = (
+"131 250 LINE",
+"470 250 LINE",
+"470 330 LINE",
+"131 330 LINE"
+);
+}
+);
+width = 600;
+},
+{
+layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+paths = (
+{
+closed = 1;
+nodes = (
+"92 224 LINE",
+"508 224 LINE",
+"508 356 LINE",
+"92 356 LINE"
+);
+}
+);
+width = 600;
+}
+);
+unicode = 002D;
+}
+);
+kerning = {
+m01 = {
+hyphen = {
+hyphen = -150;
+};
+};
+"E09E0C54-128D-4FEA-B209-1B70BEFE300B" = {
+hyphen = {
+hyphen = -50;
+};
+};
+};
+unitsPerEm = 1000;
+}

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -1524,7 +1524,7 @@ mod tests {
                 (UserCoord::new(700.0), NormalizedCoord::new(1.0)),
             ],
             static_metadata
-                .variation_model
+                .glyph_model
                 .locations()
                 .map(|loc| (only_coord(loc).to_user(&wght.converter), only_coord(loc)))
                 .collect::<Vec<_>>()


### PR DESCRIPTION
Current naive output akin to:

```
@public.kern2.w = [w wacute wcircumflex wdieresis wgrave];
@public.kern1.l = [f_f_l fl l lacute lcaron lcommaaccent];
@public.kern1.dze-cy = [dze-cy];
...etc...

feature kern {
  pos @public.kern1.dze-cy @public.kern2.Ustrait-cy (wght=-1n:-60 wght=0n:-58 wght=1n:-56);
  pos @public.kern1.n @public.kern2.W (wght=-1n:-10 wght=0n:-13 wght=1n:-18);
  pos dze-cy Te-cy (wght=-1n:-69 wght=0n:-61 wght=1n:-49);
  ...etc...
```

NOTE TO SELF: make sure we have a test where the locations in the conditionset are not identical.