### PR TITLE
First swing at task prioritization

### DIFF
--- a/fontc/src/timing.rs
+++ b/fontc/src/timing.rs
@@ -190,6 +190,7 @@ pub(crate) fn create_timer(id: AnyWorkId) -> JobTimeRunnable {
 /// The initial state of a runnable job.
 ///
 /// It may have queued from t0 to launchable but now it's go-time!
+#[derive(Debug)]
 pub(crate) struct JobTimeRunnable {
     id: AnyWorkId,
     runnable: Instant,
@@ -206,6 +207,7 @@ impl JobTimeRunnable {
     }
 }
 
+#[derive(Debug)]
 pub(crate) struct JobTimeQueued {
     id: AnyWorkId,
     runnable: Instant,

--- a/fontc/src/work.rs
+++ b/fontc/src/work.rs
@@ -149,6 +149,7 @@ impl AnyAccess {
     }
 }
 
+#[derive(Debug)]
 pub enum AnyContext {
     Fe(FeContext),
     Be(BeContext),

--- a/fontdrasil/src/orchestration.rs
+++ b/fontdrasil/src/orchestration.rs
@@ -9,6 +9,14 @@ use std::{
 
 pub const MISSING_DATA: &str = "Missing data, dependency management failed us?";
 
+/// The priority of a given job; higher priority jobs are started first.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(u8)]
+pub enum Priority {
+    High = 1,
+    Low = 100,
+}
+
 /// A type that affords identity.
 ///
 /// Frequently copied, used in hashmap/sets and printed to logs, hence the trait list.


### PR DESCRIPTION
#456 suggests priorization to get features started sooner might be a plus. This is my first try, just naively split things into high and low priority and try to launch high priority work as soon as possible.

I see the work rearrange as expected in `--emit-timing` output. Oswald appears to benefit, apparently for Google Sans rushing to features is less important. 

```
LINUX

Oswald reports gains
	$ cargo build --release && hyperfine --warmup 3 --runs 50 --prepare 'rm -rf build/' 'target/release/fontc --source ../OswaldFont/sources/Oswald.glyphs --emit-ir false'
	pri 		138.8 ms ±   9.0 ms
	main 		148.8 ms ±   8.5 ms


Google Sans isn't so clearly a win
	$ cargo build --release && hyperfine --warmup 3 --prepare 'rm -rf build/' 'target/release/fontc --source ../googlesans/source/GoogleSans/GoogleSans.designspace --emit-ir false'
	pri 		9.656 s ±  0.320 s
	main 		9.683 s ±  0.447 s

M1 MAC

Oswald reports more significant gains
       $ cargo build --release && hyperfine --warmup 10 --runs 100 --prepare 'rm -rf build/' 'target/release/fontc --source ../OswaldFont/sources/Oswald.glyphs --emit-ir false'
       pri     48.8 ms ±   3.8 ms
       main    62.7 ms ±   5.3 ms 

Google Sans gains, thought not as significantly as Oswald
       $ cargo build --release && hyperfine --warmup 3 --prepare 'rm -rf build/' 'target/release/fontc --source ../googlesans/source/GoogleSans/GoogleSans.designspace --emit-ir false'
       pri     5.694 s ±  0.029 s
       main    5.821 s ±  0.085 s
```

On Mac, with this PR applied, timing suggests kerning and fea is just massively the long pole:

<img width="1719" alt="image" src="https://github.com/googlefonts/fontc/assets/6466432/e0b9c2a3-64fa-4bd4-9b74-75fa787910d9">
