### PR TITLE
Add automated clap --version / -V CLI version string support

### DIFF
--- a/fontc/src/args.rs
+++ b/fontc/src/args.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 
 /// What font can we build for you today?
 #[derive(Serialize, Deserialize, Parser, Debug, Clone, PartialEq)]
+#[command(version)]
 pub struct Args {
     /// A designspace, ufo, or glyphs file
     #[arg(conflicts_with = "source", required_unless_present("source"))]


### PR DESCRIPTION
Adds the automated clap support for command line `--version` and `-V` options to report the fontc executable version number.

Also updates the command line `--help` documentation with the following description:

```
  -V, --version
          Print version
```