### PR TITLE
Fixup 'default-run' settings

### DIFF
--- a/fea-rs/Cargo.toml
+++ b/fea-rs/Cargo.toml
@@ -9,7 +9,6 @@ categories = ["parsing", "text-processing"]
 keywords = ["fonts", "opentype"]
 readme = "./README.md"
 edition = "2021"
-default-run = "fea-rs"
 exclude = ["test-data"]
 
 [dependencies]

--- a/fontc/Cargo.toml
+++ b/fontc/Cargo.toml
@@ -7,8 +7,8 @@ description = "A compiler for fonts."
 repository = "https://github.com/googlefonts/fontc"
 readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]
+default-run = "fontc"
 
-[features]
 
 [dependencies]
 fontdrasil = { version = "0.0.1", path = "../fontdrasil" }


### PR DESCRIPTION
This was broken because fea-rs added a bunch of new binary targets, and also had set 'default-run' to its own main binary; this sets it back to be the fontc binary.

JMM