### PR TITLE
Add support for intermediate (aka "brace") layers from Glyphs sources

### DIFF
--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -1868,15 +1868,10 @@ mod tests {
         assert_simple_kerning("designspace_from_glyphs/WghtVar.designspace");
     }
 
-    #[test]
-    fn intermediate_layer_in_designspace() {
-        // https://github.com/googlefonts/fontc/issues/400
+    fn assert_intermediate_layer(src: &str) {
         let tmp_dir = tempdir().unwrap();
         let build_dir = tmp_dir.path();
-        compile(Args::for_test(
-            build_dir,
-            "designspace_from_glyphs/IntermediateLayer/IntermediateLayer.designspace",
-        ));
+        compile(Args::for_test(build_dir, src));
 
         let font_file = build_dir.join("font.ttf");
         assert!(font_file.exists());
@@ -1922,6 +1917,26 @@ mod tests {
                 cbox_of_char(0x49, &font, vec![0.6]), // wght=700
                 cbox_of_char(0x49, &font, vec![1.0]), // wght=900
             ]
+        );
+    }
+
+    #[test]
+    fn intermediate_layer_in_glyphs2() {
+        // https://github.com/googlefonts/fontc/issues/62
+        assert_intermediate_layer("glyphs2/IntermediateLayer.glyphs");
+    }
+
+    #[test]
+    fn intermediate_layer_in_glyphs3() {
+        // https://github.com/googlefonts/fontc/issues/62
+        assert_intermediate_layer("glyphs3/IntermediateLayer.glyphs");
+    }
+
+    #[test]
+    fn intermediate_layer_in_designspace() {
+        // https://github.com/googlefonts/fontc/issues/400
+        assert_intermediate_layer(
+            "designspace_from_glyphs/IntermediateLayer/IntermediateLayer.designspace",
         );
     }
 

--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -192,7 +192,7 @@ impl Layer {
     }
 
     pub fn is_intermediate(&self) -> bool {
-        self.associated_master_id.is_some() && self.attributes.coordinates.is_some()
+        self.associated_master_id.is_some() && !self.attributes.coordinates.is_empty()
     }
 
     // TODO add is_alternate, is_color, etc.
