### PR TITLE
[ttx_diff.py] remove fontmake's --no-production-names flag

### DIFF
--- a/resources/scripts/ttx_diff.py
+++ b/resources/scripts/ttx_diff.py
@@ -118,8 +118,6 @@ def build_fontmake(source: Path, build_dir: Path, compare: str):
         "--output-dir",
         str(source.name),
         "--drop-implied-oncurves",
-        # TODO we shouldn't need these flags
-        "--no-production-names",
         # "--keep-direction",
     ]
     if compare == _COMPARE_GFTOOLS:


### PR DESCRIPTION
After PR #489 got merged, fontc should use the same glyph postscript names as fontmake does, so we no longer need to pass the --no-production-names flag to compare the two sets of fonts