### PR TITLE
Try to parallelize test execution

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -56,7 +56,7 @@ jobs:
 # so we get concurrent execution on multiple runners
 
   test-stable-fontbe:
-    name: cargo test stable
+    name: fontbe tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -68,7 +68,7 @@ jobs:
         run: cargo test -p fontbe --all-targets --all-features
 
   test-stable-fontc:
-    name: cargo test stable
+    name: fontc tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -80,7 +80,7 @@ jobs:
         run: cargo test -p fontc --all-targets --all-features
 
   test-stable-misc-quick:
-    name: cargo test stable
+    name: tests other than fontbe,fontc
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,7 +9,7 @@ on:
 
 name: Continuous integration
 
-# The check, clippy-lint, and test-stable jobs should typically be direct copies from
+# The check, clippy-lint, and test-stable-* jobs should typically be direct copies from
 # https://github.com/googlefonts/fontations/blob/main/.github/workflows/rust.yml.
 # other than the list of crates for cargo check no std
 
@@ -49,7 +49,13 @@ jobs:
       - name: cargo clippy --no-default-features
         run: cargo clippy --all-targets --no-default-features -- -D warnings
 
-  test-stable:
+# test all packages individually to ensure deterministic resolution
+# of dependencies for each package
+
+# Try to group our tests into sets of crates that take roughly equal time to run
+# so we get concurrent execution on multiple runners
+
+  test-stable-fontbe:
     name: cargo test stable
     runs-on: ubuntu-latest
     steps:
@@ -58,14 +64,29 @@ jobs:
       - name: install stable toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      # test all packages individually to ensure deterministic resolution
-      # of dependencies for each package
-      
       - name: cargo test fontbe
         run: cargo test -p fontbe --all-targets --all-features
 
+  test-stable-fontc:
+    name: cargo test stable
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+
       - name: cargo test fontc
         run: cargo test -p fontc --all-targets --all-features
+
+  test-stable-misc-quick:
+    name: cargo test stable
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
 
       - name: cargo test fontdrasil
         run: cargo test -p fontdrasil --all-targets --all-features


### PR DESCRIPTION
Logs like this suggest parallelizing tests might speed up PRs turning green:

![image](https://github.com/googlefonts/fontc/assets/6466432/1c025077-ce22-4492-9ea4-43f1e477a9db)

Put each of the 1m+ items into it's own job and everything else into one.

JMM