### PR TITLE
make input arg positional, add -o/--output-file option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Install the latest version of Rust, https://www.rust-lang.org/tools/install.
 ### Build a simple test font
 
 ```shell
-$ cargo run -p fontc -- --source resources/testdata/wght_var.designspace
+$ cargo run -p fontc -- resources/testdata/wght_var.designspace
 ```
 
 ### Emit IR to enable incremental builds
@@ -36,7 +36,7 @@ the build working directory, so that the next time you run fontc with the same s
 only what changed will be rebuilt.
 
 ```shell
-$ cargo run -p fontc -- --incremental --source resources/testdata/wght_var.designspace
+$ cargo run -p fontc -- --incremental resources/testdata/wght_var.designspace
 $ ls build/
 ```
 
@@ -46,7 +46,7 @@ Google Fonts has lots, you could try https://github.com/rsheeter/google_fonts_so
 Once you have them you could try building them:
 
 ```shell
-cargo run --package fontc -- --source ../google_fonts_sources/sources/ofl/notosanskayahli/sources/NotoSansKayahLi.designspace
+cargo run --package fontc -- ../google_fonts_sources/sources/ofl/notosanskayahli/sources/NotoSansKayahLi.designspace
 ```
 
 ## Plan
@@ -95,7 +95,7 @@ Only relatively large changes are effectively detected this way:
 
 ```shell
 # On each branch, typically main and your branch run hyperfine:
-$ cargo build --release && hyperfine --warmup 3 --runs 250 --prepare 'rm -rf build/' 'target/release/fontc --source ../OswaldFont/sources/Oswald.glyphs'
+$ cargo build --release && hyperfine --warmup 3 --runs 250 --prepare 'rm -rf build/' 'target/release/fontc ../OswaldFont/sources/Oswald.glyphs'
 
 # Ideally mean+σ of the improved branch is < mean-σ for main.
 # For example, p2s is probably faster here:
@@ -118,7 +118,7 @@ $ export RUST_LOG=error
 $ export CARGO_PROFILE_RELEASE_DEBUG=true
 
 # Build something and capture a flamegraph of it
-$ rm -rf build/ && cargo flamegraph -p fontc --  --source ../OswaldFont/sources/Oswald.glyphs
+$ rm -rf build/ && cargo flamegraph -p fontc -- ../OswaldFont/sources/Oswald.glyphs
 
 # TIPS
 
@@ -146,7 +146,7 @@ is very useful when you want to zoom in on a specific operation. For example, to
 ```shell
 # Generate a perf.data
 # You can also use perf record but cargo flamegraph seems to have nice capture settings for Rust rigged
-$ rm -rf build/ perf.data && cargo flamegraph -p fontc --  --source ../OswaldFont/sources/Oswald.glyphs
+$ rm -rf build/ perf.data && cargo flamegraph -p fontc -- ../OswaldFont/sources/Oswald.glyphs
 
 # ^ produced flamegraph.svg but it's very noisy, lets narrow our focus
 # Example assumes https://github.com/brendangregg/FlameGraph is cloned in a sibling directory to fontc

