### PR TITLE
Generate missing .notdef like ufo2ft

### DIFF
--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -312,7 +312,7 @@ mod tests {
     use fontbe::orchestration::{
         AnyWorkId, Context as BeContext, Glyph, LocaFormatWrapper, WorkId as BeWorkIdentifier,
     };
-    use fontdrasil::types::{GlyphName, NOTDEF};
+    use fontdrasil::types::GlyphName;
     use fontir::{
         ir::{self, KernParticipant},
         orchestration::{Context as FeContext, Persistable, WorkId as FeWorkIdentifier},
@@ -1273,10 +1273,14 @@ mod tests {
             .fe_context
             .preliminary_glyph_order
             .get()
-            .contains(&NOTDEF));
+            .contains(&GlyphName::NOTDEF));
         assert_eq!(
             Some(0),
-            result.fe_context.glyph_order.get().glyph_id(&NOTDEF)
+            result
+                .fe_context
+                .glyph_order
+                .get()
+                .glyph_id(&GlyphName::NOTDEF)
         );
 
         let font_file = build_dir.join("font.ttf");

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -312,7 +312,7 @@ mod tests {
     use fontbe::orchestration::{
         AnyWorkId, Context as BeContext, Glyph, LocaFormatWrapper, WorkId as BeWorkIdentifier,
     };
-    use fontdrasil::types::GlyphName;
+    use fontdrasil::types::{GlyphName, NOTDEF};
     use fontir::{
         ir::{self, KernParticipant},
         orchestration::{Context as FeContext, Persistable, WorkId as FeWorkIdentifier},
@@ -520,12 +520,14 @@ mod tests {
                 BeWorkIdentifier::Font.into(),
                 BeWorkIdentifier::Fvar.into(),
                 BeWorkIdentifier::Glyf.into(),
+                BeWorkIdentifier::GlyfFragment(".notdef".into()).into(),
                 BeWorkIdentifier::GlyfFragment("bar".into()).into(),
                 BeWorkIdentifier::GlyfFragment("plus".into()).into(),
                 BeWorkIdentifier::Gpos.into(),
                 BeWorkIdentifier::Gsub.into(),
                 BeWorkIdentifier::Gdef.into(),
                 BeWorkIdentifier::Gvar.into(),
+                BeWorkIdentifier::GvarFragment(".notdef".into()).into(),
                 BeWorkIdentifier::GvarFragment("bar".into()).into(),
                 BeWorkIdentifier::GvarFragment("plus".into()).into(),
                 BeWorkIdentifier::Head.into(),
@@ -829,12 +831,13 @@ mod tests {
         let result = compile(Args::for_test(build_dir, "static.designspace"));
 
         // See resources/testdata/Static-Regular.ufo/glyphs
+        // generated .notdef, 8 points, 2 contours
         // space, 0 points, 0 contour
         // bar, 4 points, 1 contour
         // plus, 12 points, 1 contour
         // element of, 0 points, 0 contours
         assert_eq!(
-            vec![(0, 0), (4, 1), (12, 1), (0, 0)],
+            vec![(8, 2), (0, 0), (4, 1), (12, 1), (0, 0)],
             result
                 .glyphs()
                 .read()
@@ -891,26 +894,26 @@ mod tests {
         // Per source, glyphs should be period, comma, non_uniform_scale
         // Period is simple, the other two use it as a component
         let glyph_data = result.glyphs();
-        let glyphs = glyph_data.read();
-        assert!(glyphs.len() > 1, "{glyphs:#?}");
-        let period_idx = result.get_glyph_index("period");
-        assert!(
-            matches!(glyphs[0], Some(glyf::Glyph::Simple(..))),
-            "{glyphs:#?}"
-        );
-        for (idx, glyph) in glyphs.iter().enumerate() {
-            if idx == period_idx.try_into().unwrap() {
-                assert!(
-                    matches!(glyphs[idx], Some(glyf::Glyph::Simple(..))),
-                    "glyphs[{idx}] should be simple\n{glyph:#?}\nAll:\n{glyphs:#?}"
-                );
-            } else {
-                assert!(
-                    matches!(glyphs[idx], Some(glyf::Glyph::Composite(..))),
-                    "glyphs[{idx}] should be composite\n{glyph:#?}\nAll:\n{glyphs:#?}"
-                );
-            }
-        }
+        let all_glyphs = glyph_data.read();
+
+        assert!(matches!(
+            (
+                all_glyphs[result.get_glyph_index("period") as usize]
+                    .as_ref()
+                    .unwrap(),
+                all_glyphs[result.get_glyph_index("comma") as usize]
+                    .as_ref()
+                    .unwrap(),
+                all_glyphs[result.get_glyph_index("non_uniform_scale") as usize]
+                    .as_ref()
+                    .unwrap(),
+            ),
+            (
+                glyf::Glyph::Simple(..),
+                glyf::Glyph::Composite(..),
+                glyf::Glyph::Composite(..),
+            ),
+        ));
     }
 
     #[test]
@@ -1018,11 +1021,12 @@ mod tests {
                 .collect();
             assert_eq!(
                 vec![
-                    (0x002C, 1),
-                    (0x002E, 0),
-                    (0x0030, 2),
-                    (0x031, 3),
-                    (0x032, 4)
+                    (0x0000, 0),
+                    (0x002C, 2),
+                    (0x002E, 1),
+                    (0x0030, 3),
+                    (0x031, 4),
+                    (0x032, 5)
                 ],
                 cp_and_gid,
                 "start {:?}\nend {:?}id_delta {:?}",
@@ -1260,6 +1264,33 @@ mod tests {
     }
 
     #[test]
+    fn compile_generates_notdef() {
+        let temp_dir = tempdir().unwrap();
+        let build_dir = temp_dir.path();
+        let result = compile(Args::for_test(build_dir, "glyphs2/WghtVar.glyphs"));
+
+        assert!(!result
+            .fe_context
+            .preliminary_glyph_order
+            .get()
+            .contains(&NOTDEF));
+        assert_eq!(
+            Some(0),
+            result.fe_context.glyph_order.get().glyph_id(&NOTDEF)
+        );
+
+        let font_file = build_dir.join("font.ttf");
+        assert!(font_file.exists());
+        let buf = fs::read(font_file).unwrap();
+        let font = FontRef::new(&buf).unwrap();
+
+        assert_eq!(
+            GlyphId::new(0),
+            font.cmap().unwrap().map_codepoint(0u32).unwrap()
+        );
+    }
+
+    #[test]
     fn compile_glyphs_font_with_weight_axis() {
         let temp_dir = tempdir().unwrap();
         let build_dir = temp_dir.path();
@@ -1280,9 +1311,10 @@ mod tests {
                 GlyphId::new(0),
                 GlyphId::new(1),
                 GlyphId::new(2),
-                GlyphId::new(5),
+                GlyphId::new(3),
+                GlyphId::new(6),
             ],
-            [0x20, 0x21, 0x2d, 0x3d]
+            [0x00, 0x20, 0x21, 0x2d, 0x3d]
                 .iter()
                 .map(|cp| font.cmap().unwrap().map_codepoint(*cp as u32).unwrap())
                 .collect::<Vec<_>>()

--- a/fontdrasil/src/types.rs
+++ b/fontdrasil/src/types.rs
@@ -10,10 +10,10 @@ use smol_str::SmolStr;
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct GlyphName(SmolStr);
 
-/// The name of the undefined glyph
-pub static NOTDEF: GlyphName = GlyphName(SmolStr::new_inline(".notdef"));
-
 impl GlyphName {
+    /// The name of the undefined glyph
+    pub const NOTDEF: GlyphName = GlyphName(SmolStr::new_inline(".notdef"));
+
     pub fn as_str(&self) -> &str {
         self.0.as_str()
     }

--- a/fontdrasil/src/types.rs
+++ b/fontdrasil/src/types.rs
@@ -10,6 +10,9 @@ use smol_str::SmolStr;
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct GlyphName(SmolStr);
 
+/// The name of the undefined glyph
+pub static NOTDEF: GlyphName = GlyphName(SmolStr::new_inline(".notdef"));
+
 impl GlyphName {
     pub fn as_str(&self) -> &str {
         self.0.as_str()

--- a/fontir/src/glyph.rs
+++ b/fontir/src/glyph.rs
@@ -10,7 +10,7 @@ use std::{
 
 use fontdrasil::{
     orchestration::{Access, Work},
-    types::{GlyphName, NOTDEF},
+    types::GlyphName,
 };
 use kurbo::Affine;
 use log::{debug, log_enabled, trace};
@@ -363,15 +363,15 @@ fn ensure_notdef_exists_and_is_gid_0(
     glyph_order: &mut GlyphOrder,
 ) -> Result<(), WorkError> {
     // Make sure we have a .notdef and that it's gid 0
-    match glyph_order.glyph_id(&NOTDEF) {
+    match glyph_order.glyph_id(&GlyphName::NOTDEF) {
         Some(0) => (), // .notdef is gid 0; life is good
         Some(..) => {
-            trace!("Move {} to gid 0", NOTDEF);
-            glyph_order.set_glyph_id(&NOTDEF, 0);
+            trace!("Move {} to gid 0", GlyphName::NOTDEF);
+            glyph_order.set_glyph_id(&GlyphName::NOTDEF, 0);
         }
         None => {
-            trace!("Generate {} and make it gid 0", NOTDEF);
-            glyph_order.set_glyph_id(&NOTDEF, 0);
+            trace!("Generate {} and make it gid 0", GlyphName::NOTDEF);
+            glyph_order.set_glyph_id(&GlyphName::NOTDEF, 0);
             let static_metadata = context.static_metadata.get();
             let metrics = context
                 .global_metrics
@@ -471,10 +471,6 @@ impl Work<Context, WorkId, WorkError> for GlyphOrderWork {
         } else {
             trace!("No new glyphs, final glyph order == preliminary glyph order");
         }
-
-        let Some(0) = new_glyph_order.glyph_id(&NOTDEF) else {
-            todo!(".notdef must be present and must be gid 0")
-        };
 
         context.glyph_order.set(new_glyph_order);
         Ok(())

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -13,7 +13,7 @@ use crate::{
 use chrono::{DateTime, Utc};
 use font_types::NameId;
 use font_types::Tag;
-use fontdrasil::types::{GlyphName, GroupName, NOTDEF};
+use fontdrasil::types::{GlyphName, GroupName};
 use indexmap::IndexSet;
 use kurbo::{Affine, BezPath, PathEl, Point};
 use log::warn;
@@ -1027,7 +1027,7 @@ impl GlyphBuilder {
         path.close_path();
 
         Self {
-            name: NOTDEF.clone(),
+            name: GlyphName::NOTDEF.clone(),
             codepoints: HashSet::from([0]),
             sources: HashMap::from([(
                 default_location,

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -13,7 +13,7 @@ use crate::{
 use chrono::{DateTime, Utc};
 use font_types::NameId;
 use font_types::Tag;
-use fontdrasil::types::{GlyphName, GroupName};
+use fontdrasil::types::{GlyphName, GroupName, NOTDEF};
 use indexmap::IndexSet;
 use kurbo::{Affine, BezPath, PathEl, Point};
 use log::warn;
@@ -25,7 +25,7 @@ use std::{
     io::Read,
     path::PathBuf,
 };
-use write_fonts::tables::os2::SelectionFlags;
+use write_fonts::{tables::os2::SelectionFlags, OtRound};
 
 pub const DEFAULT_VENDOR_ID: &str = "NONE";
 const DEFAULT_VENDOR_ID_TAG: Tag = Tag::new(b"NONE");
@@ -153,6 +153,17 @@ impl GlyphOrder {
 
     pub fn len(&self) -> usize {
         self.0.len()
+    }
+
+    pub(crate) fn set_glyph_id(&mut self, name: &GlyphName, new_index: usize) {
+        match self.0.get_index_of(name) {
+            Some(index) if index == new_index => (), // nop
+            Some(index) => self.0.move_index(index, new_index),
+            None => {
+                self.insert(name.clone());
+                self.set_glyph_id(name, new_index)
+            }
+        }
     }
 }
 
@@ -974,6 +985,59 @@ impl GlyphBuilder {
         }
         self.sources.insert(unique_location.clone(), source);
         Ok(())
+    }
+
+    /// * see <https://github.com/googlefonts/ufo2ft/blob/b3895a96ca910c1764df016bfee4719448cfec4a/Lib/ufo2ft/outlineCompiler.py#L1666-L1694>
+    pub fn new_notdef(
+        default_location: NormalizedLocation,
+        upem: u16,
+        ascender: f32,
+        descender: f32,
+    ) -> Self {
+        let upem = upem as f32;
+        let width: u16 = (upem * 0.5).ot_round();
+        let width = width as f64;
+        let stroke: u16 = (upem * 0.05).ot_round();
+        let stroke = stroke as f64;
+
+        let mut path = BezPath::new();
+
+        // outer box
+        let x_min = stroke;
+        let x_max = width - stroke;
+        let y_max = ascender as f64;
+        let y_min = descender as f64;
+        path.move_to((x_min, y_min));
+        path.line_to((x_max, y_min));
+        path.line_to((x_max, y_max));
+        path.line_to((x_min, y_max));
+        path.line_to((x_min, y_min));
+        path.close_path();
+
+        // inner, cut out, box
+        let x_min = x_min + stroke;
+        let x_max = x_max - stroke;
+        let y_max = y_max - stroke;
+        let y_min = y_min + stroke;
+        path.move_to((x_min, y_min));
+        path.line_to((x_min, y_max));
+        path.line_to((x_max, y_max));
+        path.line_to((x_max, y_min));
+        path.line_to((x_min, y_min));
+        path.close_path();
+
+        Self {
+            name: NOTDEF.clone(),
+            codepoints: HashSet::from([0]),
+            sources: HashMap::from([(
+                default_location,
+                GlyphInstance {
+                    width,
+                    contours: vec![path],
+                    ..Default::default()
+                },
+            )]),
+        }
     }
 }
 

--- a/resources/testdata/glyphs2/Mono.glyphs
+++ b/resources/testdata/glyphs2/Mono.glyphs
@@ -5,9 +5,8 @@ fontMaster = (
         id = m01;
     }
 );
-glyphs = (
-{
-    glyphname = First;
+glyphs = ({
+    glyphname = .notdef;
     layers = (
         {
             layerId = m01;


### PR DESCRIPTION
For WghtVar.glyphs, which does not define notdef, we get this:

<img width="111" alt="image" src="https://github.com/googlefonts/fontc/assets/6466432/cfcd38e4-9ec3-4a16-923f-38e929d05668">

```shell
$ python resources/scripts/ttx_diff.py ../OswaldFont/sources/Oswald.glyphs
# default parameter comparison
COMPARISON
  Only fontmake produced 'HVAR'
  DIFF 'GDEF', build/default/fontc.GDEF.ttx build/default/fontmake.GDEF.ttx
  DIFF 'GPOS', build/default/fontc.GPOS.ttx build/default/fontmake.GPOS.ttx
  DIFF 'GSUB', build/default/fontc.GSUB.ttx build/default/fontmake.GSUB.ttx
  Identical 'GlyphOrder'
  Identical 'OS_2'
  Identical 'STAT'
  Identical 'avar'
  Identical 'cmap'
  Identical 'fvar'
  Identical 'glyf'
  DIFF 'gvar', build/default/fontc.gvar.ttx build/default/fontmake.gvar.ttx
  Identical 'head'
  Identical 'hhea'
  Identical 'hmtx'
  Identical 'loca'
  Identical 'maxp'
  Identical 'name'
  Identical 'post'

```

Fixes #149 
Fixes #420