### PR TITLE
Add merge_group to on:

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,5 +1,6 @@
 on:
   pull_request:
+  merge_group:
   push:
     branches:
       - main


### PR DESCRIPTION
Trying to get setup to turn on merge queues (https://github.blog/2023-07-12-github-merge-queue-is-generally-available/) per https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#configuring-continuous-integration-ci-workflows-for-merge-queues