--- a/fontbe/src/paths.rs
+++ b/fontbe/src/paths.rs
@@ -11,6 +11,7 @@ pub struct Paths {
     build_dir: PathBuf,
     glyph_dir: PathBuf,
     debug_dir: PathBuf,
+    output_file: Option<PathBuf>,
 }
 
 impl Paths {
@@ -22,7 +23,14 @@ impl Paths {
             build_dir,
             glyph_dir,
             debug_dir,
+            output_file: None,
         }
+    }
+
+    pub fn with_output_file(build_dir: &Path, output_file: &Path) -> Paths {
+        let mut paths = Paths::new(build_dir);
+        paths.output_file = Some(output_file.to_path_buf());
+        paths
     }
 
     pub fn build_dir(&self) -> &Path {
@@ -35,6 +43,10 @@ impl Paths {
 
     pub fn glyph_dir(&self) -> &Path {
         &self.glyph_dir
+    }
+
+    pub fn output_file(&self) -> Option<&Path> {
+        self.output_file.as_deref()
     }
 
     fn glyph_glyf_file(&self, name: &str) -> PathBuf {
@@ -71,7 +83,11 @@ impl Paths {
             WorkId::Os2 => self.build_dir.join("os2.table"),
             WorkId::Post => self.build_dir.join("post.table"),
             WorkId::Stat => self.build_dir.join("stat.table"),
-            WorkId::Font => self.build_dir.join("font.ttf"),
+            WorkId::Font => self
+                .output_file
+                .as_ref()
+                .map(|p| p.to_path_buf())
+                .unwrap_or_else(|| self.build_dir.join("font.ttf")),
         }
     }
 }

--- a/fontc/src/change_detector.rs
+++ b/fontc/src/change_detector.rs
@@ -56,6 +56,7 @@ impl ChangeDetector {
     pub fn new(
         config: Config,
         ir_paths: IrPaths,
+        be_paths: BePaths,
         prev_inputs: Input,
         timer: &mut JobTimer,
     ) -> Result<ChangeDetector, Error> {
@@ -63,9 +64,8 @@ impl ChangeDetector {
             .queued()
             .run();
 
-        let mut ir_source = ir_source(&config.args.source)?;
+        let mut ir_source = ir_source(config.args.source())?;
         let mut current_inputs = ir_source.inputs().map_err(Error::FontIrError)?;
-        let be_paths = BePaths::new(ir_paths.build_dir());
 
         let glyph_name_filter = config
             .args

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -68,6 +68,13 @@ pub fn init_paths(args: &Args) -> Result<(IrPaths, BePaths), Error> {
     } else {
         BePaths::new(&args.build_dir)
     };
+    // create the output file's parent directory if it doesn't exist
+    if let Some(output_file) = &args.output_file {
+        if let Some(parent) = output_file.parent() {
+            require_dir(parent)?;
+        }
+    }
+
     // the build dir stores the IR (for incremental builds) and the default output
     // file ('font.ttf') so we don't need to create one unless we're writing to it
     if args.output_file.is_none() || args.incremental {

--- a/fontc/src/main.rs
+++ b/fontc/src/main.rs
@@ -52,8 +52,13 @@ fn run() -> Result<(), Error> {
     let prev_inputs = config.init()?;
     timer.add(time.complete());
 
-    let mut change_detector =
-        ChangeDetector::new(config.clone(), ir_paths.clone(), prev_inputs, &mut timer)?;
+    let mut change_detector = ChangeDetector::new(
+        config.clone(),
+        ir_paths.clone(),
+        be_paths.clone(),
+        prev_inputs,
+        &mut timer,
+    )?;
 
     let workload = fontc::create_workload(&mut change_detector, timer)?;
 

--- a/resources/scripts/ots_test.sh
+++ b/resources/scripts/ots_test.sh
@@ -3,7 +3,7 @@
 set -o nounset
 set -o errexit
 
-cargo run -p fontc -- --source resources/testdata/static.designspace
+cargo run -p fontc -- resources/testdata/static.designspace
 
 cd build
 

--- a/resources/scripts/time_build.py
+++ b/resources/scripts/time_build.py
@@ -61,7 +61,7 @@ def current_branch() -> str:
 def compile_time(source):
     # crude but we're looking for large deltas here
     start = time.perf_counter()
-    run(("target/release/fontc", "--source", source))
+    run(("target/release/fontc", source))
     end = time.perf_counter()
     return end - start
 

--- a/resources/scripts/ttx_diff.py
+++ b/resources/scripts/ttx_diff.py
@@ -101,10 +101,9 @@ def build_fontc(source: Path, build_dir: Path, compare: str):
         # "--keep-direction",
         # no longer required, still useful to get human-readable glyph names in diff
         "--no-production-names",
-        "--source",
-        str(source),
         "--build-dir",
         ".",
+        str(source),
     ]
     if compare == _COMPARE_GFTOOLS:
         cmd.append("--flatten-components")

--- a/smoke_test/smoke_test.py
+++ b/smoke_test/smoke_test.py
@@ -30,7 +30,6 @@ def fontc_command(source) -> Tuple[str, ...]:
         "--package",
         "fontc",
         "--",
-        "--source",
         str(source)
     )
 


### PR DESCRIPTION
This adds a new `-o`/`--output-file` CLI flag to tell fontc where to save the output file. It keeps defaulting to the existing `build/font.ttf` like before (we may want to change that to use, say, the font's postscript name e.g. Oswald-Regular.ttf, so one could build more than one font in the same default build directory without overwriting them? but that's a separate issue). 

Also, I changed so that the input source is a positional argument, but I didn't want to break existing usages of `-s`/`--source` option so I kept the latter and made them two methods mutually exclusive, and require at least one of the two is not None before the final Args can be constructed.

So the old way of calling fontc continues to work (e.g. `fontc --source Oswald.glyphs` or `fontc -s Oswald.glyphs`), but now you can simply do `fontc Oswald.glyphs -o Oswald.ttf` which looks nicer. Or even `fontc -o Oswald.{ttf,glyphs}` :)