### PR TITLE
skip avar segments when they are all identity mappings

### DIFF
--- a/fontbe/src/avar.rs
+++ b/fontbe/src/avar.rs
@@ -97,13 +97,8 @@ impl Work<Context, AnyWorkId, Error> for AvarWork {
             .filter_map(to_segment_map)
             .filter(|sm| !sm.axis_value_maps.is_empty())
             .collect();
-        if axis_segment_maps.is_empty() {
-            debug!("Skip avar; no interesting mappings");
-            return Ok(());
-        }
-        context
-            .avar
-            .set_unconditionally(Avar::new(axis_segment_maps).into());
+        let avar = (!axis_segment_maps.is_empty()).then_some(Avar::new(axis_segment_maps));
+        context.avar.set_unconditionally(avar.into());
         Ok(())
     }
 }

--- a/fontbe/src/avar.rs
+++ b/fontbe/src/avar.rs
@@ -21,7 +21,7 @@ pub fn create_avar_work() -> Box<BeWork> {
     Box::new(AvarWork {})
 }
 
-fn to_segment_map(axis: &Axis) -> SegmentMaps {
+fn to_segment_map(axis: &Axis) -> Option<SegmentMaps> {
     // default normalization
     let default_converter = CoordConverter::new(
         vec![
@@ -57,6 +57,11 @@ fn to_segment_map(axis: &Axis) -> SegmentMaps {
 
     // avar maps from the default normalization to the actual one,
     // using normalized values on both sides.
+    // All identity mappings are not interesting so we can skip them.
+    if mappings.iter().all(|(k, v)| k == v) {
+        return None;
+    }
+
     let mappings = mappings
         .iter()
         .map(|(default_norm, actual_norm)| {
@@ -64,7 +69,7 @@ fn to_segment_map(axis: &Axis) -> SegmentMaps {
         })
         .collect();
 
-    SegmentMaps::new(mappings)
+    Some(SegmentMaps::new(mappings))
 }
 
 impl Work<Context, AnyWorkId, Error> for AvarWork {
@@ -86,17 +91,19 @@ impl Work<Context, AnyWorkId, Error> for AvarWork {
             debug!("Skip avar; this is not a variable font");
             return Ok(());
         }
-        context.avar.set_unconditionally(
-            Avar::new(
-                static_metadata
-                    .axes
-                    .iter()
-                    .map(to_segment_map)
-                    .filter(|sm| !sm.axis_value_maps.is_empty())
-                    .collect(),
-            )
-            .into(),
-        );
+        let axis_segment_maps: Vec<_> = static_metadata
+            .axes
+            .iter()
+            .filter_map(to_segment_map)
+            .filter(|sm| !sm.axis_value_maps.is_empty())
+            .collect();
+        if axis_segment_maps.is_empty() {
+            debug!("Skip avar; no interesting mappings");
+            return Ok(());
+        }
+        context
+            .avar
+            .set_unconditionally(Avar::new(axis_segment_maps).into());
         Ok(())
     }
 }
@@ -148,8 +155,7 @@ mod tests {
         ];
         for i in 1..mappings.len() {
             let mappings = mappings[0..i].to_vec();
-            let segmap = to_segment_map(&axis(mappings, 1));
-            assert_eq!(vec![(-1.0, -1.0), (0.0, 0.0), (1.0, 1.0),], dump(segmap));
+            assert!(to_segment_map(&axis(mappings, 1)).is_none());
         }
     }
 
@@ -163,7 +169,7 @@ mod tests {
         ];
         assert_eq!(
             vec![(-1.0, -1.0), (0.0, 0.0), (0.75, 0.95), (1.0, 1.0),],
-            dump(to_segment_map(&axis(mappings, 1)))
+            dump(to_segment_map(&axis(mappings, 1)).unwrap())
         );
     }
 
@@ -178,7 +184,7 @@ mod tests {
         ];
         assert_eq!(
             vec![(-1.0, -1.0), (0.0, 0.0), (0.3333, 0.4943), (1.0, 1.0),],
-            dump(to_segment_map(&axis(mappings, 0)))
+            dump(to_segment_map(&axis(mappings, 0)).unwrap())
         );
     }
 }

--- a/fontbe/src/error.rs
+++ b/fontbe/src/error.rs
@@ -56,6 +56,8 @@ pub enum Error {
     VariationModelError(GlyphName, VariationModelError),
     #[error("Missing file:{0}")]
     FileExpected(PathBuf),
+    #[error("Missing {0}")]
+    MissingTable(Tag),
 }
 
 #[derive(Debug)]

--- a/fontbe/src/font.rs
+++ b/fontbe/src/font.rs
@@ -76,7 +76,7 @@ fn has(context: &Context, id: WorkId) -> bool {
     }
 }
 
