### PR TITLE
Add verbose debugging version reporting

### DIFF
--- a/fontc/Cargo.toml
+++ b/fontc/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "fontc"
 version = "0.0.1"
+build = "build.rs"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "A compiler for fonts."
@@ -48,3 +49,6 @@ pretty_assertions.workspace = true
 skrifa.workspace = true
 kurbo.workspace = true
 chrono.workspace = true
+
+[build-dependencies]
+vergen = { version = "8.0.0", features = ["build", "cargo", "git", "gitcl", "rustc"] }

--- a/fontc/Cargo.toml
+++ b/fontc/Cargo.toml
@@ -51,4 +51,4 @@ kurbo.workspace = true
 chrono.workspace = true
 
 [build-dependencies]
-vergen = { version = "8.0.0", features = ["build", "cargo", "git", "gitcl", "rustc"] }
+vergen = { version = "8.2.6", features = ["build", "cargo", "git", "gitcl", "rustc"] }

--- a/fontc/build.rs
+++ b/fontc/build.rs
@@ -1,0 +1,14 @@
+use std::error::Error;
+use vergen::EmitBuilder;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    // Emit the instructions
+    EmitBuilder::builder()
+        .quiet()
+        .idempotent()
+        .all_cargo()
+        .all_git()
+        .all_rustc()
+        .emit()?;
+    Ok(())
+}

--- a/fontc/src/args.rs
+++ b/fontc/src/args.rs
@@ -11,7 +11,11 @@ use serde::{Deserialize, Serialize};
 #[command(version)]
 pub struct Args {
     /// A designspace, ufo, or glyphs file
-    #[arg(conflicts_with = "source", required_unless_present("source"))]
+    #[arg(
+        conflicts_with = "source",
+        required_unless_present("source"),
+        required_unless_present("verbose_version")
+    )]
     input_source: Option<PathBuf>,
 
     /// DEPRECATED: old name for positional input file
@@ -78,6 +82,12 @@ pub struct Args {
     // https://github.com/googlefonts/fontmake/blob/6a8b2907/Lib/fontmake/__main__.py#L602
     #[arg(long, default_value = "false")]
     pub no_production_names: bool,
+
+    /// Print verbose version information for debugging
+    // Includes fontc git commit, rustc host triple, rustc version and channel, llvm version,
+    // cargo profile, and cargo optimization level.
+    #[arg(long = "vv", default_value = "false")]
+    pub verbose_version: bool,
 }
 
 impl Args {
@@ -123,6 +133,7 @@ impl Args {
             skip_features: false,
             keep_direction: false,
             no_production_names: false,
+            verbose_version: false,
         }
     }
 

