### PR TITLE
Add 'GlyphSet' type to fea-rs to encode the property of a sorted & deduped set of glyphs

### DIFF
--- a/fea-rs/src/common.rs
+++ b/fea-rs/src/common.rs
@@ -9,7 +9,9 @@ pub use write_fonts::types::GlyphId;
 mod glyph_class;
 mod glyph_map;
 
-pub use glyph_class::GlyphClass;
+pub(crate) use glyph_class::GlyphClass;
+
+pub use glyph_class::GlyphSet;
 pub use glyph_map::GlyphMap;
 
 /// A glyph name
@@ -19,7 +21,7 @@ pub type GlyphName = SmolStr;
 ///
 /// Various places in the FEA spec accept either a single glyph or a glyph class.
 #[derive(Debug, Clone)]
-pub enum GlyphOrClass {
+pub(crate) enum GlyphOrClass {
     /// A resolved GlyphId
     Glyph(GlyphId),
     /// A resolved glyph class

--- a/fea-rs/src/common/glyph_class.rs
+++ b/fea-rs/src/common/glyph_class.rs
@@ -6,11 +6,70 @@ use super::GlyphOrClass;
 
 /// A glyph class, as used in the FEA spec.
 ///
-/// This type is currently somewhat confused; in certain places the spec expects
-/// that a glyph class is sorted and deduplicated, and in other places it expects
-/// a glyph class to be an arbitrary sequence of glyphs.
+/// This should not be confused with the `ClassDef` table used in OpenType.
+/// In a feature file, a glyph class is an ordered sequence of glyphs, and
+/// may contain duplicates.
+///
+/// For example, single sub format C can take the form,
+///
+/// ```fea
+/// sub [a b c] by [z z d];
+/// # equivalent to:
+/// sub a by z;
+/// sub b by z;
+/// sub c by d;
+/// ```
+///
+/// See the [spec docs] for more information.
+///
+/// [spec docs]: http://adobe-type-tools.github.io/afdko/OpenTypeFeatureFileSpecification.html#2g-glyph-classes
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub(crate) struct GlyphClass(Rc<[GlyphId]>);
+
+/// A sorted set of unique glyph ids.
+///
+/// This type exists to clearly separate the use of 'glyph class' in the fea spec
+/// from how we use it when building tables that contain OpenType glyph ClassDefs.
+///
+/// In the former case, we want to be able to do things like compare for equality
+/// and stabily sort, so we ensure that these classes are sorted and deduped.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct GlyphClass(Rc<[GlyphId]>);
+pub struct GlyphSet(Rc<[GlyphId]>);
+
+impl GlyphClass {
+    pub(crate) fn items(&self) -> &[GlyphId] {
+        &self.0
+    }
+
+    /// Return a new, empty glyph class
+    pub fn empty() -> Self {
+        Self(Rc::new([]))
+    }
+
+    /// Return a `GlyphSet` containing the unique glyphs in this class.
+    pub(crate) fn to_glyph_set(&self) -> GlyphSet {
+        self.iter().collect()
+    }
+
+    pub(crate) fn iter(&self) -> impl Iterator<Item = GlyphId> + '_ {
+        self.items().iter().copied()
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+impl GlyphSet {
+    /// Iterate over the glyphs in this class
+    pub fn iter(&self) -> impl Iterator<Item = GlyphId> + '_ {
+        self.0.iter().copied()
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.0.len()
+    }
+}
 
 impl std::iter::FromIterator<GlyphId> for GlyphClass {
     fn from_iter<T: IntoIterator<Item = GlyphId>>(iter: T) -> Self {
@@ -28,36 +87,30 @@ impl<'a> std::iter::IntoIterator for &'a GlyphClass {
     }
 }
 
-impl GlyphClass {
-    pub(crate) fn items(&self) -> &[GlyphId] {
-        &self.0
-    }
-
-    /// Return a new, empty glyph class
-    pub fn empty() -> Self {
-        Self(Rc::new([]))
-    }
-
-    pub(crate) fn sort_and_dedupe(&self) -> GlyphClass {
-        //idfk I guess this is fine
-        let mut vec = self.0.iter().cloned().collect::<Vec<_>>();
-        vec.sort_unstable();
-        vec.dedup();
-        GlyphClass(vec.into())
-    }
-
-    pub(crate) fn iter(&self) -> impl Iterator<Item = GlyphId> + '_ {
-        self.items().iter().copied()
-    }
-
-    pub(crate) fn len(&self) -> usize {
-        self.0.len()
-    }
-}
-
 impl From<Vec<GlyphId>> for GlyphClass {
     fn from(src: Vec<GlyphId>) -> GlyphClass {
         GlyphClass(src.into())
+    }
+}
+
+impl From<GlyphClass> for GlyphSet {
+    fn from(value: GlyphClass) -> Self {
+        value.iter().collect::<Vec<_>>().into()
+    }
+}
+
+// our base constructor; all other logic goes through here
+impl From<Vec<GlyphId>> for GlyphSet {
+    fn from(mut value: Vec<GlyphId>) -> Self {
+        value.sort_unstable();
+        value.dedup();
+        Self(value.into())
+    }
+}
+
+impl std::iter::FromIterator<GlyphId> for GlyphSet {
+    fn from_iter<T: IntoIterator<Item = GlyphId>>(iter: T) -> Self {
+        iter.into_iter().collect::<Vec<_>>().into()
     }
 }
 

--- a/fea-rs/src/compile/feature_writer.rs
+++ b/fea-rs/src/compile/feature_writer.rs
@@ -10,7 +10,7 @@ use write_fonts::{
     types::Tag,
 };
 
-use crate::common::GlyphClass;
+use crate::GlyphSet;
 
 use super::{
     features::FeatureLookups,
@@ -31,7 +31,7 @@ pub struct FeatureBuilder<'a> {
     pub(crate) tables: &'a mut Tables,
     pub(crate) lookups: Vec<(LookupId, PositionLookup)>,
     pub(crate) features: BTreeMap<FeatureKey, FeatureLookups>,
-    mark_filter_sets: HashMap<GlyphClass, FilterSetId>,
+    mark_filter_sets: HashMap<GlyphSet, FilterSetId>,
     // because there may already be defined filter sets from the root fea
     filter_set_id_start: usize,
 }
@@ -82,7 +82,7 @@ impl<'a> FeatureBuilder<'a> {
     pub fn add_lookup<T: GposSubtableBuilder>(
         &mut self,
         flags: LookupFlag,
-        filter_set: Option<GlyphClass>,
+        filter_set: Option<GlyphSet>,
         subtables: Vec<T>,
     ) -> LookupId {
         let filter_set_id = filter_set.map(|cls| self.get_filter_set_id(cls));
@@ -123,7 +123,7 @@ impl<'a> FeatureBuilder<'a> {
         self.features.entry(key).or_default().base = lookups;
     }
 
-    fn get_filter_set_id(&mut self, cls: GlyphClass) -> FilterSetId {
+    fn get_filter_set_id(&mut self, cls: GlyphSet) -> FilterSetId {
         let next_id = self.filter_set_id_start + self.mark_filter_sets.len();
         //.expect("too many filter sets");
         *self.mark_filter_sets.entry(cls).or_insert_with(|| {

--- a/fea-rs/src/compile/lookups.rs
+++ b/fea-rs/src/compile/lookups.rs
@@ -28,7 +28,7 @@ use write_fonts::{
 };
 
 use crate::{
-    common::{GlyphClass, GlyphId, GlyphOrClass},
+    common::{GlyphId, GlyphOrClass, GlyphSet},
     compile::lookups::contextual::ChainOrNot,
     Kind,
 };
@@ -854,8 +854,8 @@ impl SomeLookup {
 
     pub(crate) fn add_gpos_type_2_class(
         &mut self,
-        one: GlyphClass,
-        two: GlyphClass,
+        one: GlyphSet,
+        two: GlyphSet,
         val_one: ValueRecord,
         val_two: ValueRecord,
     ) {

--- a/fea-rs/src/compile/lookups/contextual.rs
+++ b/fea-rs/src/compile/lookups/contextual.rs
@@ -342,7 +342,7 @@ impl ContextBuilder {
             .iter()
             .flat_map(|rule| rule.context.iter().map(|x| &x.0))
         {
-            if !builder.checked_add(class.to_class().unwrap()) {
+            if !builder.checked_add(class.to_class().unwrap().into()) {
                 return None;
             }
         }
@@ -542,14 +542,14 @@ impl ChainContextBuilder {
 
         let mut backtrack = ClassDefBuilder2::default();
         for class in self.0.rules.iter().flat_map(|rule| rule.backtrack.iter()) {
-            if !backtrack.checked_add(class.to_class().unwrap()) {
+            if !backtrack.checked_add(class.to_class().unwrap().into()) {
                 return None;
             }
         }
 
         let mut lookahead = ClassDefBuilder2::default();
         for class in self.0.rules.iter().flat_map(|rule| rule.lookahead.iter()) {
-            if !lookahead.checked_add(class.to_class().unwrap()) {
+            if !lookahead.checked_add(class.to_class().unwrap().into()) {
                 return None;
             }
         }
@@ -575,25 +575,25 @@ impl ChainContextBuilder {
 
         for rule in &self.0.rules {
             let cls_idx = *input_map
-                .get(&rule.first_input_sequence_item().to_class().unwrap())
+                .get(&rule.first_input_sequence_item().to_class().unwrap().into())
                 .unwrap();
             let backtrack = rule
                 .backtrack
                 .iter()
-                .map(|cls| backtrack_map.get(&cls.to_class().unwrap()).unwrap())
+                .map(|cls| backtrack_map.get(&cls.to_class().unwrap().into()).unwrap())
                 .copied()
                 .collect();
             let lookahead = rule
                 .lookahead
                 .iter()
-                .map(|cls| lookahead_map.get(&cls.to_class().unwrap()).unwrap())
+                .map(|cls| lookahead_map.get(&cls.to_class().unwrap().into()).unwrap())
                 .copied()
                 .collect();
             let input = rule
                 .context
                 .iter()
                 .skip(1)
-                .map(|(cls, _)| input_map.get(&cls.to_class().unwrap()).unwrap())
+                .map(|(cls, _)| input_map.get(&cls.to_class().unwrap().into()).unwrap())
                 .copied()
                 .collect();
 

--- a/fea-rs/src/compile/lookups/gpos_builders.rs
+++ b/fea-rs/src/compile/lookups/gpos_builders.rs
@@ -12,7 +12,7 @@ use write_fonts::{
     types::GlyphId,
 };
 
-use crate::common::GlyphClass;
+use crate::common::GlyphSet;
 
 use super::{Builder, ClassDefBuilder2, VariationIndexContainingLookup};
 
@@ -122,7 +122,7 @@ struct GlyphPairPosBuilder(BTreeMap<GlyphId, BTreeMap<GlyphId, (ValueRecord, Val
 
 #[derive(Clone, Debug)]
 struct ClassPairPosSubtable {
-    items: BTreeMap<GlyphClass, BTreeMap<GlyphClass, (ValueRecord, ValueRecord)>>,
+    items: BTreeMap<GlyphSet, BTreeMap<GlyphSet, (ValueRecord, ValueRecord)>>,
     classdef_1: ClassDefBuilder2,
     classdef_2: ClassDefBuilder2,
 }
@@ -160,9 +160,9 @@ impl VariationIndexContainingLookup for PairPosBuilder {
 impl ClassPairPosBuilder {
     fn insert(
         &mut self,
-        class1: GlyphClass,
+        class1: GlyphSet,
         record1: ValueRecord,
-        class2: GlyphClass,
+        class2: GlyphSet,
         record2: ValueRecord,
     ) {
         let key = (record1.format(), record2.format());
@@ -182,14 +182,14 @@ impl ClassPairPosBuilder {
 }
 
 impl ClassPairPosSubtable {
-    fn can_add(&self, class1: &GlyphClass, class2: &GlyphClass) -> bool {
+    fn can_add(&self, class1: &GlyphSet, class2: &GlyphSet) -> bool {
         self.classdef_1.can_add(class1) && self.classdef_2.can_add(class2)
     }
 
     fn add(
         &mut self,
-        class1: GlyphClass,
-        class2: GlyphClass,
+        class1: GlyphSet,
+        class2: GlyphSet,
         record1: ValueRecord,
         record2: ValueRecord,
     ) {
@@ -221,9 +221,9 @@ impl PairPosBuilder {
     /// Insert a new class-based kerning rule.
     pub fn insert_classes(
         &mut self,
-        class1: GlyphClass,
+        class1: GlyphSet,
         record1: ValueRecord,
-        class2: GlyphClass,
+        class2: GlyphSet,
         record2: ValueRecord,
     ) {
         self.classes.insert(class1, record1, class2, record2)
@@ -302,7 +302,7 @@ impl Builder for ClassPairPosSubtable {
         let (class1def, class1map) = self.classdef_1.build();
         let (class2def, class2map) = self.classdef_2.build();
 
-        let coverage = self.items.keys().flat_map(GlyphClass::iter).collect();
+        let coverage = self.items.keys().flat_map(GlyphSet::iter).collect();
 
         let mut out = vec![write_gpos::Class1Record::default(); self.items.len()];
         for (cls1, stuff) in self.items {

--- a/fea-rs/src/compile/tables/gdef.rs
+++ b/fea-rs/src/compile/tables/gdef.rs
@@ -19,7 +19,7 @@ use write_fonts::tables::{
 };
 
 use super::{VariationIndexRemapping, VariationStoreBuilder};
-use crate::common::GlyphClass;
+use crate::common::{GlyphClass, GlyphSet};
 
 /// Data collected from a GDEF block.
 #[derive(Clone, Debug, Default)]
@@ -28,7 +28,7 @@ pub struct GdefBuilder {
     pub attach: BTreeMap<GlyphId, BTreeSet<u16>>,
     pub ligature_pos: BTreeMap<GlyphId, Vec<CaretValue>>,
     pub mark_attach_class: BTreeMap<GlyphId, u16>,
-    pub mark_glyph_sets: Vec<GlyphClass>,
+    pub mark_glyph_sets: Vec<GlyphSet>,
     pub var_store: Option<VariationStoreBuilder>,
 }
 
@@ -123,8 +123,10 @@ impl GdefBuilder {
     }
 
     /// Errors if the class contains a glyph that is already in an existing class.
-    pub fn add_glyph_class(
+    pub(crate) fn add_glyph_class(
         &mut self,
+        // technically should be a GlyphSet, but we're storing it as individual
+        // glyphs and this is private API, so :shrug:
         glyphs: GlyphClass,
         class: ClassId,
     ) -> Result<(), (GlyphId, ClassId)> {

--- a/fea-rs/src/lib.rs
+++ b/fea-rs/src/lib.rs
@@ -15,7 +15,7 @@ pub mod util;
 #[cfg(test)]
 mod tests;
 
-pub use common::{GlyphClass, GlyphIdent, GlyphMap, GlyphName};
+pub use common::{GlyphIdent, GlyphMap, GlyphName, GlyphSet};
 pub use compile::Compiler;
 pub use diagnostic::{Diagnostic, Level};
 pub use parse::{ParseTree, TokenSet};

--- a/fea-rs/test-data/compile-tests/mini-latin/good/single_sub_format_c.fea
+++ b/fea-rs/test-data/compile-tests/mini-latin/good/single_sub_format_c.fea
@@ -1,0 +1,6 @@
+# single sub format c uses things that look like glyph classes, except that
+# duplicates are allowed, and order matters.
+feature test {
+    # sub a by z, b by z, c by m, d by k.
+    sub [a b c d] by [z z m k];
+} test;

--- a/fea-rs/test-data/compile-tests/mini-latin/good/single_sub_format_c.ttx
+++ b/fea-rs/test-data/compile-tests/mini-latin/good/single_sub_format_c.ttx
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont>
+
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=1 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="test"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=1 -->
+      <Lookup index="0">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0">
+          <Substitution in="a" out="z"/>
+          <Substitution in="b" out="z"/>
+          <Substitution in="c" out="m"/>
+          <Substitution in="d" out="k"/>
+        </SingleSubst>
+      </Lookup>
+    </LookupList>
+  </GSUB>
+
+</ttFont>

--- a/fontbe/src/features.rs
+++ b/fontbe/src/features.rs
@@ -16,7 +16,7 @@ use fea_rs::{
         PairPosBuilder, VariationInfo,
     },
     parse::{SourceLoadError, SourceResolver},
-    Compiler, GlyphClass, GlyphMap, GlyphName as FeaRsGlyphName,
+    Compiler, GlyphMap, GlyphName as FeaRsGlyphName, GlyphSet,
 };
 use font_types::{GlyphId, Tag};
 use fontdrasil::{coords::NormalizedLocation, types::Axis};
@@ -241,7 +241,7 @@ impl<'a> FeatureWriter<'a> {
             .groups
             .iter()
             .map(|(class_name, glyph_set)| {
-                let glyph_class: GlyphClass = glyph_set
+                let glyph_class: GlyphSet = glyph_set
                     .iter()
                     .map(|name| GlyphId::new(self.glyph_map.glyph_id(name).unwrap_or(0) as u16))
                     .collect();
@@ -288,11 +288,11 @@ impl<'a> FeatureWriter<'a> {
                     let right = glyph_classes
                         .get(right)
                         .ok_or_else(|| Error::MissingGlyphId(right.clone()))?;
-                    for gid1 in right {
+                    for gid1 in right.iter() {
                         ppos_subtables.insert_pair(
                             gid0,
                             x_adv_record.clone(),
-                            *gid1,
+                            gid1,
                             empty_record.clone(),
                         );
                     }
@@ -302,9 +302,9 @@ impl<'a> FeatureWriter<'a> {
                         .get(left)
                         .ok_or_else(|| Error::MissingGlyphId(left.clone()))?;
                     let gid1 = self.glyph_id(right)?;
-                    for gid0 in left {
+                    for gid0 in left.iter() {
                         ppos_subtables.insert_pair(
-                            *gid0,
+                            gid0,
                             x_adv_record.clone(),
                             gid1,
                             empty_record.clone(),


### PR DESCRIPTION
This is a funny patch, but it addresses a long-standing wart in fea-rs that regained my attention in the process of working through how our ClassDefs were assigning ids differently than was fontmake.

The tl;dr is that what FEA calls a 'glyphclass' is just an arbitrary sequence of glyphs. In several places, however, we use these classes in places where we are representing members of an OpenType ClassDef. In these cases, we need to do things like compare two sets for equality, and in this case we want to have a fixed order, and ignore duplicates.

The previous implementation was ad-hoc, using a `sort_and_dedupe` method in certain places, where it would take some arbitrary `GlyphClass` and turn it into one that conformed to these expectations; but we were not using it consistently, and it would have been easy to overlook.

With this change, I've added a new type, `GlyphSet`, which is sorted and deduped by construction. This type is used in our public API anywhere we are working with OpenType ClassDefs (really just in the PairPos builder and in mark filtering sets) and so the previous `GlyphClass` type can go back to being private API.

