### PR TITLE
Capture anchors in glyphs and ufo 2 fontir

### DIFF
--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -496,53 +496,91 @@ mod tests {
         result
     }
 
-    #[test]
-    fn compile_work() {
+    fn assert_compile_work(source: &str, glyphs: Vec<&str>) {
         let temp_dir = tempdir().unwrap();
         let build_dir = temp_dir.path();
 
-        let result = compile(Args::for_test(build_dir, "wght_var.designspace"));
+        let result = compile(Args::for_test(build_dir, source));
         let mut completed = result.work_executed.iter().cloned().collect::<Vec<_>>();
-        completed.sort();
-        assert_eq!(
-            vec![
-                AnyWorkId::Fe(FeWorkIdentifier::StaticMetadata),
-                FeWorkIdentifier::GlobalMetrics.into(),
-                FeWorkIdentifier::Glyph("bar".into()).into(),
-                FeWorkIdentifier::Glyph("plus".into()).into(),
-                FeWorkIdentifier::PreliminaryGlyphOrder.into(),
-                FeWorkIdentifier::GlyphOrder.into(),
-                FeWorkIdentifier::Features.into(),
-                FeWorkIdentifier::Kerning.into(),
-                BeWorkIdentifier::Features.into(),
-                BeWorkIdentifier::Avar.into(),
-                BeWorkIdentifier::Cmap.into(),
-                BeWorkIdentifier::Font.into(),
-                BeWorkIdentifier::Fvar.into(),
-                BeWorkIdentifier::Glyf.into(),
-                BeWorkIdentifier::GlyfFragment(".notdef".into()).into(),
-                BeWorkIdentifier::GlyfFragment("bar".into()).into(),
-                BeWorkIdentifier::GlyfFragment("plus".into()).into(),
-                BeWorkIdentifier::Gpos.into(),
-                BeWorkIdentifier::Gsub.into(),
-                BeWorkIdentifier::Gdef.into(),
-                BeWorkIdentifier::Gvar.into(),
-                BeWorkIdentifier::GvarFragment(".notdef".into()).into(),
-                BeWorkIdentifier::GvarFragment("bar".into()).into(),
-                BeWorkIdentifier::GvarFragment("plus".into()).into(),
-                BeWorkIdentifier::Head.into(),
-                BeWorkIdentifier::Hhea.into(),
-                BeWorkIdentifier::Hmtx.into(),
-                BeWorkIdentifier::Loca.into(),
-                BeWorkIdentifier::LocaFormat.into(),
-                BeWorkIdentifier::Maxp.into(),
-                BeWorkIdentifier::Name.into(),
-                BeWorkIdentifier::Os2.into(),
-                BeWorkIdentifier::Post.into(),
-                BeWorkIdentifier::Stat.into(),
-            ],
-            completed
+
+        let mut expected = vec![
+            AnyWorkId::Fe(FeWorkIdentifier::StaticMetadata),
+            FeWorkIdentifier::GlobalMetrics.into(),
+            FeWorkIdentifier::PreliminaryGlyphOrder.into(),
+            FeWorkIdentifier::GlyphOrder.into(),
+            FeWorkIdentifier::Features.into(),
+            FeWorkIdentifier::Kerning.into(),
+            BeWorkIdentifier::Features.into(),
+            BeWorkIdentifier::Avar.into(),
+            BeWorkIdentifier::Cmap.into(),
+            BeWorkIdentifier::Font.into(),
+            BeWorkIdentifier::Fvar.into(),
+            BeWorkIdentifier::Glyf.into(),
+            BeWorkIdentifier::Gpos.into(),
+            BeWorkIdentifier::Gsub.into(),
+            BeWorkIdentifier::Gdef.into(),
+            BeWorkIdentifier::Gvar.into(),
+            BeWorkIdentifier::Head.into(),
+            BeWorkIdentifier::Hhea.into(),
+            BeWorkIdentifier::Hmtx.into(),
+            BeWorkIdentifier::Loca.into(),
+            BeWorkIdentifier::LocaFormat.into(),
+            BeWorkIdentifier::Maxp.into(),
+            BeWorkIdentifier::Name.into(),
+            BeWorkIdentifier::Os2.into(),
+            BeWorkIdentifier::Post.into(),
+            BeWorkIdentifier::Stat.into(),
+        ];
+
+        expected.extend(
+            glyphs
+                .iter()
+                .map(|n| FeWorkIdentifier::Glyph((*n).into()).into()),
         );
+        expected.extend(
+            glyphs
+                .iter()
+                .map(|n| FeWorkIdentifier::Anchor((*n).into()).into()),
+        );
+        expected.extend(
+            glyphs
+                .iter()
+                .map(|n| BeWorkIdentifier::GlyfFragment((*n).into()).into()),
+        );
+        expected.extend(
+            glyphs
+                .iter()
+                .map(|n| BeWorkIdentifier::GvarFragment((*n).into()).into()),
+        );
+
+        expected.extend(vec![
+            BeWorkIdentifier::GlyfFragment((".notdef").into()).into(),
+            BeWorkIdentifier::GvarFragment((".notdef").into()).into(),
+        ]);
+
+        completed.sort();
+        expected.sort();
+        assert_eq!(expected, completed);
+    }
+
+    #[test]
+    fn compile_work_for_designspace() {
+        assert_compile_work("wght_var.designspace", vec!["bar", "plus"])
+    }
+
+    #[test]
+    fn compile_work_for_glyphs() {
+        assert_compile_work(
+            "glyphs3/WghtVar.glyphs",
+            vec![
+                "bracketleft",
+                "bracketright",
+                "exclam",
+                "hyphen",
+                "manual-component",
+                "space",
+            ],
+        )
     }
 
     #[test]
@@ -582,6 +620,7 @@ mod tests {
         assert_eq!(
             vec![
                 AnyWorkId::Fe(FeWorkIdentifier::Glyph("bar".into())),
+                FeWorkIdentifier::Anchor("bar".into()).into(),
                 BeWorkIdentifier::Cmap.into(),
                 BeWorkIdentifier::Font.into(),
                 BeWorkIdentifier::Glyf.into(),

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -61,6 +61,7 @@ pub fn init_paths(args: &Args) -> Result<(IrPaths, BePaths), Error> {
 
     require_dir(ir_paths.build_dir())?;
     if args.emit_ir {
+        require_dir(ir_paths.anchor_ir_dir())?;
         require_dir(ir_paths.glyph_ir_dir())?;
         require_dir(be_paths.glyph_dir())?;
     }

--- a/fontir/src/error.rs
+++ b/fontir/src/error.rs
@@ -1,7 +1,7 @@
 use std::{error, io, path::PathBuf};
 
 use font_types::{InvalidTag, Tag};
-use fontdrasil::types::GlyphName;
+use fontdrasil::types::{AnchorName, GlyphName};
 use kurbo::Point;
 use thiserror::Error;
 
@@ -134,6 +134,17 @@ pub enum WorkError {
     AxisMustMapMax(Tag),
     #[error("No kerning group or glyph for name {0:?}")]
     InvalidKernSide(String),
+    #[error("Multiple definitions for glyph {glyph} anchor {anchor} at {loc:?}")]
+    AmbiguousAnchor {
+        glyph: GlyphName,
+        anchor: AnchorName,
+        loc: NormalizedLocation,
+    },
+    #[error("No value at default for glyph {glyph} anchor {anchor}")]
+    NoDefaultForAnchor {
+        glyph: GlyphName,
+        anchor: AnchorName,
+    },
 }
 
 /// An async work error, hence one that must be Send

--- a/fontir/src/orchestration.rs
+++ b/fontir/src/orchestration.rs
@@ -308,7 +308,7 @@ pub enum WorkId {
     GlyphOrder,
     Features,
     Kerning,
-    Anchors,
+    Anchor(GlyphName),
 }
 
 impl Identifier for WorkId {}
@@ -371,7 +371,7 @@ pub struct Context {
     pub glyphs: FeContextMap<ir::Glyph>,
     pub features: FeContextItem<ir::Features>,
     pub kerning: FeContextItem<ir::Kerning>,
-    pub anchors: FeContextItem<ir::Anchors>,
+    pub anchors: FeContextMap<ir::GlyphAnchors>,
 }
 
 pub fn set_cached<T>(lock: &Arc<RwLock<Option<Arc<T>>>>, value: T) {
@@ -430,7 +430,7 @@ impl Context {
             glyphs: ContextMap::new(acl.clone(), persistent_storage.clone()),
             features: ContextItem::new(WorkId::Features, acl.clone(), persistent_storage.clone()),
             kerning: ContextItem::new(WorkId::Kerning, acl.clone(), persistent_storage.clone()),
-            anchors: ContextItem::new(WorkId::Anchors, acl, persistent_storage),
+            anchors: ContextMap::new(acl, persistent_storage),
         }
     }
 

--- a/fontir/src/paths.rs
+++ b/fontir/src/paths.rs
@@ -17,7 +17,7 @@ pub struct Paths {
 impl Paths {
     pub fn new(build_dir: &Path) -> Paths {
         let build_dir = build_dir.to_path_buf();
-        let anchor_ir_dir = build_dir.join("glyph_ir");
+        let anchor_ir_dir = build_dir.join("anchor_ir");
         let glyph_ir_dir = build_dir.join("glyph_ir");
         let ir_input_file = build_dir.join("irinput.yml");
         Paths {
@@ -30,6 +30,10 @@ impl Paths {
 
     pub fn build_dir(&self) -> &Path {
         &self.build_dir
+    }
+
+    pub fn anchor_ir_dir(&self) -> &Path {
+        &self.anchor_ir_dir
     }
 
     pub fn glyph_ir_dir(&self) -> &Path {

--- a/fontir/src/paths.rs
+++ b/fontir/src/paths.rs
@@ -9,6 +9,7 @@ use crate::orchestration::WorkId;
 #[derive(Debug, Clone)]
 pub struct Paths {
     build_dir: PathBuf,
+    anchor_ir_dir: PathBuf,
     glyph_ir_dir: PathBuf,
     ir_input_file: PathBuf,
 }
@@ -16,10 +17,12 @@ pub struct Paths {
 impl Paths {
     pub fn new(build_dir: &Path) -> Paths {
         let build_dir = build_dir.to_path_buf();
+        let anchor_ir_dir = build_dir.join("glyph_ir");
         let glyph_ir_dir = build_dir.join("glyph_ir");
         let ir_input_file = build_dir.join("irinput.yml");
         Paths {
             build_dir,
+            anchor_ir_dir,
             glyph_ir_dir,
             ir_input_file,
         }
@@ -37,13 +40,17 @@ impl Paths {
         &self.ir_input_file
     }
 
+    fn anchor_ir_file(&self, name: &str) -> PathBuf {
+        self.anchor_ir_dir.join(glyph_file(name, ".yml"))
+    }
+
     fn glyph_ir_file(&self, name: &str) -> PathBuf {
         self.glyph_ir_dir.join(glyph_file(name, ".yml"))
     }
 
     pub fn target_file(&self, id: &WorkId) -> PathBuf {
         match id {
-            WorkId::Anchors => self.build_dir.join("anchors.yml"),
+            WorkId::Anchor(name) => self.anchor_ir_file(name.as_str()),
             WorkId::StaticMetadata => self.build_dir.join("static_metadata.yml"),
             WorkId::PreliminaryGlyphOrder => self.build_dir.join("glyph_order.preliminary.yml"),
             WorkId::GlyphOrder => self.build_dir.join("glyph_order.yml"),

--- a/fontir/src/source.rs
+++ b/fontir/src/source.rs
@@ -64,7 +64,8 @@ pub trait Source {
     /// Expected to return a Vec aligned with the glyph_names input. That is,
     /// result vec nth entry is the work for the nth glyph name.
     ///
-    /// When run work should update [Context] with [crate::ir::Glyph] for the glyph name.
+    /// When run work should update [Context] with [crate::ir::Glyph] and [crate::ir::Anchor]
+    /// for the glyph name.
     fn create_glyph_ir_work(
         &self,
         glyph_names: &IndexSet<GlyphName>,

--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -1378,7 +1378,7 @@ impl TryFrom<RawLayer> for Layer {
                 } else if let Some(pos) = ra.position {
                     Point::from_plist(Plist::String(pos))
                 } else {
-                    panic!("No position for anchor {ra:?}");
+                    Point::ZERO
                 };
                 Anchor { name: ra.name, pos }
             })


### PR DESCRIPTION
Anchors are very helpful if you want ot eventually build marks.

An unfortunate implication of anchors living in glyphs is features will end up unable to start until all FE glyphs are done. This is hard to avoid given that the anchors live with the glyphs in both major source formats.

It would be possible to just bundle anchors with glyph ir but for now I didn't.