### PR TITLE
Bump OTS testing version to latest

### DIFF
--- a/resources/scripts/ots_test.sh
+++ b/resources/scripts/ots_test.sh
@@ -7,7 +7,7 @@ cargo run -p fontc -- resources/testdata/static.designspace
 
 cd build
 
-OTS_VER=9.0.0
+OTS_VER=9.1.0
 rm -f "ots-${OTS_VER}-Linux.zip"
 rm -rf "ots-${OTS_VER}-Linux"
 curl -OL "https://github.com/khaledhosny/ots/releases/download/v${OTS_VER}/ots-${OTS_VER}-Linux.zip"


### PR DESCRIPTION
Updates the ots_test.sh shell script to use the latest OTS release version (v9.0.0 => v9.1.0)

related: #589 