### PR TITLE
Housekeeping: let work tell us dependencies and what it reads/writes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ parking_lot = "0.12.1"
 fea-rs = "0.9.0"
 font-types = { version = "0.3.2", features = ["serde"] }
 read-fonts = "0.7.0"
-write-fonts = "0.10.0"
+write-fonts = "0.10.1"
 skrifa = "0.6.0"
 
 bitflags = "2.0"

--- a/fontc/src/error.rs
+++ b/fontc/src/error.rs
@@ -21,4 +21,6 @@ pub enum Error {
     TasksFailed(Vec<(AnyWorkId, String)>),
     #[error("Invalid regex")]
     BadRegex(#[from] regex::Error),
+    #[error("Unable to proceed")]
+    UnableToProceed,
 }

--- a/fontc/src/main.rs
+++ b/fontc/src/main.rs
@@ -33,7 +33,7 @@ fn main() -> Result<(), Error> {
     let fe_root = FeContext::new_root(
         config.args.flags(),
         ir_paths,
-        change_detector.current_inputs().clone(),
+        workload.current_inputs().clone(),
     );
     let be_root = BeContext::new_root(config.args.flags(), be_paths, &fe_root);
     workload.exec(&fe_root, &be_root)?;

--- a/fontc/src/work.rs
+++ b/fontc/src/work.rs
@@ -101,7 +101,7 @@ impl AnyWork {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum AnyAccess {
     Be(Access<AnyWorkId>),
     Fe(Access<WorkId>),

--- a/fontc/src/work.rs
+++ b/fontc/src/work.rs
@@ -2,7 +2,7 @@
 //!
 //! Basically enums that can be a FeWhatever or a BeWhatever.
 
-use std::{collections::HashSet, fmt::Display};
+use std::fmt::Display;
 
 use fontbe::{
     error::Error as BeError,
@@ -42,6 +42,7 @@ impl Display for AnyWorkError {
 }
 
 // Work of any type, FE, BE, ... some future pass, w/e
+#[derive(Debug)]
 pub enum AnyWork {
     Fe(Box<IrWork>),
     Be(Box<BeWork>),
@@ -60,13 +61,30 @@ impl From<Box<BeWork>> for AnyWork {
 }
 
 impl AnyWork {
+    pub fn id(&self) -> AnyWorkId {
+        match self {
+            AnyWork::Be(work) => work.id(),
+            AnyWork::Fe(work) => work.id().into(),
+        }
+    }
+
+    pub fn read_access(&self) -> AnyAccess {
+        match self {
+            AnyWork::Be(work) => work.read_access().into(),
+            AnyWork::Fe(work) => work.read_access().into(),
+        }
+    }
+
+    pub fn write_access(&self) -> AnyAccess {
+        match self {
+            AnyWork::Be(work) => work.write_access().into(),
+            AnyWork::Fe(work) => work.write_access().into(),
+        }
+    }
+
     pub fn also_completes(&self) -> Vec<AnyWorkId> {
         match self {
-            AnyWork::Be(work) => work
-                .also_completes()
-                .into_iter()
-                .map(|id| id.into())
-                .collect(),
+            AnyWork::Be(work) => work.also_completes().into_iter().collect(),
             AnyWork::Fe(work) => work
                 .also_completes()
                 .into_iter()
@@ -83,20 +101,55 @@ impl AnyWork {
     }
 }
 
+#[derive(Debug)]
+pub enum AnyAccess {
+    Be(Access<AnyWorkId>),
+    Fe(Access<WorkId>),
+}
+
+impl From<Access<AnyWorkId>> for AnyAccess {
+    fn from(value: Access<AnyWorkId>) -> Self {
+        AnyAccess::Be(value)
+    }
+}
+
+impl From<Access<WorkId>> for AnyAccess {
+    fn from(value: Access<WorkId>) -> Self {
+        AnyAccess::Fe(value)
+    }
+}
+
+impl AnyAccess {
+    pub fn check(&self, id: &AnyWorkId) -> bool {
+        match self {
+            AnyAccess::Be(access) => access.check(id),
+            AnyAccess::Fe(access) => {
+                let AnyWorkId::Fe(id) = id else {
+                    return false;
+                };
+                access.check(id)
+            }
+        }
+    }
+
+    pub fn unwrap_be(&self) -> Access<AnyWorkId> {
+        match self {
+            AnyAccess::Fe(..) => panic!("Not BE access"),
+            AnyAccess::Be(access) => access.clone(),
+        }
+    }
+
+    pub fn unwrap_fe(&self) -> Access<WorkId> {
+        match self {
+            AnyAccess::Fe(access) => access.clone(),
+            AnyAccess::Be(..) => panic!("Not FE access"),
+        }
+    }
+}
+
 pub enum AnyContext {
     Fe(FeContext),
     Be(BeContext),
-}
-
-pub enum ReadAccess {
-    Dependencies,
-    Custom(Access<AnyWorkId>),
-}
-
-impl ReadAccess {
-    pub fn custom(func: impl Fn(&AnyWorkId) -> bool + Send + Sync + 'static) -> Self {
-        Self::Custom(Access::custom(func))
-    }
 }
 
 impl AnyContext {
@@ -104,16 +157,13 @@ impl AnyContext {
         fe_root: &FeContext,
         be_root: &BeContext,
         work_id: &AnyWorkId,
-        dependencies: HashSet<AnyWorkId>,
-        read_access: ReadAccess,
-        write_access: Access<AnyWorkId>,
+        read_access: AnyAccess,
+        write_access: AnyAccess,
     ) -> AnyContext {
-        let read_access = match read_access {
-            ReadAccess::Dependencies => Access::custom(move |id| dependencies.contains(id)),
-            ReadAccess::Custom(access_fn) => access_fn,
-        };
         match work_id {
-            AnyWorkId::Be(..) => AnyContext::Be(be_root.copy_for_work(read_access, write_access)),
+            AnyWorkId::Be(..) => AnyContext::Be(
+                be_root.copy_for_work(read_access.unwrap_be(), write_access.unwrap_be()),
+            ),
             AnyWorkId::Fe(..) => AnyContext::Fe(fe_root.copy_for_work(
                 Access::custom(move |id: &WorkId| read_access.check(&AnyWorkId::Fe(id.clone()))),
                 Access::custom(move |id: &WorkId| write_access.check(&AnyWorkId::Fe(id.clone()))),

--- a/fontc/src/workload.rs
+++ b/fontc/src/workload.rs
@@ -3,20 +3,23 @@
 use std::collections::{HashMap, HashSet};
 
 use crossbeam_channel::{Receiver, TryRecvError};
-use fontbe::orchestration::{AnyWorkId, Context as BeContext, WorkId as BeWorkIdentifier};
+use fontbe::orchestration::{AnyWorkId, Context as BeContext};
 use fontdrasil::orchestration::Access;
-use fontir::orchestration::{Context as FeContext, WorkId as FeWorkIdentifier};
-use log::debug;
+use fontir::{
+    orchestration::{Context as FeContext, WorkId as FeWorkIdentifier},
+    source::Input,
+};
+use log::{debug, trace};
 
 use crate::{
-    work::{AnyContext, AnyWork, AnyWorkError, ReadAccess},
-    Error,
+    work::{AnyAccess, AnyContext, AnyWork, AnyWorkError},
+    ChangeDetector, Error,
 };
 
 /// A set of interdependent jobs to execute.
-#[derive(Default)]
-pub struct Workload {
-    pre_success: usize,
+#[derive(Debug)]
+pub struct Workload<'a> {
+    pub(crate) change_detector: &'a ChangeDetector,
     job_count: usize,
     success: HashSet<AnyWorkId>,
     error: Vec<(AnyWorkId, String)>,
@@ -27,15 +30,18 @@ pub struct Workload {
 }
 
 /// A unit of executable work plus the identifiers of work that it depends on
+///
+/// Exists to allow us to modify dependencies, such as adding new ones.
+#[derive(Debug)]
 pub(crate) struct Job {
     // The actual task
     pub(crate) work: AnyWork,
-    // Things that must happen before we execute. Our  task can read these things.
-    pub(crate) dependencies: HashSet<AnyWorkId>,
-    // Things our job needs read access to. Usually all our dependencies.
-    pub(crate) read_access: ReadAccess,
+    // Things our job needs read access to. Job won't run if anything it can read is pending.
+    pub(crate) read_access: AnyAccess,
     // Things our job needs write access to
-    pub(crate) write_access: Access<AnyWorkId>,
+    pub(crate) write_access: AnyAccess,
+    // Does this job actually need to execute?
+    pub(crate) run: bool,
 }
 
 enum RecvType {
@@ -43,9 +49,48 @@ enum RecvType {
     NonBlocking,
 }
 
-impl Workload {
-    pub fn new() -> Workload {
-        Self::default()
+impl<'a> Workload<'a> {
+    pub fn new(change_detector: &'a ChangeDetector) -> Workload {
+        Workload {
+            change_detector,
+            job_count: 0,
+            success: Default::default(),
+            error: Default::default(),
+            also_completes: Default::default(),
+            jobs_pending: Default::default(),
+        }
+    }
+
+    /// True if job might read what other produces
+    fn might_read(&self, job: &Job, other: &Job) -> bool {
+        let other_id = other.work.id();
+        let result = job.read_access.check(&other_id)
+            || self
+                .also_completes
+                .get(&other_id)
+                .map(|also| also.iter().any(|other_id| job.read_access.check(other_id)))
+                .unwrap_or_default();
+        result
+    }
+
+    pub fn current_inputs(&self) -> &Input {
+        self.change_detector.current_inputs()
+    }
+
+    // TODO flags would be clearer than multiple bools
+    pub(crate) fn add(&mut self, work: AnyWork, should_run: bool) {
+        let id = work.id();
+        let read_access = work.read_access();
+        let write_access = work.write_access();
+        self.insert(
+            id,
+            Job {
+                work,
+                read_access,
+                write_access,
+                run: should_run,
+            },
+        );
     }
 
     pub(crate) fn insert(&mut self, id: AnyWorkId, job: Job) {
@@ -57,24 +102,11 @@ impl Workload {
         self.job_count += 1;
     }
 
-    pub(crate) fn is_dependency(&mut self, id: &AnyWorkId, dep: &AnyWorkId) -> bool {
-        self.jobs_pending
-            .get(id)
-            .map(|job| job.dependencies.contains(dep))
-            .unwrap_or(false)
-    }
-
-    pub(crate) fn mark_success(&mut self, id: impl Into<AnyWorkId>) {
-        if self.success.insert(id.into()) {
-            self.pre_success += 1;
-        }
-    }
-
     fn mark_also_completed(&mut self, success: &AnyWorkId) {
         let Some(also_completed) = self.also_completes.get(success) else { return };
         for id in also_completed {
-            if self.success.insert(id.clone()) {
-                self.pre_success += 1;
+            if !self.success.insert(id.clone()) {
+                panic!("Multiple completions of {id:?}");
             }
         }
     }
@@ -84,60 +116,65 @@ impl Workload {
 
         self.mark_also_completed(&success);
 
-        match success {
-            // When a glyph finishes IR, register BE work for it
-            AnyWorkId::Fe(FeWorkIdentifier::Glyph(glyph_name)) => {
-                super::add_glyph_be_job(self, fe_root, glyph_name)
+        // When glyph order finalizes, add BE work for any new glyphs
+        if let AnyWorkId::Fe(FeWorkIdentifier::GlyphOrder) = success {
+            let preliminary_glyph_order = fe_root.preliminary_glyph_order.get();
+            for glyph_name in fe_root
+                .glyph_order
+                .get()
+                .difference(&preliminary_glyph_order)
+            {
+                debug!("Generating a BE job for {glyph_name}");
+                super::add_glyph_be_job(self, glyph_name.clone());
             }
+        }
+    }
 
-            // When static metadata finalizes, add BE work for any new glyphs
-            // If anything progresses before we've done this we have a graph bug
-            AnyWorkId::Fe(FeWorkIdentifier::FinalizeStaticMetadata) => {
-                for glyph_name in fe_root.get_final_static_metadata().glyph_order.iter() {
-                    let glyph_work_id =
-                        AnyWorkId::Be(BeWorkIdentifier::GlyfFragment(glyph_name.clone()));
-                    let gvar_work_id =
-                        AnyWorkId::Be(BeWorkIdentifier::GvarFragment(glyph_name.clone()));
-                    if self.jobs_pending.contains_key(&glyph_work_id) {
-                        continue;
-                    }
+    fn can_run_scan(&self, job: &Job) -> bool {
+        // Job can only run if *no* incomplete jobs exist whose output it could read
+        !self
+            .jobs_pending
+            .iter()
+            .filter(|(other_id, _)| !self.success.contains(other_id))
+            .any(|(_, other_job)| self.might_read(job, other_job))
+    }
 
-                    debug!("Adding dependencies on {glyph_name}");
-
-                    // It would be lovely if our new glyph was in glyf, and gvar
-                    // loca hides with glyf. hmtx blocks on glyf.
-                    for (merge_work_id, new_dep) in [
-                        (BeWorkIdentifier::Glyf, &glyph_work_id),
-                        (BeWorkIdentifier::Gvar, &gvar_work_id),
-                    ] {
-                        self.jobs_pending
-                            .get_mut(&AnyWorkId::Be(merge_work_id))
-                            .unwrap()
-                            .dependencies
-                            .insert(new_dep.clone());
-                    }
-
-                    super::add_glyph_be_job(self, fe_root, glyph_name.clone());
-                }
-            }
-
-            _ => (),
+    fn can_run(&self, job: &Job) -> bool {
+        // Custom access requires a scan across pending jobs, hence avoidance is nice
+        match &job.read_access {
+            AnyAccess::Fe(access) => match access {
+                Access::None => true,
+                Access::One(id) => !self.jobs_pending.contains_key(&id.into()),
+                Access::Set(ids) => !ids
+                    .iter()
+                    .any(|id| self.jobs_pending.contains_key(&id.into())),
+                Access::Custom(..) => self.can_run_scan(job),
+                Access::All => self.can_run_scan(job),
+            },
+            AnyAccess::Be(access) => match access {
+                Access::None => true,
+                Access::One(id) => !self.jobs_pending.contains_key(id),
+                Access::Set(ids) => !ids.iter().any(|id| self.jobs_pending.contains_key(id)),
+                Access::Custom(..) => self.can_run_scan(job),
+                Access::All => self.can_run_scan(job),
+            },
         }
     }
 
     pub fn launchable(&self) -> Vec<AnyWorkId> {
-        self.jobs_pending
+        let launchable = self
+            .jobs_pending
             .iter()
             .filter_map(|(id, job)| {
-                let can_start = job.dependencies.is_subset(&self.success);
-                if !can_start && log::log_enabled!(log::Level::Trace) {
-                    let mut unfulfilled_deps: Vec<_> =
-                        job.dependencies.difference(&self.success).collect();
-                    unfulfilled_deps.sort();
-                };
-                can_start.then(|| id.clone())
+                if self.can_run(job) {
+                    Some(id.clone())
+                } else {
+                    None
+                }
             })
-            .collect()
+            .collect();
+        trace!("Launchable: {launchable:?}");
+        launchable
     }
 
     pub fn exec(mut self, fe_root: &FeContext, be_root: &BeContext) -> Result<(), Error> {
@@ -148,28 +185,35 @@ impl Workload {
             // Whenever a task completes see if it was the last incomplete dependency of other task(s)
             // and spawn them if it was
             // TODO timeout and die it if takes too long to make forward progress or we're spinning w/o progress
-            while self.success.len() < self.job_count + self.pre_success {
+            while self.success.len() < self.job_count {
                 // Spawn anything that is currently executable (has no unfulfilled dependencies)
                 for id in self.launchable() {
-                    log::trace!("Start {:?}", id);
                     let job = self.jobs_pending.remove(&id).unwrap();
-                    let work = job.work;
-                    let work_context = AnyContext::for_work(
-                        fe_root,
-                        be_root,
-                        &id,
-                        job.dependencies,
-                        job.read_access,
-                        job.write_access,
-                    );
-
+                    log::trace!("Start {:?}", id);
                     let send = send.clone();
-                    scope.spawn(move |_| {
-                        let result = work.exec(work_context);
-                        if let Err(e) = send.send((id.clone(), result)) {
-                            log::error!("Unable to write {:?} to completion channel: {}", id, e);
-                        }
-                    })
+                    let work = job.work;
+                    if job.run {
+                        let work_context = AnyContext::for_work(
+                            fe_root,
+                            be_root,
+                            &id,
+                            job.read_access,
+                            job.write_access,
+                        );
+
+                        scope.spawn(move |_| {
+                            let result = work.exec(work_context);
+                            if let Err(e) = send.send((id.clone(), result)) {
+                                log::error!(
+                                    "Unable to write {:?} to completion channel: {}",
+                                    id,
+                                    e
+                                );
+                            }
+                        })
+                    } else if let Err(e) = send.send((id.clone(), Ok(()))) {
+                        log::error!("Unable to write nop {:?} to completion channel: {}", id, e);
+                    }
                 }
 
                 // Block for things to phone home to say they are done
@@ -185,11 +229,11 @@ impl Workload {
         // If ^ exited due to error the scope awaited any live tasks; capture their results
         self.read_completions(&recv, RecvType::NonBlocking)?;
 
-        if self.error.is_empty() && self.success.len() != self.job_count + self.pre_success {
+        if self.error.is_empty() && self.success.len() != self.job_count {
             panic!(
                 "No errors but only {}/{} succeeded?!",
                 self.success.len(),
-                self.job_count + self.pre_success
+                self.job_count
             );
         }
 
@@ -234,7 +278,7 @@ impl Workload {
             }
             log::debug!(
                 "{}/{} complete, most recently {:?}",
-                self.error.len() + self.success.len() - self.pre_success,
+                self.error.len() + self.success.len(),
                 self.job_count,
                 completed_id
             );
@@ -250,9 +294,27 @@ impl Workload {
         Ok(successes)
     }
 
+    #[cfg(test)]
+    fn unfulfilled_deps(&self, job: &Job) -> Vec<AnyWorkId> {
+        let mut unfulfilled = self
+            .jobs_pending
+            .iter()
+            .filter_map(|(id, other_job)| {
+                if self.might_read(job, other_job) {
+                    Some(id)
+                } else {
+                    None
+                }
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        unfulfilled.sort();
+        unfulfilled
+    }
+
     /// Run all pending jobs.
     ///
-    /// Returns the set of ids for tasks that are finished as a result of this run.
+    /// Returns the set of ids for tasks that executed as a result of this run.
     #[cfg(test)]
     pub fn run_for_test(&mut self, fe_root: &FeContext, be_root: &BeContext) -> HashSet<AnyWorkId> {
         let pre_success = self.success.clone();
@@ -260,21 +322,21 @@ impl Workload {
             let launchable = self.launchable();
             if launchable.is_empty() {
                 log::error!("Completed:");
-                for id in self.success.iter() {
+                let mut success: Vec<_> = self.success.iter().collect();
+                success.sort();
+                for id in success {
                     log::error!("  {id:?}");
                 }
                 log::error!("Unable to proceed with:");
                 for (id, job) in self.jobs_pending.iter() {
-                    let unfulfilled = job
-                        .dependencies
-                        .iter()
-                        .filter(|id| !self.success.contains(id))
-                        .collect::<Vec<_>>();
-                    log::error!(
-                        "  {:?}, happens-after {:?}, unfulfilled {unfulfilled:?}",
-                        id,
-                        job.dependencies
-                    );
+                    let unfulfilled = self.unfulfilled_deps(job);
+                    log::error!("  {id:?}, has unfulfilled dependencies: {unfulfilled:?}");
+                    for id in unfulfilled.iter() {
+                        log::error!(
+                            "    {id:?}, has unfulfilled dependencies: {:?}",
+                            self.unfulfilled_deps(self.jobs_pending.get(id).unwrap())
+                        );
+                    }
                 }
                 assert!(
                     !launchable.is_empty(),
@@ -284,24 +346,19 @@ impl Workload {
 
             let id = &launchable[0];
             let job = self.jobs_pending.remove(id).unwrap();
-            let context = AnyContext::for_work(
-                fe_root,
-                be_root,
-                id,
-                job.dependencies,
-                job.read_access,
-                job.write_access,
-            );
-            log::debug!("Exec {:?}", id);
-            job.work
-                .exec(context)
-                .unwrap_or_else(|e| panic!("{id:?} failed: {e:?}"));
-            assert!(
-                self.success.insert(id.clone()),
-                "We just did {id:?} a second time?"
-            );
-
-            self.handle_success(fe_root, id.clone());
+            if job.run {
+                let context =
+                    AnyContext::for_work(fe_root, be_root, id, job.read_access, job.write_access);
+                log::debug!("Exec {:?}", id);
+                job.work
+                    .exec(context)
+                    .unwrap_or_else(|e| panic!("{id:?} failed: {e:?}"));
+                assert!(
+                    self.success.insert(id.clone()),
+                    "We just did {id:?} a second time?"
+                );
+                self.handle_success(fe_root, id.clone());
+            }
         }
         self.success.difference(&pre_success).cloned().collect()
     }

--- a/fontir/src/orchestration.rs
+++ b/fontir/src/orchestration.rs
@@ -4,20 +4,18 @@ use std::{
     collections::HashMap,
     fmt::Debug,
     fs::File,
-    io::{BufReader, BufWriter},
-    path::Path,
+    hash::Hash,
+    io::{BufReader, BufWriter, Read, Write},
     sync::Arc,
 };
 
+use crate::{error::WorkError, ir, paths::Paths, source::Input};
 use bitflags::bitflags;
 use fontdrasil::{
-    orchestration::{Access, AccessControlList, Work, MISSING_DATA},
+    orchestration::{Access, AccessControlList, Identifier, Work},
     types::GlyphName,
 };
 use parking_lot::RwLock;
-use serde::{de::DeserializeOwned, Serialize};
-
-use crate::{error::WorkError, ir, paths::Paths, source::Input};
 
 bitflags! {
     #[derive(Clone, Copy, Debug)]
@@ -34,55 +32,6 @@ bitflags! {
     }
 }
 
-pub type ContextItem<T> = Arc<RwLock<Option<Arc<T>>>>;
-
-/// Generates fn $getter_name(&self) -> Arc<$value_type>.
-///
-/// Assumes we are in an impl block for a Context and that
-/// self.$lock_name is a ContextItem<$ir_type>
-///
-/// <https://veykril.github.io/tlborm/decl-macros/minutiae/fragment-specifiers.html>
-#[macro_export]
-macro_rules! context_accessors {
-    ($getter_name:ident, $setter_name:ident, $has_name:ident, $lock_name:ident, $value_type:ty, $id:expr, $restore_fn:ident, $prepersist_fn:ident) => {
-        pub fn $getter_name(&self) -> Arc<$value_type> {
-            let id = $id;
-            self.acl.assert_read_access(&id.clone().into());
-            {
-                let rl = self.$lock_name.read();
-                if rl.is_some() {
-                    return rl.as_ref().unwrap().clone();
-                }
-            }
-            set_cached(&self.$lock_name, $restore_fn(&self.paths.target_file(&id)));
-            let rl = self.$lock_name.read();
-            rl.as_ref().expect(MISSING_DATA).clone()
-        }
-
-        pub fn $has_name(&self) -> bool {
-            let id = $id;
-            self.acl.assert_read_access(&id.clone().into());
-            {
-                let rl = self.$lock_name.read();
-                if rl.is_some() {
-                    return true;
-                }
-            }
-            self.paths.target_file(&id).is_file()
-        }
-
-        pub fn $setter_name(&self, value: $value_type) {
-            let id = $id;
-            self.acl.assert_write_access(&id.clone().into());
-            if self.flags.contains(Flags::EMIT_IR) {
-                let buf = $prepersist_fn(&value);
-                self.persist(&self.paths.target_file(&id), &buf);
-            }
-            set_cached(&self.$lock_name, value);
-        }
-    };
-}
-
 impl Default for Flags {
     /// Match the way gftools configures fontmake by default
     fn default() -> Self {
@@ -90,26 +39,313 @@ impl Default for Flags {
     }
 }
 
+/// Clones are cheap and reference the same wrapped item courtesy of Arc
+///
+/// Courtesy of Arc this is Clone even if T isn't
+#[derive(Default)]
+pub struct ContextItem<I, T, P>
+where
+    I: Identifier,
+{
+    id: I,
+    acl: Arc<AccessControlList<I>>,
+    persistent_storage: Arc<P>,
+    value: Arc<RwLock<Option<Arc<T>>>>,
+}
+
+impl<I, T, P> ContextItem<I, T, P>
+where
+    I: Identifier,
+    P: PersistentStorage<I>,
+    T: Persistable,
+{
+    pub fn new(id: I, acl: Arc<AccessControlList<I>>, persistent_storage: Arc<P>) -> Self {
+        ContextItem {
+            id,
+            acl,
+            persistent_storage,
+            value: Default::default(),
+        }
+    }
+
+    pub fn clone_with_acl(&self, acl: Arc<AccessControlList<I>>) -> Self {
+        ContextItem {
+            id: self.id.clone(),
+            acl,
+            persistent_storage: self.persistent_storage.clone(),
+            value: self.value.clone(),
+        }
+    }
+
+    /// Read item that you are sure must exist. Panic if not.
+    ///
+    /// Intended for use in [Work] to access items present in
+    /// [Work::read_access]. If these are missing something is horribly
+    /// wrong and we should kerplode.
+    pub fn get(&self) -> Arc<T> {
+        if let Some(in_memory) = self.try_get() {
+            return in_memory;
+        }
+
+        // it's *not* in memory but perhaps it's written down?
+        if self.persistent_storage.active() {
+            if let Some(mut reader) = self.persistent_storage.reader(&self.id) {
+                let restored = T::read(&mut reader);
+                *self.value.write() = Some(Arc::from(restored));
+            }
+        }
+
+        // if we still don't have an answer just give up
+        self.try_get()
+            .unwrap_or_else(|| panic!("{:?} is not available", self.id))
+    }
+
+    /// Read an item that might not exist
+    pub fn try_get(&self) -> Option<Arc<T>> {
+        self.acl.assert_read_access(&self.id);
+        self.value.read().as_ref().cloned()
+    }
+
+    /// Update the value of the item whether or not it has changed.
+    ///
+    /// The change will be logged and anything relying on change detection, such as
+    /// conditional execution of dependent tasks, will fire.
+    ///
+    /// [ContextItem::set] is preferable where possible.
+    ///
+    /// This exists largely because write types in fontations do not always implement PartialEq.
+    /// TODO: should they?
+    pub fn set_unconditionally(&self, value: T) {
+        self.acl.assert_write_access(&self.id);
+
+        if self.persistent_storage.active() {
+            let mut writer = self.persistent_storage.writer(&self.id);
+            value.write(&mut writer);
+        }
+
+        *self.value.write() = Some(Arc::from(value));
+    }
+}
+
+impl<I, T, P> ContextItem<I, T, P>
+where
+    I: Identifier,
+    T: PartialEq + Persistable,
+    P: PersistentStorage<I>,
+{
+    /// Update the value if it has changed.
+    ///
+    /// Change logging and dependent task execution will only fire if the value changed.
+    pub fn set(&self, value: T) {
+        self.acl.assert_write_access(&self.id);
+
+        // nop?
+        if self
+            .value
+            .read()
+            .as_ref()
+            .map(|arc| **arc == value)
+            .unwrap_or(false)
+        {
+            return;
+        }
+
+        self.set_unconditionally(value);
+    }
+}
+
+/// Clones are cheap and reference the same wrapped item courtesy of Arc
+///
+/// Courtesy of Arc this is Clone even if T isn't
+#[derive(Default)]
+pub struct ContextMap<I, T, P>
+where
+    I: Identifier,
+    T: IdAware<I>,
+    P: PersistentStorage<I>,
+{
+    acl: Arc<AccessControlList<I>>,
+    persistent_storage: Arc<P>,
+    value: Arc<RwLock<HashMap<I, Arc<T>>>>,
+}
+
+impl<I, T, P> ContextMap<I, T, P>
+where
+    I: Identifier,
+    T: IdAware<I> + Persistable,
+    P: PersistentStorage<I>,
+{
+    pub fn new(acl: Arc<AccessControlList<I>>, persistent_storage: Arc<P>) -> Self {
+        ContextMap {
+            acl,
+            persistent_storage,
+            value: Default::default(),
+        }
+    }
+
+    pub fn clone_with_acl(&self, acl: Arc<AccessControlList<I>>) -> Self {
+        ContextMap {
+            acl,
+            persistent_storage: self.persistent_storage.clone(),
+            value: self.value.clone(),
+        }
+    }
+
+    /// Read an item that might not exist
+    pub fn try_get(&self, id: &I) -> Option<Arc<T>> {
+        self.acl.assert_read_access(id);
+        self.value.read().get(id).cloned()
+    }
+
+    /// Read item that you are sure must exist. Panic if not.
+    ///
+    /// Intended for use in [Work] to access items present in
+    /// [Work::read_access]. If these are missing something is horribly
+    /// wrong and we should kerplode.
+    pub fn get(&self, id: &I) -> Arc<T> {
+        if let Some(in_memory) = self.try_get(id) {
+            return in_memory;
+        }
+
+        // it's *not* in memory but perhaps it's written down?
+        if self.persistent_storage.active() {
+            if let Some(mut reader) = self.persistent_storage.reader(id) {
+                let restored = T::read(&mut reader);
+                self.value.write().insert(id.clone(), Arc::from(restored));
+            }
+        }
+
+        // if we still don't have an answer just give up
+        self.try_get(id)
+            .unwrap_or_else(|| panic!("{:?} is not available", id))
+    }
+}
+
+impl<I, T, Ir> ContextMap<I, T, Ir>
+where
+    I: Identifier,
+    T: IdAware<I> + Persistable,
+    Ir: PersistentStorage<I>,
+{
+    pub fn set_unconditionally(&self, value: T) {
+        let key = value.id();
+        self.acl.assert_write_access(&key);
+
+        if self.persistent_storage.active() {
+            let mut writer = self.persistent_storage.writer(&key);
+            value.write(&mut writer);
+        }
+
+        self.value.write().insert(key, Arc::from(value));
+    }
+}
+
+impl<I, T, Ir> ContextMap<I, T, Ir>
+where
+    I: Identifier,
+    T: IdAware<I> + PartialEq + Persistable,
+    Ir: PersistentStorage<I>,
+{
+    pub fn set(&self, value: T) {
+        let key = value.id();
+        self.acl.assert_write_access(&key);
+
+        // nop?
+        if self
+            .value
+            .read()
+            .get(&key)
+            .map(|arc| **arc == value)
+            .unwrap_or(false)
+        {
+            return;
+        }
+
+        self.set_unconditionally(value);
+    }
+}
+
+pub trait IdAware<I> {
+    fn id(&self) -> I;
+}
+
+pub trait Persistable {
+    fn read(from: &mut dyn Read) -> Self;
+    fn write(&self, to: &mut dyn Write);
+}
+
+/// Reads and writes to somewhere that lives longer than processes.
+///
+/// This enables the compiler to restore state from prior executions which is
+/// crucial to incremental operation.
+pub trait PersistentStorage<I> {
+    fn active(&self) -> bool;
+    /// None if there is nothing written down for id
+    fn reader(&self, id: &I) -> Option<Box<dyn Read>>;
+    fn writer(&self, id: &I) -> Box<dyn Write>;
+}
+
 // Unique identifier of work. If there are no fields work is unique.
 // Meant to be small and cheap to copy around.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum WorkId {
     /// Build the initial static metadata.
-    InitStaticMetadata,
+    ///
+    /// Contains all names, axes, etc. Does NOT contain the final glyph order.
+    StaticMetadata,
     /// Build potentially variable font-wide metrics.
     GlobalMetrics,
     Glyph(GlyphName),
     GlyphIrDelete(GlyphName),
-    /// Update static metadata based on what we learned from IR
+    /// Glyph order from source, prior to adjustment
     ///
-    /// Notably, IR glyphs with both components and paths may split into multiple
-    /// BE glyphs so the glyph order may change.
-    FinalizeStaticMetadata,
+    /// Typically whatever2ir would populate this and then
+    /// it would be used to produce GlyphOrder.
+    ///
+    /// Most things should use GlyphOrder not this.
+    PreliminaryGlyphOrder,
+    /// The final glyph order. Most things that need glyph order should rely on this.
+    GlyphOrder,
     Features,
     Kerning,
 }
 
+impl Identifier for WorkId {}
+
 pub type IrWork = dyn Work<Context, WorkId, WorkError> + Send;
+
+pub struct IrPersistentStorage {
+    active: bool,
+    pub(crate) paths: Paths,
+}
+
+impl PersistentStorage<WorkId> for IrPersistentStorage {
+    fn active(&self) -> bool {
+        self.active
+    }
+
+    fn reader(&self, id: &WorkId) -> Option<Box<dyn Read>> {
+        let file = self.paths.target_file(id);
+        if !file.exists() {
+            return None;
+        }
+        let raw_file = File::open(file.clone())
+            .map_err(|e| panic!("Unable to write {file:?} {e}"))
+            .unwrap();
+        Some(Box::from(BufReader::new(raw_file)))
+    }
+
+    fn writer(&self, id: &WorkId) -> Box<dyn Write> {
+        let file = self.paths.target_file(id);
+        let raw_file = File::create(file.clone())
+            .map_err(|e| panic!("Unable to write {file:?} {e}"))
+            .unwrap();
+        Box::from(BufWriter::new(raw_file))
+    }
+}
+
+type FeContextItem<T> = ContextItem<WorkId, T, IrPersistentStorage>;
+type FeContextMap<T> = ContextMap<WorkId, T, IrPersistentStorage>;
 
 /// Read/write access to data for async work.
 ///
@@ -119,22 +355,21 @@ pub type IrWork = dyn Work<Context, WorkId, WorkError> + Send;
 pub struct Context {
     pub flags: Flags,
 
-    pub(crate) paths: Arc<Paths>,
+    pub(crate) persistent_storage: Arc<IrPersistentStorage>,
 
     // The input we're working on. Note that change detection may mean we only process
     // a subset of the full input.
     pub input: Arc<Input>,
 
-    acl: AccessControlList<WorkId>,
-
     // work results we've completed or restored from disk
     // We create individual caches so we can return typed results from get fns
-    init_static_metadata: ContextItem<ir::StaticMetadata>,
-    final_static_metadata: ContextItem<ir::StaticMetadata>,
-    global_metrics: ContextItem<ir::GlobalMetrics>,
-    glyph_ir: Arc<RwLock<HashMap<GlyphName, Arc<ir::Glyph>>>>,
-    feature_ir: ContextItem<ir::Features>,
-    kerning: ContextItem<ir::Kerning>,
+    pub static_metadata: FeContextItem<ir::StaticMetadata>,
+    pub preliminary_glyph_order: FeContextItem<ir::GlyphOrder>,
+    pub glyph_order: FeContextItem<ir::GlyphOrder>,
+    pub global_metrics: FeContextItem<ir::GlobalMetrics>,
+    pub glyphs: FeContextMap<ir::Glyph>,
+    pub features: FeContextItem<ir::Features>,
+    pub kerning: FeContextItem<ir::Kerning>,
 }
 
 pub fn set_cached<T>(lock: &Arc<RwLock<Option<Arc<T>>>>, value: T) {
@@ -144,32 +379,54 @@ pub fn set_cached<T>(lock: &Arc<RwLock<Option<Arc<T>>>>, value: T) {
 
 impl Context {
     fn copy(&self, acl: AccessControlList<WorkId>) -> Context {
+        let acl = Arc::from(acl);
         Context {
             flags: self.flags,
-            paths: self.paths.clone(),
+            persistent_storage: self.persistent_storage.clone(),
             input: self.input.clone(),
-            acl,
-            init_static_metadata: self.init_static_metadata.clone(),
-            final_static_metadata: self.final_static_metadata.clone(),
-            global_metrics: self.global_metrics.clone(),
-            glyph_ir: self.glyph_ir.clone(),
-            feature_ir: self.feature_ir.clone(),
-            kerning: self.kerning.clone(),
+            static_metadata: self.static_metadata.clone_with_acl(acl.clone()),
+            preliminary_glyph_order: self.preliminary_glyph_order.clone_with_acl(acl.clone()),
+            glyph_order: self.glyph_order.clone_with_acl(acl.clone()),
+            global_metrics: self.global_metrics.clone_with_acl(acl.clone()),
+            glyphs: self.glyphs.clone_with_acl(acl.clone()),
+            features: self.features.clone_with_acl(acl.clone()),
+            kerning: self.kerning.clone_with_acl(acl),
         }
     }
 
     pub fn new_root(flags: Flags, paths: Paths, input: Input) -> Context {
+        let acl = Arc::from(AccessControlList::read_only());
+        let persistent_storage = Arc::from(IrPersistentStorage {
+            active: flags.contains(Flags::EMIT_IR),
+            paths,
+        });
         Context {
             flags,
-            paths: Arc::from(paths),
+            persistent_storage: persistent_storage.clone(),
             input: Arc::from(input),
-            acl: AccessControlList::read_only(),
-            init_static_metadata: Arc::from(RwLock::new(None)),
-            final_static_metadata: Arc::from(RwLock::new(None)),
-            global_metrics: Arc::from(RwLock::new(None)),
-            glyph_ir: Arc::from(RwLock::new(HashMap::new())),
-            feature_ir: Arc::from(RwLock::new(None)),
-            kerning: Arc::from(RwLock::new(None)),
+            static_metadata: ContextItem::new(
+                WorkId::StaticMetadata,
+                acl.clone(),
+                persistent_storage.clone(),
+            ),
+            preliminary_glyph_order: ContextItem::new(
+                WorkId::PreliminaryGlyphOrder,
+                acl.clone(),
+                persistent_storage.clone(),
+            ),
+            glyph_order: ContextItem::new(
+                WorkId::GlyphOrder,
+                acl.clone(),
+                persistent_storage.clone(),
+            ),
+            global_metrics: ContextItem::new(
+                WorkId::GlobalMetrics,
+                acl.clone(),
+                persistent_storage.clone(),
+            ),
+            glyphs: ContextMap::new(acl.clone(), persistent_storage.clone()),
+            features: ContextItem::new(WorkId::Features, acl.clone(), persistent_storage.clone()),
+            kerning: ContextItem::new(WorkId::Kerning, acl, persistent_storage),
         }
     }
 
@@ -183,78 +440,5 @@ impl Context {
 
     pub fn read_only(&self) -> Context {
         self.copy(AccessControlList::read_only())
-    }
-
-    fn maybe_persist<V>(&self, file: &Path, content: &V)
-    where
-        V: ?Sized + Serialize + Debug,
-    {
-        if !self.flags.contains(Flags::EMIT_IR) {
-            return;
-        }
-        self.persist(file, content);
-    }
-
-    fn persist<V>(&self, file: &Path, content: &V)
-    where
-        V: ?Sized + Serialize + Debug,
-    {
-        let raw_file = File::create(file)
-            .map_err(|e| panic!("Unable to write {file:?} {e}"))
-            .unwrap();
-        let buf_io = BufWriter::new(raw_file);
-        serde_yaml::to_writer(buf_io, &content)
-            .map_err(|e| panic!("Unable to serialize\n{content:#?}\nto {file:?}: {e}"))
-            .unwrap();
-    }
-
-    fn set_cached_glyph(&self, ir: ir::Glyph) {
-        let mut wl = self.glyph_ir.write();
-        wl.insert(ir.name.clone(), Arc::from(ir));
-    }
-
-    pub fn get_glyph_ir(&self, glyph_name: &GlyphName) -> Arc<ir::Glyph> {
-        let id = WorkId::Glyph(glyph_name.clone());
-        self.acl.assert_read_access(&id);
-        {
-            let rl = self.glyph_ir.read();
-            if let Some(glyph) = rl.get(glyph_name) {
-                return glyph.clone();
-            }
-        }
-        self.set_cached_glyph(restore(&self.paths.target_file(&id)));
-        let rl = self.glyph_ir.read();
-        rl.get(glyph_name).expect(MISSING_DATA).clone()
-    }
-
-    pub fn set_glyph_ir(&self, ir: ir::Glyph) {
-        let id = WorkId::Glyph(ir.name.clone());
-        self.acl.assert_write_access(&id);
-        self.maybe_persist(&self.paths.target_file(&id), &ir);
-        self.set_cached_glyph(ir);
-    }
-
-    context_accessors! { get_init_static_metadata, set_init_static_metadata, has_init_static_metadata, init_static_metadata, ir::StaticMetadata, WorkId::InitStaticMetadata, restore, nop }
-    context_accessors! { get_final_static_metadata, set_final_static_metadata, has_final_static_metadata, final_static_metadata, ir::StaticMetadata, WorkId::FinalizeStaticMetadata, restore, nop }
-    context_accessors! { get_global_metrics, set_global_metrics, has_global_metrics, global_metrics, ir::GlobalMetrics, WorkId::GlobalMetrics, restore, nop }
-    context_accessors! { get_features, set_features, has_feature_ir, feature_ir, ir::Features, WorkId::Features, restore, nop }
-    context_accessors! { get_kerning, set_kerning, has_kerning, kerning, ir::Kerning, WorkId::Kerning, restore, nop }
-}
-
-fn nop<T>(v: &T) -> &T {
-    v
-}
-
-fn restore<V>(file: &Path) -> V
-where
-    V: ?Sized + DeserializeOwned,
-{
-    let raw_file = File::open(file)
-        .map_err(|e| panic!("Unable to read {file:?} {e}"))
-        .unwrap();
-    let buf_io = BufReader::new(raw_file);
-    match serde_yaml::from_reader(buf_io) {
-        Ok(v) => v,
-        Err(e) => panic!("Unable to deserialize {file:?} {e}"),
     }
 }

--- a/fontir/src/paths.rs
+++ b/fontir/src/paths.rs
@@ -43,8 +43,9 @@ impl Paths {
 
     pub fn target_file(&self, id: &WorkId) -> PathBuf {
         match id {
-            WorkId::InitStaticMetadata => self.build_dir.join("static_metadata.preliminary.yml"),
-            WorkId::FinalizeStaticMetadata => self.build_dir.join("static_metadata.yml"),
+            WorkId::StaticMetadata => self.build_dir.join("static_metadata.yml"),
+            WorkId::PreliminaryGlyphOrder => self.build_dir.join("glyph_order.preliminary.yml"),
+            WorkId::GlyphOrder => self.build_dir.join("glyph_order.yml"),
             WorkId::GlobalMetrics => self.build_dir.join("global_metrics.yml"),
             WorkId::Glyph(name) => self.glyph_ir_file(name.as_str()),
             WorkId::GlyphIrDelete(name) => {

--- a/fontir/src/serde.rs
+++ b/fontir/src/serde.rs
@@ -13,8 +13,8 @@ use write_fonts::tables::os2::SelectionFlags;
 use crate::{
     coords::{CoordConverter, DesignCoord, NormalizedLocation, UserCoord},
     ir::{
-        Axis, GlobalMetric, GlobalMetrics, Glyph, GlyphBuilder, GlyphInstance, KernParticipant,
-        Kerning, MiscMetadata, NameKey, NamedInstance, StaticMetadata,
+        Axis, GlobalMetric, GlobalMetrics, Glyph, GlyphBuilder, GlyphInstance, GlyphOrder,
+        KernParticipant, Kerning, MiscMetadata, NameKey, NamedInstance, StaticMetadata,
     },
     stateset::{FileState, MemoryState, State, StateIdentifier, StateSet},
 };
@@ -60,7 +60,6 @@ pub struct StaticMetadataSerdeRepr {
     pub glyph_locations: Vec<NormalizedLocation>,
     pub names: HashMap<NameKey, String>,
     pub misc: MiscSerdeRepr,
-    pub glyph_order: Vec<String>,
 }
 
 impl From<StaticMetadataSerdeRepr> for StaticMetadata {
@@ -70,7 +69,6 @@ impl From<StaticMetadataSerdeRepr> for StaticMetadata {
             from.names,
             from.axes,
             from.named_instances,
-            from.glyph_order.into_iter().map(|s| s.into()).collect(),
             from.glyph_locations.into_iter().collect(),
         )
         .unwrap()
@@ -87,12 +85,22 @@ impl From<StaticMetadata> for StaticMetadataSerdeRepr {
             glyph_locations,
             names: from.names,
             misc: from.misc.into(),
-            glyph_order: from
-                .glyph_order
-                .into_iter()
-                .map(|n| n.as_str().to_string())
-                .collect(),
         }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct GlyphOrderSerdeRepr(Vec<String>);
+
+impl From<GlyphOrderSerdeRepr> for GlyphOrder {
+    fn from(value: GlyphOrderSerdeRepr) -> Self {
+        value.0.into_iter().map(|v| v.into()).collect()
+    }
+}
+
+impl From<GlyphOrder> for GlyphOrderSerdeRepr {
+    fn from(value: GlyphOrder) -> Self {
+        GlyphOrderSerdeRepr(value.into_iter().map(|v| v.to_string()).collect())
     }
 }
 

--- a/fontir/src/source.rs
+++ b/fontir/src/source.rs
@@ -15,6 +15,7 @@ use crate::{
 };
 
 /// Destroy a file, such as the IR for a deleted glyph
+#[derive(Debug)]
 pub struct DeleteWork {
     glyph_name: GlyphName,
 }
@@ -31,7 +32,7 @@ impl Work<Context, WorkId, WorkError> for DeleteWork {
     }
 
     fn exec(&self, context: &Context) -> Result<(), WorkError> {
-        let path = context.paths.target_file(&self.id());
+        let path = context.persistent_storage.paths.target_file(&self.id());
         debug!("Delete {:#?}", path);
         if path.exists() {
             fs::remove_file(&path).map_err(WorkError::IoError)?

--- a/glyphs2fontir/src/toir.rs
+++ b/glyphs2fontir/src/toir.rs
@@ -220,6 +220,7 @@ fn ir_axes(font: &Font) -> Result<Vec<ir::Axis>, Error> {
 }
 
 /// A [Font] with some prework to convert to IR predone.
+#[derive(Debug)]
 pub struct FontInfo {
     pub font: Font,
     /// Index by master id


### PR DESCRIPTION
Large but mostly boring cleanup. Took longer than I care to admit to get everything wired up and working again :D

Move the knowledge of read/write access to the work. Define dependencies in terms of read access: if you can read it you depend on it and therefore must happen after it. Eliminate separate storage of dependencies, it was duplicative and quite weird when inconsistent with read_access.

Eliminate the macro for Context items, preferring to instead write reusable types ContextItem and ContextMap, as @cmyr once suggested.

Files (there are several) named orchestration.rs are probably the most interesting part; the rest is essentially repetitive updates to match the new interfaces. I would start with `fontdrasil/src/orchestration.rs`, then `fontir/src/orchestration.rs` and finally `fontbe/src/orchestration.rs`.