### PR TITLE
Add test files that restrict glyph export

### DIFF
--- a/resources/testdata/designspace_from_glyphs/WghtVar-Regular.ufo/glyphs/hyphen.glif
+++ b/resources/testdata/designspace_from_glyphs/WghtVar-Regular.ufo/glyphs/hyphen.glif
@@ -5,7 +5,7 @@
   <outline>
     <contour>
       <point x="131" y="330" type="line"/>
-      <point x="131" y="250" type="line"/>
+      <point x="131" y="250" type="line" name="hr00"/>
       <point x="470" y="250" type="line"/>
       <point x="470" y="330" type="line"/>
     </contour>

--- a/resources/testdata/designspace_from_glyphs/WghtVar.designspace
+++ b/resources/testdata/designspace_from_glyphs/WghtVar.designspace
@@ -19,4 +19,12 @@
       </location>
     </source>
   </sources>
+  <lib>
+    <dict>
+      <key>public.skipExportGlyphs</key>
+      <array>
+        <string>hyphen</string>
+      </array>
+    </dict>
+  </lib>
 </designspace>

--- a/resources/testdata/designspace_from_glyphs/WghtVar_Anchors-Bold.ufo/glyphs/brevecomb.glif
+++ b/resources/testdata/designspace_from_glyphs/WghtVar_Anchors-Bold.ufo/glyphs/brevecomb.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="brevecomb" format="2">
+  <unicode hex="0306"/>
+  <anchor x="210" y="510" name="_top"/>
+  <outline>
+    <contour>
+      <point x="132" y="728" type="line"/>
+      <point x="132" y="658" type="line"/>
+      <point x="462" y="658" type="line"/>
+      <point x="462" y="728" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>600</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/resources/testdata/designspace_from_glyphs/WghtVar_Anchors-Bold.ufo/glyphs/contents.plist
+++ b/resources/testdata/designspace_from_glyphs/WghtVar_Anchors-Bold.ufo/glyphs/contents.plist
@@ -4,6 +4,8 @@
   <dict>
     <key>A</key>
     <string>A_.glif</string>
+    <key>brevecomb</key>
+    <string>brevecomb.glif</string>
     <key>macroncomb</key>
     <string>macroncomb.glif</string>
     <key>space</key>

--- a/resources/testdata/designspace_from_glyphs/WghtVar_Anchors-Bold.ufo/lib.plist
+++ b/resources/testdata/designspace_from_glyphs/WghtVar_Anchors-Bold.ufo/lib.plist
@@ -63,16 +63,21 @@
       <string>A</string>
       <string>space</string>
       <string>macroncomb</string>
+      <string>brevecomb</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
       <key>A</key>
       <string>base</string>
+      <key>brevecomb</key>
+      <string>mark</string>
       <key>macroncomb</key>
       <string>mark</string>
     </dict>
     <key>public.postscriptNames</key>
     <dict>
+      <key>brevecomb</key>
+      <string>uni0306</string>
       <key>macroncomb</key>
       <string>uni0304</string>
     </dict>

--- a/resources/testdata/designspace_from_glyphs/WghtVar_Anchors-Regular.ufo/glyphs/brevecomb.glif
+++ b/resources/testdata/designspace_from_glyphs/WghtVar_Anchors-Regular.ufo/glyphs/brevecomb.glif
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="brevecomb" format="2">
+  <unicode hex="0306"/>
+  <anchor x="200" y="500" name="_top"/>
+  <outline>
+    <contour>
+      <point x="140" y="724" type="line"/>
+      <point x="140" y="661" type="line"/>
+      <point x="454" y="661" type="line"/>
+      <point x="454" y="724" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>600</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/resources/testdata/designspace_from_glyphs/WghtVar_Anchors-Regular.ufo/glyphs/contents.plist
+++ b/resources/testdata/designspace_from_glyphs/WghtVar_Anchors-Regular.ufo/glyphs/contents.plist
@@ -4,6 +4,8 @@
   <dict>
     <key>A</key>
     <string>A_.glif</string>
+    <key>brevecomb</key>
+    <string>brevecomb.glif</string>
     <key>macroncomb</key>
     <string>macroncomb.glif</string>
     <key>space</key>

--- a/resources/testdata/designspace_from_glyphs/WghtVar_Anchors-Regular.ufo/lib.plist
+++ b/resources/testdata/designspace_from_glyphs/WghtVar_Anchors-Regular.ufo/lib.plist
@@ -63,16 +63,21 @@
       <string>A</string>
       <string>space</string>
       <string>macroncomb</string>
+      <string>brevecomb</string>
     </array>
     <key>public.openTypeCategories</key>
     <dict>
       <key>A</key>
       <string>base</string>
