### PR TITLE
Read with timeout instead of blocking

### DIFF
--- a/fontc/src/error.rs
+++ b/fontc/src/error.rs
@@ -23,4 +23,8 @@ pub enum Error {
     BadRegex(#[from] regex::Error),
     #[error("Unable to proceed")]
     UnableToProceed,
+    // Not sure what the best message is, for this; it probably means that
+    // a thread has panicked?
+    #[error("A task stopped responding unexpectedly")]
+    InternalError,
 }


### PR DESCRIPTION
Previously we were using a blocking read to wait for completions, which would deadlock if a worker thread had panicked.

Now we will read in a loop, and return an error if we timeout.

I've arbitrarily decided that ten seconds is a reasoanble timeout interval, but it might not be! We also may wish to make this setting configurable.

With this, we will no longer hang (#365) although I do think we should look into better handling of panics (and I'm going to poke at that a bit more, now)