### PR TITLE
feature writer api

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,3 @@ members = [
     "fea-rs",
     "fea-lsp",
 ]
-
-[patch.crates-io]
-fea-rs = { git = "https://github.com/cmyr/fea-rs.git", branch = "public-feature-builder-api" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,3 +49,6 @@ members = [
     "fea-rs",
     "fea-lsp",
 ]
+
+[patch.crates-io]
+fea-rs = { git = "https://github.com/cmyr/fea-rs.git", branch = "public-feature-builder-api" }

--- a/fea-rs/src/common.rs
+++ b/fea-rs/src/common.rs
@@ -3,6 +3,7 @@
 use std::fmt::{Display, Formatter};
 
 use smol_str::SmolStr;
+use write_fonts::tables::gpos::AnchorTable;
 pub use write_fonts::types::GlyphId;
 
 mod glyph_class;
@@ -34,6 +35,11 @@ pub enum GlyphIdent {
     Name(GlyphName),
     /// a CID
     Cid(u16),
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct MarkClass {
+    pub(crate) members: Vec<(GlyphClass, Option<AnchorTable>)>,
 }
 
 impl<T: Into<GlyphName>> From<T> for GlyphIdent {

--- a/fea-rs/src/common/glyph_class.rs
+++ b/fea-rs/src/common/glyph_class.rs
@@ -29,15 +29,16 @@ impl<'a> std::iter::IntoIterator for &'a GlyphClass {
 }
 
 impl GlyphClass {
-    pub fn items(&self) -> &[GlyphId] {
+    pub(crate) fn items(&self) -> &[GlyphId] {
         &self.0
     }
 
+    /// Return a new, empty glyph class
     pub fn empty() -> Self {
         Self(Rc::new([]))
     }
 
-    pub fn sort_and_dedupe(&self) -> GlyphClass {
+    pub(crate) fn sort_and_dedupe(&self) -> GlyphClass {
         //idfk I guess this is fine
         let mut vec = self.0.iter().cloned().collect::<Vec<_>>();
         vec.sort_unstable();
@@ -45,11 +46,11 @@ impl GlyphClass {
         GlyphClass(vec.into())
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = GlyphId> + '_ {
+    pub(crate) fn iter(&self) -> impl Iterator<Item = GlyphId> + '_ {
         self.items().iter().copied()
     }
 
-    pub fn len(&self) -> usize {
+    pub(crate) fn len(&self) -> usize {
         self.0.len()
     }
 }

--- a/fea-rs/src/compile.rs
+++ b/fea-rs/src/compile.rs
@@ -15,7 +15,10 @@ use self::error::UfoGlyphOrderError;
 pub use compiler::Compiler;
 pub use feature_writer::{FeatureBuilder, FeatureProvider};
 pub use language_system::LanguageSystem;
-pub use lookups::{FeatureKey, LookupId, PairPosBuilder};
+pub use lookups::{
+    FeatureKey, LookupId, MarkToBaseBuilder, MarkToMarkBuilder, PairPosBuilder,
+    PreviouslyAssignedClass,
+};
 pub use opts::Opts;
 pub use output::Compilation;
 pub use variations::{AxisLocation, VariationInfo};

--- a/fea-rs/src/compile.rs
+++ b/fea-rs/src/compile.rs
@@ -13,6 +13,9 @@ use self::{
 use self::error::UfoGlyphOrderError;
 
 pub use compiler::Compiler;
+pub use feature_writer::{FeatureBuilder, FeatureProvider};
+pub use language_system::LanguageSystem;
+pub use lookups::{FeatureKey, LookupId, PairPosBuilder};
 pub use opts::Opts;
 pub use output::Compilation;
 pub use variations::{AxisLocation, VariationInfo};
@@ -23,6 +26,7 @@ pub use variations::MockVariationInfo;
 mod compile_ctx;
 mod compiler;
 pub mod error;
+mod feature_writer;
 mod features;
 mod glyph_range;
 mod language_system;

--- a/fea-rs/src/compile/compile_ctx.rs
+++ b/fea-rs/src/compile/compile_ctx.rs
@@ -245,10 +245,20 @@ impl<'a> CompilationCtx<'a> {
             return;
         };
 
-        let mut builder =
-            FeatureBuilder::new(&self.default_lang_systems, self.mark_filter_sets.len());
+        let mut builder = FeatureBuilder::new(
+            &self.default_lang_systems,
+            &mut self.tables,
+            self.mark_filter_sets.len(),
+        );
         writer.add_features(&mut builder);
-        todo!("now actually try to merge in the generated features?");
+
+        // now we need to merge in the newly generated features.
+        let id_map = self.lookups.merge_external_lookups(builder.lookups);
+        builder
+            .features
+            .values_mut()
+            .for_each(|feat| feat.base.iter_mut().for_each(|id| *id = id_map.get(*id)));
+        self.features.merge_external_features(builder.features);
     }
 
     /// Infer/update GDEF table as required.

--- a/fea-rs/src/compile/compile_ctx.rs
+++ b/fea-rs/src/compile/compile_ctx.rs
@@ -966,11 +966,11 @@ impl<'a> CompilationCtx<'a> {
                             .as_ref()
                             .expect("no null anchors in mark-to-mark (check validation)");
                         for glyph in glyphs.iter() {
-                            subtable.insert_mark(glyph, class_name.clone(), anchor.clone())?;
+                            subtable.insert_mark1(glyph, class_name.clone(), anchor.clone())?;
                         }
                     }
                     for base in base_ids.iter() {
-                        subtable.insert_base(
+                        subtable.insert_mark2(
                             base,
                             class_name,
                             base_anchor

--- a/fea-rs/src/compile/compiler.rs
+++ b/fea-rs/src/compile/compiler.rs
@@ -13,7 +13,7 @@ use crate::{
 
 use super::{
     error::{CompilerError, DiagnosticSet},
-    Compilation, Opts, VariationInfo,
+    Compilation, FeatureProvider, Opts, VariationInfo,
 };
 
 const DEFAULT_N_MESSAGES_TO_PRINT: usize = 100;
@@ -36,6 +36,7 @@ pub struct Compiler<'a> {
     glyph_map: &'a GlyphMap,
     // variable fonts only
     var_info: Option<&'a dyn VariationInfo>,
+    feature_writer: Option<&'a dyn FeatureProvider>,
     print_warnings: bool,
     max_n_errors: usize,
     opts: Opts,
@@ -56,6 +57,7 @@ impl<'a> Compiler<'a> {
             root_path: root_path.into(),
             glyph_map,
             var_info: None,
+            feature_writer: None,
             opts: Default::default(),
             print_warnings: false,
             resolver: Default::default(),
@@ -73,6 +75,12 @@ impl<'a> Compiler<'a> {
     /// Provide [`VariationInfo`], necessary when compiling features for a variable font.
     pub fn with_variable_info(mut self, var_info: &'a dyn VariationInfo) -> Self {
         self.var_info = Some(var_info);
+        self
+    }
+
+    /// Provide [`FeatureWriter`] to provide additional features during compilation
+    pub fn with_feature_writer(mut self, feature_writer: &'a dyn FeatureProvider) -> Self {
+        self.feature_writer = Some(feature_writer);
         self
     }
 
@@ -141,7 +149,12 @@ impl<'a> Compiler<'a> {
         let diagnostics = super::validate(&tree, self.glyph_map, self.var_info);
         print_warnings_return_errors(diagnostics, &tree, self.print_warnings, self.max_n_errors)
             .map_err(CompilerError::ValidationFail)?;
-        let mut ctx = super::CompilationCtx::new(self.glyph_map, tree.source_map(), self.var_info);
+        let mut ctx = super::CompilationCtx::new(
+            self.glyph_map,
+            tree.source_map(),
+            self.var_info,
+            self.feature_writer,
+        );
         ctx.compile(&tree.typed_root());
 
         // we 'take' the errors here because it's easier for us to handle the

--- a/fea-rs/src/compile/compiler.rs
+++ b/fea-rs/src/compile/compiler.rs
@@ -78,7 +78,7 @@ impl<'a> Compiler<'a> {
         self
     }
 
-    /// Provide [`FeatureWriter`] to provide additional features during compilation
+    /// Provide [`FeatureProvider`] to provide additional features during compilation
     pub fn with_feature_writer(mut self, feature_writer: &'a dyn FeatureProvider) -> Self {
         self.feature_writer = Some(feature_writer);
         self

--- a/fea-rs/src/compile/feature_writer.rs
+++ b/fea-rs/src/compile/feature_writer.rs
@@ -15,7 +15,7 @@ use super::{
     features::FeatureLookups,
     language_system::{DefaultLanguageSystems, LanguageSystem},
     lookups::{FeatureKey, FilterSetId, LookupBuilder, LookupId, PositionLookup},
-    tables::Tables,
+    tables::{GdefBuilder, Tables},
 };
 
 /// A trait that can be implemented by the client to do custom feature writing.
@@ -70,6 +70,11 @@ impl<'a> FeatureBuilder<'a> {
     /// An iterator over the default language systems registered in the FEA
     pub fn language_systems(&self) -> impl Iterator<Item = LanguageSystem> + 'a {
         self.language_systems.iter()
+    }
+
+    /// If the FEA text contained an explicit GDEF table block, return its contents
+    pub fn gdef(&self) -> Option<&GdefBuilder> {
+        self.tables.gdef.as_ref()
     }
 
     /// Define a new mark class, for use in mark-base and mark-mark rules.

--- a/fea-rs/src/compile/feature_writer.rs
+++ b/fea-rs/src/compile/feature_writer.rs
@@ -1,0 +1,132 @@
+//! API for the client to manually add additional features
+
+use std::collections::{BTreeMap, HashMap};
+
+use smol_str::SmolStr;
+use write_fonts::tables::{gpos::AnchorTable, layout::LookupFlag};
+
+use crate::common::{GlyphClass, MarkClass};
+
+use super::{
+    features::FeatureLookups,
+    language_system::{DefaultLanguageSystems, LanguageSystem},
+    lookups::{FeatureKey, FilterSetId, LookupBuilder, LookupId, PositionLookup},
+};
+
+/// A trait that can be implemented by the client to do custom feature writing.
+pub trait FeatureProvider {
+    /// The client can write additional features into the provided builder
+    fn add_features(&self, builder: &mut FeatureBuilder);
+}
+
+/// A structure that allows client code to add additional features to the compilation.
+pub struct FeatureBuilder<'a> {
+    pub(crate) language_systems: &'a DefaultLanguageSystems,
+    pub(crate) lookups: Vec<PositionLookup>,
+    pub(crate) features: BTreeMap<FeatureKey, FeatureLookups>,
+    pub(crate) mark_classes: HashMap<SmolStr, MarkClass>,
+    mark_filter_sets: HashMap<GlyphClass, FilterSetId>,
+    // because there may already be defined filter sets from the root fea
+    filter_set_id_start: usize,
+}
+
+pub trait GposSubtableBuilder: Sized {
+    #[doc(hidden)]
+    fn to_pos_lookup(
+        flags: LookupFlag,
+        filter_set: Option<FilterSetId>,
+        subtables: Vec<Self>,
+    ) -> ExternalGposLookup;
+}
+
+/// An externally created GPOS lookup.
+///
+/// This only exists so that we can avoid making our internal types `pub`.
+pub struct ExternalGposLookup(PositionLookup);
+
+impl<'a> FeatureBuilder<'a> {
+    pub(crate) fn new(
+        language_systems: &'a DefaultLanguageSystems,
+        filter_set_id_start: usize,
+    ) -> Self {
+        Self {
+            language_systems,
+            lookups: Default::default(),
+            features: Default::default(),
+            mark_classes: Default::default(),
+            mark_filter_sets: Default::default(),
+            filter_set_id_start,
+        }
+    }
+
+    /// An iterator over the default language systems registered in the FEA
+    pub fn language_systems(&self) -> impl Iterator<Item = LanguageSystem> + 'a {
+        self.language_systems.iter()
+    }
+
+    /// Define a new mark class, for use in mark-base and mark-mark rules.
+    ///
+    /// TODO: do we want to ensure there are no redefinitions? do we want
+    /// return an error? do we want to uphold any other invariants?
+    ///
+    /// ALSO: mark class IDs depend on definition order in the source.
+    /// I have no idea how best to approximate that in this API :/
+    pub fn define_mark_class(
+        &mut self,
+        class_name: impl Into<SmolStr>,
+        members: Vec<(GlyphClass, Option<AnchorTable>)>,
+    ) {
+        self.mark_classes
+            .insert(class_name.into(), MarkClass { members });
+    }
+
+    /// Create a new lookup.
+    ///
+    /// The `LookupId` that is returned can then be included in features via
+    /// the [`add_feature`] method.
+    pub fn add_lookup<T: GposSubtableBuilder>(
+        &mut self,
+        flags: LookupFlag,
+        filter_set: Option<GlyphClass>,
+        subtables: Vec<T>,
+    ) -> LookupId {
+        let filter_set_id = filter_set.map(|cls| self.get_filter_set_id(cls));
+        let lookup = T::to_pos_lookup(flags, filter_set_id, subtables);
+        let next_id = self.lookups.len();
+        self.lookups.push(lookup.0);
+        LookupId::External(next_id)
+    }
+
+    /// Create a new feature, registered for a particular language system.
+    ///
+    /// The caller must call this method once for each language system under
+    /// which a feature is to be registered.
+    pub fn add_feature(&mut self, key: FeatureKey, lookups: Vec<LookupId>) {
+        self.features.entry(key).or_default().base = lookups;
+    }
+
+    fn get_filter_set_id(&mut self, cls: GlyphClass) -> FilterSetId {
+        let next_id = self.filter_set_id_start + self.mark_filter_sets.len();
+        //.expect("too many filter sets");
+        *self.mark_filter_sets.entry(cls).or_insert_with(|| {
+            next_id
+                .try_into()
+                // is this in any way an expected error condition?
+                .expect("too many filter sets?")
+        })
+    }
+}
+
+impl<T> GposSubtableBuilder for T
+where
+    T: Default,
+    LookupBuilder<T>: Into<PositionLookup>,
+{
+    fn to_pos_lookup(
+        flags: LookupFlag,
+        filter_set: Option<FilterSetId>,
+        subtables: Vec<Self>,
+    ) -> ExternalGposLookup {
+        ExternalGposLookup(LookupBuilder::new_with_lookups(flags, filter_set, subtables).into())
+    }
+}

--- a/fea-rs/src/compile/feature_writer.rs
+++ b/fea-rs/src/compile/feature_writer.rs
@@ -95,8 +95,7 @@ impl<'a> FeatureBuilder<'a> {
 
     /// Create a new lookup.
     ///
-    /// The `LookupId` that is returned can then be included in features via
-    /// the [`add_feature`] method.
+    /// The `LookupId` that is returned can then be included in features
     pub fn add_lookup<T: GposSubtableBuilder>(
         &mut self,
         flags: LookupFlag,

--- a/fea-rs/src/compile/features.rs
+++ b/fea-rs/src/compile/features.rs
@@ -222,6 +222,19 @@ impl AllFeatures {
         result
     }
 
+    //FIXME: what do we do with conflicts?
+    pub(crate) fn merge_external_features(
+        &mut self,
+        features: BTreeMap<FeatureKey, FeatureLookups>,
+    ) {
+        for (key, lookups) in features {
+            self.get_or_insert(key).base.extend(lookups.base);
+            if !lookups.variations.is_empty() {
+                panic!("specifying feature variations from feature writer is not yet supported");
+            }
+        }
+    }
+
     #[cfg(test)]
     fn get_base(&self, key: &FeatureKey) -> Option<&[LookupId]> {
         self.features.get(key).map(|x| x.base.as_slice())

--- a/fea-rs/src/compile/features.rs
+++ b/fea-rs/src/compile/features.rs
@@ -410,6 +410,7 @@ fn split_lookups(lookups: &[LookupId]) -> (Vec<u16>, Vec<u16>) {
             LookupId::Gpos(_) => gpos.push(lookup.to_gpos_id_or_die()),
             LookupId::Gsub(_) => gsub.push(lookup.to_gsub_id_or_die()),
             LookupId::Empty => (),
+            LookupId::External(_) => panic!("external lookups should not be present at split time"),
         }
     }
 

--- a/fea-rs/src/compile/language_system.rs
+++ b/fea-rs/src/compile/language_system.rs
@@ -8,6 +8,7 @@ use super::{lookups::FeatureKey, tags};
 
 /// A script/language pair
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[allow(missing_docs)]
 pub struct LanguageSystem {
     pub script: Tag,
     pub language: Tag,
@@ -36,13 +37,14 @@ impl DefaultLanguageSystems {
         self.items.contains(key)
     }
 
-    pub(crate) fn iter(&self) -> impl Iterator<Item = LanguageSystem> + '_ {
+    pub fn iter(&self) -> impl Iterator<Item = LanguageSystem> + '_ {
         self.items.iter().copied()
     }
 }
 
 impl LanguageSystem {
-    pub(crate) fn to_feature_key(self, feature: Tag) -> FeatureKey {
+    /// Generate a `FeatureKey` for this langauge system.
+    pub fn to_feature_key(self, feature: Tag) -> FeatureKey {
         let LanguageSystem { script, language } = self;
         FeatureKey {
             feature,

--- a/fea-rs/src/compile/lookups.rs
+++ b/fea-rs/src/compile/lookups.rs
@@ -40,10 +40,8 @@ use contextual::{
     SubChainContextBuilder, SubContextBuilder,
 };
 
-use gpos::{
-    CursivePosBuilder, MarkToBaseBuilder, MarkToLigBuilder, MarkToMarkBuilder, SinglePosBuilder,
-};
-pub use gpos::{PairPosBuilder, PreviouslyAssignedClass};
+use gpos::{CursivePosBuilder, MarkToLigBuilder, SinglePosBuilder};
+pub use gpos::{MarkToBaseBuilder, MarkToMarkBuilder, PairPosBuilder, PreviouslyAssignedClass};
 use gsub::{AlternateSubBuilder, LigatureSubBuilder, MultipleSubBuilder, SingleSubBuilder};
 pub(crate) use helpers::ClassDefBuilder2;
 

--- a/fea-rs/src/compile/lookups.rs
+++ b/fea-rs/src/compile/lookups.rs
@@ -1148,8 +1148,8 @@ impl Builder for PosSubBuilder<SubstitutionLookup> {
 impl FeatureKey {
     /// Create a new feature key for the provided feature, language, and script.
     ///
-    /// If you already have a [`LanguageSystem`], you can create a `FeatureKey`
-    /// with the [`LanguageSystem::to_feature_key`] method.
+    /// If you already have a [`super::LanguageSystem`], you can create a [`FeatureKey`]
+    /// with the [`super::LanguageSystem::to_feature_key`] method.
     pub fn new(feature: Tag, language: Tag, script: Tag) -> Self {
         FeatureKey {
             feature,

--- a/fea-rs/src/compile/lookups/gpos.rs
+++ b/fea-rs/src/compile/lookups/gpos.rs
@@ -108,6 +108,9 @@ fn cmp_coverage_key(coverage: &CoverageTable) -> impl Ord {
     (std::cmp::Reverse(coverage.len()), coverage.iter().next())
 }
 
+/// A builder for GPOS type 2 (PairPos) subtables
+///
+/// This builder can build both glyph and class-based kerning subtables.
 #[derive(Clone, Debug, Default)]
 pub struct PairPosBuilder {
     pairs: GlyphPairPosBuilder,
@@ -200,7 +203,8 @@ impl ClassPairPosSubtable {
 }
 
 impl PairPosBuilder {
-    pub(crate) fn insert_pair(
+    /// Insert a new kerning pair
+    pub fn insert_pair(
         &mut self,
         glyph1: GlyphId,
         record1: ValueRecord,
@@ -214,7 +218,8 @@ impl PairPosBuilder {
             .insert(glyph2, (record1, record2));
     }
 
-    pub(crate) fn insert_classes(
+    /// Insert a new class-based kerning rule.
+    pub fn insert_classes(
         &mut self,
         class1: GlyphClass,
         record1: ValueRecord,

--- a/fea-rs/src/compile/lookups/gpos.rs
+++ b/fea-rs/src/compile/lookups/gpos.rs
@@ -429,6 +429,7 @@ impl Builder for MarkList {
     }
 }
 
+/// A builder for GPOS Lookup Type 4, Mark-to-Base
 #[derive(Clone, Debug, Default)]
 pub struct MarkToBaseBuilder {
     marks: MarkList,
@@ -445,9 +446,11 @@ impl VariationIndexContainingLookup for MarkToBaseBuilder {
     }
 }
 
-/// An error indicating a given glyph is has be
+/// An error indicating a given glyph has been assigned to multiple mark classes
 pub struct PreviouslyAssignedClass {
+    /// The ID of the glyph in conflict
     pub glyph_id: GlyphId,
+    /// The name of the previous class
     pub class: SmolStr,
 }
 
@@ -465,15 +468,18 @@ impl MarkToBaseBuilder {
         self.marks.insert(glyph, class, anchor)
     }
 
+    /// Insert a new base glyph.
     pub fn insert_base(&mut self, glyph: GlyphId, class: &SmolStr, anchor: AnchorTable) {
         let class = self.marks.get_class(class);
         self.bases.entry(glyph).or_default().push((class, anchor))
     }
 
+    /// Returns an iterator over all of the base glyphs
     pub fn base_glyphs(&self) -> impl Iterator<Item = GlyphId> + Clone + '_ {
         self.bases.keys().copied()
     }
 
+    /// Returns an iterator over all of the mark glyphs
     pub fn mark_glyphs(&self) -> impl Iterator<Item = GlyphId> + Clone + '_ {
         self.marks.glyphs()
     }
@@ -587,6 +593,7 @@ impl Builder for MarkToLigBuilder {
     }
 }
 
+/// A builder for GPOS Type 6 (Mark-to-Mark)
 #[derive(Clone, Debug, Default)]
 pub struct MarkToMarkBuilder {
     attaching_marks: MarkList,
@@ -594,7 +601,11 @@ pub struct MarkToMarkBuilder {
 }
 
 impl MarkToMarkBuilder {
-    pub fn insert_mark(
+    /// Add a new mark1 (combining) glyph.
+    ///
+    /// If this glyph already exists in another mark class, we return the
+    /// previous class; this is likely an error.
+    pub fn insert_mark1(
         &mut self,
         glyph: GlyphId,
         class: SmolStr,
@@ -603,15 +614,18 @@ impl MarkToMarkBuilder {
         self.attaching_marks.insert(glyph, class, anchor)
     }
 
-    pub fn insert_base(&mut self, glyph: GlyphId, class: &SmolStr, anchor: AnchorTable) {
+    /// Insert a new mark2 (base) glyph
+    pub fn insert_mark2(&mut self, glyph: GlyphId, class: &SmolStr, anchor: AnchorTable) {
         let id = self.attaching_marks.get_class(class);
         self.base_marks.entry(glyph).or_default().push((id, anchor))
     }
 
+    /// Returns an iterator over all of the mark1 glyphs
     pub fn mark1_glyphs(&self) -> impl Iterator<Item = GlyphId> + Clone + '_ {
         self.attaching_marks.glyphs()
     }
 
+    /// Returns an iterator over all of the mark2 glyphs
     pub fn mark2_glyphs(&self) -> impl Iterator<Item = GlyphId> + Clone + '_ {
         self.base_marks.keys().copied()
     }

--- a/fea-rs/src/compile/tables/gdef.rs
+++ b/fea-rs/src/compile/tables/gdef.rs
@@ -21,8 +21,9 @@ use write_fonts::tables::{
 use super::{VariationIndexRemapping, VariationStoreBuilder};
 use crate::common::GlyphClass;
 
+/// Data collected from a GDEF block.
 #[derive(Clone, Debug, Default)]
-pub(crate) struct GdefBuilder {
+pub struct GdefBuilder {
     pub glyph_classes: HashMap<GlyphId, ClassId>,
     pub attach: BTreeMap<GlyphId, BTreeSet<u16>>,
     pub ligature_pos: BTreeMap<GlyphId, Vec<CaretValue>>,

--- a/fea-rs/src/lib.rs
+++ b/fea-rs/src/lib.rs
@@ -15,7 +15,7 @@ pub mod util;
 #[cfg(test)]
 mod tests;
 
-pub use common::{GlyphIdent, GlyphMap, GlyphName};
+pub use common::{GlyphClass, GlyphIdent, GlyphMap, GlyphName};
 pub use compile::Compiler;
 pub use diagnostic::{Diagnostic, Level};
 pub use parse::{ParseTree, TokenSet};

--- a/fontbe/src/features.rs
+++ b/fontbe/src/features.rs
@@ -1,7 +1,7 @@
 //! Feature binary compilation.
 
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     error::Error as StdError,
     ffi::{OsStr, OsString},
     fmt::Display,
@@ -11,20 +11,22 @@ use std::{
 };
 
 use fea_rs::{
-    compile::{Compilation, VariationInfo},
+    compile::{Compilation, FeatureBuilder, FeatureProvider, PairPosBuilder, VariationInfo},
     parse::{SourceLoadError, SourceResolver},
-    Compiler, GlyphMap, GlyphName as FeaRsGlyphName,
+    Compiler, GlyphClass, GlyphMap, GlyphName as FeaRsGlyphName,
 };
-use font_types::Tag;
+use font_types::{GlyphId, Tag};
 use fontdrasil::{coords::NormalizedLocation, types::Axis};
 use fontir::{
     ir::{Features, GlyphOrder, KernParticipant, Kerning, StaticMetadata},
     orchestration::{Flags, WorkId as FeWorkId},
 };
+
 use log::{debug, error, trace, warn};
+use ordered_float::OrderedFloat;
 
 use fontdrasil::orchestration::{Access, Work};
-use write_fonts::OtRound;
+use write_fonts::{tables::gpos::ValueRecord, tables::layout::LookupFlag, OtRound};
 
 use crate::{
     error::Error,
@@ -108,6 +110,190 @@ impl<'a> FeaVariationInfo<'a> {
                 .collect(),
             static_metadata,
         }
+    }
+}
+
+struct FeatureWriter<'a> {
+    kerning: &'a Kerning,
+    glyph_map: &'a GlyphOrder,
+    static_metadata: &'a StaticMetadata,
+}
+
+impl<'a> FeatureWriter<'a> {
+    fn new(
+        static_metadata: &'a StaticMetadata,
+        kerning: &'a Kerning,
+        glyph_map: &'a GlyphOrder,
+    ) -> Self {
+        FeatureWriter {
+            kerning,
+            static_metadata,
+            glyph_map,
+        }
+    }
+
+    //TODO: at least for kerning, we should be able to generate the lookups
+    //as a separate worktask, and then just add them at the end.
+    fn add_kerning_features(&self, builder: &mut FeatureBuilder) {
+        if self.kerning.is_empty() {
+            return;
+        }
+
+        // a little helper closure used below
+        let name_to_gid = |name| {
+            self.glyph_map
+                .glyph_id(name)
+                .map(|val| GlyphId::new(val as u16))
+                .unwrap_or(GlyphId::NOTDEF)
+        };
+
+        // convert the groups stored in the Kerning object into the glyph classes
+        // expected by fea-rs:
+        let glyph_classes = self
+            .kerning
+            .groups
+            .iter()
+            .map(|(class_name, glyph_set)| {
+                let glyph_class: GlyphClass = glyph_set
+                    .iter()
+                    .map(|name| GlyphId::new(self.glyph_map.glyph_id(name).unwrap_or(0) as u16))
+                    .collect();
+                (class_name, glyph_class)
+            })
+            .collect::<HashMap<_, _>>();
+
+        let mut ppos_subtables = PairPosBuilder::default();
+
+        // now for each kerning entry, directly add a rule to the builder:
+        for ((left, right), values) in &self.kerning.kerns {
+            let (default_value, deltas) = self
+                .resolve_variable_metric(values)
+                .expect("FIGURE OUT ERRORS");
+
+            let mut x_adv_record = ValueRecord::new().with_x_advance(default_value);
+            let empty_record = ValueRecord::default();
+
+            if !deltas.is_empty() {
+                let var_idx = builder.add_deltas(deltas);
+                x_adv_record = x_adv_record.with_x_advance_device(var_idx);
+            }
+
+            match (left, right) {
+                (KernParticipant::Glyph(left), KernParticipant::Glyph(right)) => {
+                    let gid0 = name_to_gid(left);
+                    let gid1 = name_to_gid(right);
+                    ppos_subtables.insert_pair(gid0, x_adv_record, gid1, empty_record);
+                }
+                (KernParticipant::Group(left), KernParticipant::Group(right)) => {
+                    let left = glyph_classes.get(left).unwrap().clone();
+                    let right = glyph_classes.get(right).unwrap().clone();
+                    ppos_subtables.insert_classes(left, x_adv_record, right, empty_record);
+                }
+                // if groups are mixed with glyphs then we enumerate the group
+                (KernParticipant::Glyph(left), KernParticipant::Group(right)) => {
+                    let gid0 = name_to_gid(left);
+                    let right = glyph_classes.get(right).unwrap();
+                    for gid1 in right {
+                        ppos_subtables.insert_pair(
+                            gid0,
+                            x_adv_record.clone(),
+                            *gid1,
+                            empty_record.clone(),
+                        );
+                    }
+                }
+                (KernParticipant::Group(left), KernParticipant::Glyph(right)) => {
+                    let left = glyph_classes.get(left).unwrap();
+                    let gid1 = name_to_gid(right);
+                    for gid0 in left {
+                        ppos_subtables.insert_pair(
+                            *gid0,
+                            x_adv_record.clone(),
+                            gid1,
+                            empty_record.clone(),
+                        );
+                    }
+                }
+            }
+        }
+
+        // now we have a builder for the pairpos subtables, so we can make
+        // a lookup:
+        let lookup_id = builder.add_lookup(LookupFlag::empty(), None, vec![ppos_subtables]);
+        let kern = Tag::new(b"kern");
+        let lookups = vec![lookup_id];
+        // now register this feature for each of the default language systems
+        for langsys in builder.language_systems() {
+            let feature_key = langsys.to_feature_key(kern);
+            builder.add_feature(feature_key, lookups.clone());
+        }
+    }
+
+    //NOTE: this is basically identical to the same method on FeaVariationInfo,
+    //except they have slightly different inputs?
+    fn resolve_variable_metric(
+        &self,
+        values: &BTreeMap<NormalizedLocation, OrderedFloat<f32>>,
+    ) -> Result<
+        (
+            i16,
+            Vec<(write_fonts::tables::variations::VariationRegion, i16)>,
+        ),
+        Error,
+    > {
+        let var_model = &self.static_metadata.variation_model;
+
+        let point_seqs = values
+            .iter()
+            .map(|(pos, value)| (pos.to_owned(), vec![value.0 as f64]))
+            .collect();
+        let raw_deltas: Vec<_> = var_model
+            .deltas(&point_seqs)
+            .expect("FIXME: MAKE OUR ERROR TYPE SUPPORT ? HERE")
+            .into_iter()
+            .map(|(region, values)| {
+                assert!(values.len() == 1, "{} values?!", values.len());
+                (region, values[0])
+            })
+            .collect();
+
+        let default_value: i16 = raw_deltas
+            .iter()
+            .filter_map(|(region, value)| {
+                let scaler = region.scalar_at(&var_model.default).into_inner();
+                match scaler {
+                    scaler if scaler == 0.0 => None,
+                    scaler => Some(scaler * *value as f32),
+                }
+            })
+            .sum::<f32>()
+            .ot_round();
+
+        let mut deltas = Vec::with_capacity(raw_deltas.len());
+        for (region, value) in raw_deltas.iter().filter(|(r, _)| !r.is_default()) {
+            // https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#variation-regions
+            // Array of region axis coordinates records, in the order of axes given in the 'fvar' table.
+            let mut region_axes = Vec::with_capacity(self.static_metadata.axes.len());
+            for axis in self.static_metadata.axes.iter() {
+                let Some(tent) = region.get(&axis.tag) else {
+                    todo!("FIXME: add this error conversion!")
+                };
+                region_axes.push(tent.to_region_axis_coords());
+            }
+            deltas.push((
+                write_fonts::tables::variations::VariationRegion { region_axes },
+                value.ot_round(),
+            ));
+        }
+
+        Ok((default_value, deltas))
+    }
+}
+
+impl<'a> FeatureProvider for FeatureWriter<'a> {
+    fn add_features(&self, builder: &mut FeatureBuilder) {
+        self.add_kerning_features(builder);
+        //TODO: add mark features
     }
 }
 
@@ -230,15 +416,18 @@ impl FeatureWork {
         &self,
         static_metadata: &StaticMetadata,
         features: &Features,
-        glyph_order: GlyphMap,
+        glyph_order: &GlyphOrder,
+        kerning: &Kerning,
     ) -> Result<Compilation, Error> {
         let var_info = FeaVariationInfo::new(static_metadata);
+        let feature_writer = FeatureWriter::new(static_metadata, kerning, &glyph_order);
+        let fears_glyph_map = create_glyphmap(glyph_order);
         let compiler = match features {
             Features::File {
                 fea_file,
                 include_dir,
             } => {
-                let mut compiler = Compiler::new(OsString::from(fea_file), &glyph_order);
+                let mut compiler = Compiler::new(OsString::from(fea_file), &fears_glyph_map);
                 if let Some(include_dir) = include_dir {
                     compiler = compiler.with_project_root(include_dir)
                 }
@@ -250,7 +439,7 @@ impl FeatureWork {
             } => {
                 let root = OsString::new();
                 let mut compiler =
-                    Compiler::new(root.clone(), &glyph_order).with_resolver(InMemoryResolver {
+                    Compiler::new(root.clone(), &fears_glyph_map).with_resolver(InMemoryResolver {
                         content_path: root,
                         content: Arc::from(fea_content.as_str()),
                         include_dir: include_dir.clone(),
@@ -262,7 +451,8 @@ impl FeatureWork {
             }
             Features::Empty => panic!("compile isn't supposed to be called for Empty"),
         }
-        .with_variable_info(&var_info);
+        .with_variable_info(&var_info)
+        .with_feature_writer(&feature_writer);
         compiler.compile().map_err(Error::FeaCompileError)
     }
 }
@@ -297,154 +487,6 @@ fn create_glyphmap(glyph_order: &GlyphOrder) -> GlyphMap {
         .collect()
 }
 
-fn push_identifier(fea: &mut String, identifier: &KernParticipant) {
-    match identifier {
-        KernParticipant::Glyph(name) => fea.push_str(name.as_str()),
-        KernParticipant::Group(name) => {
-            fea.push('@');
-            fea.push_str(name.as_str());
-        }
-    }
-}
-
-#[inline]
-fn enumerated(kp1: &KernParticipant, kp2: &KernParticipant) -> bool {
-    // Glyph to class or class to glyph pairs are interpreted as 'class exceptions' to class pairs
-    // and are thus prefixed with 'enum' keyword so they will be enumerated as specific glyph-glyph pairs.
-    // http://adobe-type-tools.github.io/afdko/OpenTypeFeatureFileSpecification.html#6bii-enumerating-pairs
-    // https://github.com/googlefonts/ufo2ft/blob/b3895a9/Lib/ufo2ft/featureWriters/kernFeatureWriter.py#L360
-    kp1.is_group() ^ kp2.is_group()
-}
-
-/// Create a single variable fea describing the kerning for the entire variation space.
-///
-/// No merge baby! - [context](https://github.com/fonttools/fonttools/issues/3168#issuecomment-1608787520)
-///
-/// To match existing behavior, all kerns must have values for all locations for which any kerning is specified.
-/// See <https://github.com/fonttools/fonttools/issues/3168#issuecomment-1603631080> for more.
-/// Missing values are populated using the <https://unifiedfontobject.org/versions/ufo3/kerning.plist/#kerning-value-lookup-algorithm>.
-/// In future it is likely sparse kerning - blanks filled by interpolation - will be permitted.
-///
-/// * See <https://github.com/fonttools/fonttools/issues/3168> wrt sparse kerning.
-/// * See <https://github.com/adobe-type-tools/afdko/pull/1350> wrt variable fea.
-fn create_kerning_fea(kerning: &Kerning) -> Result<String, Error> {
-    // Every kern must be defined at these locations. For human readability lets order things consistently.
-    let kerned_locations: HashSet<_> = kerning.kerns.values().flat_map(|v| v.keys()).collect();
-    let mut kerned_locations: Vec<_> = kerned_locations.into_iter().collect();
-    kerned_locations.sort();
-
-    if log::log_enabled!(log::Level::Trace) {
-        trace!(
-            "The following {} locations have kerning:",
-            kerned_locations.len()
-        );
-        for pos in kerned_locations.iter() {
-            trace!("  {pos:?}");
-        }
-    }
-
-    // For any kern that is incompletely specified fill in the missing values using UFO kerning lookup
-    // Not 100% sure if this is correct for .glyphs but lets start there
-    // Generate variable format kerning per https://github.com/adobe-type-tools/afdko/pull/1350
-    // Use design values per discussion on https://github.com/harfbuzz/boring-expansion-spec/issues/94
-    let mut fea = String::new();
-    fea.reserve(8192); // TODO is this a good value?
-    fea.push_str("\n\n# fontc generated kerning\n\n");
-
-    if kerning.is_empty() {
-        return Ok(fea);
-    }
-
-    // TODO eliminate singleton groups, e.g. @public.kern1.Je-cy = [Je-cy];
-
-    // 1) Generate classes (http://adobe-type-tools.github.io/afdko/OpenTypeFeatureFileSpecification.html#2.g.ii)
-    // @classname = [glyph1 glyph2 glyph3];
-    for (name, members) in kerning.groups.iter() {
-        fea.push('@');
-        fea.push_str(name.as_str());
-        fea.push_str(" = [");
-        for member in members {
-            fea.push_str(member.as_str());
-            fea.push(' ');
-        }
-        fea.remove(fea.len() - 1);
-        fea.push_str("];\n");
-    }
-    fea.push_str("\n\n");
-
-    // 2) Generate pairpos (http://adobe-type-tools.github.io/afdko/OpenTypeFeatureFileSpecification.html#6.b)
-    // it's likely that many kerns use the same location string, might as well remember the string edition
-
-    let mut pos_strings = HashMap::new();
-    fea.push_str("feature kern {\n");
-    for ((participant1, participant2), values) in kerning.kerns.iter() {
-        fea.push_str("  ");
-        if enumerated(participant1, participant2) {
-            fea.push_str("enum ");
-        }
-        fea.push_str("pos ");
-        push_identifier(&mut fea, participant1);
-        fea.push(' ');
-        push_identifier(&mut fea, participant2);
-
-        // See https://github.com/adobe-type-tools/afdko/pull/1350#issuecomment-845219109 for syntax
-        // <value>n for normalized, per https://github.com/harfbuzz/boring-expansion-spec/issues/94#issuecomment-1608007111
-        fea.push_str(" (");
-        for location in kerned_locations.iter() {
-            // TODO can we skip some values by dropping where value == interpolated value?
-            let advance_adjustment = values
-                .get(location)
-                .map(|f| f.into_inner())
-                // TODO: kerning lookup
-                .unwrap_or_else(|| 0.0);
-
-            let pos_str = pos_strings.entry(*location).or_insert_with(|| {
-                location
-                    .iter()
-                    .map(|(tag, value)| format!("{tag}={}n", value.into_inner()))
-                    .collect::<Vec<_>>()
-                    .join(",")
-            });
-
-            fea.push_str(pos_str);
-            fea.push(':');
-            fea.push_str(&format!("{} ", advance_adjustment));
-        }
-        fea.remove(fea.len() - 1);
-        fea.push_str(");\n");
-    }
-    fea.push_str("} kern;\n");
-
-    Ok(fea)
-}
-
-fn integrate_kerning(features: &Features, kern_fea: String) -> Result<Features, Error> {
-    // TODO: insert at proper spot, there's a magic marker that might be present
-    match features {
-        Features::Empty => Ok(Features::Memory {
-            fea_content: kern_fea,
-            include_dir: None,
-        }),
-        Features::Memory {
-            fea_content,
-            include_dir,
-        } => Ok(Features::Memory {
-            fea_content: format!("{fea_content}{kern_fea}"),
-            include_dir: include_dir.clone(),
-        }),
-        Features::File {
-            fea_file,
-            include_dir,
-        } => {
-            let fea_content = fs::read_to_string(fea_file).map_err(Error::IoError)?;
-            Ok(Features::Memory {
-                fea_content: format!("{fea_content}{kern_fea}"),
-                include_dir: include_dir.clone(),
-            })
-        }
-    }
-}
-
 impl Work<Context, AnyWorkId, Error> for FeatureWork {
     fn id(&self) -> AnyWorkId {
         WorkId::Features.into()
@@ -472,12 +514,7 @@ impl Work<Context, AnyWorkId, Error> for FeatureWork {
         let glyph_order = context.ir.glyph_order.get();
         let kerning = context.ir.kerning.get();
 
-        let features = if !kerning.is_empty() {
-            let kern_fea = create_kerning_fea(&kerning)?;
-            integrate_kerning(&context.ir.features.get(), kern_fea)?
-        } else {
-            (*context.ir.features.get()).clone()
-        };
+        let features = (*context.ir.features.get()).clone();
 
         if !matches!(features, Features::Empty) {
             if log::log_enabled!(log::Level::Trace) {
@@ -486,8 +523,7 @@ impl Work<Context, AnyWorkId, Error> for FeatureWork {
                 }
             }
 
-            let glyph_map = create_glyphmap(glyph_order.as_ref());
-            let result = self.compile(&static_metadata, &features, glyph_map);
+            let result = self.compile(&static_metadata, &features, &glyph_order, &kerning);
             if result.is_err() || context.flags.contains(Flags::EMIT_DEBUG) {
                 if let Features::Memory { fea_content, .. } = &features {
                     write_debug_fea(context, result.is_err(), "compile failed", fea_content);

--- a/fontbe/src/features.rs
+++ b/fontbe/src/features.rs
@@ -420,7 +420,7 @@ impl FeatureWork {
         kerning: &Kerning,
     ) -> Result<Compilation, Error> {
         let var_info = FeaVariationInfo::new(static_metadata);
-        let feature_writer = FeatureWriter::new(static_metadata, kerning, &glyph_order);
+        let feature_writer = FeatureWriter::new(static_metadata, kerning, glyph_order);
         let fears_glyph_map = create_glyphmap(glyph_order);
         let compiler = match features {
             Features::File {

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -1938,8 +1938,8 @@ mod tests {
 
         for table_tag in table_tags {
             let tag = Tag::new(table_tag);
-            assert!(font_with_fea.data_for_tag(tag).is_some());
-            assert!(font_without_fea.data_for_tag(tag).is_none());
+            assert!(font_with_fea.data_for_tag(tag).is_some(), "Expected font with fea to have {tag}");
+            assert!(font_without_fea.data_for_tag(tag).is_none(), "Expected font without fea to not have {tag}");
         }
     }
 

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -1938,8 +1938,14 @@ mod tests {
 
         for table_tag in table_tags {
             let tag = Tag::new(table_tag);
-            assert!(font_with_fea.data_for_tag(tag).is_some(), "Expected font with fea to have {tag}");
-            assert!(font_without_fea.data_for_tag(tag).is_none(), "Expected font without fea to not have {tag}");
+            assert!(
+                font_with_fea.data_for_tag(tag).is_some(),
+                "Expected font built from {source} with fea to have {tag}"
+            );
+            assert!(
+                font_without_fea.data_for_tag(tag).is_none(),
+                "Expected font build from {source} without fea to not have {tag}"
+            );
         }
     }
 

--- a/fontdrasil/src/types.rs
+++ b/fontdrasil/src/types.rs
@@ -25,6 +25,10 @@ impl GlyphName {
     pub fn empty() -> GlyphName {
         "".into()
     }
+
+    pub fn into_inner(self) -> SmolStr {
+        self.0
+    }
 }
 
 impl From<String> for GlyphName {


### PR DESCRIPTION
Migrate https://github.com/cmyr/fea-rs/pull/241 to fontc. Rebase on #516; that should be merged first.

Fix a test that took up failing because we assumed no user features meant no features at all and that stopped being true when we added feature writers.

Copied from fea-rs, @cmyr's notes:

This PR is a start on providing API that allows the client to specify additional feature code at compile time, without needing to use FEA as an IR.

This involves:
- letting the client provide us with a `FeatureWriter` type during compilation
- calling this type after the compilation pass, but before assembling the final tables
- letting it add new lookups and features
- and merging these features and lookups into the overall set before building the final tables

It also involves making certain internal types public, such as some of our lookup builders.


This is a WIP. Currently unresolved:

- how we handle errors
- merging lookups in any way that is not just concatenation
- support for mark rules