### PR TITLE
Remove Access::Custom; it forces table scans to figure out what can run

### DIFF
--- a/fontbe/src/avar.rs
+++ b/fontbe/src/avar.rs
@@ -96,7 +96,7 @@ impl Work<Context, AnyWorkId, Error> for AvarWork {
     }
 
     fn read_access(&self) -> Access<AnyWorkId> {
-        Access::One(FeWorkId::StaticMetadata.into())
+        Access::Variant(AnyWorkId::Fe(FeWorkId::StaticMetadata))
     }
 
     /// Generate [avar](https://learn.microsoft.com/en-us/typography/opentype/spec/avar)

--- a/fontbe/src/cmap.rs
+++ b/fontbe/src/cmap.rs
@@ -1,8 +1,9 @@
 //! Generates a [cmap](https://learn.microsoft.com/en-us/typography/opentype/spec/cmap) table.
 
-use std::sync::Arc;
-
-use fontdrasil::orchestration::{Access, Work};
+use fontdrasil::{
+    orchestration::{Access, AccessBuilder, Work},
+    types::GlyphName,
+};
 use fontir::orchestration::WorkId as FeWorkId;
 
 use write_fonts::{tables::cmap::Cmap, types::GlyphId};
@@ -25,12 +26,10 @@ impl Work<Context, AnyWorkId, Error> for CmapWork {
     }
 
     fn read_access(&self) -> Access<AnyWorkId> {
-        Access::Custom(Arc::new(|id| {
-            matches!(
-                id,
-                AnyWorkId::Fe(FeWorkId::GlyphOrder) | AnyWorkId::Fe(FeWorkId::Glyph(..))
-            )
-        }))
+        AccessBuilder::new()
+            .variant(FeWorkId::GlyphOrder)
+            .variant(FeWorkId::Glyph(GlyphName::NOTDEF))
+            .build()
     }
 
     /// Generate [cmap](https://learn.microsoft.com/en-us/typography/opentype/spec/cmap)

