### PR TITLE
Include source info when writing logs

### DIFF
--- a/fontc/src/main.rs
+++ b/fontc/src/main.rs
@@ -12,9 +12,9 @@ fn main() -> Result<(), Error> {
             let ts = buf.timestamp_micros();
             writeln!(
                 buf,
-                "{}: {:?}: {}: {}",
-                ts,
+                "[{ts} {:?} {} {}] {}",
                 std::thread::current().id(),
+                record.target(),
                 buf.default_level_style(record.level())
                     .value(record.level()),
                 record.args()


### PR DESCRIPTION
I'm not sure if this is contentious or not?

Before:
2023-07-12T15:59:18.091023Z: ThreadId(1): DEBUG: 7624 glyphs identified After:
[2023-07-12T15:58:38.552647Z ThreadId(1) ufo2fontir::source DEBUG] 7624 glyphs identified`

So this is slightly more verbose, but knowing where a message was logged from is very helpful when debugging. If we want to shave more characters we can use millis instead of micros in the timestamp, and assign custom thread names in the threadpool.