### PR TITLE
Optionally eliminate components with transforms to match gftools

### DIFF
--- a/fontc/src/args.rs
+++ b/fontc/src/args.rs
@@ -31,6 +31,12 @@ pub struct Args {
     #[arg(long, default_value = "false")]
     pub flatten_components: bool,
 
+    /// Whether a component is allowed to have a non-identity 2x2 transform.
+    ///
+    /// If not, any source component that does will be flattened
+    #[arg(long, default_value = "true", action = ArgAction::Set)]
+    pub allow_component_transforms: bool,
+
     /// Whether to out timing data, notably a visualization of threadpool execution of tasks.
     ///
     /// See <https://github.com/googlefonts/fontc/pull/443>
@@ -59,6 +65,10 @@ impl Args {
         flags.set(Flags::EMIT_DEBUG, self.emit_debug);
         flags.set(Flags::PREFER_SIMPLE_GLYPHS, self.prefer_simple_glyphs);
         flags.set(Flags::FLATTEN_COMPONENTS, self.flatten_components);
+        flags.set(
+            Flags::ALLOW_COMPONENT_TRANSFORM,
+            self.allow_component_transforms,
+        );
         flags.set(Flags::EMIT_TIMING, self.emit_timing);
 
         flags
@@ -80,6 +90,7 @@ impl Args {
             build_dir: build_dir.to_path_buf(),
             prefer_simple_glyphs: Flags::default().contains(Flags::PREFER_SIMPLE_GLYPHS),
             flatten_components: Flags::default().contains(Flags::FLATTEN_COMPONENTS),
+            allow_component_transforms: Flags::default().contains(Flags::ALLOW_COMPONENT_TRANSFORM),
             compile_features: true,
         }
     }

--- a/fontc/src/args.rs
+++ b/fontc/src/args.rs
@@ -34,8 +34,9 @@ pub struct Args {
     /// Whether a component is allowed to have a non-identity 2x2 transform.
     ///
     /// If not, any source component that does will be flattened
-    #[arg(long, default_value = "true", action = ArgAction::Set)]
-    pub allow_component_transforms: bool,
+    /// Named to match the ufo2ft flag as suggested in <https://github.com/googlefonts/fontc/pull/480#discussion_r1343801553>
+    #[arg(long, default_value = "false")]
+    pub decompose_transformed_components: bool,
 
     /// Whether to out timing data, notably a visualization of threadpool execution of tasks.
     ///
@@ -66,8 +67,8 @@ impl Args {
         flags.set(Flags::PREFER_SIMPLE_GLYPHS, self.prefer_simple_glyphs);
         flags.set(Flags::FLATTEN_COMPONENTS, self.flatten_components);
         flags.set(
-            Flags::ALLOW_COMPONENT_TRANSFORM,
-            self.allow_component_transforms,
+            Flags::DECOMPOSE_TRANSFORMED_COMPONENTS,
+            self.decompose_transformed_components,
         );
         flags.set(Flags::EMIT_TIMING, self.emit_timing);
 
@@ -90,7 +91,8 @@ impl Args {
             build_dir: build_dir.to_path_buf(),
             prefer_simple_glyphs: Flags::default().contains(Flags::PREFER_SIMPLE_GLYPHS),
             flatten_components: Flags::default().contains(Flags::FLATTEN_COMPONENTS),
-            allow_component_transforms: Flags::default().contains(Flags::ALLOW_COMPONENT_TRANSFORM),
+            decompose_transformed_components: Flags::default()
+                .contains(Flags::DECOMPOSE_TRANSFORMED_COMPONENTS),
             compile_features: true,
         }
     }

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -1039,7 +1039,7 @@ mod tests {
         let temp_dir = tempdir().unwrap();
         let build_dir = temp_dir.path();
         let mut args = Args::for_test(build_dir, "glyphs2/Component.glyphs");
-        args.allow_component_transforms = false;
+        args.decompose_transformed_components = true;
         let result = compile(args);
 
         let glyph_data = result.glyphs();

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -1035,6 +1035,32 @@ mod tests {
     }
 
     #[test]
+    fn eliminate_2x2_transforms() {
+        let temp_dir = tempdir().unwrap();
+        let build_dir = temp_dir.path();
+        let mut args = Args::for_test(build_dir, "glyphs2/Component.glyphs");
+        args.allow_component_transforms = false;
+        let result = compile(args);
+
+        let glyph_data = result.glyphs();
+        let glyphs = glyph_data.read();
+
+        // Not an identity 2x2, should be simplified
+        let Some(glyf::Glyph::Simple(..)) =
+            &glyphs[result.get_glyph_index("simple_transform_again") as usize]
+        else {
+            panic!("Expected a simple glyph\n{glyphs:#?}");
+        };
+
+        // Identity 2x2, should be left as a component
+        let Some(glyf::Glyph::Composite(..)) =
+            &glyphs[result.get_glyph_index("translate_only") as usize]
+        else {
+            panic!("Expected a composite glyph\n{glyphs:#?}");
+        };
+    }
+
+    #[test]
     fn writes_cmap() {
         let temp_dir = tempdir().unwrap();
         let build_dir = temp_dir.path();
@@ -1075,7 +1101,8 @@ mod tests {
                     (0x002E, 1),
                     (0x0030, 3),
                     (0x031, 4),
-                    (0x032, 5)
+                    (0x032, 5),
+                    (0x033, 6)
                 ],
                 cp_and_gid,
                 "start {:?}\nend {:?}id_delta {:?}",

--- a/fontir/src/glyph.rs
+++ b/fontir/src/glyph.rs
@@ -402,6 +402,15 @@ impl Work<Context, WorkId, WorkError> for GlyphOrderWork {
             }
         }
 
+        if !context.flags.contains(Flags::ALLOW_COMPONENT_TRANSFORM) {
+            for glyph_name in new_glyph_order.iter() {
+                let glyph = context.glyphs.get(&WorkId::Glyph(glyph_name.clone()));
+                if glyph.has_nonidentity_2x2() {
+                    convert_components_to_contours(context, &glyph)?;
+                }
+            }
+        }
+
         ensure_notdef_exists_and_is_gid_0(context, &mut new_glyph_order)?;
 
         // We now have the final static metadata

--- a/fontir/src/glyph.rs
+++ b/fontir/src/glyph.rs
@@ -402,7 +402,10 @@ impl Work<Context, WorkId, WorkError> for GlyphOrderWork {
             }
         }
 
-        if !context.flags.contains(Flags::ALLOW_COMPONENT_TRANSFORM) {
+        if context
+            .flags
+            .contains(Flags::DECOMPOSE_TRANSFORMED_COMPONENTS)
+        {
             for glyph_name in new_glyph_order.iter() {
                 let glyph = context.glyphs.get(&WorkId::Glyph(glyph_name.clone()));
                 if glyph.has_nonidentity_2x2() {

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -1016,6 +1016,16 @@ impl Glyph {
     pub(crate) fn has_consistent_components(&self) -> bool {
         self.has_consistent_2x2_transforms
     }
+
+    /// Does the glyph have any component with a non-identity 2x2
+    ///
+    /// See <https://github.com/googlefonts/fontc/issues/291#issuecomment-1557358538>
+    pub(crate) fn has_nonidentity_2x2(&self) -> bool {
+        self.sources
+            .values()
+            .flat_map(|inst| inst.components.iter())
+            .any(|c| c.transform.as_coeffs()[..4] != [1.0, 0.0, 0.0, 1.0])
+    }
 }
 
 impl IdAware<WorkId> for Glyph {

--- a/fontir/src/orchestration.rs
+++ b/fontir/src/orchestration.rs
@@ -29,15 +29,15 @@ bitflags! {
         // If set, a composite that references another composite will replace that composite with the
         // glyph(s) it references until only simple (contour) glyphs are referenced
         const FLATTEN_COMPONENTS = 0b00001000;
+        const ALLOW_COMPONENT_TRANSFORM = 0b00010000;
         // If set a files reporting on timing will be emitted to disk
-        const EMIT_TIMING = 0b00010000;
+        const EMIT_TIMING = 0b00100000;
     }
 }
 
 impl Default for Flags {
-    /// Match the way gftools configures fontmake by default
     fn default() -> Self {
-        Flags::EMIT_IR | Flags::PREFER_SIMPLE_GLYPHS
+        Flags::EMIT_IR | Flags::PREFER_SIMPLE_GLYPHS | Flags::ALLOW_COMPONENT_TRANSFORM
     }
 }
 

--- a/fontir/src/orchestration.rs
+++ b/fontir/src/orchestration.rs
@@ -29,7 +29,7 @@ bitflags! {
         // If set, a composite that references another composite will replace that composite with the
         // glyph(s) it references until only simple (contour) glyphs are referenced
         const FLATTEN_COMPONENTS = 0b00001000;
-        const ALLOW_COMPONENT_TRANSFORM = 0b00010000;
+        const DECOMPOSE_TRANSFORMED_COMPONENTS = 0b00010000;
         // If set a files reporting on timing will be emitted to disk
         const EMIT_TIMING = 0b00100000;
     }
@@ -37,7 +37,7 @@ bitflags! {
 
 impl Default for Flags {
     fn default() -> Self {
-        Flags::EMIT_IR | Flags::PREFER_SIMPLE_GLYPHS | Flags::ALLOW_COMPONENT_TRANSFORM
+        Flags::EMIT_IR | Flags::PREFER_SIMPLE_GLYPHS
     }
 }
 

--- a/resources/scripts/ttx_diff.py
+++ b/resources/scripts/ttx_diff.py
@@ -104,6 +104,8 @@ def build_fontc(source: Path, build_dir: Path, compare: str):
     ]
     if compare == _COMPARE_GFTOOLS:
         cmd.append("--flatten-components")
+        cmd.append("--allow-component-transforms")
+        cmd.append("false")
     return build(cmd, build_dir, "fontc", lambda: (build_dir / "font.ttf",))
 
 

--- a/resources/scripts/ttx_diff.py
+++ b/resources/scripts/ttx_diff.py
@@ -104,8 +104,7 @@ def build_fontc(source: Path, build_dir: Path, compare: str):
     ]
     if compare == _COMPARE_GFTOOLS:
         cmd.append("--flatten-components")
-        cmd.append("--allow-component-transforms")
-        cmd.append("false")
+        cmd.append("--decompose-transformed-components")
     return build(cmd, build_dir, "fontc", lambda: (build_dir / "font.ttf",))
 
 

--- a/resources/testdata/glyphs2/Component.glyphs
+++ b/resources/testdata/glyphs2/Component.glyphs
@@ -117,6 +117,23 @@ width = 600;
 }
 );
 unicode = 0032;
+},
+{
+glyphname = translate_only;
+lastChange = "2023-01-20 20:22:39 +0000";
+layers = (
+{
+components = (
+{
+name = period;
+transform = "{1, 0, 0, 1, 50, 50}";
+}
+);
+layerId = m01;
+width = 600;
+}
+);
+unicode = 0033;
 }
 );
 unitsPerEm = 1000;


### PR DESCRIPTION
https://github.com/googlefonts/fontc/issues/291#issuecomment-1557358538 notes "if we want to match gftools default behavior of decomposing unconditionally all transformed components we need to add a corresponding option to fontc"

So ... do that. After this the glyf and gvar diff in ttx_diff gftools mode is down to a very few points where we're off by one:

![image](https://github.com/googlefonts/fontc/assets/6466432/2861e2b1-63a6-407a-8f35-34277a050e9a)
