### PR TITLE
[fontir] Use common rust method names in Location

### DIFF
--- a/fontir/src/coords.rs
+++ b/fontir/src/coords.rs
@@ -247,13 +247,13 @@ impl<T: Copy> Location<T> {
         Location(BTreeMap::new())
     }
 
-    pub fn set_pos(&mut self, axis: impl Into<String>, pos: T) -> &mut Location<T> {
+    /// Insert a new axis + value pair into this location.
+    pub fn insert(&mut self, axis: impl Into<String>, pos: T) {
         self.0.insert(axis.into(), pos);
-        self
     }
 
-    pub fn rm_pos(&mut self, axis: &str) {
-        self.0.remove(axis);
+    pub fn remove(&mut self, axis: &str) -> Option<T> {
+        self.0.remove(axis)
     }
 
     pub fn iter(&self) -> impl Iterator<Item = (&String, &T)> {
@@ -264,11 +264,11 @@ impl<T: Copy> Location<T> {
         self.0.keys()
     }
 
-    pub fn has(&self, axis_name: &String) -> bool {
+    pub fn contains(&self, axis_name: &str) -> bool {
         self.0.contains_key(axis_name)
     }
 
-    pub fn get(&self, axis_name: &String) -> Option<T> {
+    pub fn get(&self, axis_name: &str) -> Option<T> {
         self.0.get(axis_name).copied()
     }
 
@@ -322,7 +322,7 @@ impl NormalizedLocation {
         )
     }
 
-    pub fn has_non_zero(&self, axis_name: &String) -> bool {
+    pub fn has_non_zero(&self, axis_name: &str) -> bool {
         self.get(axis_name).unwrap_or_default().into_inner() != OrderedFloat(0.0)
     }
 

--- a/fontir/src/variations.rs
+++ b/fontir/src/variations.rs
@@ -75,8 +75,8 @@ impl VariationModel {
 
             // Fill in missing axis positions with 0
             for axis in axes.iter() {
-                if !location.has(&axis.name) {
-                    location.set_pos(axis.name.clone(), NormalizedCoord::new(0.0));
+                if !location.contains(&axis.name) {
+                    location.insert(axis.name.clone(), NormalizedCoord::new(0.0));
                 }
             }
 

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -996,8 +996,8 @@ mod tests {
             (72.0, 700.0),
         ] {
             let mut loc = UserLocation::new();
-            loc.set_pos("Optical Size", UserCoord::new(*opsz));
-            loc.set_pos("Weight", UserCoord::new(*wght));
+            loc.insert("Optical Size", UserCoord::new(*opsz));
+            loc.insert("Weight", UserCoord::new(*wght));
             let loc = loc;
             expected_locations.insert(loc);
         }
@@ -1028,8 +1028,8 @@ mod tests {
             (1.0, 1.0),
         ] {
             let mut loc = NormalizedLocation::new();
-            loc.set_pos("Optical Size", NormalizedCoord::new(*opsz));
-            loc.set_pos("Weight", NormalizedCoord::new(*wght));
+            loc.insert("Optical Size", NormalizedCoord::new(*opsz));
+            loc.insert("Weight", NormalizedCoord::new(*wght));
             let loc = loc;
             expected_locations.insert(loc);
         }

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -1256,7 +1256,7 @@ mod tests {
         pos: f32,
     ) {
         let mut loc = DesignLocation::new();
-        loc.set_pos(axis, DesignCoord::new(pos));
+        loc.insert(axis, DesignCoord::new(pos));
         add_to
             .entry(testdata_dir().join(glif_file))
             .or_default()
@@ -1330,7 +1330,7 @@ mod tests {
         let (source, _) = load_wght_var();
         let ds = source.load_designspace().unwrap();
         let mut loc = DesignLocation::new();
-        loc.set_pos("Weight", DesignCoord::new(400.0));
+        loc.insert("Weight", DesignCoord::new(400.0));
         assert_eq!(
             loc,
             to_design_location(&default_master(&ds).unwrap().1.location)

--- a/ufo2fontir/src/toir.rs
+++ b/ufo2fontir/src/toir.rs
@@ -221,7 +221,7 @@ mod tests {
     #[test]
     pub fn captures_codepoints() {
         let mut norm_loc = NormalizedLocation::new();
-        norm_loc.set_pos("Weight", NormalizedCoord::new(0.0));
+        norm_loc.insert("Weight", NormalizedCoord::new(0.0));
         let glyph = to_ir_glyph(
             "bar".into(),
             &HashMap::from([(


### PR DESCRIPTION
This makes the API more discoverable and intuitive to users familiar with other Rust collection types.