### PR TITLE
Add an allowlist for prints and permit a few

### DIFF
--- a/resources/scripts/check_no_println.sh
+++ b/resources/scripts/check_no_println.sh
@@ -79,6 +79,21 @@ else
     matches=$(diff_rust_lines_with_prints "$from_ref" "$to_ref")
 fi
 
+# https://stackoverflow.com/q/1527049
+function join() {
+    local IFS="$1";
+    shift;
+    echo "$*";
+}
+
+allowlist=()
+allowlist+=("fea-rs/src/bin/")
+allowlist+=("fea-rs/src/util/ttx.rs")
+
+allowlist=$(join "|" "${allowlist[@]}")
+echo grep -v "($allowlist)"
+matches=$(grep -vP "($allowlist)" <<< "$matches")
+
 if [ ! -z "$matches" ]; then
     echo "Error: The following Rust source files contain println! or eprintln! statements:"
     echo "$matches"


### PR DESCRIPTION
A few remain; I believe these need to either go away or move to `fea-rs/src/bin/` (e.g. the compile and print warnings fn)

```shell
$ resources/scripts/check_no_println.sh
Error: The following Rust source files contain println! or eprintln! statements:
fea-rs/src/compile/compiler.rs:182:             eprintln!("{}", tree.format_diagnostic(&w, is_tty));
fea-rs/src/token_tree.rs:327:                     eprintln!(
fea-rs/src/token_tree/rewrite.rs:134:         eprintln!("\"");
Please remove or comment out the println! and eprintln! statements before pushing.
```