### PR TITLE
must follow fvar axes order when building gvar GlyphDeltas

### DIFF
--- a/fontir/src/variations.rs
+++ b/fontir/src/variations.rs
@@ -465,6 +465,10 @@ impl VariationRegion {
     pub fn is_default(&self) -> bool {
         self.active_axes.is_empty()
     }
+
+    pub fn get(&self, tag: &Tag) -> Option<&Tent> {
+        self.axis_tents.get(tag)
+    }
 }
 
 /// The min/peak/max of a masters influence.


### PR DESCRIPTION
TupleBuilder was iterating over VariationRegion's axis_tents which is a BTreeMap, but it should instead iterate over the region's tents following the fvar's axis order, that's what the gvar Tuples must follow. Otherwise we store deltas for the wrong axes!