### PR TITLE
Use fontations Glyph enum

### DIFF
--- a/fontbe/src/glyphs.rs
+++ b/fontbe/src/glyphs.rs
@@ -22,7 +22,7 @@ use read_fonts::{
 };
 use write_fonts::{
     tables::{
-        glyf::{Bbox, Component, ComponentFlags, CompositeGlyph, SimpleGlyph},
+        glyf::{Bbox, Component, ComponentFlags, CompositeGlyph, Glyph, SimpleGlyph},
         variations::iup_delta_optimize,
     },
     OtRound,
@@ -30,7 +30,7 @@ use write_fonts::{
 
 use crate::{
     error::{Error, GlyphProblem},
-    orchestration::{AnyWorkId, BeWork, Context, Glyph, GvarFragment, LocaFormat, WorkId},
+    orchestration::{AnyWorkId, BeWork, Context, GvarFragment, LocaFormat, NamedGlyph, WorkId},
 };
 
 #[derive(Debug)]
@@ -281,7 +281,7 @@ impl Work<Context, AnyWorkId, Error> for GlyphWork {
                 let composite = create_composite(context, ir_glyph, default_location, &components)?;
                 context
                     .glyphs
-                    .set_unconditionally(Glyph::new_composite(name.clone(), composite));
+                    .set_unconditionally(NamedGlyph::new(name.clone(), composite));
                 let point_seqs = point_seqs_for_composite_glyph(ir_glyph);
                 (name, point_seqs, Vec::new())
             }
@@ -309,7 +309,7 @@ impl Work<Context, AnyWorkId, Error> for GlyphWork {
                 };
                 context
                     .glyphs
-                    .set_unconditionally(Glyph::new_simple(name.clone(), base_glyph.clone()));
+                    .set_unconditionally(NamedGlyph::new(name.clone(), base_glyph.clone()));
 
                 let mut contour_end = 0;
                 let mut contour_ends = Vec::with_capacity(base_glyph.contours().len());
@@ -661,7 +661,7 @@ fn compute_composite_bboxes(context: &Context) -> Result<(), Error> {
     let mut bbox_acquired: HashMap<GlyphName, Rect> = HashMap::new();
     let mut composites = glyphs
         .values()
-        .filter(|glyph| matches!(glyph.as_ref(), Glyph::Composite(..)))
+        .filter(|glyph| !glyph.is_simple())
         .collect::<Vec<_>>();
 
     trace!("Resolve bbox for {} composites", composites.len());
@@ -670,9 +670,11 @@ fn compute_composite_bboxes(context: &Context) -> Result<(), Error> {
 
         // Hopefully we can figure out some of those bboxes!
         for composite in composites.iter() {
-            let Glyph::Composite(glyph_name, composite) = composite.as_ref() else {
+            let glyph_name = &composite.name;
+            let Glyph::Composite(composite) = &composite.glyph else {
                 panic!("Only composites should be in our vector of composites!!");
             };
+
             let mut missing_boxes = false;
             let boxes: Vec<_> = composite
                 .components()
@@ -686,9 +688,9 @@ fn compute_composite_bboxes(context: &Context) -> Result<(), Error> {
                         glyphs
                             .get(ref_glyph_name)
                             .map(|g| g.as_ref().clone())
-                            .and_then(|g| match g {
+                            .and_then(|g| match &g.glyph {
                                 Glyph::Composite(..) => None,
-                                Glyph::Simple(_, simple_glyph) => Some(bbox2rect(simple_glyph.bbox)),
+                                Glyph::Simple(simple_glyph) => Some(bbox2rect(simple_glyph.bbox)),
                             })
                     });
                     if bbox.is_none() {
@@ -715,7 +717,7 @@ fn compute_composite_bboxes(context: &Context) -> Result<(), Error> {
         }
 
         // Kerplode if we didn't make any progress this spin
-        composites.retain(|composite| !bbox_acquired.contains_key(composite.glyph_name()));
+        composites.retain(|composite| !bbox_acquired.contains_key(&composite.name));
         if pending == composites.len() {
             panic!("Unable to make progress on composite bbox, stuck at\n{composites:?}");
         }
@@ -727,7 +729,7 @@ fn compute_composite_bboxes(context: &Context) -> Result<(), Error> {
             .glyphs
             .get(&WorkId::GlyfFragment(glyph_name.clone()).into()))
         .clone();
-        let Glyph::Composite(_, composite) = &mut glyph else {
+        let Glyph::Composite(composite) = &mut glyph.glyph else {
             panic!("{glyph_name} is not a composite; we shouldn't be trying to update it");
         };
         composite.bbox = bbox.into(); // delay conversion to Bbox to avoid accumulating rounding error

--- a/fontbe/src/glyphs.rs
+++ b/fontbe/src/glyphs.rs
@@ -22,7 +22,7 @@ use read_fonts::{
 };
 use write_fonts::{
     tables::{
-        glyf::{Bbox, Component, ComponentFlags, CompositeGlyph, Glyph, SimpleGlyph},
+        glyf::{Bbox, Component, ComponentFlags, CompositeGlyph, Glyph as RawGlyph, SimpleGlyph},
         variations::iup_delta_optimize,
     },
     OtRound,
@@ -30,7 +30,7 @@ use write_fonts::{
 
 use crate::{
     error::{Error, GlyphProblem},
-    orchestration::{AnyWorkId, BeWork, Context, GvarFragment, LocaFormat, NamedGlyph, WorkId},
+    orchestration::{AnyWorkId, BeWork, Context, Glyph, GvarFragment, LocaFormat, WorkId},
 };
 
 #[derive(Debug)]
@@ -281,7 +281,7 @@ impl Work<Context, AnyWorkId, Error> for GlyphWork {
                 let composite = create_composite(context, ir_glyph, default_location, &components)?;
                 context
                     .glyphs
-                    .set_unconditionally(NamedGlyph::new(name.clone(), composite));
+                    .set_unconditionally(Glyph::new(name.clone(), composite));
                 let point_seqs = point_seqs_for_composite_glyph(ir_glyph);
                 (name, point_seqs, Vec::new())
             }
@@ -309,7 +309,7 @@ impl Work<Context, AnyWorkId, Error> for GlyphWork {
                 };
                 context
                     .glyphs
-                    .set_unconditionally(NamedGlyph::new(name.clone(), base_glyph.clone()));
+                    .set_unconditionally(Glyph::new(name.clone(), base_glyph.clone()));
 
                 let mut contour_end = 0;
                 let mut contour_ends = Vec::with_capacity(base_glyph.contours().len());
@@ -671,7 +671,7 @@ fn compute_composite_bboxes(context: &Context) -> Result<(), Error> {
         // Hopefully we can figure out some of those bboxes!
         for composite in composites.iter() {
             let glyph_name = &composite.name;
-            let Glyph::Composite(composite) = &composite.glyph else {
+            let RawGlyph::Composite(composite) = &composite.data else {
                 panic!("Only composites should be in our vector of composites!!");
             };
 
@@ -688,9 +688,9 @@ fn compute_composite_bboxes(context: &Context) -> Result<(), Error> {
                         glyphs
                             .get(ref_glyph_name)
                             .map(|g| g.as_ref().clone())
-                            .and_then(|g| match &g.glyph {
-                                Glyph::Composite(..) => None,
-                                Glyph::Simple(simple_glyph) => Some(bbox2rect(simple_glyph.bbox)),
+                            .and_then(|g| match &g.data {
+                                RawGlyph::Composite(..) => None,
+                                RawGlyph::Simple(simple_glyph) => Some(bbox2rect(simple_glyph.bbox)),
                             })
                     });
                     if bbox.is_none() {
@@ -729,7 +729,7 @@ fn compute_composite_bboxes(context: &Context) -> Result<(), Error> {
             .glyphs
             .get(&WorkId::GlyfFragment(glyph_name.clone()).into()))
         .clone();
-        let Glyph::Composite(composite) = &mut glyph.glyph else {
+        let RawGlyph::Composite(composite) = &mut glyph.data else {
             panic!("{glyph_name} is not a composite; we shouldn't be trying to update it");
         };
         composite.bbox = bbox.into(); // delay conversion to Bbox to avoid accumulating rounding error

--- a/fontbe/src/orchestration.rs
+++ b/fontbe/src/orchestration.rs
@@ -27,9 +27,9 @@ use serde::{Deserialize, Serialize};
 use write_fonts::{
     dump_table,
     tables::{
-        avar::Avar, cmap::Cmap, fvar::Fvar, glyf::Glyph, gpos::Gpos, gsub::Gsub, gvar::GlyphDeltas,
-        head::Head, hhea::Hhea, maxp::Maxp, name::Name, os2::Os2, post::Post, stat::Stat,
-        variations::Tuple,
+        avar::Avar, cmap::Cmap, fvar::Fvar, glyf::Glyph as RawGlyph, gpos::Gpos, gsub::Gsub,
+        gvar::GlyphDeltas, head::Head, hhea::Hhea, maxp::Maxp, name::Name, os2::Os2, post::Post,
+        stat::Stat, variations::Tuple,
     },
     validate::Validate,
     FontWrite, OtRound,
@@ -115,44 +115,46 @@ impl From<WorkId> for AnyWorkId {
 }
 
 /// A glyph and its associated name
+///
+/// See <https://learn.microsoft.com/en-us/typography/opentype/spec/glyf>
 #[derive(Debug, Clone)]
-pub struct NamedGlyph {
+pub struct Glyph {
     pub name: GlyphName,
-    pub glyph: Glyph,
+    pub data: RawGlyph,
 }
 
-impl NamedGlyph {
-    pub(crate) fn new(name: GlyphName, glyph: impl Into<Glyph>) -> Self {
+impl Glyph {
+    pub(crate) fn new(name: GlyphName, glyph: impl Into<RawGlyph>) -> Self {
         Self {
             name,
-            glyph: glyph.into(),
+            data: glyph.into(),
         }
     }
 
     pub fn is_simple(&self) -> bool {
-        matches!(&self.glyph, Glyph::Simple(_))
+        matches!(&self.data, RawGlyph::Simple(_))
     }
 
     pub fn to_bytes(&self) -> Vec<u8> {
-        dump_table(&self.glyph).unwrap()
+        dump_table(&self.data).unwrap()
     }
 }
 
-impl IdAware<AnyWorkId> for NamedGlyph {
+impl IdAware<AnyWorkId> for Glyph {
     fn id(&self) -> AnyWorkId {
         AnyWorkId::Be(WorkId::GlyfFragment(self.name.clone()))
     }
 }
 
-impl Persistable for NamedGlyph {
+impl Persistable for Glyph {
     fn read(from: &mut dyn Read) -> Self {
         let (name, bytes): (GlyphName, Vec<u8>) = bincode::deserialize_from(from).unwrap();
-        let glyph = Glyph::read(bytes.as_slice().into()).unwrap();
-        NamedGlyph { name, glyph }
+        let glyph = RawGlyph::read(bytes.as_slice().into()).unwrap();
+        Glyph { name, data: glyph }
     }
 
     fn write(&self, to: &mut dyn Write) {
-        let glyph_bytes = dump_table(&self.glyph).unwrap();
+        let glyph_bytes = dump_table(&self.data).unwrap();
         let to_write = (&self.name, glyph_bytes);
         bincode::serialize_into(to, &to_write).unwrap();
     }
@@ -366,7 +368,7 @@ pub struct Context {
 
     // work results we've completed or restored from disk
     pub gvar_fragments: BeContextMap<GvarFragment>,
-    pub glyphs: BeContextMap<NamedGlyph>,
+    pub glyphs: BeContextMap<Glyph>,
 
     pub avar: BeContextItem<BeValue<Avar>>,
     pub cmap: BeContextItem<BeValue<Cmap>>,

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -310,7 +310,7 @@ mod tests {
 
     use chrono::{Duration, TimeZone, Utc};
     use fontbe::orchestration::{
-        AnyWorkId, Context as BeContext, LocaFormat, NamedGlyph, WorkId as BeWorkIdentifier,
+        AnyWorkId, Context as BeContext, Glyph, LocaFormat, WorkId as BeWorkIdentifier,
     };
     use fontdrasil::types::GlyphName;
     use fontir::{
@@ -344,7 +344,7 @@ mod tests {
     use tempfile::{tempdir, TempDir};
     use write_fonts::{
         dump_table,
-        tables::glyf::{Bbox, Glyph},
+        tables::glyf::{Bbox, Glyph as RawGlyph},
     };
 
     use super::*;
@@ -754,10 +754,10 @@ mod tests {
         buf
     }
 
-    fn read_be_glyph(build_dir: &Path, name: &str) -> Glyph {
+    fn read_be_glyph(build_dir: &Path, name: &str) -> RawGlyph {
         let raw_glyph = read_file(&build_dir.join(format!("glyphs/{name}.glyf")));
         let read: &mut dyn Read = &mut raw_glyph.as_slice();
-        NamedGlyph::read(read).glyph
+        Glyph::read(read).data
     }
 
     #[test]
@@ -767,7 +767,7 @@ mod tests {
         assert!(glyph.default_instance().contours.is_empty(), "{glyph:?}");
         assert_eq!(2, glyph.default_instance().components.len(), "{glyph:?}");
 
-        let Glyph::Composite(glyph) = read_be_glyph(temp_dir.path(), glyph.name.as_str()) else {
+        let RawGlyph::Composite(glyph) = read_be_glyph(temp_dir.path(), glyph.name.as_str()) else {
             panic!("Expected a simple glyph");
         };
         let raw_glyph = dump_table(&glyph).unwrap();
@@ -783,7 +783,7 @@ mod tests {
         assert!(glyph.default_instance().components.is_empty(), "{glyph:?}");
         assert_eq!(2, glyph.default_instance().contours.len(), "{glyph:?}");
 
-        let Glyph::Simple(glyph) = read_be_glyph(temp_dir.path(), glyph.name.as_str()) else {
+        let RawGlyph::Simple(glyph) = read_be_glyph(temp_dir.path(), glyph.name.as_str()) else {
             panic!("Expected a simple glyph");
         };
         assert_eq!(2, glyph.contours().len());
@@ -795,7 +795,7 @@ mod tests {
         let build_dir = temp_dir.path();
         compile(Args::for_test(build_dir, "static.designspace"));
 
-        let Glyph::Simple( glyph) = read_be_glyph(build_dir, "bar") else {
+        let RawGlyph::Simple( glyph) = read_be_glyph(build_dir, "bar") else {
             panic!("Expected a simple glyph");
         };
 


### PR DESCRIPTION
A bit of cleanup on top of  #379.

 This renames the backend 'Glyph' type to 'NamedGlyph', and turns it into a simple struct, containing a `write-fonts` Glyph and the associated name.

This also lets us delete the GlyphPersistable type, since we don't need to store a flag indicating whether the glyph is simple or composite.