### PR TITLE
use BezPath::reverse_subpaths() from latest kurbo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ bitflags = "2.0"
 chrono = { version = "0.4.24", features = ["serde"] }
 filetime = "0.2.18"
 indexmap = "1.9.2"
-kurbo = { version = "0.9.4", features = ["serde"] }
+kurbo = { version = "0.10.2", features = ["serde"] }
 ordered-float = { version = "4.1.0", features = ["serde"] }
 smol_str = { version = "0.1.24", features = ["serde"] }
 quick-xml = { version = "0.29.0", features = ["serialize"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,11 @@ env_logger = "0.10.0"
 
 parking_lot = "0.12.1"
 
-fea-rs = "0.17.0"
+fea-rs = "0.18.0"
 font-types = { version = "0.4.0", features = ["serde"] }
-read-fonts = "0.11.2"
-write-fonts = { version = "0.16.0", features = ["serde"] }
-skrifa = "0.10.1"
+read-fonts = "0.12.0"
+write-fonts = { version = "0.17.0", features = ["serde"] }
+skrifa = "0.11.0"
 
 bitflags = "2.0"
 chrono = { version = "0.4.24", features = ["serde"] }


### PR DESCRIPTION
Added with kurbo 0.10.2 in https://github.com/linebender/kurbo/pull/307

has same functionality as ReverseContourPen when applied to BezPath, but without the loss of precision from f64 to f32