### PR TITLE
WIP: adapt fontc to latest changes in write-fonts' iup_delta_optimize API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ parking_lot = "0.12.1"
 fea-rs = "0.16.1"
 font-types = { version = "0.4.0", features = ["serde"] }
 read-fonts = "0.11.1"
-write-fonts = "0.15"
+write-fonts = { path = "../fontations/write-fonts", features = ["serde"] }
 skrifa = "0.10.0"
 
 bitflags = "2.0"
@@ -48,3 +48,10 @@ members = [
     "ufo2fontir",
     "fontc",
 ]
+
+[patch.crates-io]
+font-types =  { path = "../fontations/font-types" }
+read-fonts =  { path = "../fontations/read-fonts" }
+write-fonts = { path = "../fontations/write-fonts" }
+skrifa =  { path = "../fontations/skrifa" }
+fea-rs = { path = "../fea-rs/fea-rs" }

--- a/fontbe/src/error.rs
+++ b/fontbe/src/error.rs
@@ -6,7 +6,10 @@ use fontdrasil::types::GlyphName;
 use fontir::{error::VariationModelError, variations::DeltaError};
 use read_fonts::ReadError;
 use thiserror::Error;
-use write_fonts::tables::{glyf::MalformedPath, gvar::GvarInputError, variations::IupError};
+use write_fonts::tables::{
+    glyf::MalformedPath,
+    gvar::{iup::IupError, GvarInputError},
+};
 
 #[derive(Debug, Error)]
 pub enum Error {

--- a/fontbe/src/gvar.rs
+++ b/fontbe/src/gvar.rs
@@ -83,7 +83,10 @@ impl Work<Context, AnyWorkId, Error> for GvarWork {
 mod tests {
     use font_types::F2Dot14;
     use fontir::ir::GlyphOrder;
-    use write_fonts::tables::{gvar::GlyphDeltas, variations::Tuple};
+    use write_fonts::tables::{
+        gvar::{GlyphDelta, GlyphDeltas},
+        variations::Tuple,
+    };
 
     use super::make_variations;
 
@@ -103,7 +106,7 @@ mod tests {
                 // At the maximum extent (normalized pos 1.0) of our axis, add +1, +1
                 v if v == glyph_with_var => vec![GlyphDeltas::new(
                     Tuple::new(vec![F2Dot14::from_f32(1.0)]),
-                    vec![Some((1, 1))],
+                    vec![GlyphDelta::new(1, 1, false)],
                     None,
                 )],
                 v => panic!("unexpected {v}"),


### PR DESCRIPTION
A couple of changes in write-fonts lead to fontc no longer working when pointed to latest fontations' HEAD, notably:
https://github.com/googlefonts/fontations/pull/616
https://github.com/googlefonts/fontations/pull/619

This is basically derived from @cmyr's https://github.com/googlefonts/fontc/compare/main...iup-api branch, without the debugging stuff.

Not ready to merged yet until new fontations crates get released