### PR TITLE
don't emit IR by default and rename option to --incremental

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,17 @@ Install the latest version of Rust, https://www.rust-lang.org/tools/install.
 $ cargo run -p fontc -- --source resources/testdata/wght_var.designspace
 ```
 
+### Emit IR to enable incremental builds
+
+If you pass the `--incremental` (or `-i`) option, the IR will be written to disk inside
+the build working directory, so that the next time you run fontc with the same source file
+only what changed will be rebuilt.
+
+```shell
+$ cargo run -p fontc -- --incremental --source resources/testdata/wght_var.designspace
+$ ls build/
+```
+
 ### Sources to play with
 
 Google Fonts has lots, you could try https://github.com/rsheeter/google_fonts_sources to get some.
@@ -84,7 +95,7 @@ Only relatively large changes are effectively detected this way:
 
 ```shell
 # On each branch, typically main and your branch run hyperfine:
-$ cargo build --release && hyperfine --warmup 3 --runs 250 --prepare 'rm -rf build/' 'target/release/fontc --source ../OswaldFont/sources/Oswald.glyphs --emit-ir false'
+$ cargo build --release && hyperfine --warmup 3 --runs 250 --prepare 'rm -rf build/' 'target/release/fontc --source ../OswaldFont/sources/Oswald.glyphs'
 
 # Ideally mean+σ of the improved branch is < mean-σ for main.
 # For example, p2s is probably faster here:
@@ -107,7 +118,7 @@ $ export RUST_LOG=error
 $ export CARGO_PROFILE_RELEASE_DEBUG=true
 
 # Build something and capture a flamegraph of it
-$ rm -rf build/ && cargo flamegraph -p fontc --  --source ../OswaldFont/sources/Oswald.glyphs --emit-ir false
+$ rm -rf build/ && cargo flamegraph -p fontc --  --source ../OswaldFont/sources/Oswald.glyphs
 
 # TIPS
 
