### PR TITLE
Restore the ability to produce a meaningful flamegraph

### DIFF
--- a/fontc/src/workload.rs
+++ b/fontc/src/workload.rs
@@ -1,6 +1,5 @@
 //! Tracking jobs to run
 
-use rayon::ThreadPoolBuilder;
 use std::{
     collections::{HashMap, HashSet},
     panic::AssertUnwindSafe,
@@ -242,13 +241,9 @@ impl<'a> Workload<'a> {
 
         // a flag we set if we panic
         let abort_queued_jobs = Arc::new(AtomicBool::new(false));
-        // build a custom threadpool. we use this to ensure all threads are named
-        let threadpool = ThreadPoolBuilder::new()
-            .thread_name(|n| format!("tp{n}"))
-            .build()
-            .expect("failed to init thread pool");
 
-        threadpool.in_place_scope(|scope| {
+        // Do NOT assign custom thread names because it makes flamegraph root each thread individually
+        rayon::in_place_scope(|scope| {
             // Whenever a task completes see if it was the last incomplete dependency of other task(s)
             // and spawn them if it was
             // TODO timeout and die it if takes too long to make forward progress or we're spinning w/o progress


### PR DESCRIPTION
Assignment of thread names causes each to root individually in flamegraph, making it essentially useless. Note the tp0, 1, etc:

![image](https://github.com/googlefonts/fontc/assets/6466432/9f08f215-98b7-4ee0-8aa3-4fed93b59d80)

If we don't name them the flamegraph is very useful:

![image](https://github.com/googlefonts/fontc/assets/6466432/5abb7029-d819-4fe8-8ea9-fba2a290fbcd)

So don't name the threads. If we *really* like thread names we can make it optional - even on by default - in a followon while also documenting how to get a good flamegraph.

JMM.