### PR TITLE
[fea-rs] ensure first wins when specific kern rules conflict

### DIFF
--- a/fea-rs/src/compile/lookups/gpos_builders.rs
+++ b/fea-rs/src/compile/lookups/gpos_builders.rs
@@ -211,11 +211,23 @@ impl PairPosBuilder {
         glyph2: GlyphId,
         record2: ValueRecord,
     ) {
+        // "When specific kern pair rules conflict, the first rule specified is used,
+        // and later conflicting rule are skipped"
+        // https://adobe-type-tools.github.io/afdko/OpenTypeFeatureFileSpecification.html#6bii-enumerating-pairs
+        // E.g.:
+        //   @A = [A Aacute Agrave]
+        //   feature kern {
+        //     pos A B 100;
+        //     enum pos @A B -50;
+        //   } kern;
+        // should result in a A B kerning value of 100, not -50.
+        // https://github.com/googlefonts/fontc/issues/550
         self.pairs
             .0
             .entry(glyph1)
             .or_default()
-            .insert(glyph2, (record1, record2));
+            .entry(glyph2)
+            .or_insert((record1, record2));
     }
 
     /// Insert a new class-based kerning rule.

--- a/fea-rs/test-data/compile-tests/mini-latin/good/early_kern_rules_win.fea
+++ b/fea-rs/test-data/compile-tests/mini-latin/good/early_kern_rules_win.fea
@@ -1,0 +1,5 @@
+# https://github.com/googlefonts/fontc/issues/550
+feature kern {
+    pos A B 100;
+    enum pos A B -50;
+} kern;

--- a/fea-rs/test-data/compile-tests/mini-latin/good/early_kern_rules_win.ttx
+++ b/fea-rs/test-data/compile-tests/mini-latin/good/early_kern_rules_win.ttx
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont>
+
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=1 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="kern"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=1 -->
+      <Lookup index="0">
+        <LookupType value="2"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <PairPos index="0" Format="1">
+          <Coverage>
+            <Glyph value="A"/>
+          </Coverage>
+          <ValueFormat1 value="4"/>
+          <ValueFormat2 value="0"/>
+          <!-- PairSetCount=1 -->
+          <PairSet index="0">
+            <!-- PairValueCount=1 -->
+            <PairValueRecord index="0">
+              <SecondGlyph value="B"/>
+              <Value1 XAdvance="100"/>
+            </PairValueRecord>
+          </PairSet>
+        </PairPos>
+      </Lookup>
+    </LookupList>
+  </GPOS>
+
+</ttFont>


### PR DESCRIPTION
Thanks @simoncozens for reporting this and proposing a fix, I just applied that and added a test for confirm.

https://adobe-type-tools.github.io/afdko/OpenTypeFeatureFileSpecification.html#6bii-enumerating-pairs

> Specific pairs generated by an enum rule may be overridden by specifying preceding single pairs. Because of this case, it is not an error when specific kern pairs conflict because they have the same glyphs. When specific kern pair rules conflict, the first rule specified is used, and later conflicting rule are skipped.

Fixes https://github.com/googlefonts/fontc/issues/550