### PR TITLE
ensure non-export glyphs get pruned from kerning groups

### DIFF
--- a/fontbe/src/features.rs
+++ b/fontbe/src/features.rs
@@ -244,14 +244,12 @@ impl<'a> FeatureWriter<'a> {
             .kerning
             .groups
             .iter()
-            .map(|(class_name, glyph_set)| {
-                let glyph_class: GlyphSet = glyph_set
-                    .iter()
-                    .map(|name| GlyphId::new(self.glyph_map.glyph_id(name).unwrap_or(0) as u16))
-                    .collect();
-                (class_name, glyph_class)
+            .map(|(class_name, members)| {
+                let glyph_class: Result<GlyphSet, Error> =
+                    members.iter().map(|name| self.glyph_id(name)).collect();
+                glyph_class.map(|set| (class_name, set))
             })
-            .collect::<BTreeMap<_, _>>();
+            .collect::<Result<BTreeMap<_, _>, Error>>()?;
 
         let mut ppos_subtables = PairPosBuilder::default();
 

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -609,6 +609,8 @@ impl Work<Context, WorkId, WorkError> for KerningWork {
         // If glyph uses a group for either side it goes in that group
         font.glyphs
             .iter()
+            // ignore non-export glyphs
+            .filter(|(_, glyph)| glyph.export)
             .flat_map(|(glyph_name, glyph)| {
                 glyph
                     .right_kern

--- a/resources/testdata/designspace_from_glyphs/WghtVar_NoExport-Bold.ufo/groups.plist
+++ b/resources/testdata/designspace_from_glyphs/WghtVar_NoExport-Bold.ufo/groups.plist
@@ -10,6 +10,10 @@
     <array>
       <string>bracketright</string>
     </array>
+    <key>public.kern1.hyphen_R</key>
+    <array>
+      <string>hyphen</string>
+    </array>
     <key>public.kern2.bracketleft_L</key>
     <array>
       <string>bracketleft</string>
@@ -17,6 +21,10 @@
     <key>public.kern2.bracketright_L</key>
     <array>
       <string>bracketright</string>
+    </array>
+    <key>public.kern2.hyphen_L</key>
+    <array>
+      <string>hyphen</string>
     </array>
   </dict>
 </plist>

--- a/resources/testdata/designspace_from_glyphs/WghtVar_NoExport-Bold.ufo/kerning.plist
+++ b/resources/testdata/designspace_from_glyphs/WghtVar_NoExport-Bold.ufo/kerning.plist
@@ -12,9 +12,9 @@
       <key>exclam</key>
       <integer>-100</integer>
     </dict>
-    <key>hyphen</key>
+    <key>public.kern1.hyphen_R</key>
     <dict>
-      <key>hyphen</key>
+      <key>public.kern2.hyphen_L</key>
       <integer>-50</integer>
     </dict>
   </dict>

--- a/resources/testdata/designspace_from_glyphs/WghtVar_NoExport-Regular.ufo/groups.plist
+++ b/resources/testdata/designspace_from_glyphs/WghtVar_NoExport-Regular.ufo/groups.plist
@@ -10,6 +10,10 @@
     <array>
       <string>bracketright</string>
     </array>
+    <key>public.kern1.hyphen_R</key>
+    <array>
+      <string>hyphen</string>
+    </array>
     <key>public.kern2.bracketleft_L</key>
     <array>
       <string>bracketleft</string>
@@ -17,6 +21,10 @@
     <key>public.kern2.bracketright_L</key>
     <array>
       <string>bracketright</string>
+    </array>
+    <key>public.kern2.hyphen_L</key>
+    <array>
+      <string>hyphen</string>
     </array>
   </dict>
 </plist>

--- a/resources/testdata/designspace_from_glyphs/WghtVar_NoExport-Regular.ufo/kerning.plist
+++ b/resources/testdata/designspace_from_glyphs/WghtVar_NoExport-Regular.ufo/kerning.plist
@@ -16,15 +16,15 @@
       <key>public.kern2.bracketright_L</key>
       <integer>-160</integer>
     </dict>
-    <key>hyphen</key>
-    <dict>
-      <key>hyphen</key>
-      <integer>-150</integer>
-    </dict>
     <key>public.kern1.bracketleft_R</key>
     <dict>
       <key>exclam</key>
       <integer>-165</integer>
+    </dict>
+    <key>public.kern1.hyphen_R</key>
+    <dict>
+      <key>public.kern2.hyphen_L</key>
+      <integer>-150</integer>
     </dict>
   </dict>
 </plist>

--- a/resources/testdata/glyphs2/WghtVar_NoExport.glyphs
+++ b/resources/testdata/glyphs2/WghtVar_NoExport.glyphs
@@ -140,7 +140,7 @@ unicode = 0021;
 {
 export = 0;
 glyphname = hyphen;
-lastChange = "2023-11-09 15:45:52 +0000";
+lastChange = "2023-11-09 16:34:37 +0000";
 layers = (
 {
 anchors = (
@@ -193,6 +193,8 @@ nodes = (
 width = 600;
 }
 );
+leftKerningGroup = hyphen_L;
+rightKerningGroup = hyphen_R;
 unicode = 002D;
 },
 {
@@ -328,6 +330,9 @@ m01 = {
 "@MMK_L_bracketleft_R" = {
 exclam = -165;
 };
+"@MMK_L_hyphen_R" = {
+"@MMK_R_hyphen_L" = -150;
+};
 bracketleft = {
 bracketright = -300;
 };
@@ -336,19 +341,16 @@ exclam = {
 exclam = -360;
 hyphen = 20;
 };
-hyphen = {
-hyphen = -150;
-};
 };
 "E09E0C54-128D-4FEA-B209-1B70BEFE300B" = {
+"@MMK_L_hyphen_R" = {
+"@MMK_R_hyphen_L" = -50;
+};
 bracketleft = {
 bracketright = -150;
 };
 exclam = {
 exclam = -100;
-};
-hyphen = {
-hyphen = -50;
 };
 };
 };

--- a/resources/testdata/glyphs3/WghtVar_NoExport.glyphs
+++ b/resources/testdata/glyphs3/WghtVar_NoExport.glyphs
@@ -148,7 +148,9 @@ unicode = 33;
 {
 export = 0;
 glyphname = hyphen;
-lastChange = "2023-11-09 15:45:52 +0000";
+kernLeft = hyphen_L;
+kernRight = hyphen_R;
+lastChange = "2023-11-09 16:34:37 +0000";
 layers = (
 {
 anchors = (
@@ -339,6 +341,9 @@ m01 = {
 "@MMK_L_bracketleft_R" = {
 exclam = -165;
 };
+"@MMK_L_hyphen_R" = {
+"@MMK_R_hyphen_L" = -150;
+};
 bracketleft = {
 bracketright = -300;
 };
@@ -347,19 +352,16 @@ exclam = {
 exclam = -360;
 hyphen = 20;
 };
-hyphen = {
-hyphen = -150;
-};
 };
 "E09E0C54-128D-4FEA-B209-1B70BEFE300B" = {
+"@MMK_L_hyphen_R" = {
+"@MMK_R_hyphen_L" = -50;
+};
 bracketleft = {
 bracketright = -150;
 };
 exclam = {
 exclam = -100;
-};
-hyphen = {
-hyphen = -50;
 };
 };
 };


### PR DESCRIPTION
to trigger the other issue noted at https://github.com/googlefonts/fontc/issues/555#issuecomment-1804163641

> when collecting the glyph groups, we let non-export glyphs in the kerning groups IR, but the the fontbe kern feature generator arbitrarily assigns gid 0 (.notdef?!) to missing glyphs when construcing the coverages which is wrong. Since we are pruning pairs from the kerning IR when single glyphs are not in the glyph order, we should similarly also prune missing/non-export glyphs when they occur inside a kerning group as we construct the kerning IR.