+      <key>brevecomb</key>
+      <string>mark</string>
       <key>macroncomb</key>
       <string>mark</string>
     </dict>
     <key>public.postscriptNames</key>
     <dict>
+      <key>brevecomb</key>
+      <string>uni0306</string>
       <key>macroncomb</key>
       <string>uni0304</string>
     </dict>

--- a/resources/testdata/designspace_from_glyphs/make_designspace.sh
+++ b/resources/testdata/designspace_from_glyphs/make_designspace.sh
@@ -17,3 +17,4 @@ rm -rf resources/testdata/designspace_from_glyphs/*.ufo
 generate_designspace resources/testdata/glyphs3/IntermediateLayer.glyphs
 generate_designspace resources/testdata/glyphs3/WghtVar.glyphs
 generate_designspace resources/testdata/glyphs3/WghtVar_Anchors.glyphs
+generate_designspace resources/testdata/glyphs3/WghtVar_NoExport.glyphs

--- a/resources/testdata/glyphs2/WghtVar_NoExport.glyphs
+++ b/resources/testdata/glyphs2/WghtVar_NoExport.glyphs
@@ -1,0 +1,337 @@
+{
+.appVersion = "3226";
+DisplayStrings = (
+"![]!"
+);
+copyright = "Copy!";
+customParameters = (
+{
+name = "Use Typo Metrics";
+value = 1;
+},
+{
+name = "Has WWS Names";
+value = 1;
+},
+{
+name = description;
+value = "The greatest weight var";
+},
+{
+name = localizedFamilyName;
+value = "Spanish;SpanishWghtVar";
+},
+{
+name = licenseURL;
+value = "https://example.com/my/font/license";
+},
+{
+name = versionString;
+value = "New Value";
+},
+{
+name = Axes;
+value = (
+{
+Name = Weight;
+Tag = wght;
+}
+);
+}
+);
+date = "2022-12-01 04:52:20 +0000";
+familyName = WghtVar;
+fontMaster = (
+{
+alignmentZones = (
+"{737, 16}",
+"{0, -16}",
+"{-42, -16}"
+);
+ascender = 737;
+capHeight = 702;
+descender = -42;
+id = m01;
+weightValue = 400;
+xHeight = 501;
+},
+{
+ascender = 800;
+capHeight = 700;
+descender = -200;
+id = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+weight = Bold;
+weightValue = 700;
+xHeight = 500;
+}
+);
+glyphs = (
+{
+glyphname = space;
+lastChange = "2022-12-01 04:58:12 +0000";
+layers = (
+{
+layerId = m01;
+width = 200;
+},
+{
+layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+width = 600;
+}
+);
+unicode = 0020;
+},
+{
+glyphname = exclam;
+lastChange = "2023-06-07 22:35:08 +0000";
+layers = (
+{
+layerId = m01;
+paths = (
+{
+closed = 1;
+nodes = (
+"354 183 LINE",
+"414 585 LINE",
+"178 585 LINE",
+"238 182 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"354 0 LINE",
+"354 107 LINE",
+"238 107 LINE",
+"238 0 LINE"
+);
+}
+);
+width = 600;
+},
+{
+layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+paths = (
+{
+closed = 1;
+nodes = (
+"364 176 LINE",
+"434 605 LINE",
+"159 605 LINE",
+"228 174 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"364 -20 LINE",
+"364 94 LINE",
+"228 94 LINE",
+"228 -20 LINE"
+);
+}
+);
+width = 600;
+}
+);
+unicode = 0021;
+},
+{
+export = 0;
+glyphname = hyphen;
+lastChange = "2023-11-07 18:00:55 +0000";
+layers = (
+{
+layerId = m01;
+paths = (
+{
+closed = 1;
+nodes = (
+"131 250 LINE {name = hr00;}",
+"470 250 LINE",
+"470 330 LINE",
+"131 330 LINE"
+);
+}
+);
+width = 600;
+},
+{
+layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+paths = (
+{
+closed = 1;
+nodes = (
+"92 224 LINE",
+"508 224 LINE",
+"508 356 LINE",
+"92 356 LINE"
+);
+}
+);
+width = 600;
+}
+);
+unicode = 002D;
+},
+{
+glyphname = bracketleft;
+lastChange = "2023-06-07 22:37:02 +0000";
+layers = (
+{
+layerId = m01;
+paths = (
+{
+closed = 1;
+nodes = (
+"324 637 LINE",
+"324 51 LINE",
+"454 51 LINE",
+"454 -10 LINE",
+"259 -10 LINE",
+"259 696 LINE",
+"454 696 LINE",
+"454 637 LINE"
+);
+}
+);
+width = 600;
+},
+{
+layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+paths = (
+{
+closed = 1;
+nodes = (
+"324 629 LINE",
+"324 58 LINE",
+"454 58 LINE",
+"454 -17 LINE",
+"243 -17 LINE",
+"243 704 LINE",
+"454 704 LINE",
+"454 629 LINE"
+);
+}
+);
+width = 600;
+}
+);
+leftKerningGroup = bracketleft_L;
+rightKerningGroup = bracketleft_R;
+unicode = 005B;
+},
+{
+glyphname = bracketright;
+lastChange = "2023-06-07 22:35:47 +0000";
+layers = (
+{
+layerId = m01;
+paths = (
+{
+closed = 1;
+nodes = (
+"259 696 LINE",
+"454 696 LINE",
+"454 -10 LINE",
+"259 -10 LINE",
+"259 51 LINE",
+"389 51 LINE",
+"389 637 LINE",
+"259 637 LINE"
+);
+}
+);
+width = 600;
+},
+{
+layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+paths = (
+{
+closed = 1;
+nodes = (
+"243 704 LINE",
+"454 704 LINE",
+"454 -17 LINE",
+"243 -17 LINE",
+"243 58 LINE",
+"373 58 LINE",
+"373 629 LINE",
+"243 629 LINE"
+);
+}
+);
+width = 600;
+}
+);
+leftKerningGroup = bracketright_L;
+rightKerningGroup = bracketright_R;
+unicode = 005D;
+},
+{
+glyphname = "manual-component";
+lastChange = "2023-11-07 18:07:12 +0000";
+layers = (
+{
+components = (
+{
+name = hyphen;
+transform = "{1, 0, 0, 1, 0, 100}";
+},
+{
+name = hyphen;
+}
+);
+layerId = m01;
+width = 600;
+},
+{
+components = (
+{
+name = hyphen;
+transform = "{1.15, 0, 0, 1.25, 10, 100}";
+},
+{
+name = hyphen;
+}
+);
+layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+width = 600;
+}
+);
+unicode = 003D;
+}
+);
+kerning = {
+m01 = {
+"@MMK_L_bracketleft_R" = {
+exclam = -165;
+};
+bracketleft = {
+bracketright = -300;
+};
+exclam = {
+"@MMK_R_bracketright_L" = -160;
+exclam = -360;
+hyphen = 20;
+};
+hyphen = {
+hyphen = -150;
+};
+};
+"E09E0C54-128D-4FEA-B209-1B70BEFE300B" = {
+bracketleft = {
+bracketright = -150;
+};
+exclam = {
+exclam = -100;
+};
+hyphen = {
+hyphen = -50;
+};
+};
+};
+unitsPerEm = 1000;
+versionMajor = 42;
+versionMinor = 42;
+}

--- a/resources/testdata/glyphs3/WghtVar_NoExport.glyphs
+++ b/resources/testdata/glyphs3/WghtVar_NoExport.glyphs
@@ -1,0 +1,407 @@
+{
+.appVersion = "3226";
+.formatVersion = 3;
+DisplayStrings = (
+"![]!"
+);
+axes = (
+{
+name = Weight;
+tag = wght;
+}
+);
+customParameters = (
+{
+name = "Use Typo Metrics";
+value = 1;
+},
+{
+name = "Has WWS Names";
+value = 1;
+}
+);
+date = "2022-12-01 04:52:20 +0000";
+familyName = WghtVar;
+fontMaster = (
+{
+axesValues = (
+400
+);
+id = m01;
+metricValues = (
+{
+over = 16;
+pos = 737;
+},
+{
+over = -16;
+},
+{
+over = -16;
+pos = -42;
+},
+{
+pos = 702;
+},
+{
+pos = 501;
+}
+);
+name = Regular;
+},
+{
+axesValues = (
+700
+);
+iconName = Bold;
+id = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+metricValues = (
+{
+pos = 800;
+},
+{
+},
+{
+pos = -200;
+},
+{
+pos = 700;
+},
+{
+pos = 500;
+}
+);
+name = Bold;
+}
+);
+glyphs = (
+{
+glyphname = space;
+lastChange = "2022-12-01 04:58:12 +0000";
+layers = (
+{
+layerId = m01;
+width = 200;
+},
+{
+layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+width = 600;
+}
+);
+unicode = 32;
+},
+{
+glyphname = exclam;
+lastChange = "2023-06-07 22:35:08 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(354,183,l),
+(414,585,l),
+(178,585,l),
+(238,182,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(354,0,l),
+(354,107,l),
+(238,107,l),
+(238,0,l)
+);
+}
+);
+width = 600;
+},
+{
+layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(364,176,l),
+(434,605,l),
+(159,605,l),
+(228,174,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(364,-20,l),
+(364,94,l),
+(228,94,l),
+(228,-20,l)
+);
+}
+);
+width = 600;
+}
+);
+unicode = 33;
+},
+{
+export = 0;
+glyphname = hyphen;
+lastChange = "2023-11-07 18:00:55 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(131,250,l,{
+name = hr00;
+}),
+(470,250,l),
+(470,330,l),
+(131,330,l)
+);
+}
+);
+width = 600;
+},
+{
+layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(92,224,l),
+(508,224,l),
+(508,356,l),
+(92,356,l)
+);
+}
+);
+width = 600;
+}
+);
+unicode = 45;
+},
+{
+glyphname = bracketleft;
+kernLeft = bracketleft_L;
+kernRight = bracketleft_R;
+lastChange = "2023-06-07 22:37:02 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(324,637,l),
+(324,51,l),
+(454,51,l),
+(454,-10,l),
+(259,-10,l),
+(259,696,l),
+(454,696,l),
+(454,637,l)
+);
+}
+);
+width = 600;
+},
+{
+layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(324,629,l),
+(324,58,l),
+(454,58,l),
+(454,-17,l),
+(243,-17,l),
+(243,704,l),
+(454,704,l),
+(454,629,l)
+);
+}
+);
+width = 600;
+}
+);
+unicode = 91;
+},
+{
+glyphname = bracketright;
+kernLeft = bracketright_L;
+kernRight = bracketright_R;
+lastChange = "2023-06-07 22:35:47 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(259,696,l),
+(454,696,l),
+(454,-10,l),
+(259,-10,l),
+(259,51,l),
+(389,51,l),
+(389,637,l),
+(259,637,l)
+);
+}
+);
+width = 600;
+},
+{
+layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(243,704,l),
+(454,704,l),
+(454,-17,l),
+(243,-17,l),
+(243,58,l),
+(373,58,l),
+(373,629,l),
+(243,629,l)
+);
+}
+);
+width = 600;
+}
+);
+unicode = 93;
+},
+{
+glyphname = "manual-component";
+lastChange = "2023-11-07 18:07:30 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+pos = (0,100);
+ref = hyphen;
+},
+{
+ref = hyphen;
+}
+);
+width = 600;
+},
+{
+layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+shapes = (
+{
+pos = (10,100);
+ref = hyphen;
+scale = (1.15,1.25);
+},
+{
+ref = hyphen;
+}
+);
+width = 600;
+}
+);
+unicode = 61;
+}
+);
+kerningLTR = {
+m01 = {
+"@MMK_L_bracketleft_R" = {
+exclam = -165;
+};
+bracketleft = {
+bracketright = -300;
+};
+exclam = {
+"@MMK_R_bracketright_L" = -160;
+exclam = -360;
+hyphen = 20;
+};
+hyphen = {
+hyphen = -150;
+};
+};
+"E09E0C54-128D-4FEA-B209-1B70BEFE300B" = {
+bracketleft = {
+bracketright = -150;
+};
+exclam = {
+exclam = -100;
+};
+hyphen = {
+hyphen = -50;
+};
+};
+};
+metrics = (
+{
+type = ascender;
+},
+{
+type = baseline;
+},
+{
+type = descender;
+},
+{
+type = "cap height";
+},
+{
+type = "x-height";
+}
+);
+properties = (
+{
+key = copyrights;
+values = (
+{
+language = dflt;
+value = "Copy!";
+}
+);
+},
+{
+key = descriptions;
+values = (
+{
+language = dflt;
+value = "The greatest weight var";
+},
+{
+language = ESP;
+value = "The greatest Spanish weight var";
+}
+);
+},
+{
+key = familyNames;
+values = (
+{
+language = ESP;
+value = SpanishWghtVar;
+}
+);
+},
+{
+key = licenseURL;
+value = "https://example.com/my/font/license";
+},
+{
+key = versionString;
+value = "New Value";
+}
+);
+unitsPerEm = 1000;
+versionMajor = 42;
+versionMinor = 42;
+}


### PR DESCRIPTION
Re-ran resources/testdata/designspace_from_glyphs/make_designspace.sh with new input. It also changed some existing files.

hyphen is not exported while being used as a component, meant to trigger "If the non-export glyphs are used as components in other composite glyphs, [the components will get decomposed](https://github.com/googlefonts/ufo2ft/blob/efb4658890ba645292a9c6bc055c91afe225c4a1/Lib/ufo2ft/util.py#L65-L87) as the base glyphs they point to get pruned." (https://github.com/googlefonts/fontc/issues/532)

The new test files are not yet used and would not compile correctly if they were. Baby steps.