### PR TITLE
[chore] Update manifests post fea-rs merge

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,31 +1,31 @@
 [workspace.dependencies]
 
+# external deps
 bincode = "1.3.3"
 serde = {version = "1.0", features = ["derive"] }
 serde_yaml = "0.9.14"
-
-thiserror = "1.0.37"
-
-log = "0.4"
-env_logger = "0.10.0"
-
-parking_lot = "0.12.1"
-
-fea-rs = "0.18.0"
-font-types = { version = "0.4.0", features = ["serde"] }
-read-fonts = "0.12.0"
-write-fonts = { version = "0.17.0", features = ["serde"] }
-skrifa = "0.11.0"
-
 bitflags = "2.0"
 chrono = { version = "0.4.24", features = ["serde"] }
 filetime = "0.2.18"
-indexmap = "1.9.2"
+indexmap = "2.0"
 kurbo = { version = "0.10.2", features = ["serde"] }
 ordered-float = { version = "4.1.0", features = ["serde"] }
-smol_str = { version = "0.1.24", features = ["serde"] }
-quick-xml = { version = "0.29.0", features = ["serialize"] }
+smol_str = { version = "0.2.0", features = ["serde"] }
+quick-xml = { version = "0.30.0", features = ["serialize"] }
 regex = "1.7.1"
+thiserror = "1.0.37"
+log = "0.4"
+env_logger = "0.10.0"
+parking_lot = "0.12.1"
+clap = { version = "4.0.32", features = ["derive"] }
+rayon = "1.6"
+
+# fontations etc
+font-types = { version = "0.4.0", features = ["serde"] }
+read-fonts = "0.12.0"
+write-fonts = { version = "0.17.0", features = ["serde", "read"] }
+skrifa = "0.11.0"
+norad = "0.12"
 
 # dev dependencies
 diff = "0.1.12"

--- a/fea-rs/Cargo.toml
+++ b/fea-rs/Cargo.toml
@@ -4,30 +4,31 @@ version = "0.18.0"
 license = "MIT/Apache-2.0"
 authors = ["Colin Rofls <colin@cmyr.net>"]
 description = "Tools for working with Adobe OpenType Feature files."
-repository = "https://github.com/cmyr/fea-rs"
+repository = "https://github.com/googlefonts/fontc"
 categories = ["parsing", "text-processing"]
 keywords = ["fonts", "opentype"]
-readme = "../README.md"
+readme = "./README.md"
 edition = "2021"
 default-run = "fea-rs"
 exclude = ["test-data"]
 
 [dependencies]
 ansi_term = "0.12.1"
-smol_str = "0.2.0"
-norad = { version = "0.12", optional = true } # Used in the compile binary
-write-fonts = { version = "0.17.0", features = ["read"] }
-chrono = "0.4.3"
-diff = { version = "0.1.12", optional = true }
-rayon = { version = "1.6", optional = true }
-serde = { version = "1.0.147", features = ["derive"], optional = true }
 serde_json = {version = "1.0.87", optional = true }
-thiserror = "1.0.37"
-clap = { version = "4.0.32", features = ["derive"], optional = true }
-log = "0.4"
-env_logger = "0.10.0"
-indexmap = "2.0"
-ordered-float = "4.1.0"
+
+diff = { workspace = true, optional = true }
+norad = { workspace = true, optional = true } # Used in the compile binary
+serde = { workspace = true, optional = true }
+rayon = { workspace = true, optional = true }
+clap = { workspace = true, optional = true }
+write-fonts.workspace = true
+smol_str.workspace = true
+chrono.workspace = true
+indexmap.workspace = true
+thiserror.workspace = true
+ordered-float.workspace = true
+log.workspace = true
+env_logger.workspace = true
 
 [features]
 test = ["diff", "rayon", "serde", "serde_json", "clap"]

--- a/fontbe/Cargo.toml
+++ b/fontbe/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["text-processing", "parsing", "graphics"]
 [dependencies]
 fontdrasil = { version = "0.0.1", path = "../fontdrasil" }
 fontir = { version = "0.0.1", path = "../fontir" }
+fea-rs = { version = "0.18.0", path = "../fea-rs" }
 
 serde.workspace = true
 bincode.workspace = true
@@ -32,7 +33,6 @@ write-fonts.workspace = true
 
 kurbo.workspace = true
 
-fea-rs.workspace = true
 smol_str.workspace = true
 
 chrono.workspace = true

--- a/fontc/Cargo.toml
+++ b/fontc/Cargo.toml
@@ -33,11 +33,10 @@ indexmap.workspace = true
 regex.workspace = true
 
 write-fonts.workspace = true
+clap.workspace = true
+rayon.workspace = true
 
 # just for fontc!
-clap = { version = "4.2.1", features = ["derive"] }
-
-rayon = "1.6.0"
 crossbeam-channel = "0.5.6"
 
 [dev-dependencies]

--- a/ufo2fontir/Cargo.toml
+++ b/ufo2fontir/Cargo.toml
@@ -31,9 +31,9 @@ indexmap.workspace = true
 quick-xml.workspace = true
 
 chrono.workspace = true
+norad.workspace = true
 
 # unique to me!
-norad = "0.12"
 plist = { version =  "1.3.1", features = ["serde"] }
 
 [dev-dependencies]


### PR DESCRIPTION
This makes fea-rs use the workspace deps where possible, and makes fontbe use the local fea-rs.

It also makes a few other updates to update paths & urls in fea-rs/Cargo.toml, and it bumps a few out of date dependencies.