### PR TITLE
Improve plist ergonomics

### DIFF
--- a/glyphs-reader/plist_derive/src/lib.rs
+++ b/glyphs-reader/plist_derive/src/lib.rs
@@ -21,7 +21,7 @@ pub fn derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let expanded = quote! {
         impl crate::from_plist::FromPlist for #name {
             fn from_plist(plist: crate::plist::Plist) -> Self {
-                let mut map = plist.into_btreemap();
+                let mut map = plist.expect_dict().unwrap();
                 #name {
                     #deser
                 }

--- a/glyphs-reader/src/from_plist.rs
+++ b/glyphs-reader/src/from_plist.rs
@@ -14,7 +14,7 @@ pub trait FromPlistOpt {
 
 impl FromPlist for String {
     fn from_plist(plist: Plist) -> Self {
-        plist.into_string()
+        plist.expect_string().unwrap()
     }
 }
 
@@ -40,7 +40,7 @@ impl FromPlist for f64 {
 impl<T: FromPlist> FromPlist for Vec<T> {
     fn from_plist(plist: Plist) -> Self {
         let mut result = Vec::new();
-        for element in plist.into_vec() {
+        for element in plist.expect_array().unwrap() {
             result.push(FromPlist::from_plist(element));
         }
         result


### PR DESCRIPTION
This is an attmept to smooth over some papercuts, motivated by reviewing the glyphspackage PR.

- This makes the error type an actual error type
- adds type aliases for Dictionary/Array
- Adds simple methods for trying to cast from a generic plist enum to dict/array/string, returning a useable error if the types are wrong