### PR TITLE
fea-rs => fontc coords

### DIFF
--- a/fea-rs/Cargo.toml
+++ b/fea-rs/Cargo.toml
@@ -13,6 +13,7 @@ default-run = "fea-rs"
 exclude = ["test-data"]
 
 [dependencies]
+fontdrasil = { version = "0.0.1", path = "../fontdrasil" }
 ansi_term = "0.12.1"
 serde_json = {version = "1.0.87", optional = true }
 

--- a/fea-rs/src/bin/compile.rs
+++ b/fea-rs/src/bin/compile.rs
@@ -38,12 +38,13 @@ fn run() -> Result<(), Error> {
         Compiler::new(fea, &glyph_names).with_opts(Opts::new().make_post_table(args.post));
     if let Some(var_info) = var_info.as_ref() {
         log::info!("compiling with {} mock variation axes", var_info.axes.len());
-        for (tag, info) in &var_info.axes {
+        for axis in &var_info.axes {
             log::info!(
-                "{tag}: ({}, {}, {})",
-                info.min_value,
-                info.default_value,
-                info.max_value
+                "{}: ({}, {}, {})",
+                axis.tag,
+                axis.min.into_inner(),
+                axis.default.into_inner(),
+                axis.max.into_inner()
             );
         }
 

--- a/fea-rs/src/compile.rs
+++ b/fea-rs/src/compile.rs
@@ -15,7 +15,7 @@ use self::error::UfoGlyphOrderError;
 pub use compiler::Compiler;
 pub use opts::Opts;
 pub use output::Compilation;
-pub use variations::{AxisInfo, AxisLocation, VariationInfo};
+pub use variations::{AxisLocation, VariationInfo};
 
 #[cfg(any(test, feature = "test", feature = "cli"))]
 pub use variations::MockVariationInfo;


### PR DESCRIPTION
* Make fontbe depend on the local fea-rs
* Share coord types
* Simplify the VariationInfo trait as a result. 

Fixes https://github.com/cmyr/fea-rs/issues/242

Note that I retained the fea-rs AxisLocation to represent the raw value parsed. It has to be turned into a fontdrasil coord to be able to change types.