### PR TITLE
Use display representations when logging errors

### DIFF
--- a/fontbe/src/error.rs
+++ b/fontbe/src/error.rs
@@ -12,7 +12,7 @@ use write_fonts::tables::{glyf::BadKurbo, gvar::GvarInputError, variations::IupE
 pub enum Error {
     #[error("IO failure")]
     IoError(#[from] io::Error),
-    #[error("Fea compilation failure")]
+    #[error("Fea compilation failure {0}")]
     FeaCompileError(#[from] CompilerError),
     #[error("'{0}' {1}")]
     GlyphError(GlyphName, GlyphProblem),

--- a/fontc/src/workload.rs
+++ b/fontc/src/workload.rs
@@ -228,7 +228,7 @@ impl Workload {
                     inserted
                 }
                 Err(e) => {
-                    log::error!("{:?} failed {:?}", completed_id, e);
+                    log::error!("{completed_id:?} failed {e}");
                     self.error.push((completed_id.clone(), format!("{e}")));
                     true
                 }


### PR DESCRIPTION
`Display` is intended to be human readable, and will generally produce better output than `Debug`.

This is particularly true in fea-rs, where we have fancy display impls.

Motivated by trying to debug #349. I have some fixes up, but there's a bunch of other nasty stuff in the FEA here that I need to look into.

