### PR TITLE
bump fea-rs dep to 0.9.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ env_logger = "0.10.0"
 
 parking_lot = "0.12.1"
 
-fea-rs = "0.9.0"
+fea-rs = "0.9.1"
 font-types = { version = "0.3.2", features = ["serde"] }
 read-fonts = "0.7.0"
 write-fonts = "0.10.1"


### PR DESCRIPTION
should fix some issues compiling GoogleSans, see https://github.com/googlefonts/googlesans/issues/586#issuecomment-1613351936

JMM