### PR TITLE
Fix MissingGlyphId while building mark feature with a non-export glyph with anchors

### DIFF
--- a/fontbe/src/features.rs
+++ b/fontbe/src/features.rs
@@ -161,6 +161,7 @@ struct MarkGroup<'a> {
 
 fn create_mark_groups<'a>(
     anchors: &HashMap<GlyphName, &'a GlyphAnchors>,
+    glyph_order: &GlyphOrder,
 ) -> HashMap<MarkGroupName<'a>, MarkGroup<'a>> {
     let mut groups: HashMap<MarkGroupName<'a>, MarkGroup> = Default::default();
     for (glyph_name, glyph_anchors) in anchors.iter() {
@@ -168,7 +169,10 @@ fn create_mark_groups<'a>(
         // considering only glyphs with anchors,
         //  - glyphs with *only* base anchors are bases
         //  - glyphs with *any* mark anchor are marks
-
+        // We ignore glyphs missing from the glyph order (e.g. no-export glyphs)
+        if !glyph_order.contains(glyph_name) {
+            continue;
+        }
         let mut base = true; // TODO: only a base if user rules allow it
         for anchor in glyph_anchors.anchors.iter() {
             let anchor_info = AnchorInfo::new(&anchor.name);
@@ -344,7 +348,7 @@ impl<'a> FeatureWriter<'a> {
             anchors.insert(glyph_name.clone(), glyph_anchors);
         }
 
-        let mark_groups = create_mark_groups(&anchors);
+        let mark_groups = create_mark_groups(&anchors, self.glyph_map);
 
         // Build the actual mark base and mark mark constructs using fea-rs builders
 

--- a/resources/testdata/designspace_from_glyphs/WghtVar_NoExport-Bold.ufo/glyphs/hyphen.glif
+++ b/resources/testdata/designspace_from_glyphs/WghtVar_NoExport-Bold.ufo/glyphs/hyphen.glif
@@ -2,6 +2,8 @@
 <glyph name="hyphen" format="2">
   <advance width="600"/>
   <unicode hex="002D"/>
+  <anchor x="280" y="163" name="_top"/>
+  <anchor x="277" y="426" name="top"/>
   <outline>
     <contour>
       <point x="92" y="356" type="line"/>

--- a/resources/testdata/designspace_from_glyphs/WghtVar_NoExport-Bold.ufo/lib.plist
+++ b/resources/testdata/designspace_from_glyphs/WghtVar_NoExport-Bold.ufo/lib.plist
@@ -35,7 +35,7 @@
       </dict>
     </array>
     <key>com.schriftgestaltung.customParameter.GSFont.disablesAutomaticAlignment</key>
-    <false/>
+    <true/>
     <key>com.schriftgestaltung.customParameter.GSFont.useNiceNames</key>
     <integer>1</integer>
     <key>com.schriftgestaltung.customParameter.GSFontMaster.customValue</key>
@@ -67,6 +67,11 @@
       <string>bracketright</string>
       <string>manual-component</string>
     </array>
+    <key>public.openTypeCategories</key>
+    <dict>
+      <key>hyphen</key>
+      <string>base</string>
+    </dict>
     <key>public.postscriptNames</key>
     <dict>
       <key>manual-component</key>

--- a/resources/testdata/designspace_from_glyphs/WghtVar_NoExport-Regular.ufo/glyphs/hyphen.glif
+++ b/resources/testdata/designspace_from_glyphs/WghtVar_NoExport-Regular.ufo/glyphs/hyphen.glif
@@ -2,6 +2,8 @@
 <glyph name="hyphen" format="2">
   <advance width="600"/>
   <unicode hex="002D"/>
+  <anchor x="279" y="186" name="_top"/>
+  <anchor x="273" y="411" name="top"/>
   <outline>
     <contour>
       <point x="131" y="330" type="line"/>

--- a/resources/testdata/designspace_from_glyphs/WghtVar_NoExport-Regular.ufo/lib.plist
+++ b/resources/testdata/designspace_from_glyphs/WghtVar_NoExport-Regular.ufo/lib.plist
@@ -35,7 +35,7 @@
       </dict>
     </array>
     <key>com.schriftgestaltung.customParameter.GSFont.disablesAutomaticAlignment</key>
-    <false/>
+    <true/>
     <key>com.schriftgestaltung.customParameter.GSFont.useNiceNames</key>
     <integer>1</integer>
     <key>com.schriftgestaltung.customParameter.GSFontMaster.customValue</key>
@@ -67,6 +67,11 @@
       <string>bracketright</string>
       <string>manual-component</string>
     </array>
+    <key>public.openTypeCategories</key>
+    <dict>
+      <key>hyphen</key>
+      <string>base</string>
+    </dict>
     <key>public.postscriptNames</key>
     <dict>
       <key>manual-component</key>

--- a/resources/testdata/glyphs2/WghtVar_NoExport.glyphs
+++ b/resources/testdata/glyphs2/WghtVar_NoExport.glyphs
@@ -40,6 +40,7 @@ Tag = wght;
 }
 );
 date = "2022-12-01 04:52:20 +0000";
+disablesAutomaticAlignment = 1;
 familyName = WghtVar_NoExport;
 fontMaster = (
 {
@@ -139,9 +140,19 @@ unicode = 0021;
 {
 export = 0;
 glyphname = hyphen;
-lastChange = "2023-11-07 18:00:55 +0000";
+lastChange = "2023-11-09 15:45:52 +0000";
 layers = (
 {
+anchors = (
+{
+name = _top;
+position = "{279, 186}";
+},
+{
+name = top;
+position = "{273, 411}";
+}
+);
 layerId = m01;
 paths = (
 {
@@ -157,6 +168,16 @@ nodes = (
 width = 600;
 },
 {
+anchors = (
+{
+name = _top;
+position = "{280, 163}";
+},
+{
+name = top;
+position = "{277, 426}";
+}
+);
 layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
 paths = (
 {
@@ -270,7 +291,7 @@ unicode = 005D;
 },
 {
 glyphname = "manual-component";
-lastChange = "2023-11-07 18:07:12 +0000";
+lastChange = "2023-11-09 15:45:41 +0000";
 layers = (
 {
 components = (

--- a/resources/testdata/glyphs3/WghtVar_NoExport.glyphs
+++ b/resources/testdata/glyphs3/WghtVar_NoExport.glyphs
@@ -148,9 +148,19 @@ unicode = 33;
 {
 export = 0;
 glyphname = hyphen;
-lastChange = "2023-11-07 18:00:55 +0000";
+lastChange = "2023-11-09 15:45:52 +0000";
 layers = (
 {
+anchors = (
+{
+name = _top;
+pos = (279,186);
+},
+{
+name = top;
+pos = (273,411);
+}
+);
 layerId = m01;
 shapes = (
 {
@@ -168,6 +178,16 @@ name = hr00;
 width = 600;
 },
 {
+anchors = (
+{
+name = _top;
+pos = (280,163);
+},
+{
+name = top;
+pos = (277,426);
+}
+);
 layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
 shapes = (
 {
@@ -281,7 +301,7 @@ unicode = 93;
 },
 {
 glyphname = "manual-component";
-lastChange = "2023-11-07 18:07:30 +0000";
+lastChange = "2023-11-09 15:45:41 +0000";
 layers = (
 {
 layerId = m01;
@@ -401,6 +421,9 @@ key = versionString;
 value = "New Value";
 }
 );
+settings = {
+disablesAutomaticAlignment = 1;
+};
 unitsPerEm = 1000;
 versionMajor = 42;
 versionMinor = 42;


### PR DESCRIPTION
the first commit adds a bunch of anchors to a no-export glyph "hyphen" in WghtVar_NoExport.glyphs test file to  trigger issue https://github.com/googlefonts/fontc/issues/555

Will follow up with a fix