### PR TITLE
[fea-rs] Disable printing in test

### DIFF
--- a/fea-rs/src/parse/context.rs
+++ b/fea-rs/src/parse/context.rs
@@ -439,7 +439,7 @@ mod tests {
         );
         assert_eq!(top_level_nodes[1].kind(), Kind::FeatureNode);
 
-        resolved.root.debug_print_structure(true);
+        //resolved.root.debug_print_structure(true);
         assert_eq!(resolved.map.resolve_range(10..15), (b_id, 10..15));
         assert_eq!(resolved.map.resolve_range(29..33), (a_id, 14..18));
         assert_eq!(resolved.map.resolve_range(49..52), (c_id, 16..19));


### PR DESCRIPTION
I believe this was turned on by accident when I migrated fea-rs into this repo, and I noticed it was sometimes showing up in test output.

This was confusing, since normally rustc swallows stderr during test execution, and only prints it if a test fails? but apparently this depends on some implementation detail of `eprintln`, and does not apply when you do the `writeln` hack.

JMM