### PR TITLE
Don't block on glyph order if you don't have to

### DIFF
--- a/fontc/src/change_detector.rs
+++ b/fontc/src/change_detector.rs
@@ -59,7 +59,7 @@ impl ChangeDetector {
         prev_inputs: Input,
         timer: &mut JobTimer,
     ) -> Result<ChangeDetector, Error> {
-        let time = create_timer(AnyWorkId::InternalTiming("new change detector"))
+        let time = create_timer(AnyWorkId::InternalTiming("new change detector"), 0)
             .queued()
             .run();
 

--- a/fontc/src/error.rs
+++ b/fontc/src/error.rs
@@ -21,6 +21,6 @@ pub enum Error {
     TasksFailed(Vec<(AnyWorkId, String)>),
     #[error("Invalid regex")]
     BadRegex(#[from] regex::Error),
-    #[error("Unable to proceed")]
-    UnableToProceed,
+    #[error("Unable to proceed; {0} jobs stuck pending")]
+    UnableToProceed(usize),
 }

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -293,7 +293,7 @@ pub fn create_workload(
     change_detector: &mut ChangeDetector,
     timer: JobTimer,
 ) -> Result<Workload, Error> {
-    let time = create_timer(AnyWorkId::InternalTiming("Create workload"))
+    let time = create_timer(AnyWorkId::InternalTiming("Create workload"), 0)
         .queued()
         .run();
     let mut workload = change_detector.create_workload(timer)?;

--- a/fontc/src/main.rs
+++ b/fontc/src/main.rs
@@ -23,7 +23,7 @@ fn main() {
 
 fn run() -> Result<(), Error> {
     let mut timer = JobTimer::new(Instant::now());
-    let time = create_timer(AnyWorkId::InternalTiming("Init logger"))
+    let time = create_timer(AnyWorkId::InternalTiming("Init logger"), 0)
         .queued()
         .run();
     env_logger::builder()
@@ -43,7 +43,7 @@ fn run() -> Result<(), Error> {
         .init();
     timer.add(time.complete());
 
-    let time = create_timer(AnyWorkId::InternalTiming("Init config"))
+    let time = create_timer(AnyWorkId::InternalTiming("Init config"), 0)
         .queued()
         .run();
     let args = Args::parse();


### PR DESCRIPTION
I believe I can also migrate some of the work in glyph order out of it to avoid having it block the world.

Before, glyph order blocks all be work:

![image](https://github.com/googlefonts/fontc/assets/6466432/7e4f7c8c-fa4a-4609-94ab-3cdc700649db)

After, some be (blue) work can happen before glyph order:

![image](https://github.com/googlefonts/fontc/assets/6466432/b15544be-10d1-4a2b-b1b2-2836dcb8d216)

Hopefully part of a series leading to improvements wrt #456.
