### PR TITLE
[ufo2fontir] Fix for optional designspace names

### DIFF
--- a/ufo2fontir/Cargo.toml
+++ b/ufo2fontir/Cargo.toml
@@ -33,7 +33,7 @@ quick-xml.workspace = true
 chrono.workspace = true
 
 # unique to me!
-norad = "0.10.2"
+norad = "0.11"
 plist = { version =  "1.3.1", features = ["serde"] }
 
 [dev-dependencies]

--- a/ufo2fontir/src/toir.rs
+++ b/ufo2fontir/src/toir.rs
@@ -97,7 +97,7 @@ pub fn master_locations(
         .iter()
         .map(|s| {
             (
-                s.name.clone(),
+                s.name.clone().unwrap(),
                 to_design_location(&tags_by_name, &s.location).to_normalized(&axes),
             )
         })


### PR DESCRIPTION
The upstream API has changed to make the 'name' fields on instance/source types optional. This patch is the minimal fix, where we check all names on load and insert placeholders if they are missing.

An alternative solution might be to use something other than the name to uniquely identify these objects.


This is a draft as the upstream PR (https://github.com/linebender/norad/pull/313) has not yet been merged.