@@ -135,7 +146,7 @@ is very useful when you want to zoom in on a specific operation. For example, to
 ```shell
 # Generate a perf.data
 # You can also use perf record but cargo flamegraph seems to have nice capture settings for Rust rigged
-$ rm -rf build/ perf.data && cargo flamegraph -p fontc --  --source ../OswaldFont/sources/Oswald.glyphs --emit-ir false
+$ rm -rf build/ perf.data && cargo flamegraph -p fontc --  --source ../OswaldFont/sources/Oswald.glyphs
 
 # ^ produced flamegraph.svg but it's very noisy, lets narrow our focus
 # Example assumes https://github.com/brendangregg/FlameGraph is cloned in a sibling directory to fontc

--- a/fontc/src/args.rs
+++ b/fontc/src/args.rs
@@ -14,8 +14,17 @@ pub struct Args {
     pub source: PathBuf,
 
     /// Whether to write IR to disk. Must be true if you want incremental compilation.
-    #[arg(short, long, default_value = "true", action = ArgAction::Set)]
-    pub emit_ir: bool,
+    #[arg(
+        short,
+        long,
+        num_args = 0..=1,
+        default_value = "false",
+        default_missing_value = "true",
+        // pre-existing long name kept as alias for backwards compatibility
+        alias = "emit-ir",
+        action = ArgAction::Set,
+    )]
+    pub incremental: bool,
 
     /// Whether to write additional debug files to disk.
     #[arg(long, default_value = "false")]
@@ -76,7 +85,7 @@ impl Args {
     pub fn flags(&self) -> Flags {
         let mut flags = Flags::default();
 
-        flags.set(Flags::EMIT_IR, self.emit_ir);
+        flags.set(Flags::EMIT_IR, self.incremental);
         flags.set(Flags::EMIT_DEBUG, self.emit_debug);
         flags.set(Flags::PREFER_SIMPLE_GLYPHS, self.prefer_simple_glyphs);
         flags.set(Flags::FLATTEN_COMPONENTS, self.flatten_components);
@@ -101,7 +110,7 @@ impl Args {
         Args {
             glyph_name_filter: None,
             source,
-            emit_ir: true,
+            incremental: true,
             emit_debug: false, // they get destroyed by test cleanup
             emit_timing: false,
             build_dir: build_dir.to_path_buf(),

--- a/fontc/src/change_detector.rs
+++ b/fontc/src/change_detector.rs
@@ -93,7 +93,7 @@ impl ChangeDetector {
             prev_inputs,
             current_inputs,
             be_paths,
-            emit_ir: config.args.emit_ir,
+            emit_ir: config.args.incremental,
             skip_features: config.args.skip_features,
         })
     }

--- a/fontc/src/config.rs
+++ b/fontc/src/config.rs
@@ -47,7 +47,7 @@ impl Config {
                 fs::remove_file(ir_input_file)
                     .map_err(|_| Error::FileExpected(ir_input_file.to_owned()))?;
             }
-            if self.args.emit_ir {
+            if self.args.incremental {
                 fs::write(config_file, serde_yaml::to_string(self)?)?;
             }
         };

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -64,7 +64,7 @@ pub fn init_paths(args: &Args) -> Result<(IrPaths, BePaths), Error> {
     let be_paths = BePaths::new(&args.build_dir);
 
     require_dir(ir_paths.build_dir())?;
-    if args.emit_ir {
+    if args.incremental {
         require_dir(ir_paths.anchor_ir_dir())?;
         require_dir(ir_paths.glyph_ir_dir())?;
         require_dir(be_paths.glyph_dir())?;
@@ -82,7 +82,7 @@ pub fn init_paths(args: &Args) -> Result<(IrPaths, BePaths), Error> {
 pub fn write_font_file(args: &Args, be_context: &BeContext) -> Result<(), Error> {
     // if IR is off the font didn't get written yet (nothing did), otherwise it's done already
     let font_file = be_context.font_file();
-    if !args.emit_ir {
+    if !args.incremental {
         fs::write(font_file, be_context.font.get().get()).map_err(Error::IoError)?;
     } else if !font_file.exists() {
         return Err(Error::FileExpected(font_file));
@@ -772,7 +772,7 @@ mod tests {
     fn compile_fea_with_includes_no_ir() {
         assert_compiles_with_gpos_and_gsub("fea_include.designspace", |args| {
             args.emit_debug = false;
-            args.emit_ir = false;
+            args.incremental = false;
         });
     }
 
@@ -1498,7 +1498,7 @@ mod tests {
         let temp_dir = tempdir().unwrap();
         let build_dir = temp_dir.path();
         let mut args = Args::for_test(build_dir, "glyphs2/WghtVar.glyphs");
-        args.emit_ir = false;
+        args.incremental = false;
         compile(args);
 
         let outputs = fs::read_dir(build_dir)

--- a/fontir/src/orchestration.rs
+++ b/fontir/src/orchestration.rs
@@ -41,7 +41,7 @@ bitflags! {
 
 impl Default for Flags {
     fn default() -> Self {
-        Flags::EMIT_IR | Flags::PREFER_SIMPLE_GLYPHS | Flags::PRODUCTION_NAMES
+        Flags::PREFER_SIMPLE_GLYPHS | Flags::PRODUCTION_NAMES
     }
 }
 

--- a/resources/scripts/time_build.py
+++ b/resources/scripts/time_build.py
@@ -61,7 +61,7 @@ def current_branch() -> str:
 def compile_time(source):
     # crude but we're looking for large deltas here
     start = time.perf_counter()
-    run(("target/release/fontc", "--source", source, "--emit-ir", "false"))
+    run(("target/release/fontc", "--source", source))
     end = time.perf_counter()
     return end - start
 


### PR DESCRIPTION
As discussed with Rod in chat, we prefer to have incremental builds be opt-in rather than opt-out. Not only it's faster to build without, but also it reduces the risk that the casual user might incur in potential bugs on subsequent builds related to incomplete inter-task dependencies (I know, we should test this code path more to be more confident about it).

Also I propose to rename the option from `--emit-ir` to `--incremental` because the latter communicates the intent better to the user. The old name is kept for backward compatibility but it won't be shown in the --help.

The flag takes an optional bool argument, which can thus be omitted altogether for simplicity.
E.g. --incremental is equivalent to --emit-ir=true; omitting the whole flag (default behavior) is equivalent to --emit-ir=false or --incremental=false.