### PR TITLE
Update fea-rs/fontations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,11 @@ env_logger = "0.10.0"
 
 parking_lot = "0.12.1"
 
-fea-rs = "0.10.0"
-font-types = { version = "0.3.3", features = ["serde"] }
-read-fonts = "0.8.0"
-write-fonts = "0.11.0"
-skrifa = "0.7.0"
+fea-rs = "0.11.0"
+font-types = { version = "0.3.4", features = ["serde"] }
+read-fonts = "0.9.0"
+write-fonts = "0.12.0"
+skrifa = "0.8.0"
 
 bitflags = "2.0"
 chrono = { version = "0.4.24", features = ["serde"] }


### PR DESCRIPTION
With this update, fea-rs is capable of writing out the ItemVariationStore.

@rsheeter maybe rebase #373 on top of this? I've tried patching it and I'm getting I still have one test failure, but with a new message I haven't investigated yet.