### PR TITLE
Postscript names for UFO sources

### DIFF
--- a/fontbe/src/features.rs
+++ b/fontbe/src/features.rs
@@ -645,6 +645,7 @@ mod tests {
             ],
             Default::default(),
             HashSet::from([min_wght, def_wght, max_wght]),
+            Default::default(),
         )
         .unwrap()
     }

--- a/fontbe/src/fvar.rs
+++ b/fontbe/src/fvar.rs
@@ -114,6 +114,7 @@ mod tests {
             axes.to_vec(),
             Default::default(),
             Default::default(),
+            Default::default(),
         )
         .unwrap()
     }

--- a/fontbe/src/post.rs
+++ b/fontbe/src/post.rs
@@ -37,8 +37,14 @@ impl Work<Context, AnyWorkId, Error> for PostWork {
         // TODO optionally drop glyph names with format 3.0.
         // TODO a more serious post
         let static_metadata = context.ir.static_metadata.get();
+        let postscript_names = &static_metadata.postscript_names;
         let glyph_order = context.ir.glyph_order.get();
-        let mut post = Post::new_v2(glyph_order.iter().map(|g| g.as_str()));
+        let mut post = Post::new_v2(glyph_order.iter().map(|g| {
+            postscript_names
+                .get(g)
+                .map(String::as_str)
+                .unwrap_or(g.as_str())
+        }));
         post.underline_position = FWord::new(static_metadata.misc.underline_position.0 as i16);
         post.underline_thickness = FWord::new(static_metadata.misc.underline_thickness.0 as i16);
         context.post.set_unconditionally(post.into());

--- a/fontbe/src/post.rs
+++ b/fontbe/src/post.rs
@@ -39,12 +39,11 @@ impl Work<Context, AnyWorkId, Error> for PostWork {
         let static_metadata = context.ir.static_metadata.get();
         let postscript_names = &static_metadata.postscript_names;
         let glyph_order = context.ir.glyph_order.get();
-        let mut post = Post::new_v2(glyph_order.iter().map(|g| {
-            postscript_names
-                .get(g)
-                .map(String::as_str)
-                .unwrap_or(g.as_str())
-        }));
+        let mut post = Post::new_v2(
+            glyph_order
+                .iter()
+                .map(|g| postscript_names.get(g).unwrap_or(g).as_str()),
+        );
         post.underline_position = FWord::new(static_metadata.misc.underline_position.0 as i16);
         post.underline_thickness = FWord::new(static_metadata.misc.underline_thickness.0 as i16);
         context.post.set_unconditionally(post.into());

--- a/fontc/src/args.rs
+++ b/fontc/src/args.rs
@@ -118,19 +118,22 @@ impl Args {
 mod tests {
     use clap::Parser;
     use fontir::orchestration::Flags;
+    use log::{debug, LevelFilter};
 
     use crate::Args;
 
     // It's awkward to get the Flags::default values into #[arg] so test for consistency
     #[test]
     fn arg_default_matches_flags_default() {
+        let _ = env_logger::builder()
+            .is_test(true)
+            .format_timestamp(None)
+            .filter_level(LevelFilter::Debug)
+            .try_init();
         let arg_default = Args::parse_from(vec!["program", "--source", "dont.care"]).flags();
         let flags_default = Flags::default();
-        println!(
-            "flags_default: {:#032b}\nargs_default:  {:#032b}",
-            flags_default.bits(),
-            arg_default.bits()
-        );
+        debug!("flags_default: {:#032b}", flags_default.bits());
+        debug!("args_default:  {:#032b}", arg_default.bits());
         assert_eq!(flags_default.bits(), arg_default.bits());
     }
 }

--- a/fontc/src/args.rs
+++ b/fontc/src/args.rs
@@ -65,7 +65,7 @@ pub struct Args {
     pub keep_direction: bool,
 
     /// Don't rename glyphs with production names
-    #[arg(long, default_value = "true")]
+    #[arg(long, default_value = "false")]
     pub no_production_names: bool,
 }
 
@@ -109,6 +109,7 @@ impl Args {
                 .contains(Flags::DECOMPOSE_TRANSFORMED_COMPONENTS),
             skip_features: false,
             keep_direction: false,
+            no_production_names: false,
         }
     }
 }
@@ -125,6 +126,11 @@ mod tests {
     fn arg_default_matches_flags_default() {
         let arg_default = Args::parse_from(vec!["program", "--source", "dont.care"]).flags();
         let flags_default = Flags::default();
+        println!(
+            "flags_default: {:#032b}\nargs_default:  {:#032b}",
+            flags_default.bits(),
+            arg_default.bits()
+        );
         assert_eq!(flags_default.bits(), arg_default.bits());
     }
 }

--- a/fontc/src/args.rs
+++ b/fontc/src/args.rs
@@ -63,6 +63,10 @@ pub struct Args {
     // https://github.com/googlefonts/fontmake/blob/6a8b2907/Lib/fontmake/__main__.py#L443
     #[arg(long, default_value = "false")]
     pub keep_direction: bool,
+
+    /// Don't rename glyphs with production names
+    #[arg(long, default_value = "true")]
+    pub no_production_names: bool,
 }
 
 impl Args {
@@ -80,6 +84,7 @@ impl Args {
         );
         flags.set(Flags::EMIT_TIMING, self.emit_timing);
         flags.set(Flags::KEEP_DIRECTION, self.keep_direction);
+        flags.set(Flags::PRODUCTION_NAMES, !self.no_production_names);
 
         flags
     }

--- a/fontc/src/args.rs
+++ b/fontc/src/args.rs
@@ -65,6 +65,8 @@ pub struct Args {
     pub keep_direction: bool,
 
     /// Don't rename glyphs with production names
+    // Named to match fontmake's homonymous flag:
+    // https://github.com/googlefonts/fontmake/blob/6a8b2907/Lib/fontmake/__main__.py#L602
     #[arg(long, default_value = "false")]
     pub no_production_names: bool,
 }
@@ -118,22 +120,20 @@ impl Args {
 mod tests {
     use clap::Parser;
     use fontir::orchestration::Flags;
-    use log::{debug, LevelFilter};
 
     use crate::Args;
 
     // It's awkward to get the Flags::default values into #[arg] so test for consistency
     #[test]
     fn arg_default_matches_flags_default() {
-        let _ = env_logger::builder()
-            .is_test(true)
-            .format_timestamp(None)
-            .filter_level(LevelFilter::Debug)
-            .try_init();
         let arg_default = Args::parse_from(vec!["program", "--source", "dont.care"]).flags();
         let flags_default = Flags::default();
-        debug!("flags_default: {:#032b}", flags_default.bits());
-        debug!("args_default:  {:#032b}", arg_default.bits());
-        assert_eq!(flags_default.bits(), arg_default.bits());
+        assert_eq!(
+            flags_default.bits(),
+            arg_default.bits(),
+            "mismatch in defaults. flags_default: {:#032b}. args_default: {:#032b}",
+            flags_default.bits(),
+            arg_default.bits(),
+        );
     }
 }

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -67,7 +67,9 @@ pub struct StaticMetadata {
     /// See <https://learn.microsoft.com/en-us/typography/opentype/spec/name>.
     pub names: HashMap<NameKey, String>,
 
-    pub postscript_names: HashMap<GlyphName, String>,
+    /// See <https://learn.microsoft.com/en-us/typography/opentype/spec/post> and
+    /// <https://github.com/adobe-type-tools/agl-specification>
+    pub postscript_names: PostscriptNames,
 
     /// Miscellaneous font-wide data that didn't seem worthy of top billing
     pub misc: MiscMetadata,
@@ -180,6 +182,9 @@ impl IntoIterator for GlyphOrder {
     }
 }
 
+/// Glyph names mapped to postscript names
+pub type PostscriptNames = HashMap<GlyphName, GlyphName>;
+
 /// In logical (reading) order
 type KernPair = (KernParticipant, KernParticipant);
 type KernValues = BTreeMap<NormalizedLocation, OrderedFloat<f32>>;
@@ -237,7 +242,7 @@ impl StaticMetadata {
         axes: Vec<Axis>,
         named_instances: Vec<NamedInstance>,
         glyph_locations: HashSet<NormalizedLocation>,
-        postscript_names: HashMap<GlyphName, String>,
+        postscript_names: PostscriptNames,
     ) -> Result<StaticMetadata, VariationModelError> {
         // Point axes are less exciting than ranged ones
         let variable_axes: Vec<_> = axes.iter().filter(|a| !a.is_point()).cloned().collect();

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -67,6 +67,8 @@ pub struct StaticMetadata {
     /// See <https://learn.microsoft.com/en-us/typography/opentype/spec/name>.
     pub names: HashMap<NameKey, String>,
 
+    pub postscript_names: HashMap<GlyphName, String>,
+
     /// Miscellaneous font-wide data that didn't seem worthy of top billing
     pub misc: MiscMetadata,
 }
@@ -235,6 +237,7 @@ impl StaticMetadata {
         axes: Vec<Axis>,
         named_instances: Vec<NamedInstance>,
         glyph_locations: HashSet<NormalizedLocation>,
+        postscript_names: HashMap<GlyphName, String>,
     ) -> Result<StaticMetadata, VariationModelError> {
         // Point axes are less exciting than ranged ones
         let variable_axes: Vec<_> = axes.iter().filter(|a| !a.is_point()).cloned().collect();
@@ -275,6 +278,7 @@ impl StaticMetadata {
             variation_model,
             axes_default,
             variable_axes_default,
+            postscript_names,
             misc: MiscMetadata {
                 selection_flags: Default::default(),
                 vendor_id: DEFAULT_VENDOR_ID_TAG,

--- a/fontir/src/orchestration.rs
+++ b/fontir/src/orchestration.rs
@@ -34,12 +34,14 @@ bitflags! {
         const EMIT_TIMING = 0b00100000;
         // If set, the direction of contours will NOT be reversed
         const KEEP_DIRECTION = 0b01000000;
+        // If set, production names are read & used
+        const PRODUCTION_NAMES = 0b10000000;
     }
 }
 
 impl Default for Flags {
     fn default() -> Self {
-        Flags::EMIT_IR | Flags::PREFER_SIMPLE_GLYPHS
+        Flags::EMIT_IR | Flags::PREFER_SIMPLE_GLYPHS | Flags::PRODUCTION_NAMES
     }
 }
 

--- a/fontir/src/serde.rs
+++ b/fontir/src/serde.rs
@@ -6,6 +6,7 @@ use std::{
 use chrono::{DateTime, Utc};
 use filetime::FileTime;
 use font_types::Tag;
+use fontdrasil::types::GlyphName;
 use ordered_float::OrderedFloat;
 use serde::{Deserialize, Serialize};
 use write_fonts::tables::os2::SelectionFlags;
@@ -59,6 +60,7 @@ pub(crate) struct StaticMetadataSerdeRepr {
     pub named_instances: Vec<NamedInstance>,
     pub glyph_locations: Vec<NormalizedLocation>,
     pub names: HashMap<NameKey, String>,
+    pub postscript_names: HashMap<GlyphName, String>,
     pub misc: MiscSerdeRepr,
 }
 
@@ -70,6 +72,7 @@ impl From<StaticMetadataSerdeRepr> for StaticMetadata {
             from.axes,
             from.named_instances,
             from.glyph_locations.into_iter().collect(),
+            from.postscript_names,
         )
         .unwrap()
     }
@@ -84,6 +87,7 @@ impl From<StaticMetadata> for StaticMetadataSerdeRepr {
             named_instances: from.named_instances,
             glyph_locations,
             names: from.names,
+            postscript_names: from.postscript_names,
             misc: from.misc.into(),
         }
     }

--- a/fontir/src/serde.rs
+++ b/fontir/src/serde.rs
@@ -6,7 +6,6 @@ use std::{
 use chrono::{DateTime, Utc};
 use filetime::FileTime;
 use font_types::Tag;
-use fontdrasil::types::GlyphName;
 use ordered_float::OrderedFloat;
 use serde::{Deserialize, Serialize};
 use write_fonts::tables::os2::SelectionFlags;
@@ -15,7 +14,8 @@ use crate::{
     coords::{CoordConverter, DesignCoord, NormalizedLocation, UserCoord},
     ir::{
         Axis, GlobalMetric, GlobalMetrics, Glyph, GlyphBuilder, GlyphInstance, GlyphOrder,
-        KernParticipant, Kerning, MiscMetadata, NameKey, NamedInstance, StaticMetadata,
+        KernParticipant, Kerning, MiscMetadata, NameKey, NamedInstance, PostscriptNames,
+        StaticMetadata,
     },
     stateset::{FileState, MemoryState, State, StateIdentifier, StateSet},
 };
@@ -60,7 +60,7 @@ pub(crate) struct StaticMetadataSerdeRepr {
     pub named_instances: Vec<NamedInstance>,
     pub glyph_locations: Vec<NormalizedLocation>,
     pub names: HashMap<NameKey, String>,
-    pub postscript_names: HashMap<GlyphName, String>,
+    pub postscript_names: PostscriptNames,
     pub misc: MiscSerdeRepr,
 }
 

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -348,6 +348,7 @@ impl Work<Context, WorkId, WorkError> for StaticMetadataWork {
             axes,
             named_instances,
             glyph_locations,
+            Default::default(), // TODO: impl reading PS names from Glyphs
         )
         .map_err(WorkError::VariationModelError)?;
         static_metadata.misc.selection_flags = selection_flags;

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -11,6 +11,7 @@ use fontdrasil::{
     orchestration::{Access, Work},
     types::{GlyphName, GroupName},
 };
+use fontir::ir::PostscriptNames;
 use fontir::{
     coords::{DesignLocation, NormalizedLocation, UserCoord},
     error::{Error, WorkError},
@@ -522,7 +523,7 @@ fn glyph_order(
 fn postscript_names(
     source: &norad::designspace::Source,
     designspace_dir: &Path,
-) -> Result<HashMap<GlyphName, String>, WorkError> {
+) -> Result<PostscriptNames, WorkError> {
     let lib_plist = load_plist(&designspace_dir.join(&source.filename), "lib.plist")?;
     let postscript_names = match lib_plist.get("public.postscriptNames") {
         Some(value) => {
@@ -537,9 +538,10 @@ fn postscript_names(
             postscript_names_lib
                 .iter()
                 .filter_map(|(glyph_name, ps_name)| match ps_name.as_string() {
-                    Some(ps_name) => {
-                        Some((GlyphName::from(glyph_name.as_str()), ps_name.to_owned()))
-                    }
+                    Some(ps_name) => Some((
+                        GlyphName::from(glyph_name.as_str()),
+                        GlyphName::from(ps_name),
+                    )),
                     None => {
                         warn!("public.postscriptNames: \"{glyph_name}\" has a non-string entry");
                         None

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -551,6 +551,19 @@ fn postscript_names(
         }
         None => HashMap::new(),
     };
+    // Warn about duplicate public.postscriptNames values
+    // Allocate space ahead of time for speed, and because in the happy path the set length will be
+    // the same as the map len
+    let mut duplicate_values_check = HashSet::with_capacity(postscript_names.len());
+    postscript_names
+        .values()
+        .filter(|ps_name| {
+            let ps_name = (*ps_name).clone();
+            !duplicate_values_check.insert(ps_name)
+        })
+        .for_each(|ps_name| {
+            warn!("public.postscriptNames: multiple glyphs have the postscript name \"{ps_name}\"");
+        });
     Ok(postscript_names)
 }
 

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -12,6 +12,7 @@ use fontdrasil::{
     types::{GlyphName, GroupName},
 };
 use fontir::ir::PostscriptNames;
+use fontir::orchestration::Flags;
 use fontir::{
     coords::{DesignLocation, NormalizedLocation, UserCoord},
     error::{Error, WorkError},
@@ -804,7 +805,11 @@ impl Work<Context, WorkId, WorkError> for StaticMetadataWork {
                 StyleMapStyle::BoldItalic => SelectionFlags::BOLD | SelectionFlags::ITALIC,
             };
 
-        let postscript_names = postscript_names(default_master, designspace_dir)?;
+        let postscript_names = if context.flags.contains(Flags::PRODUCTION_NAMES) {
+            postscript_names(default_master, designspace_dir)?
+        } else {
+            PostscriptNames::default()
+        };
 
         let mut static_metadata = StaticMetadata::new(
             units_per_em,

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -1345,7 +1345,7 @@ mod tests {
         (source, input)
     }
 
-    fn flags_without_emit_ir() -> Flags {
+    fn default_test_flags() -> Flags {
         Flags::default() - Flags::EMIT_IR
     }
 
@@ -1387,7 +1387,7 @@ mod tests {
     }
 
     fn build_global_metrics(name: &str) -> (impl Source, Context) {
-        let (source, context) = build_static_metadata(name, flags_without_emit_ir());
+        let (source, context) = build_static_metadata(name, default_test_flags());
         let task_context = context.copy_for_work(
             Access::one(WorkId::StaticMetadata),
             Access::one(WorkId::GlobalMetrics),
@@ -1401,7 +1401,7 @@ mod tests {
     }
 
     fn build_kerning(name: &str) -> (impl Source, Context) {
-        let (source, context) = build_static_metadata(name, flags_without_emit_ir());
+        let (source, context) = build_static_metadata(name, default_test_flags());
         build_glyph_order(&context);
 
         let task_context = context.copy_for_work(
@@ -1417,7 +1417,7 @@ mod tests {
     }
 
     fn build_glyphs(name: &str) -> (impl Source, Context) {
-        let (source, context) = build_static_metadata(name, flags_without_emit_ir());
+        let (source, context) = build_static_metadata(name, default_test_flags());
         build_glyph_order(&context);
 
         let glyph_order = context.glyph_order.get().iter().cloned().collect();
@@ -1648,7 +1648,7 @@ mod tests {
 
     #[test]
     fn captures_os2_properties() {
-        let (_, context) = build_static_metadata("fontinfo.designspace", flags_without_emit_ir());
+        let (_, context) = build_static_metadata("fontinfo.designspace", default_test_flags());
         assert_eq!(
             Tag::new(b"RODS"),
             context.static_metadata.get().misc.vendor_id
@@ -1701,7 +1701,7 @@ mod tests {
     // Was tripping up on wght_var having two <source> with the same filename, different name and xvalue
     #[test]
     fn glyph_locations() {
-        let (_, context) = build_static_metadata("wght_var.designspace", flags_without_emit_ir());
+        let (_, context) = build_static_metadata("wght_var.designspace", default_test_flags());
         let static_metadata = &context.static_metadata.get();
         let wght = static_metadata.axes.first().unwrap();
 
@@ -1747,7 +1747,7 @@ mod tests {
 
     #[test]
     fn default_underline_settings() {
-        let (_, context) = build_static_metadata("wght_var.designspace", flags_without_emit_ir());
+        let (_, context) = build_static_metadata("wght_var.designspace", default_test_flags());
         let static_metadata = &context.static_metadata.get();
         assert_eq!(
             (1000, 50.0, -75.0),
@@ -1947,7 +1947,7 @@ mod tests {
     fn static_metadata_loads_postscript_names() {
         let (_, context) = build_static_metadata(
             "designspace_from_glyphs/WghtVar.designspace",
-            flags_without_emit_ir(),
+            default_test_flags(),
         );
         let static_metadata = context.static_metadata.get();
 
@@ -1962,7 +1962,7 @@ mod tests {
 
     #[test]
     fn static_metadata_disable_postscript_names() {
-        let no_production_names = flags_without_emit_ir() - Flags::PRODUCTION_NAMES;
+        let no_production_names = default_test_flags() - Flags::PRODUCTION_NAMES;
         let (_, context) = build_static_metadata(
             "designspace_from_glyphs/WghtVar.designspace",
             no_production_names,

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -548,15 +548,16 @@ fn postscript_names(lib_plist: &plist::Dictionary) -> Result<PostscriptNames, Wo
     // Allocate space ahead of time for speed, and because in the happy path the set length will be
     // the same as the map len
     let mut duplicate_values_check = HashSet::with_capacity(postscript_names.len());
-    postscript_names
+    let duplicate_values = postscript_names
         .values()
         .filter(|ps_name| {
             let ps_name = (*ps_name).clone();
             !duplicate_values_check.insert(ps_name)
         })
-        .for_each(|ps_name| {
-            warn!("public.postscriptNames: multiple glyphs have the postscript name \"{ps_name}\"");
-        });
+        .collect::<BTreeSet<_>>();
+    if !duplicate_values.is_empty() {
+        warn!("public.postscriptNames: the following production names are used by multiple glyphs: {duplicate_values:?}");
+    }
     Ok(postscript_names)
 }
 

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -1352,10 +1352,6 @@ mod tests {
     fn build_static_metadata(name: &str, flags: Flags) -> (impl Source, Context) {
         let _ = env_logger::builder().is_test(true).try_init();
         let (source, input) = load_designspace(name);
-        assert!(
-            !flags.contains(Flags::EMIT_IR),
-            "we don't want to write anything"
-        );
         let context = Context::new_root(
             flags,
             Paths::new(Path::new("/nothing/should/write/here")),


### PR DESCRIPTION
Related to: #248

Reads postscript names from the `lib.plist` of UFO sources, and then uses them when writing the post table.

Compiling Oswald using its `Makefile` yields an identical post table to that of a fontc-compiled UFO-based Oswald.

Tests not yet updated to account for the extra field on `StaticMetadata`, or extra parameter of `StaticMetadata::new`. Very much just a proof of concept to gather feedback and see if there are any changes wanted in our approach before updating tests. Naturally, tests should also be added for reading/writing these names.

For discussion:

1. How do we want to handle duplicate postscript entry values?
2. What auto-generation do we need to implement for glyph names that are not included in AGLFN? What does `fontmake` do?
3. Do we want to add a CLI flag to use design names instead of production names, similar to `fontmake`'s `--no-production-names`?
4. Shall we implement this feature for `glyphs2fontir` in this PR?

Implementation notes/thoughts:

5. Do we want to check for equality of `public.postscriptNames` across all masters?
6. Should we read postscript names and glyph order at the same time? Or at least, without loading the plist into memory twice?
7. What error variant should we use for "public.postscriptNames is present, but not a dictionary"?
8. Does `postscript_names` belong in the top-level `StaticMetadata`, or in misc (or context, like `GlyphOrder`)?
9. Should we use a smaller type for postscript name values, i.e. `GlyphName` or `Box<str>` instead of `String`?

Tangent (though tests will currently fail if run): https://matklad.github.io/2022/10/24/actions-permissions.html