### PR TITLE
Add a visualization of thread activity

### DIFF
--- a/fontc/src/args.rs
+++ b/fontc/src/args.rs
@@ -31,6 +31,12 @@ pub struct Args {
     #[arg(long, default_value = "false")]
     pub flatten_components: bool,
 
+    /// Whether to write a visualization of threadpool execution of tasks.
+    ///
+    /// See <https://github.com/googlefonts/fontc/pull/443>
+    #[arg(long, default_value = "false")]
+    pub emit_threads: bool,
+
     /// Working directory for the build process. If emit-ir is on, written here.
     #[arg(short, long, default_value = "build")]
     pub build_dir: PathBuf,
@@ -53,6 +59,7 @@ impl Args {
         flags.set(Flags::EMIT_DEBUG, self.emit_debug);
         flags.set(Flags::PREFER_SIMPLE_GLYPHS, self.prefer_simple_glyphs);
         flags.set(Flags::FLATTEN_COMPONENTS, self.flatten_components);
+        flags.set(Flags::EMIT_THREADS, self.emit_threads);
 
         flags
     }
@@ -69,6 +76,7 @@ impl Args {
             source,
             emit_ir: true,
             emit_debug: false, // they get destroyed by test cleanup
+            emit_threads: false,
             build_dir: build_dir.to_path_buf(),
             prefer_simple_glyphs: Flags::default().contains(Flags::PREFER_SIMPLE_GLYPHS),
             flatten_components: Flags::default().contains(Flags::FLATTEN_COMPONENTS),

--- a/fontc/src/args.rs
+++ b/fontc/src/args.rs
@@ -31,11 +31,11 @@ pub struct Args {
     #[arg(long, default_value = "false")]
     pub flatten_components: bool,
 
-    /// Whether to write a visualization of threadpool execution of tasks.
+    /// Whether to out timing data, notably a visualization of threadpool execution of tasks.
     ///
     /// See <https://github.com/googlefonts/fontc/pull/443>
     #[arg(long, default_value = "false")]
-    pub emit_threads: bool,
+    pub emit_timing: bool,
 
     /// Working directory for the build process. If emit-ir is on, written here.
     #[arg(short, long, default_value = "build")]
@@ -59,7 +59,7 @@ impl Args {
         flags.set(Flags::EMIT_DEBUG, self.emit_debug);
         flags.set(Flags::PREFER_SIMPLE_GLYPHS, self.prefer_simple_glyphs);
         flags.set(Flags::FLATTEN_COMPONENTS, self.flatten_components);
-        flags.set(Flags::EMIT_THREADS, self.emit_threads);
+        flags.set(Flags::EMIT_TIMING, self.emit_timing);
 
         flags
     }
@@ -76,7 +76,7 @@ impl Args {
             source,
             emit_ir: true,
             emit_debug: false, // they get destroyed by test cleanup
-            emit_threads: false,
+            emit_timing: false,
             build_dir: build_dir.to_path_buf(),
             prefer_simple_glyphs: Flags::default().contains(Flags::PREFER_SIMPLE_GLYPHS),
             flatten_components: Flags::default().contains(Flags::FLATTEN_COMPONENTS),

--- a/fontc/src/change_detector.rs
+++ b/fontc/src/change_detector.rs
@@ -1,6 +1,6 @@
 //! tracking changes during compilation
 
-use std::{ffi::OsStr, fmt::Debug, fs, path::Path};
+use std::{ffi::OsStr, fmt::Debug, fs, path::Path, time::Instant};
 
 use bitflags::bitflags;
 use fontbe::{
@@ -165,8 +165,8 @@ impl ChangeDetector {
         workload.add(work, run);
     }
 
-    pub fn create_workload(&mut self) -> Result<Workload, Error> {
-        let mut workload = Workload::new(self);
+    pub fn create_workload(&mut self, t0: Instant) -> Result<Workload, Error> {
+        let mut workload = Workload::new(self, t0);
 
         // Create work roughly in the order it would typically occur
         // Work is eligible to run as soon as all dependencies are complete

--- a/fontc/src/main.rs
+++ b/fontc/src/main.rs
@@ -1,4 +1,8 @@
-use std::{io::{Write, BufWriter}, time::Instant, fs::OpenOptions};
+use std::{
+    fs::OpenOptions,
+    io::{BufWriter, Write},
+    time::Instant,
+};
 
 use clap::Parser;
 

--- a/fontc/src/main.rs
+++ b/fontc/src/main.rs
@@ -53,7 +53,7 @@ fn run() -> Result<(), Error> {
     let be_root = BeContext::new_root(config.args.flags(), be_paths, &fe_root);
     let mut timing = workload.exec(&fe_root, &be_root)?;
 
-    if config.args.flags().contains(Flags::EMIT_THREADS) {
+    if config.args.flags().contains(Flags::EMIT_TIMING) {
         let out_file = OpenOptions::new()
             .write(true)
             .create(true)

--- a/fontc/src/main.rs
+++ b/fontc/src/main.rs
@@ -1,10 +1,10 @@
-use std::io::Write;
+use std::{io::{Write, BufWriter}, time::Instant, fs::OpenOptions};
 
 use clap::Parser;
 
 use fontbe::orchestration::Context as BeContext;
 use fontc::{init_paths, write_font_file, Args, ChangeDetector, Config, Error};
-use fontir::orchestration::Context as FeContext;
+use fontir::orchestration::{Context as FeContext, Flags};
 
 fn main() {
     // catch and print errors manually, to avoid just seeing the Debug impls
@@ -16,6 +16,7 @@ fn main() {
 }
 
 fn run() -> Result<(), Error> {
+    let t0 = Instant::now();
     env_logger::builder()
         .format(|buf, record| {
             let ts = buf.timestamp_micros();
@@ -38,7 +39,7 @@ fn run() -> Result<(), Error> {
     let prev_inputs = config.init()?;
 
     let mut change_detector = ChangeDetector::new(config.clone(), ir_paths.clone(), prev_inputs)?;
-    let workload = fontc::create_workload(&mut change_detector)?;
+    let workload = fontc::create_workload(&mut change_detector, t0)?;
 
     let fe_root = FeContext::new_root(
         config.args.flags(),
@@ -46,7 +47,18 @@ fn run() -> Result<(), Error> {
         workload.current_inputs().clone(),
     );
     let be_root = BeContext::new_root(config.args.flags(), be_paths, &fe_root);
-    workload.exec(&fe_root, &be_root)?;
+    let mut timing = workload.exec(&fe_root, &be_root)?;
+
+    if config.args.flags().contains(Flags::EMIT_THREADS) {
+        let out_file = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(config.args.build_dir.join("threads.svg"))
+            .map_err(Error::IoError)?;
+        let mut buf = BufWriter::new(out_file);
+        timing.write_svg(&mut buf)?
+    }
 
     change_detector.finish_successfully()?;
 

--- a/fontc/src/timing.rs
+++ b/fontc/src/timing.rs
@@ -1,0 +1,277 @@
+//! Helps to understand what threads in fontc are up to.
+//!
+//! <https://github.com/googlefonts/fontc/pull/443> discusses motivation.
+
+use fontbe::orchestration::{AnyWorkId, WorkId as BeWorkIdentifier};
+use fontir::orchestration::WorkId as FeWorkIdentifier;
+use std::{collections::HashMap, io, thread::ThreadId, time::Instant};
+
+/// Tracks time for jobs that run on many threads.
+///
+/// Meant for use with a threadpool. For example, build up [JobTime] for each
+/// unit of work submitted to something like rayon and accumulate them here.
+///
+/// Currently not threadsafe, meant to be used by a central orchestrator because
+/// that happens to be what fontc does.
+#[derive(Debug)]
+pub struct JobTimer {
+    /// The beginning of time
+    t0: Instant,
+    job_times: HashMap<ThreadId, Vec<JobTime>>,
+}
+
+impl JobTimer {
+    /// Prepare to time things using the provided time zero.
+    pub fn new(t0: Instant) -> Self {
+        JobTimer {
+            t0,
+            job_times: Default::default(),
+        }
+    }
+
+    pub(crate) fn add(&mut self, timing: JobTime) {
+        self.job_times
+            .entry(timing.thread_id)
+            .or_default()
+            .push(timing);
+    }
+
+    pub fn write_svg(&mut self, out: &mut impl io::Write) -> Result<(), io::Error> {
+        let names: HashMap<_, _> = self
+            .job_times
+            .keys()
+            .enumerate()
+            .map(|(i, tid)| (*tid, format!("t{i}")))
+            .collect();
+        for timings in self.job_times.values_mut() {
+            timings.sort_by_key(|t| (t.run - self.t0).as_nanos());
+        }
+        let mut names: Vec<_> = names.into_iter().map(|(k, v)| (v, k)).collect();
+        names.sort_by(|(n1, _), (n2, _)| n1.cmp(n2));
+
+        let end_time = self
+            .job_times
+            .values()
+            .flat_map(|ts| ts.iter())
+            .map(|t| t.complete - self.t0)
+            .max()
+            .unwrap_or_default();
+
+        let prefix = r#"
+            <svg xmlns="http://www.w3.org/2000/svg">
+            <style type="text/css">
+                text {
+                font-family: monospace;
+                font-size: 12pt;
+                }
+            </style>"#;
+
+        writeln!(out, "{prefix}")?;
+        for (i, (_, tid)) in names.iter().enumerate() {
+            let timings = self.job_times.get(tid).unwrap();
+            let line_height = 15;
+            let text_height = 12;
+            let box_top = line_height * i;
+            let text_y = box_top + text_height;
+            for timing in timings {
+                let begin_pct =
+                    100.0 * (timing.run - self.t0).as_secs_f64() / end_time.as_secs_f64();
+                let exec_pct =
+                    100.0 * (timing.complete - timing.run).as_secs_f64() / end_time.as_secs_f64();
+                let fill = color(&timing.id);
+                writeln!(out, "  <g>").unwrap();
+                writeln!(
+                    out,
+                    "    <rect x=\"{begin_pct:.2}%\" y=\"{box_top}\" width=\"{exec_pct:.2}%\" height=\"{line_height}\"  fill=\"{fill}\" stroke=\"black\" />"
+                )
+                .unwrap();
+                if fill == "gray" {
+                    let text = short_name(&timing.id);
+                    writeln!(
+                        out,
+                        "    <text x=\"{begin_pct:.2}%\" y=\"{text_y}\" width=\"{exec_pct:.2}%\" height=\"{text_height}\" >{text}</text>",
+                    )
+                    .unwrap();
+                }
+                writeln!(out, "  </g>").unwrap();
+            }
+        }
+        writeln!(out, "</svg>")
+    }
+}
+
+fn short_name(id: &AnyWorkId) -> &'static str {
+    match id {
+        AnyWorkId::Fe(FeWorkIdentifier::Anchor(..)) => "anchor",
+        AnyWorkId::Fe(FeWorkIdentifier::Features) => "fea",
+        AnyWorkId::Fe(FeWorkIdentifier::GlobalMetrics) => "metrics",
+        AnyWorkId::Fe(FeWorkIdentifier::Glyph(..)) => "glyph",
+        AnyWorkId::Fe(FeWorkIdentifier::GlyphIrDelete(..)) => "rm ir",
+        AnyWorkId::Fe(FeWorkIdentifier::GlyphOrder) => "glyphorder",
+        AnyWorkId::Fe(FeWorkIdentifier::Kerning) => "kern",
+        AnyWorkId::Fe(FeWorkIdentifier::PreliminaryGlyphOrder) => "pre-go",
+        AnyWorkId::Fe(FeWorkIdentifier::StaticMetadata) => "static-meta",
+        AnyWorkId::Be(BeWorkIdentifier::Avar) => "avar",
+        AnyWorkId::Be(BeWorkIdentifier::Cmap) => "cmap",
+        AnyWorkId::Be(BeWorkIdentifier::Features) => "fea",
+        AnyWorkId::Be(BeWorkIdentifier::Font) => "font",
+        AnyWorkId::Be(BeWorkIdentifier::Fvar) => "fvar",
+        AnyWorkId::Be(BeWorkIdentifier::Gdef) => "GDEF",
+        AnyWorkId::Be(BeWorkIdentifier::Glyf) => "glyf",
+        AnyWorkId::Be(BeWorkIdentifier::GlyfFragment(..)) => "glyf-frag",
+        AnyWorkId::Be(BeWorkIdentifier::Gpos) => "GPOS",
+        AnyWorkId::Be(BeWorkIdentifier::Gsub) => "GSUB",
+        AnyWorkId::Be(BeWorkIdentifier::Gvar) => "gvar",
+        AnyWorkId::Be(BeWorkIdentifier::GvarFragment(..)) => "gvar-frag",
+        AnyWorkId::Be(BeWorkIdentifier::Head) => "head",
+        AnyWorkId::Be(BeWorkIdentifier::Hhea) => "hhea",
+        AnyWorkId::Be(BeWorkIdentifier::Hmtx) => "hmtx",
+        AnyWorkId::Be(BeWorkIdentifier::Loca) => "loca",
+        AnyWorkId::Be(BeWorkIdentifier::LocaFormat) => "loca-fmt",
+        AnyWorkId::Be(BeWorkIdentifier::Maxp) => "maxp",
+        AnyWorkId::Be(BeWorkIdentifier::Name) => "name",
+        AnyWorkId::Be(BeWorkIdentifier::Os2) => "OS/2",
+        AnyWorkId::Be(BeWorkIdentifier::Post) => "post",
+        AnyWorkId::Be(BeWorkIdentifier::Stat) => "STAT",
+        AnyWorkId::Fe(FeWorkIdentifier::Overhead) => ".",
+    }
+}
+
+fn color(id: &AnyWorkId) -> &'static str {
+    match id {
+        AnyWorkId::Fe(FeWorkIdentifier::Anchor(..)) => "gray",
+        AnyWorkId::Fe(FeWorkIdentifier::Features) => "#e18707",
+        AnyWorkId::Fe(FeWorkIdentifier::GlobalMetrics) => "gray",
+        AnyWorkId::Fe(FeWorkIdentifier::Glyph(..)) => "#830356",
+        AnyWorkId::Fe(FeWorkIdentifier::GlyphIrDelete(..)) => "gray",
+        AnyWorkId::Fe(FeWorkIdentifier::GlyphOrder) => "gray",
+        AnyWorkId::Fe(FeWorkIdentifier::Kerning) => "gray",
+        AnyWorkId::Fe(FeWorkIdentifier::PreliminaryGlyphOrder) => "gray",
+        AnyWorkId::Fe(FeWorkIdentifier::StaticMetadata) => "gray",
+        AnyWorkId::Be(BeWorkIdentifier::Avar) => "gray",
+        AnyWorkId::Be(BeWorkIdentifier::Cmap) => "gray",
+        AnyWorkId::Be(BeWorkIdentifier::Features) => "gray",
+        AnyWorkId::Be(BeWorkIdentifier::Font) => "gray",
+        AnyWorkId::Be(BeWorkIdentifier::Fvar) => "gray",
+        AnyWorkId::Be(BeWorkIdentifier::Gdef) => "gray",
+        AnyWorkId::Be(BeWorkIdentifier::Glyf) => "gray",
+        AnyWorkId::Be(BeWorkIdentifier::GlyfFragment(..)) => "#00c1c9",
+        AnyWorkId::Be(BeWorkIdentifier::Gpos) => "gray",
+        AnyWorkId::Be(BeWorkIdentifier::Gsub) => "gray",
+        AnyWorkId::Be(BeWorkIdentifier::Gvar) => "gray",
+        AnyWorkId::Be(BeWorkIdentifier::GvarFragment(..)) => "#008786",
+        AnyWorkId::Be(BeWorkIdentifier::Head) => "gray",
+        AnyWorkId::Be(BeWorkIdentifier::Hhea) => "gray",
+        AnyWorkId::Be(BeWorkIdentifier::Hmtx) => "v",
+        AnyWorkId::Be(BeWorkIdentifier::Loca) => "gray",
+        AnyWorkId::Be(BeWorkIdentifier::LocaFormat) => "gray",
+        AnyWorkId::Be(BeWorkIdentifier::Maxp) => "gray",
+        AnyWorkId::Be(BeWorkIdentifier::Name) => "gray",
+        AnyWorkId::Be(BeWorkIdentifier::Os2) => "gray",
+        AnyWorkId::Be(BeWorkIdentifier::Post) => "gray",
+        AnyWorkId::Be(BeWorkIdentifier::Stat) => "gray",
+        AnyWorkId::Fe(FeWorkIdentifier::Overhead) => "#009a00",
+    }
+}
+
+/// Start timing a job.
+///
+/// Meant to be called when a job is runnable, that is it's ready to be
+/// submitted to an execution system such as a threadpool.
+pub(crate) fn create_timer(id: AnyWorkId) -> JobTimeRunnable {
+    JobTimeRunnable {
+        id,
+        runnable: Instant::now(),
+    }
+}
+
+/// The initial state of a runnable job.
+///
+/// It may have queued from t0 to launchable but now it's go-time!
+pub(crate) struct JobTimeRunnable {
+    id: AnyWorkId,
+    runnable: Instant,
+}
+
+impl JobTimeRunnable {
+    /// Time of submission to execution queue, e.g. thread pool submission
+    pub fn queued(self) -> JobTimeQueued {
+        JobTimeQueued {
+            id: self.id,
+            runnable: self.runnable,
+            queued: Instant::now(),
+        }
+    }
+}
+
+pub(crate) struct JobTimeQueued {
+    id: AnyWorkId,
+    runnable: Instant,
+    queued: Instant,
+}
+
+impl JobTimeQueued {
+    /// Time job actually starts running, e.g. beginning of thread pool execution
+    ///
+    /// Jobs are presumed to not hop threads; we capture the current thread so we
+    /// can aggregate the time of jobs on each runner thread.
+    pub fn run(self) -> JobTimeRunning {
+        JobTimeRunning {
+            id: self.id,
+            thread: std::thread::current().id(),
+            runnable: self.runnable,
+            queued: self.queued,
+            run: Instant::now(),
+        }
+    }
+}
+
+pub(crate) struct JobTimeRunning {
+    id: AnyWorkId,
+    thread: ThreadId,
+    runnable: Instant,
+    queued: Instant,
+    run: Instant,
+}
+
+impl JobTimeRunning {
+    /// Jobs done, we have all the significant time slices.
+    ///
+    /// Gives us the final timing to submit to [JobTimer]
+    pub fn complete(self) -> JobTime {
+        JobTime {
+            id: self.id,
+            thread_id: self.thread,
+            _runnable: self.runnable,
+            _queued: self.queued,
+            run: self.run,
+            complete: Instant::now(),
+        }
+    }
+}
+
+/// Times are relative to t0 in a [JobTimer]
+#[derive(Debug)]
+pub(crate) struct JobTime {
+    id: AnyWorkId,
+    thread_id: ThreadId,
+    _runnable: Instant,
+    _queued: Instant,
+    run: Instant,
+    complete: Instant,
+}
+
+impl JobTime {
+    /// A JobTime for something that took no time, a nop
+    pub fn nop(id: AnyWorkId) -> Self {
+        let now = Instant::now();
+        JobTime {
+            id,
+            thread_id: std::thread::current().id(),
+            _runnable: now,
+            _queued: now,
+            run: now,
+            complete: now,
+        }
+    }
+}

--- a/fontir/src/orchestration.rs
+++ b/fontir/src/orchestration.rs
@@ -29,6 +29,8 @@ bitflags! {
         // If set, a composite that references another composite will replace that composite with the
         // glyph(s) it references until only simple (contour) glyphs are referenced
         const FLATTEN_COMPONENTS = 0b00001000;
+        // If set a file visualizing thread activity will be emitted to disk
+        const EMIT_THREADS = 0b00010000;
     }
 }
 
@@ -309,6 +311,8 @@ pub enum WorkId {
     Features,
     Kerning,
     Anchor(GlyphName),
+    /// Bucket to attribute overhead
+    Overhead,
 }
 
 impl Identifier for WorkId {}

--- a/fontir/src/orchestration.rs
+++ b/fontir/src/orchestration.rs
@@ -29,8 +29,8 @@ bitflags! {
         // If set, a composite that references another composite will replace that composite with the
         // glyph(s) it references until only simple (contour) glyphs are referenced
         const FLATTEN_COMPONENTS = 0b00001000;
-        // If set a file visualizing thread activity will be emitted to disk
-        const EMIT_THREADS = 0b00010000;
+        // If set a files reporting on timing will be emitted to disk
+        const EMIT_TIMING = 0b00010000;
     }
 }
 

--- a/fontir/src/paths.rs
+++ b/fontir/src/paths.rs
@@ -65,6 +65,7 @@ impl Paths {
             }
             WorkId::Features => self.build_dir.join("features.yml"),
             WorkId::Kerning => self.build_dir.join("kerning.yml"),
+            WorkId::Overhead => panic!("Should never write the overhead file"),
         }
     }
 }


### PR DESCRIPTION
How might we understand what our threads are up to? - it's hard to tell from most profiles. By visualizing it ourselves of course! First hacky draft:

![image](https://github.com/googlefonts/fontc/assets/6466432/63bf60dc-8a40-4d6f-9ffd-6fcf979ca5fb)

Above each row is a thread and time goes left to right. The pink area (color/label strategy tbd) shows very fine grained FE glyph work being distributed among threads, this is what we want. Next we see a period where nothing can be done until we have final glyph order, understandable but not what we want. We can see any speedup to glyph order production is a big win as it's delaying everything. Next we see a lot of per-glyph BE work in light blue, then a period where fea-rs is the long pole as we push toward completion. 

We can see that kern, which is executable as soon as glyph order is done and blocks backend fea, doesn't start for a quite a while which can work out poorly:

![image](https://github.com/googlefonts/fontc/assets/6466432/2d39d870-7328-469f-b363-f90d29c2114d)

https://github.com/rayon-rs/rfcs/blob/master/accepted/rfc0001-scope-scheduling.md#current-behavior-per-thread-lifo suggests the order you submit to rayon can matter a lot. When I test with Oswald it seems kern is submitted with a large batch of backend glyph work and often sits in spot 600+ in the batch. If I hack to move it to the front it executes almost immediately after glyph order:

![image](https://github.com/googlefonts/fontc/assets/6466432/b7b38a50-410c-4c19-bdc4-86be768770e5)

^ is significantly better; we will want to land some sort of prioritization. However, while this works for kern because it becomes executable at the same time as a large set of things that block on glyph order it doesn't work for fea so we still end up with fea not starting until all the be glyphs are done and then spending time as the only active task; if it had started as soon as kern finished we'd be in better shape:

![image](https://github.com/googlefonts/fontc/assets/6466432/8f8dabb1-f174-46c9-9fc1-fde70e9bc4d4)

Plenty of room for refinement but already seems useful so I will try to prepare a less hacky version to land. 