-fn bytes_for(context: &Context, id: WorkId) -> Result<Vec<u8>, Error> {
+fn bytes_for(context: &Context, id: WorkId) -> Result<Option<Vec<u8>>, Error> {
     // TODO: to_vec copies :(
     let bytes = match id {
         WorkId::Avar => to_bytes(context.avar.get().as_ref()),
@@ -84,13 +84,13 @@ fn bytes_for(context: &Context, id: WorkId) -> Result<Vec<u8>, Error> {
         WorkId::Fvar => to_bytes(context.fvar.get().as_ref()),
         WorkId::Head => to_bytes(context.head.get().as_ref()),
         WorkId::Hhea => to_bytes(context.hhea.get().as_ref()),
-        WorkId::Hmtx => context.hmtx.get().as_ref().get().to_vec(),
-        WorkId::Glyf => context.glyf.get().as_ref().get().to_vec(),
+        WorkId::Hmtx => Some(context.hmtx.get().as_ref().get().to_vec()),
+        WorkId::Glyf => Some(context.glyf.get().as_ref().get().to_vec()),
         WorkId::Gpos => to_bytes(context.gpos.get().as_ref()),
         WorkId::Gsub => to_bytes(context.gsub.get().as_ref()),
         WorkId::Gdef => to_bytes(context.gdef.get().as_ref()),
-        WorkId::Gvar => context.gvar.get().as_ref().get().to_vec(),
-        WorkId::Loca => context.loca.get().as_ref().get().to_vec(),
+        WorkId::Gvar => Some(context.gvar.get().as_ref().get().to_vec()),
+        WorkId::Loca => Some(context.loca.get().as_ref().get().to_vec()),
         WorkId::Maxp => to_bytes(context.maxp.get().as_ref()),
         WorkId::Name => to_bytes(context.name.get().as_ref()),
         WorkId::Os2 => to_bytes(context.os2.get().as_ref()),
@@ -147,8 +147,11 @@ impl Work<Context, AnyWorkId, Error> for FontWork {
                 continue;
             }
             debug!("Grabbing {tag} for final font");
-            let bytes = bytes_for(context, work_id.clone())?;
-            builder.add_raw(*tag, bytes);
+            if let Some(bytes) = bytes_for(context, work_id.clone())? {
+                builder.add_raw(*tag, bytes);
+            } else {
+                debug!("No content for {tag}");
+            }
         }
 
         debug!("Building font");

--- a/fontbe/src/metrics_and_limits.rs
+++ b/fontbe/src/metrics_and_limits.rs
@@ -351,7 +351,7 @@ impl Work<Context, AnyWorkId, Error> for MetricAndLimitWork {
         context.maxp.set_unconditionally(maxp.into());
 
         // Set x/y min/max in head
-        let mut head = context.head.get().0.clone();
+        let mut head = context.head.get().0.clone().unwrap();
         let bbox = glyph_limits.bbox.unwrap_or_default();
         head.x_min = bbox.x_min;
         head.y_min = bbox.y_min;

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -1162,7 +1162,6 @@ mod tests {
             vec![
                 Tag::new(b"OS/2"),
                 Tag::new(b"STAT"),
-                Tag::new(b"avar"),
                 Tag::new(b"cmap"),
                 Tag::new(b"fvar"),
                 Tag::new(b"glyf"),

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -1111,7 +1111,9 @@ mod tests {
         let result = compile(Args::for_test(build_dir, "glyphs2/Mono.glyphs"));
 
         let arc_hhea = result.be_context.hhea.get();
-        let hhea = &arc_hhea.0;
+        let Some(hhea) = &arc_hhea.0 else {
+            panic!("Missing hhea");
+        };
         assert_eq!(1, hhea.number_of_long_metrics);
         assert_eq!(175, hhea.min_left_side_bearing.to_i16());
         assert_eq!(50, hhea.min_right_side_bearing.to_i16());
@@ -1119,7 +1121,9 @@ mod tests {
         assert_eq!(425, hhea.advance_width_max.to_u16());
 
         let arc_maxp = result.be_context.maxp.get();
-        let maxp = &arc_maxp.0;
+        let Some(maxp) = &arc_maxp.0 else {
+            panic!("Missing maxp");
+        };
         assert_eq!(3, maxp.num_glyphs);
         assert_eq!(Some(4), maxp.max_points);
         assert_eq!(Some(1), maxp.max_contours);


### PR DESCRIPTION
Fixes #469

although a few other tests are still failing, I'm not sure exactly how to fix them.

IIUC, because in the case of all-identity maps I'm no longer writing out an avar table, the tests that attempt to compile a second time are failing because the Avar backend task is being run again, whereas they expect that it not be run...

