### PR TITLE
[fea-rs] Tweak logic for assigning glyph class ids

### DIFF
--- a/fea-rs/src/compile/lookups/helpers.rs
+++ b/fea-rs/src/compile/lookups/helpers.rs
@@ -58,11 +58,13 @@ impl ClassDefBuilder2 {
     /// to the final class ids
     pub(crate) fn build(self) -> (ClassDef, HashMap<GlyphClass, u16>) {
         let mut classes = self.classes.into_iter().collect::<Vec<_>>();
+        // we match the sort order used by fonttools, see:
+        // <https://github.com/fonttools/fonttools/blob/9a46f9d3ab01e3/Lib/fontTools/otlLib/builder.py#L2677>
         classes.sort_unstable_by_key(|cls| {
-            (std::cmp::Reverse((
-                cls.len(),
+            (
+                std::cmp::Reverse(cls.len()),
                 cls.iter().next().unwrap_or_default().to_u16(),
-            )),)
+            )
         });
         classes.dedup();
         let add_one = u16::from(!self.use_class_0);
@@ -86,7 +88,7 @@ mod tests {
     use super::*;
 
     fn make_glyph_class<const N: usize>(glyphs: [u16; N]) -> GlyphClass {
-        glyphs.iter().copied().map(GlyphId::new).collect()
+        glyphs.into_iter().map(GlyphId::new).collect()
     }
 
     #[test]
@@ -110,7 +112,7 @@ mod tests {
 
         let mut builder = ClassDefBuilder2::default();
         builder.checked_add(make_glyph_class([7, 8, 9]));
-        builder.checked_add(make_glyph_class([12, 1]));
+        builder.checked_add(make_glyph_class([1, 12]));
         builder.checked_add(make_glyph_class([3, 4]));
         let (cls, _) = builder.build();
         assert_eq!(cls.get(GlyphId::new(9)), 1);

--- a/fea-rs/src/compile/variations.rs
+++ b/fea-rs/src/compile/variations.rs
@@ -49,7 +49,7 @@ pub enum AxisLocation {
 }
 
 /// Create an axis where user coords == design coords
-#[cfg(any(test, feature = "cli"))]
+#[cfg(any(test, feature = "test", feature = "cli"))]
 fn simple_axis(tag: Tag, min: i16, default: i16, max: i16) -> Axis {
     use fontdrasil::coords::{CoordConverter, DesignCoord, UserCoord};
 

--- a/fea-rs/test-data/fonttools-tests/PairPosSubtable.expected_diff
+++ b/fea-rs/test-data/fonttools-tests/PairPosSubtable.expected_diff
@@ -1,0 +1,29 @@
+# generated automatically by fea-rs
+# this file represents an acceptable difference between the output of
+# fonttools and the output of fea-rs for a given input.
+#
+# Note: this relates to the change in sort order of classdefs, and will
+# be outdated the next time we update fonttools and these test files.
+# see https://github.com/fonttools/fonttools/issues/3321#issuecomment-1789608511
+L95
+>              <ClassDef glyph="b" class="1"/>
+>              <ClassDef glyph="o" class="1"/>
+>            </ClassDef1>
+>            <ClassDef2>
+>              <ClassDef glyph="c" class="2"/>
+>              <ClassDef glyph="d" class="2"/>
+L103
+<            </ClassDef1>
+<            <ClassDef2>
+<              <ClassDef glyph="c" class="1"/>
+<              <ClassDef glyph="d" class="1"/>
+<              <ClassDef glyph="v" class="2"/>
+<              <ClassDef glyph="w" class="2"/>
+L120
+>                <Value1 XAdvance="-20"/>
+L120
+<                <Value1 XAdvance="-10"/>
+L129
+>                <Value1 XAdvance="-10"/>
+L129
+<                <Value1 XAdvance="-20"/>

--- a/fea-rs/test-data/fonttools-tests/bug633.expected_diff
+++ b/fea-rs/test-data/fonttools-tests/bug633.expected_diff
@@ -1,0 +1,25 @@
+# generated automatically by fea-rs
+# this file represents an acceptable difference between the output of
+# fonttools and the output of fea-rs for a given input.
+#
+# Note: this relates to the change in sort order of classdefs, and will
+# be outdated the next time we update fonttools and these test files.
+# see https://github.com/fonttools/fonttools/issues/3321#issuecomment-1789608511
+L45
+>              <ClassDef glyph="C" class="2"/>
+>              <ClassDef glyph="O" class="2"/>
+>              <ClassDef glyph="V" class="1"/>
+>              <ClassDef glyph="W" class="1"/>
+L45
+<              <ClassDef glyph="C" class="1"/>
+<              <ClassDef glyph="O" class="1"/>
+<              <ClassDef glyph="V" class="2"/>
+<              <ClassDef glyph="W" class="2"/>
+L61
+>                <Value1 XAdvance="0"/>
+L61
+<                <Value1 XAdvance="-20"/>
+L65
+>                <Value1 XAdvance="-20"/>
+L65
+<                <Value1 XAdvance="0"/>


### PR DESCRIPTION
We previously matched otlLib, but that order is slightly funny and doesn't match what varLib does, and varLib is more relevant for fontc.

I expect that otlLib will be update shortly to match this behaviour in any case.