@@ -200,14 +200,14 @@ impl Layer {
 
 #[derive(Clone, Default, Debug, PartialEq, Hash)]
 pub struct LayerAttributes {
-    pub coordinates: Option<Vec<OrderedFloat<f64>>>,
+    pub coordinates: Vec<OrderedFloat<f64>>,
     // TODO: add axisRules, color, etc.
 }
 
 // hand-parse because they can take multiple shapes
 impl FromPlist for LayerAttributes {
     fn parse(tokenizer: &mut Tokenizer<'_>) -> Result<Self, crate::plist::Error> {
-        let mut coordinates = None;
+        let mut coordinates = Vec::new();
 
         tokenizer.eat(b'{')?;
 
@@ -220,7 +220,7 @@ impl FromPlist for LayerAttributes {
             tokenizer.eat(b'=')?;
             match key.as_str() {
                 "coordinates" => {
-                    coordinates = Some(tokenizer.parse()?);
+                    coordinates = tokenizer.parse()?;
                 }
                 // skip unsupported attributes for now
                 // TODO: match the others
@@ -569,7 +569,7 @@ impl RawLayer {
                 .unwrap_or_default();
         }
         if !brace_coordinates.is_empty() {
-            self.attributes.coordinates = Some(brace_coordinates);
+            self.attributes.coordinates = brace_coordinates;
         }
         // TODO: handle 'bracket' layers and other attributes
     }

--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -179,9 +179,58 @@ pub struct Glyph {
 #[derive(Debug, PartialEq, Hash)]
 pub struct Layer {
     pub layer_id: String,
+    pub associated_master_id: Option<String>,
     pub width: OrderedFloat<f64>,
     pub shapes: Vec<Shape>,
     pub anchors: Vec<Anchor>,
+    pub attributes: LayerAttributes,
+}
+
+impl Layer {
+    pub fn is_master(&self) -> bool {
+        self.associated_master_id.is_none()
+    }
+
+    pub fn is_intermediate(&self) -> bool {
+        self.associated_master_id.is_some() && self.attributes.coordinates.is_some()
+    }
+
+    // TODO add is_alternate, is_color, etc.
+}
+
+#[derive(Clone, Default, Debug, PartialEq, Hash)]
+pub struct LayerAttributes {
+    pub coordinates: Option<Vec<OrderedFloat<f64>>>,
+    // TODO: add axisRules, color, etc.
+}
+
+// hand-parse because they can take multiple shapes
+impl FromPlist for LayerAttributes {
+    fn parse(tokenizer: &mut Tokenizer<'_>) -> Result<Self, crate::plist::Error> {
+        let mut coordinates = None;
+
+        tokenizer.eat(b'{')?;
+
+        loop {
+            if tokenizer.eat(b'}').is_ok() {
+                break;
+            }
+
+            let key: String = tokenizer.parse()?;
+            tokenizer.eat(b'=')?;
+            match key.as_str() {
+                "coordinates" => {
+                    coordinates = Some(tokenizer.parse()?);
+                }
+                // skip unsupported attributes for now
+                // TODO: match the others
+                _ => tokenizer.skip_rec()?,
+            }
+            tokenizer.eat(b';')?;
+        }
+
+        Ok(LayerAttributes { coordinates })
+    }
 }
 
 #[derive(Debug, PartialEq, Hash)]
@@ -489,8 +538,21 @@ pub struct RawLayer {
     paths: Vec<Path>,
     components: Vec<Component>,
     pub anchors: Vec<RawAnchor>,
+    #[fromplist(alt_name = "attr")]
+    pub attributes: LayerAttributes,
     #[fromplist(ignore)]
     pub other_stuff: BTreeMap<String, Plist>,
+}
+
+impl RawLayer {
+    /// Return true if the layer is a draft that is not meant to be compiled.
+    ///
+    /// The presence of an associated master indicates this is not a simple 'master' instance.
+    /// Without 'attributes' that specify whether it's a special intermediate, alternate or
+    /// color layer, we can assume the non-master layer is a draft.
+    fn is_draft(&self) -> bool {
+        self.associated_master_id.is_some() && self.attributes == Default::default()
+    }
 }
 
 /// Represents a path OR a component
@@ -1468,9 +1530,11 @@ impl TryFrom<RawLayer> for Layer {
 
         Ok(Layer {
             layer_id: from.layer_id,
+            associated_master_id: from.associated_master_id,
             width: from.width,
             shapes,
             anchors,
+            attributes: from.attributes,
         })
     }
 }
@@ -1481,9 +1545,7 @@ impl TryFrom<RawGlyph> for Glyph {
     fn try_from(from: RawGlyph) -> Result<Self, Self::Error> {
         let mut instances = Vec::new();
         for layer in from.layers {
-            // The presence of an associated master indicates this is not a simple instance
-            // It's either a draft or a more complex usage, such as an alternate
-            if layer.associated_master_id.is_some() {
+            if layer.is_draft() {
                 continue;
             }
             instances.push(layer.try_into()?);

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -755,10 +755,11 @@ impl Work<Context, WorkId, WorkError> for GlyphIrWork {
                 .clone();
             // intermediate (aka 'brace') layers can override axis values from their
             // associated master
-            if let Some(coordinates) = instance.attributes.coordinates.as_ref() {
-                for (tag, coord) in design_location(&font_info.axes, coordinates)
-                    .to_normalized(&axes_by_name)
-                    .iter()
+            if !instance.attributes.coordinates.is_empty() {
+                for (tag, coord) in
+                    design_location(&font_info.axes, &instance.attributes.coordinates)
+                        .to_normalized(&axes_by_name)
+                        .iter()
                 {
                     location.insert(*tag, *coord);
                 }

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -23,7 +23,7 @@ use std::sync::Arc;
 use std::{collections::HashMap, path::PathBuf};
 
 use crate::glyphdata::is_nonspacing_mark;
-use crate::toir::{to_ir_contours_and_components, to_ir_features, FontInfo};
+use crate::toir::{design_location, to_ir_contours_and_components, to_ir_features, FontInfo};
 
 pub struct GlyphsIrSource {
     glyphs_file: PathBuf,
@@ -731,15 +731,38 @@ impl Work<Context, WorkId, WorkError> for GlyphIrWork {
 
         // Glyphs have layers that match up with masters, and masters have locations
         let mut axis_positions: HashMap<Tag, HashSet<NormalizedCoord>> = HashMap::new();
+        let axes_by_name = font_info.axes.iter().map(|a| (a.tag, a)).collect();
         for instance in glyph.layers.iter() {
-            let Some(master_idx) = font_info.master_indices.get(instance.layer_id.as_str()) else {
+            // skip not-yet-supported types of layers (e.g. alternate, color, etc.)
+            if !(instance.is_master() || instance.is_intermediate()) {
+                continue;
+            }
+            let master_id = instance
+                .associated_master_id
+                .as_ref()
+                .unwrap_or(&instance.layer_id);
+            let Some(master_idx) = font_info.master_indices.get(master_id) else {
                 return Err(WorkError::NoMasterForGlyph {
-                    master: instance.layer_id.clone(),
+                    master: master_id.clone(),
                     glyph: self.glyph_name.clone(),
                 });
             };
             let master = &font.masters[*master_idx];
-            let location = font_info.locations.get(&master.axes_values).unwrap();
+            let mut location = font_info
+                .locations
+                .get(&master.axes_values)
+                .unwrap()
+                .clone();
+            // intermediate (aka 'brace') layers can override axis values from their
+            // associated master
+            if let Some(coordinates) = instance.attributes.coordinates.as_ref() {
+                for (tag, coord) in design_location(&font_info.axes, coordinates)
+                    .to_normalized(&axes_by_name)
+                    .iter()
+                {
+                    location.insert(*tag, *coord);
+                }
+            }
 
             for (tag, coord) in location.iter() {
                 axis_positions.entry(*tag).or_default().insert(*coord);
@@ -760,7 +783,7 @@ impl Work<Context, WorkId, WorkError> for GlyphIrWork {
             };
 
             ir_glyph
-                .try_add_source(location, glyph_instance)
+                .try_add_source(&location, glyph_instance)
                 .map_err(|e| {
                     WorkError::AddGlyphSource(format!(
                         "Unable to add source to {:?} at {:?}: {}",

--- a/glyphs2fontir/src/toir.rs
+++ b/glyphs2fontir/src/toir.rs
@@ -126,7 +126,7 @@ pub(crate) fn to_ir_features(features: &[FeatureSnippet]) -> Result<ir::Features
     })
 }
 
-fn design_location(
+pub(crate) fn design_location(
     axes: &[fontdrasil::types::Axis],
     axes_values: &[OrderedFloat<f64>],
 ) -> DesignLocation {


### PR DESCRIPTION
The v2 notation is up-converted to equivalent layer attributes' coordinates as found in v3 sources.

We already have test files for glyphs{2,3}/IntermediateLayer.glyphs, because we checked them in when we added support for sparse DS sources, so the tests simply check that we get the same result whether we build from glyphs2, glyphs3 or DS sources (the latter were originally converted from .glyphs using `fontmake -o ufo`).

Fixes #62 