### PR TITLE
Remove unused quick-xml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ indexmap = "2.0"
 kurbo = { version = "0.10.2", features = ["serde"] }
 ordered-float = { version = "4.1.0", features = ["serde"] }
 smol_str = { version = "0.2.0", features = ["serde"] }
-quick-xml = { version = "0.30.0", features = ["serialize"] }
 regex = "1.7.1"
 thiserror = "1.0.37"
 log = "0.4"

--- a/glyphs2fontir/Cargo.toml
+++ b/glyphs2fontir/Cargo.toml
@@ -23,7 +23,6 @@ thiserror.workspace = true
 kurbo.workspace = true
 ordered-float.workspace = true
 indexmap.workspace = true
-quick-xml.workspace = true
 
 font-types.workspace = true
 read-fonts.workspace = true

--- a/ufo2fontir/Cargo.toml
+++ b/ufo2fontir/Cargo.toml
@@ -28,7 +28,6 @@ write-fonts.workspace = true  # for ot_round
 
 ordered-float.workspace = true
 indexmap.workspace = true
-quick-xml.workspace = true
 
 chrono.workspace = true
 norad.workspace = true


### PR DESCRIPTION
it's a norad dependency but we don't import it directly anywhere in fontc (`git grep quick_xml` returns nothing) so there's no need to have it here, is there?