--- a/fontc/src/main.rs
+++ b/fontc/src/main.rs
@@ -25,7 +25,7 @@ fn run() -> Result<(), Error> {
     let args = Args::parse();
     // handle `--vv` verbose version argument request
     if args.verbose_version {
-        print_verbose_version();
+        print_verbose_version()?;
         std::process::exit(0);
     }
     let mut timer = JobTimer::new(Instant::now());
@@ -91,27 +91,35 @@ fn run() -> Result<(), Error> {
     write_font_file(&config.args, &be_root)
 }
 
-fn print_verbose_version() {
-    println!(
+fn print_verbose_version() -> Result<(), std::io::Error> {
+    writeln!(
+        std::io::stdout(),
         "{} {} @ {}\n",
         env!("CARGO_PKG_NAME"),
         env!("CARGO_PKG_VERSION"),
         env!("VERGEN_GIT_SHA")
-    );
-    println!("{}", env!("VERGEN_RUSTC_HOST_TRIPLE"));
-    println!(
+    )?;
+    writeln!(std::io::stdout(), "{}", env!("VERGEN_RUSTC_HOST_TRIPLE"))?;
+    writeln!(
+        std::io::stdout(),
         "rustc {} (channel: {})",
         env!("VERGEN_RUSTC_SEMVER"),
         env!("VERGEN_RUSTC_CHANNEL")
-    );
-    println!("llvm {}", env!("VERGEN_RUSTC_LLVM_VERSION"));
+    )?;
+    writeln!(
+        std::io::stdout(),
+        "llvm {}",
+        env!("VERGEN_RUSTC_LLVM_VERSION")
+    )?;
     match env!("VERGEN_CARGO_DEBUG") {
-        "true" => println!("cargo profile: debug"),
-        "false" => println!("cargo profile: release"),
+        "true" => writeln!(std::io::stdout(), "cargo profile: debug")?,
+        "false" => writeln!(std::io::stdout(), "cargo profile: release")?,
         _ => (),
     };
-    println!(
+    writeln!(
+        std::io::stdout(),
         "cargo optimization level: {}",
         env!("VERGEN_CARGO_OPT_LEVEL")
-    );
+    )?;
+    Ok(())
 }

--- a/fontc/src/main.rs
+++ b/fontc/src/main.rs
@@ -102,9 +102,11 @@ fn print_verbose_version() -> Result<(), std::io::Error> {
     writeln!(std::io::stdout(), "{}", env!("VERGEN_RUSTC_HOST_TRIPLE"))?;
     writeln!(
         std::io::stdout(),
-        "rustc {} (channel: {})",
+        "rustc {} (channel: {}, {} {})",
         env!("VERGEN_RUSTC_SEMVER"),
-        env!("VERGEN_RUSTC_CHANNEL")
+        env!("VERGEN_RUSTC_CHANNEL"),
+        env!("VERGEN_RUSTC_COMMIT_HASH").get(..9).unwrap_or(""),
+        env!("VERGEN_RUSTC_COMMIT_DATE")
     )?;
     writeln!(
         std::io::stdout(),

--- a/fontc/src/main.rs
+++ b/fontc/src/main.rs
@@ -22,6 +22,12 @@ fn main() {
 }
 
 fn run() -> Result<(), Error> {
+    let args = Args::parse();
+    // handle `--vv` verbose version argument request
+    if args.verbose_version {
+        print_verbose_version();
+        std::process::exit(0);
+    }
     let mut timer = JobTimer::new(Instant::now());
     let time = create_timer(AnyWorkId::InternalTiming("Init logger"), 0)
         .queued()
@@ -46,7 +52,6 @@ fn run() -> Result<(), Error> {
     let time = create_timer(AnyWorkId::InternalTiming("Init config"), 0)
         .queued()
         .run();
-    let args = Args::parse();
     let (ir_paths, be_paths) = init_paths(&args)?;
     let config = Config::new(args)?;
     let prev_inputs = config.init()?;
@@ -84,4 +89,29 @@ fn run() -> Result<(), Error> {
     change_detector.finish_successfully()?;
 
     write_font_file(&config.args, &be_root)
+}
+
+fn print_verbose_version() {
+    println!(
+        "{} {} @ {}\n",
+        env!("CARGO_PKG_NAME"),
+        env!("CARGO_PKG_VERSION"),
+        env!("VERGEN_GIT_SHA")
+    );
+    println!("{}", env!("VERGEN_RUSTC_HOST_TRIPLE"));
+    println!(
+        "rustc {} (channel: {})",
+        env!("VERGEN_RUSTC_SEMVER"),
+        env!("VERGEN_RUSTC_CHANNEL")
+    );
+    println!("llvm {}", env!("VERGEN_RUSTC_LLVM_VERSION"));
+    match env!("VERGEN_CARGO_DEBUG") {
+        "true" => println!("cargo profile: debug"),
+        "false" => println!("cargo profile: release"),
+        _ => (),
+    };
+    println!(
+        "cargo optimization level: {}",
+        env!("VERGEN_CARGO_OPT_LEVEL")
+    );
 }


### PR DESCRIPTION
Adds a new `--vv` option for verbose debugging version reporting of:

- fontc version + git commit SHA hash
- rustc host triple
- rustc version + toolchain channel + short git commit SHA hash + commit date
- llvm version
- cargo profile (release / debug)
- cargo optimization level

Adds a new fontc package [vergen](https://crates.io/crates/vergen) build dependency and build.rs file to set the environment variables required to define these strings at build time.  Should continue to support deterministic builds with the data fields that I've included in this report.

Example output:

#### cargo nightly release build

```
$ target/release/fontc --vv
fontc 0.0.1 @ 39104650dd31603be7b97a169c468c39bc0e5674

x86_64-apple-darwin
rustc 1.76.0-nightly (channel: nightly, 3a85a5cfe 2023-11-20)
llvm 17.0
cargo profile: release
cargo optimization level: 3
```

GitHub UI formatting as pasted into the tracker:

fontc 0.0.1 @ 39104650dd31603be7b97a169c468c39bc0e5674

x86_64-apple-darwin
rustc 1.76.0-nightly (channel: nightly, 3a85a5cfe 2023-11-20)
llvm 17.0
cargo profile: release
cargo optimization level: 3

#### cargo stable debug build

```
$ target/debug/fontc --vv
fontc 0.0.1 @ 39104650dd31603be7b97a169c468c39bc0e5674

x86_64-apple-darwin
rustc 1.74.0 (channel: stable, 79e9716c9 2023-11-13)
llvm 17.0
cargo profile: debug
cargo optimization level: 0
```

GitHub UI formatting as pasted into the tracker:

fontc 0.0.1 @ 39104650dd31603be7b97a169c468c39bc0e5674

x86_64-apple-darwin
rustc 1.74.0 (channel: stable, 79e9716c9 2023-11-13)
llvm 17.0
cargo profile: debug
cargo optimization level: 0