### PR TITLE
Update fontc/Cargo.toml

### DIFF
--- a/fontc/Cargo.toml
+++ b/fontc/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "A compiler for fonts."
-repository = "https://github.com/googlefonts/fontmake-rs"
+repository = "https://github.com/googlefonts/fontc"
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]
 


### PR DESCRIPTION
Updates the repository field definition to the new googlefonts/fontc repo from the previous googlefonts/fontmake-rs repo