### PR TITLE
ufo2fontir: prefer use instance.stylename

### DIFF
--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -1513,6 +1513,17 @@ mod tests {
         );
     }
 
+    #[test]
+    fn compile_named_instances_from_designspace_with_stylename_attrs() {
+        assert_named_instances(
+            "wght_var_instance_stylename.designspace",
+            vec![
+                ("Foo".to_string(), vec![("Weight", 400.0)]),
+                ("Bar".to_string(), vec![("Weight", 700.0)]),
+            ],
+        );
+    }
+
     fn assert_fs_selection(source: &str, expected: SelectionFlags) {
         let temp_dir = tempdir().unwrap();
         let build_dir = temp_dir.path();

--- a/resources/testdata/wght_var_instance_stylename.designspace
+++ b/resources/testdata/wght_var_instance_stylename.designspace
@@ -1,0 +1,30 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<designspace format="4.1">
+  <axes>
+    <axis tag="wght" name="Weight" minimum="400" maximum="700" default="400"/>
+  </axes>
+  <sources>
+    <source filename="WghtVar-Regular.ufo" name="Wght Var Regular" familyname="Wght Var" stylename="Regular">
+      <location>
+        <dimension name="Weight" xvalue="400"/>
+      </location>
+    </source>
+    <source filename="WghtVar-Bold.ufo" name="Wght Var Bold" familyname="Wght Var" stylename="Bold">
+      <location>
+        <dimension name="Weight" xvalue="700"/>
+      </location>
+    </source>
+  </sources>
+  <instances>
+    <instance stylename="Foo">
+      <location>
+        <dimension name="Weight" xvalue="400"/>
+      </location>
+    </instance>
+    <instance stylename="Bar">
+      <location>
+        <dimension name="Weight" xvalue="700"/>
+      </location>
+    </instance>
+  </instances>
+</designspace>

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -712,7 +712,7 @@ impl Work<Context, WorkId, WorkError> for StaticMetadataWork {
                 // TODO: Also support localised names, and names inferred from axis labels
                 // (also used to build STAT table)
                 NamedInstance {
-                    name: inst.stylename.clone().unwrap_or(
+                    name: inst.stylename.clone().unwrap_or_else(|| {
                         match inst
                             .name
                             .as_ref()
@@ -721,8 +721,8 @@ impl Work<Context, WorkId, WorkError> for StaticMetadataWork {
                         {
                             Some(tail) => tail.to_string(),
                             None => inst.name.clone().unwrap(),
-                        },
-                    ),
+                        }
+                    }),
                     location: to_design_location(&tags_by_name, &inst.location)
                         .to_user(&axes_by_tag),
                 }

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -708,17 +708,24 @@ impl Work<Context, WorkId, WorkError> for StaticMetadataWork {
             .designspace
             .instances
             .iter()
-            .map(|inst| NamedInstance {
-                name: match inst
-                    .name
-                    .as_ref()
-                    .unwrap()
-                    .strip_prefix(family_prefix.as_str())
-                {
-                    Some(tail) => tail.to_string(),
-                    None => inst.name.clone().unwrap(),
-                },
-                location: to_design_location(&tags_by_name, &inst.location).to_user(&axes_by_tag),
+            .map(|inst| {
+                // TODO: Also support localised names, and names inferred from axis labels
+                // (also used to build STAT table)
+                NamedInstance {
+                    name: inst.stylename.clone().unwrap_or(
+                        match inst
+                            .name
+                            .as_ref()
+                            .unwrap()
+                            .strip_prefix(family_prefix.as_str())
+                        {
+                            Some(tail) => tail.to_string(),
+                            None => inst.name.clone().unwrap(),
+                        },
+                    ),
+                    location: to_design_location(&tags_by_name, &inst.location)
+                        .to_user(&axes_by_tag),
+                }
             })
             .collect();
 


### PR DESCRIPTION
Fixes https://github.com/googlefonts/fontc/issues/386

~~Note the previous behavior of taking instance.name and stripping familyname prefix does not match fonttools behavior so I removed it. The instance.name (like similar element name attributes in DS format) is meant as an identifier for cross-referencing elements and is not used for named instances' style names. Only instance `stylename` attribute (and the localised names if any) are used by fonttools to set the fvar's NamedInstance subFamilyNameID.~~

The `stylename` attribute can be omitted in DSv5 and be generated using axis labels, but for most projects (including those two Google private projects that we wish to use this for) they are likely to be defined explicitly so with this PR we use them.

Also note that the `compile_named_instances_from_designspace` test in fontc/lib.rs is already covering the changes in this PR (the "wght_var.designspace" has instances with correct stylename attributes)