### PR TITLE
[features] Update fea-rs to allow axis unit suffixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ env_logger = "0.10.0"
 
 parking_lot = "0.12.1"
 
-fea-rs = "0.13.2"
+fea-rs = "0.14.0"
 font-types = { version = "0.3.3", features = ["serde"] }
 read-fonts = "0.10.0"
 write-fonts = "0.14.1"


### PR DESCRIPTION
That is, axis locations can now exist in one of user, design, or normalized coordinates.