### PR TITLE
Remove most impls of From<&T>

### DIFF
--- a/fontbe/src/glyphs.rs
+++ b/fontbe/src/glyphs.rs
@@ -272,7 +272,7 @@ impl Work<Context, AnyWorkId, Error> for GlyphWork {
             .ir
             .glyphs
             .get(&FeWorkId::Glyph(self.glyph_name.clone()));
-        let glyph: CheckedGlyph = ir_glyph.try_into()?;
+        let glyph = CheckedGlyph::new(ir_glyph)?;
 
         // Hopefully in time https://github.com/harfbuzz/boring-expansion-spec means we can drop this
         let glyph = cubics_to_quadratics(glyph);
@@ -497,18 +497,7 @@ enum CheckedGlyph {
 }
 
 impl CheckedGlyph {
-    fn should_iup(&self) -> bool {
-        match self {
-            CheckedGlyph::Composite { .. } => false,
-            CheckedGlyph::Contour { .. } => true,
-        }
-    }
-}
-
-impl TryFrom<&ir::Glyph> for CheckedGlyph {
-    type Error = Error;
-
-    fn try_from(glyph: &ir::Glyph) -> Result<Self, Self::Error> {
+    fn new(glyph: &ir::Glyph) -> Result<Self, Error> {
         // every instance must have consistent component glyphs
         let components: HashSet<BTreeSet<GlyphName>> = glyph
             .sources()
@@ -606,6 +595,13 @@ impl TryFrom<&ir::Glyph> for CheckedGlyph {
                 .collect();
             CheckedGlyph::Composite { name, components }
         })
+    }
+
+    fn should_iup(&self) -> bool {
+        match self {
+            CheckedGlyph::Composite { .. } => false,
+            CheckedGlyph::Contour { .. } => true,
+        }
     }
 }
 

--- a/fontc/src/workload.rs
+++ b/fontc/src/workload.rs
@@ -154,10 +154,10 @@ impl<'a> Workload<'a> {
         match &job.read_access {
             AnyAccess::Fe(access) => match access {
                 Access::None => true,
-                Access::One(id) => !self.jobs_pending.contains_key(&id.into()),
+                Access::One(id) => !self.jobs_pending.contains_key(&id.clone().into()),
                 Access::Set(ids) => !ids
                     .iter()
-                    .any(|id| self.jobs_pending.contains_key(&id.into())),
+                    .any(|id| self.jobs_pending.contains_key(&id.clone().into())),
                 Access::Custom(..) => self.can_run_scan(job),
                 Access::All => self.can_run_scan(job),
             },

--- a/fontdrasil/src/types.rs
+++ b/fontdrasil/src/types.rs
@@ -20,12 +20,6 @@ impl GlyphName {
     }
 }
 
-impl From<&String> for GlyphName {
-    fn from(value: &String) -> Self {
-        GlyphName(value.into())
-    }
-}
-
 impl From<String> for GlyphName {
     fn from(value: String) -> Self {
         GlyphName(value.into())

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -960,16 +960,6 @@ impl TryInto<Glyph> for GlyphBuilder {
     }
 }
 
-impl From<&Glyph> for GlyphBuilder {
-    fn from(value: &Glyph) -> Self {
-        Self {
-            name: value.name.clone(),
-            codepoints: value.codepoints.clone(),
-            sources: value.sources.clone(),
-        }
-    }
-}
-
 impl From<Glyph> for GlyphBuilder {
     fn from(value: Glyph) -> Self {
         Self {

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -49,7 +49,7 @@ fn glyph_states(font: &Font) -> Result<HashMap<GlyphName, StateSet>, Error> {
     for (glyphname, glyph) in font.glyphs.iter() {
         let mut state = StateSet::new();
         state.track_memory(glyph_identifier(glyphname), glyph)?;
-        glyph_states.insert(glyphname.into(), state);
+        glyph_states.insert(glyphname.as_str().into(), state);
     }
 
     Ok(glyph_states)
@@ -379,7 +379,7 @@ impl Work<Context, WorkId, WorkError> for StaticMetadataWork {
         let glyph_order = font
             .glyph_order
             .iter()
-            .map(|s| s.into())
+            .map(|s| s.as_str().into())
             .filter(|gn| self.glyph_names.contains(gn))
             .collect();
         context.preliminary_glyph_order.set(glyph_order);
@@ -537,7 +537,7 @@ fn kern_participant(
                 side.group_prefix(),
                 raw_side.strip_prefix(side.class_prefix()).unwrap()
             );
-            let group = GroupName::from(&group_name);
+            let group = GroupName::from(group_name.as_str());
             if groups.contains_key(&group) {
                 Some(KernParticipant::Group(group))
             } else {

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -129,7 +129,7 @@ pub(crate) fn layer_dir<'a>(
     let glyph_name = source
         .layer
         .as_ref()
-        .map_or_else(GlyphName::empty, |l| l.into());
+        .map_or_else(GlyphName::empty, |l| l.as_str().into());
     if source.layer.is_none() {
         name_to_path.insert(glyph_name.clone(), PathBuf::from("glyphs"));
     }


### PR DESCRIPTION
These impls fell into one of two categories: they were either wrapping a call to clone, or they were doing acting as general constructors.

In the cases where they were wrapping a clone call, I just moved the 'clone' to the callsite. In the cases where they were acting as general constructors, I moved them into `new` methods.