--- a/fontbe/src/features.rs
+++ b/fontbe/src/features.rs
@@ -2,7 +2,7 @@
 
 use std::{
     cell::RefCell,
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{BTreeMap, HashMap},
     error::Error as StdError,
     ffi::{OsStr, OsString},
     fmt::Display,
@@ -28,7 +28,7 @@ use fontir::{
 
 use fontdrasil::{
     coords::NormalizedLocation,
-    orchestration::{Access, Work},
+    orchestration::{Access, AccessBuilder, Work},
     types::Axis,
 };
 use write_fonts::{
@@ -438,13 +438,13 @@ impl Work<Context, AnyWorkId, Error> for FeatureWork {
     }
 
     fn read_access(&self) -> Access<AnyWorkId> {
-        Access::Set(HashSet::from([
-            AnyWorkId::Fe(FeWorkId::GlyphOrder),
-            AnyWorkId::Fe(FeWorkId::StaticMetadata),
-            AnyWorkId::Fe(FeWorkId::Features),
-            AnyWorkId::Be(WorkId::Kerning),
-            AnyWorkId::Be(WorkId::Marks),
-        ]))
+        AccessBuilder::new()
+            .variant(FeWorkId::GlyphOrder)
+            .variant(FeWorkId::StaticMetadata)
+            .variant(FeWorkId::Features)
+            .variant(WorkId::Kerning)
+            .variant(WorkId::Marks)
+            .build()
     }
 
     fn also_completes(&self) -> Vec<AnyWorkId> {

--- a/fontbe/src/font.rs
+++ b/fontbe/src/font.rs
@@ -1,8 +1,6 @@
 //! Merge tables into a font
 
-use std::collections::HashSet;
-
-use fontdrasil::orchestration::{Access, Work};
+use fontdrasil::orchestration::{Access, AccessBuilder, Work};
 use fontir::orchestration::WorkId as FeWorkId;
 use log::debug;
 use write_fonts::{
@@ -110,28 +108,28 @@ impl Work<Context, AnyWorkId, Error> for FontWork {
     }
 
     fn read_access(&self) -> Access<AnyWorkId> {
-        Access::Set(HashSet::from([
-            WorkId::Avar.into(),
-            WorkId::Cmap.into(),
-            WorkId::Fvar.into(),
-            WorkId::Head.into(),
-            WorkId::Hhea.into(),
-            WorkId::Hmtx.into(),
-            WorkId::Glyf.into(),
-            WorkId::Gpos.into(),
-            WorkId::Gsub.into(),
-            WorkId::Gdef.into(),
-            WorkId::Gvar.into(),
-            WorkId::Loca.into(),
-            WorkId::Maxp.into(),
-            WorkId::Name.into(),
-            WorkId::Os2.into(),
-            WorkId::Post.into(),
-            WorkId::Stat.into(),
-            WorkId::Hvar.into(),
-            FeWorkId::StaticMetadata.into(),
-            WorkId::LocaFormat.into(),
-        ]))
+        AccessBuilder::new()
+            .variant(WorkId::Avar)
+            .variant(WorkId::Cmap)
+            .variant(WorkId::Fvar)
+            .variant(WorkId::Head)
+            .variant(WorkId::Hhea)
+            .variant(WorkId::Hmtx)
+            .variant(WorkId::Glyf)
+            .variant(WorkId::Gpos)
+            .variant(WorkId::Gsub)
+            .variant(WorkId::Gdef)
+            .variant(WorkId::Gvar)
+            .variant(WorkId::Loca)
+            .variant(WorkId::Maxp)
+            .variant(WorkId::Name)
+            .variant(WorkId::Os2)
+            .variant(WorkId::Post)
+            .variant(WorkId::Stat)
+            .variant(WorkId::Hvar)
+            .variant(WorkId::LocaFormat)
+            .variant(FeWorkId::StaticMetadata)
+            .build()
     }
 
     /// Glue binary tables into a font

--- a/fontbe/src/fvar.rs
+++ b/fontbe/src/fvar.rs
@@ -90,7 +90,7 @@ impl Work<Context, AnyWorkId, Error> for FvarWork {
     }
 
     fn read_access(&self) -> Access<AnyWorkId> {
-        Access::One(FeWorkId::StaticMetadata.into())
+        Access::Variant(AnyWorkId::Fe(FeWorkId::StaticMetadata))
     }
 
     /// Generate [fvar](https://learn.microsoft.com/en-us/typography/opentype/spec/fvar)

--- a/fontbe/src/gvar.rs
+++ b/fontbe/src/gvar.rs
@@ -1,9 +1,7 @@
 //! Generates a [gvar](https://learn.microsoft.com/en-us/typography/opentype/spec/gvar) table.
 
-use std::sync::Arc;
-
 use fontdrasil::{
-    orchestration::{Access, Work},
+    orchestration::{Access, AccessBuilder, Work},
     types::GlyphName,
 };
 use fontir::{ir::GlyphOrder, orchestration::WorkId as FeWorkId};
@@ -42,14 +40,11 @@ impl Work<Context, AnyWorkId, Error> for GvarWork {
     }
 
     fn read_access(&self) -> Access<AnyWorkId> {
-        Access::Custom(Arc::new(|id| {
-            matches!(
-                id,
-                AnyWorkId::Fe(FeWorkId::StaticMetadata)
-                    | AnyWorkId::Fe(FeWorkId::GlyphOrder)
-                    | AnyWorkId::Be(WorkId::GvarFragment(..))
-            )
-        }))
+        AccessBuilder::new()
+            .variant(FeWorkId::StaticMetadata)
+            .variant(FeWorkId::GlyphOrder)
+            .variant(WorkId::GvarFragment(GlyphName::NOTDEF))
+            .build()
     }
 
     /// Generate [gvar](https://learn.microsoft.com/en-us/typography/opentype/spec/gvar)

--- a/fontbe/src/head.rs
+++ b/fontbe/src/head.rs
@@ -1,9 +1,9 @@
 //! Generates a [head](https://learn.microsoft.com/en-us/typography/opentype/spec/head) table.
 
-use std::{collections::HashSet, env};
+use std::env;
 
 use chrono::{DateTime, TimeZone, Utc};
-use fontdrasil::orchestration::{Access, Work};
+use fontdrasil::orchestration::{Access, AccessBuilder, Work};
 use fontir::orchestration::WorkId as FeWorkId;
 use log::warn;
 use write_fonts::{
@@ -96,11 +96,11 @@ impl Work<Context, AnyWorkId, Error> for HeadWork {
     }
 
     fn read_access(&self) -> Access<AnyWorkId> {
-        Access::Set(HashSet::from([
-            FeWorkId::StaticMetadata.into(),
-            WorkId::Glyf.into(),
-            WorkId::LocaFormat.into(),
-        ]))
+        AccessBuilder::new()
+            .variant(FeWorkId::StaticMetadata)
+            .variant(WorkId::Glyf)
+            .variant(WorkId::LocaFormat)
+            .build()
     }
 
     /// Generate [head](https://learn.microsoft.com/en-us/typography/opentype/spec/head)

--- a/fontbe/src/hvar.rs
+++ b/fontbe/src/hvar.rs
@@ -2,8 +2,8 @@
 
 use std::any::type_name;
 use std::collections::{BTreeSet, HashMap};
-use std::sync::Arc;
 
+use fontdrasil::orchestration::AccessBuilder;
 use indexmap::IndexMap;
 
 use fontdrasil::{
@@ -154,14 +154,11 @@ impl Work<Context, AnyWorkId, Error> for HvarWork {
     }
 
     fn read_access(&self) -> Access<AnyWorkId> {
-        Access::Custom(Arc::new(|id| {
-            matches!(
-                id,
-                AnyWorkId::Fe(FeWorkId::Glyph(..))
-                    | AnyWorkId::Fe(FeWorkId::StaticMetadata)
-                    | AnyWorkId::Fe(FeWorkId::GlyphOrder)
-            )
-        }))
+        AccessBuilder::new()
+            .variant(FeWorkId::StaticMetadata)
+            .variant(FeWorkId::GlyphOrder)
+            .variant(FeWorkId::Glyph(GlyphName::NOTDEF))
+            .build()
     }
 
     /// Generate [HVAR](https://learn.microsoft.com/en-us/typography/opentype/spec/HVAR)

--- a/fontbe/src/kern.rs
+++ b/fontbe/src/kern.rs
@@ -1,12 +1,12 @@
 //! Generates a [Kerning] datastructure to be fed to fea-rs
 
-use std::collections::{BTreeMap, HashSet};
+use std::collections::BTreeMap;
 
 use fea_rs::{
     compile::{PairPosBuilder, ValueRecord as ValueRecordBuilder},
     GlyphSet,
 };
-use fontdrasil::orchestration::{Access, Work};
+use fontdrasil::orchestration::{Access, AccessBuilder, Work};
 use fontir::{ir::KernParticipant, orchestration::WorkId as FeWorkId};
 use write_fonts::types::GlyphId;
 
@@ -29,11 +29,11 @@ impl Work<Context, AnyWorkId, Error> for KerningWork {
     }
 
     fn read_access(&self) -> Access<AnyWorkId> {
-        Access::Set(HashSet::from([
-            FeWorkId::StaticMetadata.into(),
-            FeWorkId::Kerning.into(),
-            FeWorkId::GlyphOrder.into(),
-        ]))
+        AccessBuilder::new()
+            .variant(FeWorkId::StaticMetadata)
+            .variant(FeWorkId::Kerning)
+            .variant(FeWorkId::GlyphOrder)
+            .build()
     }
 
     /// Generate kerning data structures.

--- a/fontbe/src/marks.rs
+++ b/fontbe/src/marks.rs
@@ -7,7 +7,7 @@ use std::{
 
 use fea_rs::compile::{MarkToBaseBuilder, MarkToMarkBuilder, PreviouslyAssignedClass};
 use fontdrasil::{
-    orchestration::{Access, Work},
+    orchestration::{Access, AccessBuilder, Work},
     types::GlyphName,
 };
 
@@ -169,14 +169,11 @@ impl Work<Context, AnyWorkId, Error> for MarkWork {
     }
 
     fn read_access(&self) -> Access<AnyWorkId> {
-        Access::Custom(Arc::new(|id| {
-            matches!(
-                id,
-                AnyWorkId::Fe(FeWorkId::StaticMetadata)
-                    | AnyWorkId::Fe(FeWorkId::GlyphOrder)
-                    | AnyWorkId::Fe(FeWorkId::Anchor(..))
-            )
-        }))
+        AccessBuilder::new()
+            .variant(FeWorkId::StaticMetadata)
+            .variant(FeWorkId::GlyphOrder)
+            .variant(FeWorkId::Anchor(GlyphName::NOTDEF))
+            .build()
     }
 
     /// Generate mark data structures.

--- a/fontbe/src/metrics_and_limits.rs
+++ b/fontbe/src/metrics_and_limits.rs
@@ -4,10 +4,12 @@
 use std::{
     cmp::{max, min},
     collections::{HashMap, HashSet},
-    sync::Arc,
 };
 
-use fontdrasil::orchestration::{Access, Work};
+use fontdrasil::{
+    orchestration::{Access, AccessBuilder, Work},
+    types::GlyphName,
+};
 use fontir::orchestration::WorkId as FeWorkId;
 use write_fonts::{
     dump_table,
@@ -199,28 +201,22 @@ impl Work<Context, AnyWorkId, Error> for MetricAndLimitWork {
     }
 
     fn read_access(&self) -> Access<AnyWorkId> {
-        Access::Custom(Arc::new(|id| {
-            matches!(
-                id,
-                AnyWorkId::Fe(FeWorkId::Glyph(..))
-                    | AnyWorkId::Fe(FeWorkId::GlobalMetrics)
-                    | AnyWorkId::Fe(FeWorkId::GlyphOrder)
-                    | AnyWorkId::Be(WorkId::GlyfFragment(..))
-                    | AnyWorkId::Be(WorkId::Head)
-            )
-        }))
+        AccessBuilder::new()
+            .variant(FeWorkId::GlobalMetrics)
+            .variant(FeWorkId::GlyphOrder)
+            .variant(WorkId::Head)
+            .variant(FeWorkId::Glyph(GlyphName::NOTDEF))
+            .variant(WorkId::GlyfFragment(GlyphName::NOTDEF))
+            .build()
     }
 
     fn write_access(&self) -> Access<AnyWorkId> {
-        Access::Custom(Arc::new(|id| {
-            matches!(
-                id,
-                AnyWorkId::Be(WorkId::Hmtx)
-                    | AnyWorkId::Be(WorkId::Hhea)
-                    | AnyWorkId::Be(WorkId::Maxp)
-                    | AnyWorkId::Be(WorkId::Head)
-            )
-        }))
+        AccessBuilder::new()
+            .variant(WorkId::Hmtx)
+            .variant(WorkId::Hhea)
+            .variant(WorkId::Maxp)
+            .variant(WorkId::Head)
+            .build()
     }
 
     fn also_completes(&self) -> Vec<AnyWorkId> {

--- a/fontbe/src/name.rs
+++ b/fontbe/src/name.rs
@@ -25,7 +25,7 @@ impl Work<Context, AnyWorkId, Error> for NameWork {
     }
 
     fn read_access(&self) -> Access<AnyWorkId> {
-        Access::One(FeWorkId::StaticMetadata.into())
+        Access::Variant(AnyWorkId::Fe(FeWorkId::StaticMetadata))
     }
 
     /// Generate [name](https://learn.microsoft.com/en-us/typography/opentype/spec/name)

--- a/fontbe/src/orchestration.rs
+++ b/fontbe/src/orchestration.rs
@@ -14,7 +14,7 @@ use fea_rs::{
     GlyphMap, GlyphSet,
 };
 use fontdrasil::{
-    orchestration::{Access, AccessControlList, Identifier, Work},
+    orchestration::{Access, AccessControlList, Identifier, IdentifierDiscriminant, Work},
     types::GlyphName,
 };
 use fontir::{
@@ -101,7 +101,37 @@ pub enum WorkId {
     Stat,
 }
 
-impl Identifier for WorkId {}
+impl Identifier for WorkId {
+    fn discriminant(&self) -> IdentifierDiscriminant {
+        match self {
+            WorkId::Features => "BeFeatures",
+            WorkId::Avar => "BeAvar",
+            WorkId::Cmap => "BeCmap",
+            WorkId::Font => "BeFont",
+            WorkId::Fvar => "BeFvar",
+            WorkId::Glyf => "BeGlyf",
+            WorkId::GlyfFragment(..) => "BeGlyfFragment",
+            WorkId::Gpos => "BeGpos",
+            WorkId::Gsub => "BeGsub",
+            WorkId::Gdef => "BeGdef",
+            WorkId::Gvar => "BeGvar",
+            WorkId::GvarFragment(..) => "BeGvarFragment",
+            WorkId::Head => "BeHead",
+            WorkId::Hhea => "BeHhea",
+            WorkId::Hmtx => "BeHmtx",
+            WorkId::Hvar => "BeHvar",
+            WorkId::Kerning => "BeKerning",
+            WorkId::Loca => "BeLoca",
+            WorkId::LocaFormat => "BeLocaFormat",
+            WorkId::Marks => "BeMarks",
+            WorkId::Maxp => "BeMaxp",
+            WorkId::Name => "BeName",
+            WorkId::Os2 => "BeOs2",
+            WorkId::Post => "BePost",
+            WorkId::Stat => "BeStat",
+        }
+    }
+}
 
 // Identifies work of any type, FE, BE, ... future optimization passes, w/e.
 // Useful because BE work can very reasonably depend on FE work
@@ -113,7 +143,15 @@ pub enum AnyWorkId {
     InternalTiming(&'static str),
 }
 
-impl Identifier for AnyWorkId {}
+impl Identifier for AnyWorkId {
+    fn discriminant(&self) -> IdentifierDiscriminant {
+        match self {
+            AnyWorkId::Fe(id) => id.discriminant(),
+            AnyWorkId::Be(id) => id.discriminant(),
+            AnyWorkId::InternalTiming(..) => "InternalTiming",
+        }
+    }
+}
 
 impl AnyWorkId {
     pub fn unwrap_be(&self) -> &WorkId {

--- a/fontbe/src/os2.rs
+++ b/fontbe/src/os2.rs
@@ -1,8 +1,11 @@
 //! Generates a [OS/2](https://learn.microsoft.com/en-us/typography/opentype/spec/os2) table.
 
-use std::{cmp::Ordering, collections::HashSet, sync::Arc};
+use std::{cmp::Ordering, collections::HashSet};
 
-use fontdrasil::orchestration::{Access, Work};
+use fontdrasil::{
+    orchestration::{Access, AccessBuilder, Work},
+    types::GlyphName,
+};
 use fontir::{ir::GlobalMetricsInstance, orchestration::WorkId as FeWorkId};
 use log::warn;
 use write_fonts::{
@@ -797,19 +800,16 @@ impl Work<Context, AnyWorkId, Error> for Os2Work {
     }
 
     fn read_access(&self) -> Access<AnyWorkId> {
-        Access::Custom(Arc::new(|id| {
-            matches!(
-                id,
-                AnyWorkId::Fe(FeWorkId::Glyph(..))
-                    | AnyWorkId::Fe(FeWorkId::StaticMetadata)
-                    | AnyWorkId::Fe(FeWorkId::GlyphOrder)
-                    | AnyWorkId::Fe(FeWorkId::GlobalMetrics)
-                    | AnyWorkId::Be(WorkId::Hhea)
-                    | AnyWorkId::Be(WorkId::Hmtx)
-                    | AnyWorkId::Be(WorkId::Gpos)
-                    | AnyWorkId::Be(WorkId::Gsub)
-            )
-        }))
+        AccessBuilder::new()
+            .variant(FeWorkId::StaticMetadata)
+            .variant(FeWorkId::GlyphOrder)
+            .variant(FeWorkId::GlobalMetrics)
+            .variant(WorkId::Hhea)
+            .variant(WorkId::Hmtx)
+            .variant(WorkId::Gpos)
+            .variant(WorkId::Gsub)
+            .variant(FeWorkId::Glyph(GlyphName::NOTDEF))
+            .build()
     }
 
     /// Generate [OS/2](https://learn.microsoft.com/en-us/typography/opentype/spec/os2)

--- a/fontbe/src/post.rs
+++ b/fontbe/src/post.rs
@@ -1,8 +1,6 @@
 //! Generates a [post](https://learn.microsoft.com/en-us/typography/opentype/spec/post) table.
 
-use std::collections::HashSet;
-
-use fontdrasil::orchestration::{Access, Work};
+use fontdrasil::orchestration::{Access, AccessBuilder, Work};
 use fontir::orchestration::WorkId as FeWorkId;
 use write_fonts::{
     tables::post::Post,
@@ -28,11 +26,11 @@ impl Work<Context, AnyWorkId, Error> for PostWork {
     }
 
     fn read_access(&self) -> Access<AnyWorkId> {
-        Access::Set(HashSet::from([
-            FeWorkId::StaticMetadata.into(),
-            FeWorkId::GlobalMetrics.into(),
-            FeWorkId::GlyphOrder.into(),
-        ]))
+        AccessBuilder::new()
+            .variant(FeWorkId::StaticMetadata)
+            .variant(FeWorkId::GlyphOrder)
+            .variant(FeWorkId::GlobalMetrics)
+            .build()
     }
 
     /// Generate [post](https://learn.microsoft.com/en-us/typography/opentype/spec/post)

--- a/fontbe/src/stat.rs
+++ b/fontbe/src/stat.rs
@@ -29,7 +29,7 @@ impl Work<Context, AnyWorkId, Error> for StatWork {
     }
 
     fn read_access(&self) -> Access<AnyWorkId> {
-        Access::One(FeWorkId::StaticMetadata.into())
+        Access::Variant(AnyWorkId::Fe(FeWorkId::StaticMetadata))
     }
 
     /// Generate [stat](https://learn.microsoft.com/en-us/typography/opentype/spec/stat)

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -732,7 +732,7 @@ mod tests {
     }
 
     #[test]
-    fn second_compile_only_glyph() {
+    fn second_compile_only_glyph_ir() {
         // glyph depends on static metadata, which isn't going to run
         let result = TestCompile::compile_source("wght_var.designspace");
         assert!(result.work_executed.len() > 1);

--- a/fontc/src/timing.rs
+++ b/fontc/src/timing.rs
@@ -97,12 +97,13 @@ impl JobTimer {
                 }
                 writeln!(
                     out,
-                    "<title>{:.0}ms ({:.2}%) {:?}\nqueued at {:.0}ms\nrun at {:.0}ms\nWave {}</title>",
+                    "<title>{:.0}ms ({:.2}%) {:?}\nqueued at {:.0}ms\nrun at {:.0}ms\ndone at {:.0}ms\nWave {}</title>",
                     1000.0 * (job_end - job_start),
                     exec_pct,
                     timing.id,
                     1000.0 * job_queued,
                     1000.0 * job_start,
+                    1000.0 * job_end,
                     timing.nth_wave,
                 )
                 .unwrap();
@@ -281,7 +282,7 @@ impl JobTimeRunning {
 }
 
 /// Times are relative to t0 in a [JobTimer]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct JobTime {
     id: AnyWorkId,
     nth_wave: usize,
@@ -289,7 +290,7 @@ pub struct JobTime {
     _runnable: Instant,
     queued: Instant,
     run: Instant,
-    complete: Instant,
+    pub(crate) complete: Instant,
 }
 
 impl JobTime {

--- a/fontir/src/glyph.rs
+++ b/fontir/src/glyph.rs
@@ -3,14 +3,11 @@
 //! Notably includes splitting glyphs with contours and components into one new glyph with
 //! the contours and one updated glyph with no contours that references the new gyph as a component.
 
-use std::{
-    collections::{HashMap, HashSet, VecDeque},
-    sync::Arc,
-};
+use std::collections::{HashMap, HashSet, VecDeque};
 
 use fontdrasil::{
     coords::NormalizedLocation,
-    orchestration::{Access, Work},
+    orchestration::{Access, AccessBuilder, Work},
     types::GlyphName,
 };
 use kurbo::Affine;
@@ -336,21 +333,19 @@ impl Work<Context, WorkId, WorkError> for GlyphOrderWork {
     }
 
     fn read_access(&self) -> Access<WorkId> {
-        Access::Custom(Arc::new(|id| {
-            matches!(
-                id,
-                WorkId::Glyph(..)
-                    | WorkId::StaticMetadata
-                    | WorkId::PreliminaryGlyphOrder
-                    | WorkId::GlobalMetrics
-            )
-        }))
+        AccessBuilder::new()
+            .variant(WorkId::StaticMetadata)
+            .variant(WorkId::PreliminaryGlyphOrder)
+            .variant(WorkId::GlobalMetrics)
+            .variant(WorkId::Glyph(GlyphName::NOTDEF))
+            .build()
     }
 
     fn write_access(&self) -> Access<WorkId> {
-        Access::Custom(Arc::new(|id| {
-            matches!(id, WorkId::Glyph(..) | WorkId::GlyphOrder)
-        }))
+        AccessBuilder::new()
+            .variant(WorkId::GlyphOrder)
+            .variant(WorkId::Glyph(GlyphName::NOTDEF))
+            .build()
     }
 
     fn exec(&self, context: &Context) -> Result<(), WorkError> {
@@ -522,7 +517,7 @@ mod tests {
         let mut flags = Flags::default();
         flags.set(Flags::EMIT_IR, false); // we don't want to write anything down
         Context::new_root(flags, Paths::new(Path::new("/fake/path")), Input::new())
-            .copy_for_work(Access::all(), Access::all())
+            .copy_for_work(Access::All, Access::All)
     }
 
     struct DeepComponent {

--- a/fontir/src/orchestration.rs
+++ b/fontir/src/orchestration.rs
@@ -12,7 +12,7 @@ use std::{
 use crate::{error::WorkError, ir, paths::Paths, source::Input};
 use bitflags::bitflags;
 use fontdrasil::{
-    orchestration::{Access, AccessControlList, Identifier, Work},
+    orchestration::{Access, AccessControlList, Identifier, IdentifierDiscriminant, Work},
     types::GlyphName,
 };
 use parking_lot::RwLock;
@@ -329,7 +329,21 @@ pub enum WorkId {
     Anchor(GlyphName),
 }
 
-impl Identifier for WorkId {}
+impl Identifier for WorkId {
+    fn discriminant(&self) -> IdentifierDiscriminant {
+        match self {
+            WorkId::StaticMetadata => "IrStaticMetadata",
+            WorkId::GlobalMetrics => "IrGlobalMetrics",
+            WorkId::Glyph(..) => "IrGlyph",
+            WorkId::GlyphIrDelete(..) => "IrGlyphDelete",
+            WorkId::PreliminaryGlyphOrder => "IrPreliminaryGlyphOrder",
+            WorkId::GlyphOrder => "IrGlyphOrder",
+            WorkId::Features => "Features",
+            WorkId::Kerning => "Kerning",
+            WorkId::Anchor(..) => "IrAnchor",
+        }
+    }
+}
 
 pub type IrWork = dyn Work<Context, WorkId, WorkError> + Send;
 


### PR DESCRIPTION
Access::Custom took a closure and required a scan over pending jobs to determine if it matched any. Instead count the number of pending jobs of each type and resolve "blocks on all of type" (e.g. all IR Glyphs) by checking if the count of those pending is 0.

Key outcome is deletion of `can_run_scan` from `fontc/src/workload.rs` . hyperfine reports no significant change in performance:

```shell
$ cargo build --release && hyperfine --warmup 25 --runs 100 --prepare 'rm -rf build/' 'target/release/fontc ../OswaldFont/sources/Oswald.glyphs'
main   130.6 ms ±  10.9 ms
branch 127.9 ms ±   8.0 ms
```

A mildly amusing outcome is that you can potentially detect that all-of(something) is done before you can detect a specific id is done because the former is a decrement to an atomic and the latter requires a message to pass through a channel.

I feel like there should be a nicer way than how I've rigged AllOrOne but I haven't pinned it down.