### PR TITLE
add --compile-features=false to disable FEA compilation

### DIFF
--- a/fontc/src/args.rs
+++ b/fontc/src/args.rs
@@ -38,6 +38,10 @@ pub struct Args {
     /// Glyph names must match this regex to be processed
     #[arg(short, long, default_value = None)]
     pub glyph_name_filter: Option<String>,
+
+    /// Set to false to skip compilation of OpenType Layout features
+    #[arg(long, default_value = "true", action = ArgAction::Set)]
+    pub compile_features: bool,
 }
 
 impl Args {
@@ -68,6 +72,7 @@ impl Args {
             build_dir: build_dir.to_path_buf(),
             prefer_simple_glyphs: Flags::default().contains(Flags::PREFER_SIMPLE_GLYPHS),
             flatten_components: Flags::default().contains(Flags::FLATTEN_COMPONENTS),
+            compile_features: true,
         }
     }
 }

--- a/fontc/src/change_detector.rs
+++ b/fontc/src/change_detector.rs
@@ -43,6 +43,7 @@ pub struct ChangeDetector {
     current_inputs: Input,
     be_paths: BePaths,
     emit_ir: bool,
+    compile_features: bool,
 }
 
 impl Debug for ChangeDetector {
@@ -86,6 +87,7 @@ impl ChangeDetector {
             current_inputs,
             be_paths,
             emit_ir: config.args.emit_ir,
+            compile_features: config.args.compile_features,
         })
     }
 
@@ -142,6 +144,10 @@ impl ChangeDetector {
                 .also_completes()
                 .iter()
                 .all(|id| self.target_exists(id))
+    }
+
+    pub fn should_compile_features(&self) -> bool {
+        self.compile_features
     }
 
     /// Not all work ... works ... with this method; notably muts support input_changed.

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -1861,4 +1861,48 @@ mod tests {
             "space has no outline and should take 0 bytes of glyf"
         );
     }
+
+    fn assert_no_compile_features(source: &str, table_tags: &[&[u8; 4]]) {
+        let temp_dir = tempdir().unwrap();
+
+        let default_build_dir = temp_dir.path().join("default");
+        // default is to compile_features=true
+        compile(Args::for_test(&default_build_dir, source));
+
+        let nofea_build_dir = temp_dir.path().join("nofea");
+        let mut args = Args::for_test(&nofea_build_dir, source);
+        args.compile_features = false;
+        compile(args);
+
+        let buf1 = fs::read(default_build_dir.join("font.ttf")).unwrap();
+        let font_with_fea = FontRef::new(&buf1).unwrap();
+
+        let buf2 = fs::read(nofea_build_dir.join("font.ttf")).unwrap();
+        let font_without_fea = FontRef::new(&buf2).unwrap();
+
+        for table_tag in table_tags {
+            let tag = Tag::new(table_tag);
+            assert!(font_with_fea.data_for_tag(tag).is_some());
+            assert!(font_without_fea.data_for_tag(tag).is_none());
+        }
+    }
+
+    #[test]
+    fn no_compile_features_from_glyphs_2() {
+        assert_no_compile_features("glyphs2/WghtVar.glyphs", &[b"GDEF", b"GPOS"]);
+    }
+
+    #[test]
+    fn no_compile_features_from_glyphs_3() {
+        assert_no_compile_features("glyphs3/WghtVar.glyphs", &[b"GDEF", b"GPOS"]);
+    }
+
+    #[test]
+    fn no_compile_features_from_ufo() {
+        assert_no_compile_features(
+            "designspace_from_glyphs/WghtVar.designspace",
+            &[b"GDEF", b"GPOS"],
+        );
+        assert_no_compile_features("static.designspace", &[b"GPOS", b"GSUB"]);
+    }
 }

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -106,15 +106,19 @@ fn add_feature_ir_job(workload: &mut Workload) -> Result<(), Error> {
 fn add_feature_be_job(workload: &mut Workload) -> Result<(), Error> {
     let work = FeatureWork::create();
     // Features are extremely prone to not making sense when glyphs are filtered
-    if workload.change_detector.feature_be_change()
-        && workload.change_detector.glyph_name_filter().is_some()
-    {
-        warn!("Not processing BE Features because a glyph name filter is active");
+    if workload.change_detector.feature_be_change() {
+        if workload.change_detector.glyph_name_filter().is_some() {
+            warn!("Not processing BE Features because a glyph name filter is active");
+        }
+        if !workload.change_detector.should_compile_features() {
+            debug!("Not processing BE Features because FEA compilation is disabled");
+        }
     }
     workload.add(
         work.into(),
         workload.change_detector.feature_be_change()
-            && workload.change_detector.glyph_name_filter().is_none(),
+            && workload.change_detector.glyph_name_filter().is_none()
+            && workload.change_detector.should_compile_features(),
     );
     Ok(())
 }


### PR DESCRIPTION
Fixes #430

Adds a --compile-features={true,false} bool flag (true by default) to optionally skip OT layout features compilation.

I need to add tests and convince myself the new option is wired up in all the places it needs be, but judging from casual local testing it seems to produce the desired effect, i.e. optionally skip BE job for FEA compilation, observe font contains no GDEF/GPOS/GSUB tables.