### PR TITLE
[fontbe/avar] don't skip no-op segment maps

### DIFF
--- a/fontbe/src/avar.rs
+++ b/fontbe/src/avar.rs
@@ -22,12 +22,13 @@ pub fn create_avar_work() -> Box<BeWork> {
     Box::new(AvarWork {})
 }
 
-/// Return true if the SegmentMaps is not a boring identity map
-fn is_interesting(segment_map: &SegmentMaps) -> bool {
+/// Return true if the SegmentMaps is an identity map
+// TODO: make this a method of SegmentMaps in write-fonts
+fn is_identity(segment_map: &SegmentMaps) -> bool {
     segment_map
         .axis_value_maps
         .iter()
-        .any(|av| av.from_coordinate != av.to_coordinate)
+        .all(|av| av.from_coordinate == av.to_coordinate)
 }
 
 /// Return a default avar SegmentMaps containing the required {-1:-1, 0:0, 1:1} maps
@@ -119,8 +120,8 @@ impl Work<Context, AnyWorkId, Error> for AvarWork {
         // only when all the segment maps are uninteresting, we can omit avar
         let avar = axis_segment_maps
             .iter()
-            .any(is_interesting)
-            .then_some(Avar::new(axis_segment_maps));
+            .any(|sm| !is_identity(sm))
+            .then(|| Avar::new(axis_segment_maps));
         context.avar.set_unconditionally(avar.into());
         Ok(())
     }


### PR DESCRIPTION
GS contains a `GRAD` axis whose avar segment maps does not have any interesting mappings.
It happens to be the last one in the axis order. We were filtering out axis segment maps that contain only identity maps, leading to an avar table with fewer segment maps than there are fvar axes, which is invalid as OTS correctly points out.

So we now still emit these non-interesting segment maps when bulding avar and there's at least one of them that is not an identity map.

Also note that, despite the OT spec allows for empty segment maps for axis that don't distort the default normalization, we want to match fontmake/fonttools and emit the required {-1:1, 0:0, 1:1} mappings even when no other interesting mappings are present for an axis, because apparently some old implementations need that (see https://github.com/fonttools/fonttools/pull/1026).

Fixes #582 avar axis mismatch OTS error

I can confirm that after this, the GS avar table is the same when built with fontc vs fontmake.