### PR TITLE
Housekeeping: a work should know it's own id

### DIFF
--- a/fontbe/src/avar.rs
+++ b/fontbe/src/avar.rs
@@ -11,7 +11,7 @@ use write_fonts::tables::avar::{Avar, AxisValueMap, SegmentMaps};
 
 use crate::{
     error::Error,
-    orchestration::{BeWork, Context},
+    orchestration::{BeWork, Context, WorkId},
 };
 
 struct AvarWork {}
@@ -58,7 +58,11 @@ fn to_segment_map(axis: &Axis) -> SegmentMaps {
     SegmentMaps::new(mappings)
 }
 
-impl Work<Context, Error> for AvarWork {
+impl Work<Context, WorkId, Error> for AvarWork {
+    fn id(&self) -> WorkId {
+        WorkId::Avar
+    }
+
     /// Generate [avar](https://learn.microsoft.com/en-us/typography/opentype/spec/avar)
     ///
     /// See also <https://learn.microsoft.com/en-us/typography/opentype/spec/otvaroverview#CSN>

--- a/fontbe/src/cmap.rs
+++ b/fontbe/src/cmap.rs
@@ -6,7 +6,7 @@ use write_fonts::tables::cmap::Cmap;
 
 use crate::{
     error::Error,
-    orchestration::{BeWork, Context},
+    orchestration::{BeWork, Context, WorkId},
 };
 
 struct CmapWork {}
@@ -15,7 +15,11 @@ pub fn create_cmap_work() -> Box<BeWork> {
     Box::new(CmapWork {})
 }
 
-impl Work<Context, Error> for CmapWork {
+impl Work<Context, WorkId, Error> for CmapWork {
+    fn id(&self) -> WorkId {
+        WorkId::Cmap
+    }
+
     /// Generate [cmap](https://learn.microsoft.com/en-us/typography/opentype/spec/cmap)
     fn exec(&self, context: &Context) -> Result<(), Error> {
         // cmap only accomodates single codepoint : glyph mappings; collect all of those

--- a/fontbe/src/features.rs
+++ b/fontbe/src/features.rs
@@ -111,7 +111,11 @@ fn write_debug_fea(context: &Context, is_error: bool, why: &str, fea_content: &s
     };
 }
 
-impl Work<Context, Error> for FeatureWork {
+impl Work<Context, WorkId, Error> for FeatureWork {
+    fn id(&self) -> WorkId {
+        WorkId::Features
+    }
+
     fn exec(&self, context: &Context) -> Result<(), Error> {
         let features = context.ir.get_features();
         if !matches!(*features, Features::Empty) {

--- a/fontbe/src/font.rs
+++ b/fontbe/src/font.rs
@@ -93,7 +93,11 @@ fn bytes_for(context: &Context, id: WorkId) -> Result<Vec<u8>, Error> {
     Ok(bytes)
 }
 
-impl Work<Context, Error> for FontWork {
+impl Work<Context, WorkId, Error> for FontWork {
+    fn id(&self) -> WorkId {
+        WorkId::Font
+    }
+
     /// Glue binary tables into a font
     fn exec(&self, context: &Context) -> Result<(), Error> {
         // Lets go right ahead and believe those bytes are a font

--- a/fontbe/src/fvar.rs
+++ b/fontbe/src/fvar.rs
@@ -10,7 +10,7 @@ use write_fonts::tables::fvar::{AxisInstanceArrays, Fvar, InstanceRecord, Variat
 
 use crate::{
     error::Error,
-    orchestration::{BeWork, Context},
+    orchestration::{BeWork, Context, WorkId},
 };
 
 const HIDDEN_AXIS: u16 = 0x0001;
@@ -81,7 +81,11 @@ fn generate_fvar(static_metadata: &StaticMetadata) -> Option<Fvar> {
     Some(Fvar::new(axes_and_instances))
 }
 
-impl Work<Context, Error> for FvarWork {
+impl Work<Context, WorkId, Error> for FvarWork {
+    fn id(&self) -> WorkId {
+        WorkId::Fvar
+    }
+
     /// Generate [fvar](https://learn.microsoft.com/en-us/typography/opentype/spec/fvar)
     fn exec(&self, context: &Context) -> Result<(), Error> {
         if let Some(fvar) = generate_fvar(&context.ir.get_init_static_metadata()) {

--- a/fontbe/src/glyphs.rs
+++ b/fontbe/src/glyphs.rs
@@ -26,7 +26,7 @@ use write_fonts::{
 
 use crate::{
     error::{Error, GlyphProblem},
-    orchestration::{BeWork, Context, GlyfLoca, Glyph, GvarFragment},
+    orchestration::{BeWork, Context, GlyfLoca, Glyph, GvarFragment, WorkId},
 };
 
 struct GlyphWork {
@@ -224,7 +224,11 @@ fn point_seqs_for_composite_glyph(ir_glyph: &ir::Glyph) -> HashMap<NormalizedLoc
         .collect()
 }
 
-impl Work<Context, Error> for GlyphWork {
+impl Work<Context, WorkId, Error> for GlyphWork {
+    fn id(&self) -> WorkId {
+        WorkId::GlyfFragment(self.glyph_name.clone())
+    }
+
     fn exec(&self, context: &Context) -> Result<(), Error> {
         trace!("BE glyph work for '{}'", self.glyph_name);
 
@@ -691,7 +695,11 @@ fn compute_composite_bboxes(context: &Context) -> Result<(), Error> {
     Ok(())
 }
 
-impl Work<Context, Error> for GlyfLocaWork {
+impl Work<Context, WorkId, Error> for GlyfLocaWork {
+    fn id(&self) -> WorkId {
+        WorkId::Glyf
+    }
+
     /// Generate [glyf](https://learn.microsoft.com/en-us/typography/opentype/spec/glyf)
     /// and [loca](https://learn.microsoft.com/en-us/typography/opentype/spec/loca).
     ///

--- a/fontbe/src/gvar.rs
+++ b/fontbe/src/gvar.rs
@@ -10,7 +10,7 @@ use write_fonts::{
 
 use crate::{
     error::Error,
-    orchestration::{BeWork, Bytes, Context},
+    orchestration::{BeWork, Bytes, Context, WorkId},
 };
 
 struct GvarWork {}
@@ -38,7 +38,11 @@ fn make_variations(
         .collect()
 }
 
-impl Work<Context, Error> for GvarWork {
+impl Work<Context, WorkId, Error> for GvarWork {
+    fn id(&self) -> WorkId {
+        WorkId::Gvar
+    }
+
     /// Generate [gvar](https://learn.microsoft.com/en-us/typography/opentype/spec/gvar)
     fn exec(&self, context: &Context) -> Result<(), Error> {
         // We built the gvar fragments alongside glyphs, now we need to glue them together into a gvar table

--- a/fontbe/src/head.rs
+++ b/fontbe/src/head.rs
@@ -10,7 +10,7 @@ use write_fonts::tables::head::Head;
 
 use crate::{
     error::Error,
-    orchestration::{BeWork, Context, LocaFormat},
+    orchestration::{BeWork, Context, LocaFormat, WorkId},
 };
 
 struct HeadWork {}
@@ -86,7 +86,11 @@ fn apply_created_modified(head: &mut Head, created: Option<DateTime<Utc>>) {
     head.modified = LongDateTime::new(now);
 }
 
-impl Work<Context, Error> for HeadWork {
+impl Work<Context, WorkId, Error> for HeadWork {
+    fn id(&self) -> WorkId {
+        WorkId::Head
+    }
+
     /// Generate [head](https://learn.microsoft.com/en-us/typography/opentype/spec/head)
     fn exec(&self, context: &Context) -> Result<(), Error> {
         let static_metadata = context.ir.get_final_static_metadata();

--- a/fontbe/src/metrics_and_limits.rs
+++ b/fontbe/src/metrics_and_limits.rs
@@ -23,7 +23,7 @@ use write_fonts::{
 
 use crate::{
     error::Error,
-    orchestration::{BeWork, Bytes, Context, Glyph},
+    orchestration::{BeWork, Bytes, Context, Glyph, WorkId},
 };
 
 struct MetricAndLimitWork {}
@@ -191,7 +191,11 @@ impl FontLimits {
     }
 }
 
-impl Work<Context, Error> for MetricAndLimitWork {
+impl Work<Context, WorkId, Error> for MetricAndLimitWork {
+    fn id(&self) -> WorkId {
+        WorkId::Hmtx
+    }
+
     /// Generate:
     ///
     /// * [hmtx](https://learn.microsoft.com/en-us/typography/opentype/spec/hmtx)

--- a/fontbe/src/name.rs
+++ b/fontbe/src/name.rs
@@ -8,7 +8,7 @@ use write_fonts::{
 
 use crate::{
     error::Error,
-    orchestration::{BeWork, Context},
+    orchestration::{BeWork, Context, WorkId},
 };
 
 struct NameWork {}
@@ -17,7 +17,11 @@ pub fn create_name_work() -> Box<BeWork> {
     Box::new(NameWork {})
 }
 
-impl Work<Context, Error> for NameWork {
+impl Work<Context, WorkId, Error> for NameWork {
+    fn id(&self) -> WorkId {
+        WorkId::Name
+    }
+
     /// Generate [name](https://learn.microsoft.com/en-us/typography/opentype/spec/name)
     fn exec(&self, context: &Context) -> Result<(), Error> {
         let static_metadata = context.ir.get_init_static_metadata();

--- a/fontbe/src/orchestration.rs
+++ b/fontbe/src/orchestration.rs
@@ -273,7 +273,7 @@ fn loca_format_to_bytes(format: &LocaFormat) -> Vec<u8> {
     vec![*format as u8]
 }
 
-pub type BeWork = dyn Work<Context, Error> + Send;
+pub type BeWork = dyn Work<Context, WorkId, Error> + Send;
 pub struct GlyfLoca {
     pub glyf: Vec<u8>,
     pub raw_loca: Vec<u8>,

--- a/fontbe/src/os2.rs
+++ b/fontbe/src/os2.rs
@@ -26,7 +26,7 @@ use write_fonts::{
 
 use crate::{
     error::Error,
-    orchestration::{BeWork, Context},
+    orchestration::{BeWork, Context, WorkId},
 };
 
 /// Used to build a bitfield.
@@ -777,7 +777,11 @@ fn codepoints(context: &Context) -> HashSet<u32> {
     codepoints
 }
 
-impl Work<Context, Error> for Os2Work {
+impl Work<Context, WorkId, Error> for Os2Work {
+    fn id(&self) -> WorkId {
+        WorkId::Os2
+    }
+
     /// Generate [OS/2](https://learn.microsoft.com/en-us/typography/opentype/spec/os2)
     fn exec(&self, context: &Context) -> Result<(), Error> {
         let static_metadata = context.ir.get_final_static_metadata();

--- a/fontbe/src/post.rs
+++ b/fontbe/src/post.rs
@@ -6,7 +6,7 @@ use write_fonts::tables::post::Post;
 
 use crate::{
     error::Error,
-    orchestration::{BeWork, Context},
+    orchestration::{BeWork, Context, WorkId},
 };
 
 struct PostWork {}
@@ -15,7 +15,11 @@ pub fn create_post_work() -> Box<BeWork> {
     Box::new(PostWork {})
 }
 
-impl Work<Context, Error> for PostWork {
+impl Work<Context, WorkId, Error> for PostWork {
+    fn id(&self) -> WorkId {
+        WorkId::Post
+    }
+
     /// Generate [post](https://learn.microsoft.com/en-us/typography/opentype/spec/post)
     fn exec(&self, context: &Context) -> Result<(), Error> {
         // For now we build a v2 table by default, like fontmake does.

--- a/fontbe/src/stat.rs
+++ b/fontbe/src/stat.rs
@@ -9,7 +9,7 @@ use write_fonts::tables::stat::{AxisRecord, Stat};
 
 use crate::{
     error::Error,
-    orchestration::{BeWork, Context},
+    orchestration::{BeWork, Context, WorkId},
 };
 
 struct StatWork {}
@@ -18,7 +18,11 @@ pub fn create_stat_work() -> Box<BeWork> {
     Box::new(StatWork {})
 }
 
-impl Work<Context, Error> for StatWork {
+impl Work<Context, WorkId, Error> for StatWork {
+    fn id(&self) -> WorkId {
+        WorkId::Stat
+    }
+
     /// Generate [stat](https://learn.microsoft.com/en-us/typography/opentype/spec/stat)
     ///
     /// See <https://github.com/fonttools/fonttools/blob/main/Lib/fontTools/otlLib/builder.py#L2688-L2810>

--- a/fontdrasil/src/orchestration.rs
+++ b/fontdrasil/src/orchestration.rs
@@ -29,8 +29,12 @@ pub enum Access<I> {
 /// Naively you'd think we'd just return FnOnce + Send but that didn't want to compile
 /// See <https://github.com/rust-lang/rust/issues/29625>.
 ///
-/// Data produced by work is written into a Context (type parameter C).
-pub trait Work<C, E> {
+/// Data produced by work is written into a Context (type parameter C). The identifier
+/// type for work, I, is used to identify the task itself as well as the slots this work
+/// might wish to access in the Context.
+pub trait Work<C, I, E> {
+    /// The identifier for this work
+    fn id(&self) -> I;
     fn exec(&self, context: &C) -> Result<(), E>;
 }
 

--- a/fontir/src/glyph.rs
+++ b/fontir/src/glyph.rs
@@ -16,7 +16,7 @@ use crate::{
     coords::NormalizedLocation,
     error::WorkError,
     ir::{Component, Glyph, GlyphBuilder},
-    orchestration::{Context, Flags, IrWork},
+    orchestration::{Context, Flags, IrWork, WorkId},
 };
 
 pub fn create_finalize_static_metadata_work() -> Box<IrWork> {
@@ -355,7 +355,11 @@ fn flatten_glyph(context: &Context, glyph: &Glyph) -> Result<(), WorkError> {
     Ok(())
 }
 
-impl Work<Context, WorkError> for FinalizeStaticMetadataWork {
+impl Work<Context, WorkId, WorkError> for FinalizeStaticMetadataWork {
+    fn id(&self) -> WorkId {
+        WorkId::FinalizeStaticMetadata
+    }
+
     fn exec(&self, context: &Context) -> Result<(), WorkError> {
         // We should now have access to *all* the glyph IR
         // Some of it may need to be massaged to produce BE glyphs

--- a/fontir/src/orchestration.rs
+++ b/fontir/src/orchestration.rs
@@ -99,7 +99,7 @@ pub enum WorkId {
     /// Build potentially variable font-wide metrics.
     GlobalMetrics,
     Glyph(GlyphName),
-    GlyphIrDelete,
+    GlyphIrDelete(GlyphName),
     /// Update static metadata based on what we learned from IR
     ///
     /// Notably, IR glyphs with both components and paths may split into multiple
@@ -109,7 +109,7 @@ pub enum WorkId {
     Kerning,
 }
 
-pub type IrWork = dyn Work<Context, WorkError> + Send;
+pub type IrWork = dyn Work<Context, WorkId, WorkError> + Send;
 
 /// Read/write access to data for async work.
 ///
@@ -119,7 +119,7 @@ pub type IrWork = dyn Work<Context, WorkError> + Send;
 pub struct Context {
     pub flags: Flags,
 
-    paths: Arc<Paths>,
+    pub(crate) paths: Arc<Paths>,
 
     // The input we're working on. Note that change detection may mean we only process
     // a subset of the full input.

--- a/fontir/src/paths.rs
+++ b/fontir/src/paths.rs
@@ -47,7 +47,9 @@ impl Paths {
             WorkId::FinalizeStaticMetadata => self.build_dir.join("static_metadata.yml"),
             WorkId::GlobalMetrics => self.build_dir.join("global_metrics.yml"),
             WorkId::Glyph(name) => self.glyph_ir_file(name.as_str()),
-            WorkId::GlyphIrDelete => self.build_dir.join("delete.yml"),
+            WorkId::GlyphIrDelete(name) => {
+                self.build_dir.join(format!("delete-{}.yml", name.as_str()))
+            }
             WorkId::Features => self.build_dir.join("features.yml"),
             WorkId::Kerning => self.build_dir.join("kerning.yml"),
         }

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -8,7 +8,7 @@ use fontir::ir::{
     self, GlobalMetric, GlobalMetrics, GlyphInstance, KernParticipant, Kerning, NameBuilder,
     NameKey, NamedInstance, StaticMetadata, DEFAULT_VENDOR_ID,
 };
-use fontir::orchestration::{Context, IrWork};
+use fontir::orchestration::{Context, IrWork, WorkId};
 use fontir::source::{Input, Source};
 use fontir::stateset::StateSet;
 use glyphs_reader::{Font, InstanceType};
@@ -282,7 +282,11 @@ struct StaticMetadataWork {
     glyph_names: Arc<HashSet<GlyphName>>,
 }
 
-impl Work<Context, WorkError> for StaticMetadataWork {
+impl Work<Context, WorkId, WorkError> for StaticMetadataWork {
+    fn id(&self) -> WorkId {
+        WorkId::InitStaticMetadata
+    }
+
     fn exec(&self, context: &Context) -> Result<(), WorkError> {
         let font_info = self.font_info.as_ref();
         let font = &font_info.font;
@@ -381,7 +385,11 @@ struct GlobalMetricWork {
     font_info: Arc<FontInfo>,
 }
 
-impl Work<Context, WorkError> for GlobalMetricWork {
+impl Work<Context, WorkId, WorkError> for GlobalMetricWork {
+    fn id(&self) -> WorkId {
+        WorkId::GlobalMetrics
+    }
+
     fn exec(&self, context: &Context) -> Result<(), WorkError> {
         let font_info = self.font_info.as_ref();
         let font = &font_info.font;
@@ -457,7 +465,11 @@ struct FeatureWork {
     font_info: Arc<FontInfo>,
 }
 
-impl Work<Context, WorkError> for FeatureWork {
+impl Work<Context, WorkId, WorkError> for FeatureWork {
+    fn id(&self) -> WorkId {
+        WorkId::Features
+    }
+
     fn exec(&self, context: &Context) -> Result<(), WorkError> {
         trace!("Generate features");
         let font_info = self.font_info.as_ref();
@@ -537,7 +549,11 @@ fn kern_participant(
     }
 }
 
-impl Work<Context, WorkError> for KerningWork {
+impl Work<Context, WorkId, WorkError> for KerningWork {
+    fn id(&self) -> WorkId {
+        WorkId::Kerning
+    }
+
     fn exec(&self, context: &Context) -> Result<(), WorkError> {
         trace!("Generate IR for kerning");
         let static_metadata = context.get_final_static_metadata();
@@ -633,7 +649,11 @@ fn check_pos(
     Ok(())
 }
 
-impl Work<Context, WorkError> for GlyphIrWork {
+impl Work<Context, WorkId, WorkError> for GlyphIrWork {
+    fn id(&self) -> WorkId {
+        WorkId::Glyph(self.glyph_name.clone())
+    }
+
     fn exec(&self, context: &Context) -> Result<(), WorkError> {
         trace!("Generate IR for '{}'", self.glyph_name.as_str());
         let font_info = self.font_info.as_ref();

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -18,7 +18,7 @@ use fontir::{
         Features, GlobalMetric, GlobalMetrics, KernParticipant, Kerning, NameBuilder, NameKey,
         NamedInstance, StaticMetadata, DEFAULT_VENDOR_ID,
     },
-    orchestration::{Context, IrWork},
+    orchestration::{Context, IrWork, WorkId},
     source::{Input, Source},
     stateset::{StateIdentifier, StateSet},
 };
@@ -657,7 +657,11 @@ fn try_parse_date(raw_date: Option<&String>) -> Option<DateTime<Utc>> {
     parse_result.ok()
 }
 
-impl Work<Context, WorkError> for StaticMetadataWork {
+impl Work<Context, WorkId, WorkError> for StaticMetadataWork {
+    fn id(&self) -> WorkId {
+        WorkId::InitStaticMetadata
+    }
+
     fn exec(&self, context: &Context) -> Result<(), WorkError> {
         debug!("Static metadata for {:#?}", self.designspace_file);
         let designspace_dir = self.designspace_file.parent().unwrap();
@@ -776,7 +780,11 @@ fn is_glyph_only(source: &norad::designspace::Source) -> bool {
     source.layer.is_some()
 }
 
-impl Work<Context, WorkError> for GlobalMetricsWork {
+impl Work<Context, WorkId, WorkError> for GlobalMetricsWork {
+    fn id(&self) -> WorkId {
+        WorkId::GlobalMetrics
+    }
+
     fn exec(&self, context: &Context) -> Result<(), WorkError> {
         debug!("Global metrics for {:#?}", self.designspace_file);
         let static_metadata = context.get_init_static_metadata();
@@ -867,7 +875,11 @@ impl Work<Context, WorkError> for GlobalMetricsWork {
     }
 }
 
-impl Work<Context, WorkError> for FeatureWork {
+impl Work<Context, WorkId, WorkError> for FeatureWork {
+    fn id(&self) -> WorkId {
+        WorkId::Features
+    }
+
     fn exec(&self, context: &Context) -> Result<(), WorkError> {
         debug!("Features for {:#?}", self.designspace_file);
 
@@ -957,7 +969,11 @@ impl KernSide {
     }
 }
 
-impl Work<Context, WorkError> for KerningWork {
+impl Work<Context, WorkId, WorkError> for KerningWork {
+    fn id(&self) -> WorkId {
+        WorkId::Kerning
+    }
+
     /// See <https://github.com/googlefonts/ufo2ft/blob/3e0563814cf541f7d8ca2bb7f6e446328e0e5e76/Lib/ufo2ft/featureWriters/kernFeatureWriter.py#L302-L357>
     fn exec(&self, context: &Context) -> Result<(), WorkError> {
         debug!("Kerning for {:#?}", self.designspace_file);
@@ -1089,7 +1105,11 @@ struct GlyphIrWork {
     glif_files: HashMap<PathBuf, Vec<DesignLocation>>,
 }
 
-impl Work<Context, WorkError> for GlyphIrWork {
+impl Work<Context, WorkId, WorkError> for GlyphIrWork {
+    fn id(&self) -> WorkId {
+        WorkId::Glyph(self.glyph_name.clone())
+    }
+
     fn exec(&self, context: &Context) -> Result<(), WorkError> {
         trace!(
             "Generate glyph IR for {:?} from {:#?}",


### PR DESCRIPTION
For context, initially I wasn't sure how our work model would play out. I feel like it's settled enough to be worth tidying up. I plan to move knowledge of what slots the work reads/writes to the work itself in a subsequent PR.

`fontdrasil/src/orchestration.rs` is the interesting part, to the extent there is an interesting part. The result is just shuffling things to get id from `Work::id()`

Along the way I deleted a fixme, filing https://github.com/googlefonts/fontc/issues/355 instead.