### PR TITLE
[gsbuild] remove superflous --source CLI flag, use positional input source

### DIFF
--- a/.github/workflows/gsbuild.yml
+++ b/.github/workflows/gsbuild.yml
@@ -20,6 +20,6 @@ jobs:
           repository: googlefonts/googlesans
           token: ${{ secrets.GS_READ_FONTC }}
       - name: Compile Roman variable font
-        run: fontc --source source/GoogleSans/GoogleSans.designspace
+        run: fontc source/GoogleSans/GoogleSans.designspace
       - name: Compile Italic variable font
-        run: fontc --source source/GoogleSans/GoogleSans-Italic.designspace
+        run: fontc source/GoogleSans/GoogleSans-Italic.designspace


### PR DESCRIPTION
--source flag is no longer needed after https://github.com/googlefonts/fontc/pull/576 (though it still works)

JMM