### PR TITLE
[fontc] Ensure feature code is deterministic

### DIFF
--- a/fontbe/src/features.rs
+++ b/fontbe/src/features.rs
@@ -126,7 +126,7 @@ impl<'a> FeaVariationInfo<'a> {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 struct MarkGroupName<'a>(&'a str);
 
 /// The type of an anchor, used when generating mark features
@@ -160,10 +160,10 @@ struct MarkGroup<'a> {
 }
 
 fn create_mark_groups<'a>(
-    anchors: &HashMap<GlyphName, &'a GlyphAnchors>,
+    anchors: &BTreeMap<GlyphName, &'a GlyphAnchors>,
     glyph_order: &GlyphOrder,
-) -> HashMap<MarkGroupName<'a>, MarkGroup<'a>> {
-    let mut groups: HashMap<MarkGroupName<'a>, MarkGroup> = Default::default();
+) -> BTreeMap<MarkGroupName<'a>, MarkGroup<'a>> {
+    let mut groups: BTreeMap<MarkGroupName<'a>, MarkGroup> = Default::default();
     for (glyph_name, glyph_anchors) in anchors.iter() {
         // We assume the anchor list to be small
         // considering only glyphs with anchors,
@@ -251,7 +251,7 @@ impl<'a> FeatureWriter<'a> {
                     .collect();
                 (class_name, glyph_class)
             })
-            .collect::<HashMap<_, _>>();
+            .collect::<BTreeMap<_, _>>();
 
         let mut ppos_subtables = PairPosBuilder::default();
 
@@ -339,7 +339,7 @@ impl<'a> FeatureWriter<'a> {
     /// * <https://github.com/googlefonts/ufo2ft/issues/563>
     //TODO: could we generate as a separate task, and then just add here.
     fn add_marks(&self, builder: &mut FeatureBuilder) -> Result<(), Error> {
-        let mut anchors = HashMap::new();
+        let mut anchors = BTreeMap::new();
         for (work_id, arc_glyph_anchors) in self.raw_anchors {
             let glyph_anchors: &GlyphAnchors = arc_glyph_anchors;
             let FeWorkId::Anchor(glyph_name) = work_id else {

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -204,14 +204,14 @@ type KernValues = BTreeMap<NormalizedLocation, OrderedFloat<f32>>;
 #[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq, Eq)]
 #[serde(from = "KerningSerdeRepr", into = "KerningSerdeRepr")]
 pub struct Kerning {
-    pub groups: HashMap<GroupName, BTreeSet<GlyphName>>,
+    pub groups: BTreeMap<GroupName, BTreeSet<GlyphName>>,
     /// An adjustment to the space *between* two glyphs in logical order.
     ///
     /// Maps (side1, side2) => a mapping location:adjustment.
     ///
     /// Used for both LTR and RTL. The BE application differs but the concept
     /// is the same.
-    pub kerns: HashMap<KernPair, KernValues>,
+    pub kerns: BTreeMap<KernPair, KernValues>,
 }
 
 impl Kerning {

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -17,7 +17,7 @@ use glyphs_reader::{Font, InstanceType};
 use indexmap::IndexSet;
 use log::{debug, trace, warn};
 use read_fonts::tables::os2::SelectionFlags;
-use std::collections::{BTreeSet, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::str::FromStr;
 use std::sync::Arc;
 use std::{collections::HashMap, path::PathBuf};
@@ -539,7 +539,7 @@ struct AnchorWork {
 /// See <https://github.com/googlefonts/glyphsLib/blob/42bc1db912fd4b66f130fb3bdc63a0c1e774eb38/Lib/glyphsLib/builder/kerning.py#L53-L72>
 fn kern_participant(
     glyph_order: &GlyphOrder,
-    groups: &HashMap<GlyphName, BTreeSet<GlyphName>>,
+    groups: &BTreeMap<GlyphName, BTreeSet<GlyphName>>,
     side: KernSide,
     raw_side: &str,
 ) -> Option<KernParticipant> {

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -1033,7 +1033,7 @@ fn kerning_groups_for(
     designspace_dir: &Path,
     glyph_order: &GlyphOrder,
     source: &norad::designspace::Source,
-) -> Result<HashMap<GroupName, BTreeSet<GlyphName>>, WorkError> {
+) -> Result<BTreeMap<GroupName, BTreeSet<GlyphName>>, WorkError> {
     let ufo_dir = designspace_dir.join(&source.filename);
     let data_request = norad::DataRequest::none().groups(true);
     Ok(norad::Font::load_requested_data(&ufo_dir, data_request)


### PR DESCRIPTION
This replaces our use of HashMap with BTreeMap in various places where we later iterate over a collection, which ensures that we are constructing our features in the same order (ensuring that, for instance, the same item has the same delta set index between builds)

JMM