### PR TITLE
Restore fine-grained glyph work dependencies

### DIFF
--- a/fontbe/src/glyphs.rs
+++ b/fontbe/src/glyphs.rs
@@ -240,15 +240,13 @@ impl Work<Context, AnyWorkId, Error> for GlyphWork {
         WorkId::GlyfFragment(self.glyph_name.clone()).into()
     }
 
+    /// We need to block on all our components, but we don't know them yet.
+    ///
+    /// We could block on ALL IR glyphs, but that triggers inefficient behavior in workload.rs.
+    /// Instead, start in a hard block and update upon success of the corresponding IR job.
+    /// See fontc, workload.rs, handle_success.
     fn read_access(&self) -> Access<AnyWorkId> {
-        Access::Custom(Arc::new(|id| {
-            matches!(
-                id,
-                AnyWorkId::Fe(FeWorkId::StaticMetadata)
-                    | AnyWorkId::Fe(FeWorkId::GlyphOrder)
-                    | AnyWorkId::Fe(FeWorkId::Glyph(..))
-            )
-        }))
+        Access::Unknown
     }
 
     fn write_access(&self) -> Access<AnyWorkId> {

--- a/fontdrasil/src/orchestration.rs
+++ b/fontdrasil/src/orchestration.rs
@@ -17,8 +17,11 @@ pub trait Identifier: Debug + Clone + Eq + Hash {}
 /// A rule that represents whether access to something is permitted.
 #[derive(Clone)]
 pub enum Access<I: Identifier> {
-    /// No access is permitted
+    /// Nothing is accessed
     None,
+    /// Access requirements not yet known. Intended to be used when what access is needed
+    /// isn't initially known. Once known, access will change to some other option.
+    Unknown,
     /// Any access is permitted
     All,
     /// Access to one specific resource is permitted
@@ -33,6 +36,7 @@ impl<I: Identifier> Debug for Access<I> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::None => write!(f, "None"),
+            Self::Unknown => write!(f, "Unknown"),
             Self::All => write!(f, "All"),
             Self::One(arg0) => f.debug_tuple("One").field(arg0).finish(),
             Self::Set(arg0) => f.debug_tuple("Set").field(arg0).finish(),
@@ -154,6 +158,7 @@ impl<I: Identifier> Access<I> {
     pub fn check(&self, id: &I) -> bool {
         match self {
             Access::None => false,
+            Access::Unknown => false,
             Access::All => true,
             Access::One(allow) => id == allow,
             Access::Set(ids) => ids.contains(id),


### PR DESCRIPTION
#359 changed BE glyph work from depending on only the IR glyphs used to all IR glyphs. This forces the can run check to take a slow path (table scan) due to use of Access::Custom and inhibits concurrent execution of FE and BE glyphs.

This PR late-binds dependencies for BE glyph work. Initially access unknown - never runnable - is used and then, once the corresponding IR glyph is done, a set of the specific dependencies is used. This should be faster to evaluate runnable on and re-enable concurrent FE/BE glyph work executions.

Intended to partially address #369. 

#369 doesn't offer complete steps to reproduce but it appears to be roughly `time fontc GS designspace`. My tests and results follow (some noise from cli omitted, measured on an M1 Mac):

**Oswald 2.415s => 1.302s**

```shell
$ for br in conc main; do git checkout $br && cargo build --release && rm -rf build/ && time target/release/fontc --source ../OswaldFont/sources/Oswald.glyphs --emit-ir false; done

Switched to branch 'conc'

real	0m2.451s
user	0m0.104s
sys	0m0.019s
Switched to branch 'main'

real	0m1.302s
user	0m0.212s
sys	0m0.026s
```

Fixes #369 per https://github.com/googlefonts/fontc/pull/380#issuecomment-1669920774
