### PR TITLE
[fontc/args] don't take true|false argument in --incremental

### DIFF
--- a/fontc/src/args.rs
+++ b/fontc/src/args.rs
@@ -18,16 +18,7 @@ pub struct Args {
     source: Option<PathBuf>,
 
     /// Whether to write IR to disk. Must be true if you want incremental compilation.
-    #[arg(
-        short,
-        long,
-        num_args = 0..=1,
-        default_value = "false",
-        default_missing_value = "true",
-        // pre-existing long name kept as alias for backwards compatibility
-        alias = "emit-ir",
-        action = ArgAction::Set,
-    )]
+    #[arg(short, long, default_value = "false")]
     pub incremental: bool,
 
     /// Output file name (default: build/font.ttf)


### PR DESCRIPTION
It creates problems when you do `fontc -i font.glyphs` (as it attempts to parse the positional input source as the bool argument for --incremental) so it forces one to have to put the filename in front followed by the optional parameter, e.g. `fontc font.glyphs -i`..
I think this is an unnecessary complication and would rather drop support for the old --emit-ir=true|false flag alias... I think it's fine to simplify and only have a single bool flag `-i/--incremental` that takes no parameters.