### PR TITLE
Use fontations glyf/loca builder

### DIFF
--- a/fontbe/src/head.rs
+++ b/fontbe/src/head.rs
@@ -7,11 +7,11 @@ use font_types::{Fixed, LongDateTime};
 use fontdrasil::orchestration::{Access, Work};
 use fontir::orchestration::WorkId as FeWorkId;
 use log::warn;
-use write_fonts::tables::head::Head;
+use write_fonts::tables::{head::Head, loca::LocaFormat};
 
 use crate::{
     error::Error,
-    orchestration::{AnyWorkId, BeWork, Context, LocaFormat, WorkId},
+    orchestration::{AnyWorkId, BeWork, Context, WorkId},
 };
 
 #[derive(Debug)]
@@ -104,10 +104,10 @@ impl Work<Context, AnyWorkId, Error> for HeadWork {
     /// Generate [head](https://learn.microsoft.com/en-us/typography/opentype/spec/head)
     fn exec(&self, context: &Context) -> Result<(), Error> {
         let static_metadata = context.ir.static_metadata.get();
-        let loca_format = context.loca_format.get();
+        let loca_format = (*context.loca_format.get().as_ref()).into();
         let mut head = init_head(
             static_metadata.units_per_em,
-            *loca_format,
+            loca_format,
             static_metadata.misc.head_flags,
             static_metadata.misc.lowest_rec_ppm,
         );
@@ -130,8 +130,9 @@ mod tests {
     use chrono::{TimeZone, Utc};
     use more_asserts::assert_ge;
     use temp_env;
+    use write_fonts::tables::loca::LocaFormat;
 
-    use crate::{head::apply_created_modified, orchestration::LocaFormat};
+    use crate::head::apply_created_modified;
 
     use super::{init_head, seconds_since_mac_epoch};
 

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -310,7 +310,7 @@ mod tests {
 
     use chrono::{Duration, TimeZone, Utc};
     use fontbe::orchestration::{
-        AnyWorkId, Context as BeContext, Glyph, LocaFormat, WorkId as BeWorkIdentifier,
+        AnyWorkId, Context as BeContext, Glyph, LocaFormatWrapper, WorkId as BeWorkIdentifier,
     };
     use fontdrasil::types::GlyphName;
     use fontir::{
@@ -344,7 +344,10 @@ mod tests {
     use tempfile::{tempdir, TempDir};
     use write_fonts::{
         dump_table,
-        tables::glyf::{Bbox, Glyph as RawGlyph},
+        tables::{
+            glyf::{Bbox, Glyph as RawGlyph},
+            loca::LocaFormat,
+        },
     };
 
     use super::*;
@@ -397,9 +400,10 @@ mod tests {
     impl Glyphs {
         fn new(build_dir: &Path) -> Self {
             Glyphs {
-                loca_format: LocaFormat::read(
+                loca_format: LocaFormatWrapper::read(
                     &mut File::open(build_dir.join("loca.format")).unwrap(),
-                ),
+                )
+                .into(),
                 raw_glyf: read_file(&build_dir.join("glyf.table")),
                 raw_loca: read_file(&build_dir.join("loca.table")),
             }


### PR DESCRIPTION
Based on #382 

-----

This also uses the LocaFormat type in fontations (which was copied from here) which then forces us to hack around orphan rules.

Playing around with this i have a better understanding of the annoyance we encountered previously about serializing loca. The main question this patch raised for me, was whether or not we should just have a `GlyfAndLoca` struct that wraps both those tables, as they're always generated together? This would let us simplify some of our serialization code.