### PR TITLE
Add variable-aware ValueRecord and Anchor types to fea-rs

### DIFF
--- a/fea-rs/src/common.rs
+++ b/fea-rs/src/common.rs
@@ -3,7 +3,6 @@
 use std::fmt::{Display, Formatter};
 
 use smol_str::SmolStr;
-use write_fonts::tables::gpos::AnchorTable;
 pub use write_fonts::types::GlyphId;
 
 mod glyph_class;
@@ -13,6 +12,8 @@ pub(crate) use glyph_class::GlyphClass;
 
 pub use glyph_class::GlyphSet;
 pub use glyph_map::GlyphMap;
+
+use crate::compile::Anchor;
 
 /// A glyph name
 pub type GlyphName = SmolStr;
@@ -41,7 +42,7 @@ pub enum GlyphIdent {
 
 #[derive(Clone, Debug, Default)]
 pub(crate) struct MarkClass {
-    pub(crate) members: Vec<(GlyphClass, Option<AnchorTable>)>,
+    pub(crate) members: Vec<(GlyphClass, Option<Anchor>)>,
 }
 
 impl<T: Into<GlyphName>> From<T> for GlyphIdent {

--- a/fea-rs/src/compile.rs
+++ b/fea-rs/src/compile.rs
@@ -21,6 +21,7 @@ pub use lookups::{
 };
 pub use opts::Opts;
 pub use output::Compilation;
+pub use valuerecordext::{Anchor, ValueRecord};
 pub use variations::{AxisLocation, VariationInfo};
 
 #[cfg(any(test, feature = "test", feature = "cli"))]

--- a/fea-rs/src/compile.rs
+++ b/fea-rs/src/compile.rs
@@ -19,9 +19,9 @@ pub use lookups::{
     FeatureKey, LookupId, MarkToBaseBuilder, MarkToMarkBuilder, PairPosBuilder,
     PreviouslyAssignedClass,
 };
+pub use metrics::{Anchor, ValueRecord};
 pub use opts::Opts;
 pub use output::Compilation;
-pub use valuerecordext::{Anchor, ValueRecord};
 pub use variations::{AxisLocation, VariationInfo};
 
 #[cfg(any(test, feature = "test", feature = "cli"))]
@@ -35,12 +35,12 @@ mod features;
 mod glyph_range;
 mod language_system;
 mod lookups;
+mod metrics;
 mod opts;
 mod output;
 mod tables;
 mod tags;
 mod validate;
-mod valuerecordext;
 mod variations;
 
 /// Run the validation pass, returning any diagnostics.

--- a/fea-rs/src/compile/compile_ctx.rs
+++ b/fea-rs/src/compile/compile_ctx.rs
@@ -43,11 +43,10 @@ use super::{
     lookups::{
         AllLookups, FilterSetId, LookupFlagInfo, LookupId, PreviouslyAssignedClass, SomeLookup,
     },
+    metrics::{Anchor, DeviceOrDeltas, Metric, ValueRecord},
     output::Compilation,
     tables::{ClassId, ScriptRecord, Tables},
-    tags,
-    valuerecordext::{Anchor, DeviceOrDeltas, Metric, ValueRecord},
-    VariationInfo,
+    tags, VariationInfo,
 };
 
 /// Context that manages state for a compilation.

--- a/fea-rs/src/compile/compile_ctx.rs
+++ b/fea-rs/src/compile/compile_ctx.rs
@@ -1094,15 +1094,13 @@ impl<'a> CompilationCtx<'a> {
         if let Some(adv) = record.advance() {
             let adv = self.resolve_metric(&adv);
             if self.vertical_feature.in_eligible_vertical_feature() {
-                return ValueRecord {
-                    y_advance: Some(adv),
-                    ..Default::default()
-                };
+                return ValueRecord::new()
+                    .with_y_advance(adv.default)
+                    .with_y_advance_device(adv.device_or_deltas);
             } else {
-                return ValueRecord {
-                    x_advance: Some(adv),
-                    ..Default::default()
-                };
+                return ValueRecord::new()
+                    .with_x_advance(adv.default)
+                    .with_x_advance_device(adv.device_or_deltas);
             }
         }
 
@@ -1141,7 +1139,6 @@ impl<'a> CompilationCtx<'a> {
         result
     }
 
-    //fn resolve_metric(&mut self, metric: &typed::Metric) -> (i16, Option<PendingVariationIndex>) {
     fn resolve_metric(&mut self, metric: &typed::Metric) -> Metric {
         match metric {
             typed::Metric::Scalar(value) => value.parse_signed().into(),

--- a/fea-rs/src/compile/compile_ctx.rs
+++ b/fea-rs/src/compile/compile_ctx.rs
@@ -14,10 +14,9 @@ use write_fonts::{
     tables::{
         self,
         gdef::CaretValue,
-        gpos::{AnchorTable, ValueFormat, ValueRecord},
-        layout::{
-            ConditionFormat1, ConditionSet, FeatureVariations, LookupFlag, PendingVariationIndex,
-        },
+        gpos::ValueFormat,
+        layout::{ConditionFormat1, ConditionSet, FeatureVariations, LookupFlag},
+        variations::ivs_builder::{RemapVariationIndices, VariationStoreBuilder},
     },
     types::{F2Dot14, NameId, Tag},
 };
@@ -47,7 +46,7 @@ use super::{
     output::Compilation,
     tables::{ClassId, ScriptRecord, Tables},
     tags,
-    valuerecordext::ValueRecordExt,
+    valuerecordext::{Anchor, DeviceOrDeltas, Metric, ValueRecord},
     VariationInfo,
 };
 
@@ -88,7 +87,7 @@ pub struct CompilationCtx<'a> {
     script: Option<Tag>,
     glyph_class_defs: HashMap<SmolStr, GlyphClass>,
     mark_classes: HashMap<SmolStr, MarkClass>,
-    anchor_defs: HashMap<SmolStr, (AnchorTable, usize)>,
+    anchor_defs: HashMap<SmolStr, (Anchor, usize)>,
     value_record_defs: HashMap<SmolStr, ValueRecord>,
     conditionset_defs: ConditionSetMap,
     mark_attach_class_id: HashMap<GlyphSet, u16>,
@@ -184,18 +183,22 @@ impl<'a> CompilationCtx<'a> {
             .as_ref()
             .map(|raw| raw.build(&mut name_builder));
 
+        // the var store builder is required so that variable metrics/anchors
+        // in the GPOS table can be collected into an ItemVariationStore
+        let mut ivs = VariationStoreBuilder::new();
+
+        let (mut gsub, mut gpos) = self.lookups.build(&self.features, &mut ivs);
+        if !ivs.is_empty() {
+            self.tables
+                .gdef
+                .get_or_insert_with(Default::default)
+                .var_store = Some(ivs);
+        }
+
         let (gdef, key_map) = match self.tables.gdef.as_ref().map(|raw| raw.build()) {
             Some((gdef, key_map)) => (Some(gdef), key_map),
             None => (None, None),
         };
-        // all VariationIndex tables (in value records and anchors) currently have
-        // temporary indices; now that we've built the ItemVariationStore we need
-        // to go and update them all.
-        if let Some(key_map) = key_map {
-            self.lookups.update_variation_index_tables(&key_map);
-        }
-
-        let (mut gsub, mut gpos) = self.lookups.build(&self.features);
 
         let feature_params = self.features.build_feature_params(&mut name_builder);
 
@@ -212,6 +215,12 @@ impl<'a> CompilationCtx<'a> {
             }
         }
         if let Some(gpos) = gpos.as_mut() {
+            if let Some(key_map) = key_map {
+                // all VariationIndex tables (in value records and anchors)
+                // currently have temporary indices; now that we've built the
+                // ItemVariationStore we need to go and update them all.
+                gpos.remap_variation_indices(&key_map);
+            }
             if let Some(variations) = gpos.feature_variations.as_mut() {
                 sort_feature_variations(variations, |condset| {
                     self.conditionset_defs.sort_order(condset)
@@ -1084,15 +1093,17 @@ impl<'a> CompilationCtx<'a> {
         }
 
         if let Some(adv) = record.advance() {
-            let (adv, var_idx) = self.resolve_metric(&adv);
+            let adv = self.resolve_metric(&adv);
             if self.vertical_feature.in_eligible_vertical_feature() {
-                return ValueRecord::new()
-                    .with_y_advance(adv)
-                    .with_device(var_idx, ValueFormat::Y_ADVANCE_DEVICE);
+                return ValueRecord {
+                    y_advance: Some(adv),
+                    ..Default::default()
+                };
             } else {
-                return ValueRecord::new()
-                    .with_x_advance(adv)
-                    .with_device(var_idx, ValueFormat::X_ADVANCE_DEVICE);
+                return ValueRecord {
+                    x_advance: Some(adv),
+                    ..Default::default()
+                };
             }
         }
 
@@ -1101,20 +1112,16 @@ impl<'a> CompilationCtx<'a> {
             return Default::default();
         };
 
-        let (x_place, x_place_var) = self.resolve_metric(&x_place);
-        let (y_place, y_place_var) = self.resolve_metric(&y_place);
-        let (x_adv, x_adv_var) = self.resolve_metric(&x_adv);
-        let (y_adv, y_adv_var) = self.resolve_metric(&y_adv);
-
-        let result = ValueRecord::new()
-            .with_x_placement(x_place)
-            .with_y_placement(y_place)
-            .with_x_advance(x_adv)
-            .with_y_advance(y_adv)
-            .with_device(x_place_var, ValueFormat::X_PLACEMENT_DEVICE)
-            .with_device(y_place_var, ValueFormat::Y_PLACEMENT_DEVICE)
-            .with_device(x_adv_var, ValueFormat::X_ADVANCE_DEVICE)
-            .with_device(y_adv_var, ValueFormat::Y_ADVANCE_DEVICE);
+        let x_placement = self.resolve_metric(&x_place);
+        let y_placement = self.resolve_metric(&y_place);
+        let x_advance = self.resolve_metric(&x_adv);
+        let y_advance = self.resolve_metric(&y_adv);
+        let mut result = ValueRecord {
+            x_placement: Some(x_placement),
+            y_placement: Some(y_placement),
+            x_advance: Some(x_advance),
+            y_advance: Some(y_advance),
+        };
 
         if let Some([x_place_dev, y_place_dev, x_adv_dev, y_adv_dev]) = record.device() {
             // if we have an explicit device we must not also be variable
@@ -1127,32 +1134,29 @@ impl<'a> CompilationCtx<'a> {
                 ),
                 "checked during parsing"
             );
-            return result
-                .with_device(x_place_dev.compile(), ValueFormat::X_PLACEMENT_DEVICE)
-                .with_device(y_place_dev.compile(), ValueFormat::Y_PLACEMENT_DEVICE)
-                .with_device(x_adv_dev.compile(), ValueFormat::X_ADVANCE_DEVICE)
-                .with_device(y_adv_dev.compile(), ValueFormat::Y_ADVANCE_DEVICE);
+            result.x_advance.as_mut().unwrap().device_or_deltas = x_adv_dev.compile().into();
+            result.y_advance.as_mut().unwrap().device_or_deltas = y_adv_dev.compile().into();
+            result.x_placement.as_mut().unwrap().device_or_deltas = x_place_dev.compile().into();
+            result.y_placement.as_mut().unwrap().device_or_deltas = y_place_dev.compile().into();
         }
         result
     }
 
-    fn resolve_metric(&mut self, metric: &typed::Metric) -> (i16, Option<PendingVariationIndex>) {
+    //fn resolve_metric(&mut self, metric: &typed::Metric) -> (i16, Option<PendingVariationIndex>) {
+    fn resolve_metric(&mut self, metric: &typed::Metric) -> Metric {
         match metric {
-            typed::Metric::Scalar(value) => (value.parse_signed(), None),
+            typed::Metric::Scalar(value) => value.parse_signed().into(),
             typed::Metric::Variable(variable) => self.resolve_variable_metric(variable),
         }
     }
 
-    fn resolve_variable_metric(
-        &mut self,
-        metric: &typed::VariableMetric,
-    ) -> (i16, Option<PendingVariationIndex>) {
+    fn resolve_variable_metric(&mut self, metric: &typed::VariableMetric) -> Metric {
         let Some(var_info) = self.variation_info else {
             self.error(
                 metric.range(),
                 "variable metric only valid when compiling variable font",
             );
-            return (0, None);
+            return Default::default();
         };
 
         let mut locations = HashMap::new();
@@ -1176,14 +1180,13 @@ impl<'a> CompilationCtx<'a> {
             locations.insert(pos, metric_loc.value().parse_signed());
         }
         match var_info.resolve_variable_metric(&locations) {
-            Ok((default, deltas)) => {
-                let temp_idx = self.tables.var_store().add_deltas(deltas);
-                let var_idx = PendingVariationIndex::new(temp_idx);
-                (default, Some(var_idx))
-            }
+            Ok((default, deltas)) => Metric {
+                default,
+                device_or_deltas: DeviceOrDeltas::Deltas(deltas),
+            },
             Err(e) => {
                 self.error(metric.range(), format!("failed to compute deltas: '{e}'"));
-                (0, None)
+                Default::default()
             }
         }
     }
@@ -1797,15 +1800,15 @@ impl<'a> CompilationCtx<'a> {
         let anchor_block = anchor_def.anchor();
         let name = anchor_def.name();
         let anchor = match self.resolve_anchor(&anchor_block) {
-            Some(a @ AnchorTable::Format1(_) | a @ AnchorTable::Format2(_)) => a,
-            Some(_) => {
+            Some(a) if !a.x.has_device_or_deltas() && !a.y.has_device_or_deltas() => a,
+            _ => {
                 return self.error(
                     anchor_block.range(),
                     "named anchor definition can only be in format A or B",
                 )
             }
-            None => return,
         };
+
         if let Some(_prev) = self
             .anchor_defs
             .insert(name.text.clone(), (anchor, anchor_def.range().start))
@@ -1814,7 +1817,7 @@ impl<'a> CompilationCtx<'a> {
         }
     }
 
-    fn resolve_anchor(&mut self, item: &typed::Anchor) -> Option<AnchorTable> {
+    fn resolve_anchor(&mut self, item: &typed::Anchor) -> Option<Anchor> {
         if item.null().is_some() {
             return None;
         }
@@ -1834,33 +1837,24 @@ impl<'a> CompilationCtx<'a> {
             return None;
         };
 
-        let (x, x_var) = self.resolve_metric(&x);
-        let (y, y_var) = self.resolve_metric(&y);
-
-        if x_var.is_some() || y_var.is_some() {
-            return Some(AnchorTable::format_3(
-                x,
-                y,
-                x_var.map(Into::into),
-                y_var.map(Into::into),
-            ));
-        }
+        let x = self.resolve_metric(&x);
+        let y = self.resolve_metric(&y);
+        let mut anchor = Anchor {
+            x,
+            y,
+            contourpoint: None,
+        };
 
         if let Some(point) = item.contourpoint() {
             match point.parse_unsigned() {
-                Some(point) => Some(AnchorTable::format_2(x, y, point)),
+                Some(point) => anchor.contourpoint = Some(point),
                 None => panic!("negative contourpoint, go fix your parser"),
             }
-        } else if let Some((x_coord, y_coord)) = item.devices() {
-            Some(AnchorTable::format_3(
-                x,
-                y,
-                x_coord.compile().map(Into::into),
-                y_coord.compile().map(Into::into),
-            ))
-        } else {
-            Some(AnchorTable::format_1(x, y))
+        } else if let Some((x_dev, y_dev)) = item.devices() {
+            anchor.x.device_or_deltas = x_dev.compile().into();
+            anchor.y.device_or_deltas = y_dev.compile().into();
         }
+        Some(anchor)
     }
 
     fn define_condition_set(&mut self, node: typed::ConditionSet) {

--- a/fea-rs/src/compile/feature_writer.rs
+++ b/fea-rs/src/compile/feature_writer.rs
@@ -2,13 +2,7 @@
 
 use std::collections::{BTreeMap, HashMap};
 
-use write_fonts::{
-    tables::{
-        layout::{LookupFlag, PendingVariationIndex},
-        variations::VariationRegion,
-    },
-    types::Tag,
-};
+use write_fonts::{tables::layout::LookupFlag, types::Tag};
 
 use crate::GlyphSet;
 
@@ -90,18 +84,6 @@ impl<'a> FeatureBuilder<'a> {
         let next_id = LookupId::External(self.lookups.len());
         self.lookups.push((next_id, lookup.0));
         next_id
-    }
-
-    /// Add a set of deltas to the `ItemVariationStore`.
-    ///
-    /// Returns a `PendingVariationIndex` which should be stored whereever a
-    /// `VariationIndex` table would be expected (it will be remapped during
-    /// compilation).
-    pub fn add_deltas<T: Into<i32>>(
-        &mut self,
-        deltas: Vec<(VariationRegion, T)>,
-    ) -> PendingVariationIndex {
-        todo!("remove me!")
     }
 
     /// Add lookups to every default language system.

--- a/fea-rs/src/compile/feature_writer.rs
+++ b/fea-rs/src/compile/feature_writer.rs
@@ -101,8 +101,7 @@ impl<'a> FeatureBuilder<'a> {
         &mut self,
         deltas: Vec<(VariationRegion, T)>,
     ) -> PendingVariationIndex {
-        let delta_set_id = self.tables.var_store().add_deltas(deltas);
-        PendingVariationIndex { delta_set_id }
+        todo!("remove me!")
     }
 
     /// Add lookups to every default language system.

--- a/fea-rs/src/compile/lookups.rs
+++ b/fea-rs/src/compile/lookups.rs
@@ -53,7 +53,14 @@ pub(crate) use helpers::ClassDefBuilder2;
 // This exists because we use it to implement `LookupBuilder<T>`
 pub(crate) trait Builder {
     type Output;
-    // the var_store is only used in GPOS, but we pass it everywhere
+    // the var_store is only used in GPOS, but we pass it everywhere.
+    // This is annoying but feels like the lesser of two evils. It's easy to
+    // ignore this argument where it isn't used, and this makes the logic
+    // in LookupBuilder simpler, since it is identical for GPOS/GSUB.
+    //
+    // It would be nice if this could then be Option<&mut T>, but that type is
+    // annoying to work with, as Option<&mut _> doesn't impl Copy, so you need
+    // to do a dance anytime you use it.
     fn build(self, var_store: &mut VariationStoreBuilder) -> Self::Output;
 }
 

--- a/fea-rs/src/compile/lookups.rs
+++ b/fea-rs/src/compile/lookups.rs
@@ -29,11 +29,11 @@ use write_fonts::{
 
 use crate::{
     common::{GlyphId, GlyphOrClass, GlyphSet},
-    compile::{lookups::contextual::ChainOrNot, valuerecordext::ValueRecord},
+    compile::{lookups::contextual::ChainOrNot, metrics::ValueRecord},
     Kind,
 };
 
-use super::{features::AllFeatures, tables::ClassId, tags, valuerecordext::Anchor};
+use super::{features::AllFeatures, metrics::Anchor, tables::ClassId, tags};
 
 use contextual::{
     ContextualLookupBuilder, PosChainContextBuilder, PosContextBuilder, ReverseChainBuilder,

--- a/fea-rs/src/compile/lookups/contextual.rs
+++ b/fea-rs/src/compile/lookups/contextual.rs
@@ -17,7 +17,7 @@ use write_fonts::{
     FontWrite,
 };
 
-use crate::{common::GlyphOrClass, compile::valuerecordext::ValueRecord};
+use crate::{common::GlyphOrClass, compile::metrics::ValueRecord};
 
 use super::{
     Builder, ClassDefBuilder2, FilterSetId, LookupBuilder, LookupId, PositionLookup,

--- a/fea-rs/src/compile/lookups/gpos_builders.rs
+++ b/fea-rs/src/compile/lookups/gpos_builders.rs
@@ -14,7 +14,7 @@ use write_fonts::{
 
 use crate::{
     common::GlyphSet,
-    compile::valuerecordext::{Anchor, ValueRecord},
+    compile::metrics::{Anchor, ValueRecord},
 };
 
 use super::{Builder, ClassDefBuilder2};
@@ -351,7 +351,6 @@ impl Builder for CursivePosBuilder {
                 )
             })
             .collect();
-        //let record = write_gpos::EntryExitRecord::new(entry, exit);
         vec![write_gpos::CursivePosFormat1::new(coverage, records)]
     }
 }

--- a/fea-rs/src/compile/lookups/gpos_builders.rs
+++ b/fea-rs/src/compile/lookups/gpos_builders.rs
@@ -5,16 +5,19 @@ use std::collections::{BTreeMap, HashMap};
 use smol_str::SmolStr;
 use write_fonts::{
     tables::{
-        gpos::{self as write_gpos, AnchorTable, MarkRecord, ValueFormat, ValueRecord},
+        gpos::{self as write_gpos, MarkRecord, ValueFormat, ValueRecord as RawValueRecord},
         layout::CoverageTable,
-        variations::ivs_builder::VariationIndexRemapping,
+        variations::ivs_builder::VariationStoreBuilder,
     },
     types::GlyphId,
 };
 
-use crate::common::GlyphSet;
+use crate::{
+    common::GlyphSet,
+    compile::valuerecordext::{Anchor, ValueRecord},
+};
 
-use super::{Builder, ClassDefBuilder2, VariationIndexContainingLookup};
+use super::{Builder, ClassDefBuilder2};
 
 #[derive(Clone, Debug, Default)]
 pub struct SinglePosBuilder {
@@ -35,19 +38,11 @@ impl SinglePosBuilder {
     }
 }
 
-impl VariationIndexContainingLookup for SinglePosBuilder {
-    fn remap_variation_indices(&mut self, key_map: &VariationIndexRemapping) {
-        self.items
-            .values_mut()
-            .for_each(|x| x.remap_variation_indices(key_map))
-    }
-}
-
 impl Builder for SinglePosBuilder {
     type Output = Vec<write_gpos::SinglePos>;
 
-    fn build(self) -> Self::Output {
-        fn build_subtable(items: BTreeMap<GlyphId, &ValueRecord>) -> write_gpos::SinglePos {
+    fn build(self, var_store: &mut VariationStoreBuilder) -> Self::Output {
+        fn build_subtable(items: BTreeMap<GlyphId, &RawValueRecord>) -> write_gpos::SinglePos {
             let first = *items.values().next().unwrap();
             let use_format_1 = first.format().is_empty() || items.values().all(|val| val == &first);
             let coverage: CoverageTable = items.keys().copied().collect();
@@ -58,21 +53,26 @@ impl Builder for SinglePosBuilder {
             }
         }
         const NEW_SUBTABLE_COST: usize = 10;
+        let items = self
+            .items
+            .into_iter()
+            .map(|(glyph, anchor)| (glyph, anchor.build(var_store)))
+            .collect::<BTreeMap<_, _>>();
 
         // list of sets of glyph ids which will end up in their own subtables
         let mut subtables = Vec::new();
-        let mut group_by_record: HashMap<&ValueRecord, BTreeMap<GlyphId, &ValueRecord>> =
+        let mut group_by_record: HashMap<&RawValueRecord, BTreeMap<GlyphId, &RawValueRecord>> =
             Default::default();
 
         // first group by specific record; glyphs that share a record can use
         // the more efficient format-1 subtable type
-        for (gid, value) in &self.items {
+        for (gid, value) in &items {
             group_by_record
                 .entry(value)
                 .or_default()
                 .insert(*gid, value);
         }
-        let mut group_by_format: HashMap<ValueFormat, BTreeMap<GlyphId, &ValueRecord>> =
+        let mut group_by_format: HashMap<ValueFormat, BTreeMap<GlyphId, &RawValueRecord>> =
             Default::default();
         for (value, glyphs) in group_by_record {
             // if this saves us size, use format 1
@@ -143,23 +143,6 @@ impl Default for ClassPairPosSubtable {
 #[derive(Clone, Debug, Default, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 struct ClassPairPosBuilder(BTreeMap<(ValueFormat, ValueFormat), Vec<ClassPairPosSubtable>>);
-
-impl VariationIndexContainingLookup for PairPosBuilder {
-    fn remap_variation_indices(&mut self, key_map: &VariationIndexRemapping) {
-        self.pairs
-            .0
-            .values_mut()
-            .flat_map(|x| x.values_mut())
-            .chain(self.classes.0.values_mut().flat_map(|x| {
-                x.iter_mut()
-                    .flat_map(|x| x.items.values_mut().flat_map(|x| x.values_mut()))
-            }))
-            .for_each(|v| {
-                v.0.remap_variation_indices(key_map);
-                v.1.remap_variation_indices(key_map);
-            });
-    }
-}
 
 impl ClassPairPosBuilder {
     fn insert(
@@ -249,9 +232,9 @@ impl PairPosBuilder {
 impl Builder for PairPosBuilder {
     type Output = Vec<write_gpos::PairPos>;
 
-    fn build(self) -> Self::Output {
-        let mut out = self.pairs.build();
-        out.extend(self.classes.build());
+    fn build(self, var_store: &mut VariationStoreBuilder) -> Self::Output {
+        let mut out = self.pairs.build(var_store);
+        out.extend(self.classes.build(var_store));
         out
     }
 }
@@ -259,7 +242,7 @@ impl Builder for PairPosBuilder {
 impl Builder for GlyphPairPosBuilder {
     type Output = Vec<write_gpos::PairPos>;
 
-    fn build(self) -> Self::Output {
+    fn build(self, var_store: &mut VariationStoreBuilder) -> Self::Output {
         let mut split_by_format = BTreeMap::<_, BTreeMap<_, Vec<_>>>::default();
         for (g1, map) in self.0 {
             for (g2, (v1, v2)) in map {
@@ -268,7 +251,11 @@ impl Builder for GlyphPairPosBuilder {
                     .or_default()
                     .entry(g1)
                     .or_default()
-                    .push(write_gpos::PairValueRecord::new(g2, v1, v2));
+                    .push(write_gpos::PairValueRecord::new(
+                        g2,
+                        v1.build(var_store),
+                        v2.build(var_store),
+                    ));
             }
         }
 
@@ -286,18 +273,20 @@ impl Builder for GlyphPairPosBuilder {
 impl Builder for ClassPairPosBuilder {
     type Output = Vec<write_gpos::PairPos>;
 
-    fn build(self) -> Self::Output {
-        self.0
-            .into_values()
-            .flat_map(|subs| subs.into_iter().map(Builder::build))
-            .collect()
+    fn build(self, var_store: &mut VariationStoreBuilder) -> Self::Output {
+        // not an iterator because we have funky lifetime issues
+        let mut result = Vec::new();
+        for sub in self.0.into_values().flat_map(|subs| subs.into_iter()) {
+            result.push(sub.build(var_store));
+        }
+        result
     }
 }
 
 impl Builder for ClassPairPosSubtable {
     type Output = write_gpos::PairPos;
 
-    fn build(self) -> Self::Output {
+    fn build(self, var_store: &mut VariationStoreBuilder) -> Self::Output {
         assert!(!self.items.is_empty(), "filter before here");
         // we have a set of classes/values with a single valueformat
 
@@ -309,8 +298,8 @@ impl Builder for ClassPairPosSubtable {
             .and_then(|val| val.values().next())
             .map(|(v1, v2)| {
                 write_gpos::Class2Record::new(
-                    ValueRecord::new().with_explicit_value_format(v1.format()),
-                    ValueRecord::new().with_explicit_value_format(v2.format()),
+                    RawValueRecord::new().with_explicit_value_format(v1.format()),
+                    RawValueRecord::new().with_explicit_value_format(v2.format()),
                 )
             })
             .unwrap();
@@ -326,7 +315,8 @@ impl Builder for ClassPairPosSubtable {
             let mut records = vec![empty_record.clone(); class2map.len() + 1];
             for (class, (v1, v2)) in stuff {
                 let idx = class2map.get(&class).unwrap();
-                records[*idx as usize] = write_gpos::Class2Record::new(v1.clone(), v2.clone());
+                records[*idx as usize] =
+                    write_gpos::Class2Record::new(v1.build(var_store), v2.build(var_store));
             }
             out[*idx as usize] = write_gpos::Class1Record::new(records);
         }
@@ -336,42 +326,32 @@ impl Builder for ClassPairPosSubtable {
 
 #[derive(Clone, Debug, Default)]
 pub struct CursivePosBuilder {
-    items: BTreeMap<GlyphId, write_gpos::EntryExitRecord>,
-}
-
-impl VariationIndexContainingLookup for CursivePosBuilder {
-    fn remap_variation_indices(&mut self, key_map: &VariationIndexRemapping) {
-        self.items
-            .values_mut()
-            .flat_map(|record| {
-                record
-                    .entry_anchor
-                    .as_mut()
-                    .into_iter()
-                    .chain(record.exit_anchor.as_mut())
-            })
-            .for_each(|anchor| anchor.remap_variation_indices(key_map))
-    }
+    // (entry, exit)
+    items: BTreeMap<GlyphId, (Option<Anchor>, Option<Anchor>)>,
 }
 
 impl CursivePosBuilder {
-    pub fn insert(
-        &mut self,
-        glyph: GlyphId,
-        entry: Option<AnchorTable>,
-        exit: Option<AnchorTable>,
-    ) {
-        let record = write_gpos::EntryExitRecord::new(entry, exit);
-        self.items.insert(glyph, record);
+    pub fn insert(&mut self, glyph: GlyphId, entry: Option<Anchor>, exit: Option<Anchor>) {
+        self.items.insert(glyph, (entry, exit));
     }
 }
 
 impl Builder for CursivePosBuilder {
     type Output = Vec<write_gpos::CursivePosFormat1>;
 
-    fn build(self) -> Self::Output {
+    fn build(self, var_store: &mut VariationStoreBuilder) -> Self::Output {
         let coverage = self.items.keys().copied().collect();
-        let records = self.items.into_values().collect();
+        let records = self
+            .items
+            .into_values()
+            .map(|(entry, exit)| {
+                write_gpos::EntryExitRecord::new(
+                    entry.map(|x| x.build(var_store)),
+                    exit.map(|x| x.build(var_store)),
+                )
+            })
+            .collect();
+        //let record = write_gpos::EntryExitRecord::new(entry, exit);
         vec![write_gpos::CursivePosFormat1::new(coverage, records)]
     }
 }
@@ -379,17 +359,10 @@ impl Builder for CursivePosBuilder {
 // shared between several tables
 #[derive(Clone, Debug, Default)]
 struct MarkList {
-    glyphs: BTreeMap<GlyphId, MarkRecord>,
+    // (class id, anchor)
+    glyphs: BTreeMap<GlyphId, (u16, Anchor)>,
     // map class names to their idx for this table
     classes: HashMap<SmolStr, u16>,
-}
-
-impl VariationIndexContainingLookup for MarkList {
-    fn remap_variation_indices(&mut self, key_map: &VariationIndexRemapping) {
-        self.glyphs
-            .values_mut()
-            .for_each(|mark| mark.mark_anchor.remap_variation_indices(key_map))
-    }
 }
 
 impl MarkList {
@@ -400,19 +373,20 @@ impl MarkList {
         &mut self,
         glyph: GlyphId,
         class: SmolStr,
-        anchor: AnchorTable,
+        anchor: Anchor,
     ) -> Result<u16, PreviouslyAssignedClass> {
         let next_id = self.classes.len().try_into().unwrap();
         let id = *self.classes.entry(class).or_insert(next_id);
         if let Some(prev) = self
             .glyphs
-            .insert(glyph, MarkRecord::new(id, anchor))
-            .filter(|prev| prev.mark_class != id)
+            //.insert(glyph, MarkRecord::new(id, anchor))
+            .insert(glyph, (id, anchor))
+            .filter(|prev| prev.0 != id)
         {
             let class = self
                 .classes
                 .iter()
-                .find_map(|(name, idx)| (*idx == prev.mark_class).then(|| name.clone()))
+                .find_map(|(name, idx)| (*idx == prev.0).then(|| name.clone()))
                 .unwrap();
 
             return Err(PreviouslyAssignedClass {
@@ -438,9 +412,14 @@ impl MarkList {
 impl Builder for MarkList {
     type Output = (CoverageTable, write_gpos::MarkArray);
 
-    fn build(self) -> Self::Output {
+    fn build(self, var_store: &mut VariationStoreBuilder) -> Self::Output {
         let coverage = self.glyphs().collect();
-        let array = write_gpos::MarkArray::new(self.glyphs.into_values().collect());
+        let array = write_gpos::MarkArray::new(
+            self.glyphs
+                .into_values()
+                .map(|(class, anchor)| MarkRecord::new(class, anchor.build(var_store)))
+                .collect(),
+        );
         (coverage, array)
     }
 }
@@ -449,17 +428,7 @@ impl Builder for MarkList {
 #[derive(Clone, Debug, Default)]
 pub struct MarkToBaseBuilder {
     marks: MarkList,
-    bases: BTreeMap<GlyphId, Vec<(u16, AnchorTable)>>,
-}
-
-impl VariationIndexContainingLookup for MarkToBaseBuilder {
-    fn remap_variation_indices(&mut self, key_map: &VariationIndexRemapping) {
-        self.marks.remap_variation_indices(key_map);
-        self.bases
-            .values_mut()
-            .flat_map(|vals| vals.iter_mut().map(|(_, anchor)| anchor))
-            .for_each(|anchor| anchor.remap_variation_indices(key_map))
-    }
+    bases: BTreeMap<GlyphId, Vec<(u16, Anchor)>>,
 }
 
 /// An error indicating a given glyph has been assigned to multiple mark classes
@@ -480,13 +449,13 @@ impl MarkToBaseBuilder {
         &mut self,
         glyph: GlyphId,
         class: SmolStr,
-        anchor: AnchorTable,
+        anchor: Anchor,
     ) -> Result<u16, PreviouslyAssignedClass> {
         self.marks.insert(glyph, class, anchor)
     }
 
     /// Insert a new base glyph.
-    pub fn insert_base(&mut self, glyph: GlyphId, class: &SmolStr, anchor: AnchorTable) {
+    pub fn insert_base(&mut self, glyph: GlyphId, class: &SmolStr, anchor: Anchor) {
         let class = self.marks.get_class(class);
         self.bases.entry(glyph).or_default().push((class, anchor))
     }
@@ -505,18 +474,18 @@ impl MarkToBaseBuilder {
 impl Builder for MarkToBaseBuilder {
     type Output = Vec<write_gpos::MarkBasePosFormat1>;
 
-    fn build(self) -> Self::Output {
+    fn build(self, var_store: &mut VariationStoreBuilder) -> Self::Output {
         let MarkToBaseBuilder { marks, bases } = self;
         let n_classes = marks.classes.len();
 
-        let (mark_coverage, mark_array) = marks.build();
+        let (mark_coverage, mark_array) = marks.build(var_store);
         let base_coverage = bases.keys().copied().collect();
         let base_records = bases
             .into_values()
             .map(|anchors| {
                 let mut anchor_offsets = vec![None; n_classes];
                 for (class, anchor) in anchors {
-                    anchor_offsets[class as usize] = Some(anchor);
+                    anchor_offsets[class as usize] = Some(anchor.build(var_store));
                 }
                 write_gpos::BaseRecord::new(anchor_offsets)
             })
@@ -534,7 +503,7 @@ impl Builder for MarkToBaseBuilder {
 #[derive(Clone, Debug, Default)]
 pub struct MarkToLigBuilder {
     marks: MarkList,
-    ligatures: BTreeMap<GlyphId, Vec<BTreeMap<SmolStr, AnchorTable>>>,
+    ligatures: BTreeMap<GlyphId, Vec<BTreeMap<SmolStr, Anchor>>>,
 }
 
 impl MarkToLigBuilder {
@@ -542,12 +511,12 @@ impl MarkToLigBuilder {
         &mut self,
         glyph: GlyphId,
         class: SmolStr,
-        anchor: AnchorTable,
+        anchor: Anchor,
     ) -> Result<u16, PreviouslyAssignedClass> {
         self.marks.insert(glyph, class, anchor)
     }
 
-    pub fn add_lig(&mut self, glyph: GlyphId, components: Vec<BTreeMap<SmolStr, AnchorTable>>) {
+    pub fn add_lig(&mut self, glyph: GlyphId, components: Vec<BTreeMap<SmolStr, Anchor>>) {
         self.ligatures.insert(glyph, components);
     }
 
@@ -560,20 +529,10 @@ impl MarkToLigBuilder {
     }
 }
 
-impl VariationIndexContainingLookup for MarkToLigBuilder {
-    fn remap_variation_indices(&mut self, key_map: &VariationIndexRemapping) {
-        self.marks.remap_variation_indices(key_map);
-        self.ligatures
-            .values_mut()
-            .flat_map(|vals| vals.iter_mut().flat_map(|tree| tree.values_mut()))
-            .for_each(|anchor| anchor.remap_variation_indices(key_map))
-    }
-}
-
 impl Builder for MarkToLigBuilder {
     type Output = Vec<write_gpos::MarkLigPosFormat1>;
 
-    fn build(self) -> Self::Output {
+    fn build(self, var_store: &mut VariationStoreBuilder) -> Self::Output {
         let MarkToLigBuilder { marks, ligatures } = self;
         let n_classes = marks.classes.len();
 
@@ -591,7 +550,7 @@ impl Builder for MarkToLigBuilder {
                         let mut anchor_offsets = vec![None; n_classes];
                         for (class, anchor) in anchors {
                             let class_idx = marks.get_class(&class);
-                            anchor_offsets[class_idx as usize] = Some(anchor);
+                            anchor_offsets[class_idx as usize] = Some(anchor.build(var_store));
                         }
                         write_gpos::ComponentRecord::new(anchor_offsets)
                     })
@@ -600,7 +559,7 @@ impl Builder for MarkToLigBuilder {
             })
             .collect();
         let ligature_array = write_gpos::LigatureArray::new(ligature_array);
-        let (mark_coverage, mark_array) = marks.build();
+        let (mark_coverage, mark_array) = marks.build(var_store);
         vec![write_gpos::MarkLigPosFormat1::new(
             mark_coverage,
             ligature_coverage,
@@ -614,7 +573,7 @@ impl Builder for MarkToLigBuilder {
 #[derive(Clone, Debug, Default)]
 pub struct MarkToMarkBuilder {
     attaching_marks: MarkList,
-    base_marks: BTreeMap<GlyphId, Vec<(u16, AnchorTable)>>,
+    base_marks: BTreeMap<GlyphId, Vec<(u16, Anchor)>>,
 }
 
 impl MarkToMarkBuilder {
@@ -626,13 +585,13 @@ impl MarkToMarkBuilder {
         &mut self,
         glyph: GlyphId,
         class: SmolStr,
-        anchor: AnchorTable,
+        anchor: Anchor,
     ) -> Result<u16, PreviouslyAssignedClass> {
         self.attaching_marks.insert(glyph, class, anchor)
     }
 
     /// Insert a new mark2 (base) glyph
-    pub fn insert_mark2(&mut self, glyph: GlyphId, class: &SmolStr, anchor: AnchorTable) {
+    pub fn insert_mark2(&mut self, glyph: GlyphId, class: &SmolStr, anchor: Anchor) {
         let id = self.attaching_marks.get_class(class);
         self.base_marks.entry(glyph).or_default().push((id, anchor))
     }
@@ -648,34 +607,24 @@ impl MarkToMarkBuilder {
     }
 }
 
-impl VariationIndexContainingLookup for MarkToMarkBuilder {
-    fn remap_variation_indices(&mut self, key_map: &VariationIndexRemapping) {
-        self.attaching_marks.remap_variation_indices(key_map);
-        self.base_marks
-            .values_mut()
-            .flat_map(|vals| vals.iter_mut().map(|(_, anchor)| anchor))
-            .for_each(|anchor| anchor.remap_variation_indices(key_map))
-    }
-}
-
 impl Builder for MarkToMarkBuilder {
     type Output = Vec<write_gpos::MarkMarkPosFormat1>;
 
-    fn build(self) -> Self::Output {
+    fn build(self, var_store: &mut VariationStoreBuilder) -> Self::Output {
         let MarkToMarkBuilder {
             attaching_marks,
             base_marks,
         } = self;
         let n_classes = attaching_marks.classes.len();
 
-        let (mark_coverage, mark_array) = attaching_marks.build();
+        let (mark_coverage, mark_array) = attaching_marks.build(var_store);
         let mark2_coverage = base_marks.keys().copied().collect();
         let mark2_records = base_marks
             .into_values()
             .map(|anchors| {
                 let mut anchor_offsets = vec![None; n_classes];
                 for (class, anchor) in anchors {
-                    anchor_offsets[class as usize] = Some(anchor);
+                    anchor_offsets[class as usize] = Some(anchor.build(var_store));
                 }
                 write_gpos::Mark2Record::new(anchor_offsets)
             })

--- a/fea-rs/src/compile/lookups/gsub_builders.rs
+++ b/fea-rs/src/compile/lookups/gsub_builders.rs
@@ -3,7 +3,7 @@
 use std::{collections::BTreeMap, convert::TryFrom};
 
 use write_fonts::{
-    tables::gsub as write_gsub,
+    tables::{gsub as write_gsub, variations::ivs_builder::VariationStoreBuilder},
     types::{FixedSize, GlyphId},
 };
 
@@ -59,7 +59,7 @@ impl SingleSubBuilder {
 impl Builder for SingleSubBuilder {
     type Output = Vec<write_gsub::SingleSubst>;
 
-    fn build(self) -> Self::Output {
+    fn build(self, _: &mut VariationStoreBuilder) -> Self::Output {
         const COST_OF_EXTRA_SUB1F1_SUBTABLE: usize = 2 + // extra offset
             2 + 2 + 2 + // format1 table itself
             2 + 2; // extra coverage table
@@ -147,7 +147,7 @@ pub struct MultipleSubBuilder {
 impl Builder for MultipleSubBuilder {
     type Output = Vec<write_gsub::MultipleSubstFormat1>;
 
-    fn build(self) -> Self::Output {
+    fn build(self, _: &mut VariationStoreBuilder) -> Self::Output {
         let coverage = self.items.keys().copied().collect();
         let seq_tables = self
             .items
@@ -193,7 +193,7 @@ impl AlternateSubBuilder {
 impl Builder for AlternateSubBuilder {
     type Output = Vec<write_gsub::AlternateSubstFormat1>;
 
-    fn build(self) -> Self::Output {
+    fn build(self, _: &mut VariationStoreBuilder) -> Self::Output {
         let coverage = self.items.keys().copied().collect();
         let seq_tables = self
             .items
@@ -230,7 +230,7 @@ impl LigatureSubBuilder {
 impl Builder for LigatureSubBuilder {
     type Output = Vec<write_gsub::LigatureSubstFormat1>;
 
-    fn build(self) -> Self::Output {
+    fn build(self, _: &mut VariationStoreBuilder) -> Self::Output {
         let coverage = self.items.keys().copied().collect();
         let lig_sets = self
             .items

--- a/fea-rs/src/compile/metrics.rs
+++ b/fea-rs/src/compile/metrics.rs
@@ -1,4 +1,4 @@
-//! Extra helper methods on ValueRecord
+//! Variable-first metrics, ValueRecords & Anchors
 
 use write_fonts::tables::{
     gpos::{AnchorTable, ValueFormat},
@@ -34,6 +34,7 @@ pub struct Anchor {
     pub contourpoint: Option<u16>,
 }
 
+/// Either a `Device` table or a set of deltas
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum DeviceOrDeltas {

--- a/fea-rs/src/compile/tables.rs
+++ b/fea-rs/src/compile/tables.rs
@@ -57,16 +57,6 @@ pub(crate) struct VmtxBuilder {
     pub advances_y: Vec<(GlyphId, i16)>,
 }
 
-impl Tables {
-    // convenience method to access the varstore, creating it if it doesn't exist
-    pub(crate) fn var_store(&mut self) -> &mut VariationStoreBuilder {
-        self.gdef
-            .get_or_insert_with(Default::default)
-            .var_store
-            .get_or_insert_with(Default::default)
-    }
-}
-
 // this is the value used in python fonttools when writing this table
 const DATE_2011_12_13_H11_M22_S33: LongDateTime = LongDateTime::new(1323780153);
 

--- a/fontbe/src/features.rs
+++ b/fontbe/src/features.rs
@@ -199,12 +199,8 @@ impl<'a> FeatureWriter<'a> {
         }
         let mut ppos_subtables = PairPosBuilder::default();
 
-        let mut var_indices = HashMap::new();
-        for (idx, deltas) in self.kerning.deltas().enumerate() {
-            var_indices.insert(idx, builder.add_deltas(deltas.clone()));
-        }
         for kern in self.kerning.kerns() {
-            kern.insert_into(&var_indices, &mut ppos_subtables);
+            kern.insert_into(&mut ppos_subtables);
         }
 
         // now we have a builder for the pairpos subtables, so we can make
@@ -252,7 +248,7 @@ impl<'a> FeatureWriter<'a> {
                     .insert_mark(
                         mark.gid,
                         mark_base.class.clone(),
-                        mark.create_anchor_table(builder)?,
+                        mark.create_anchor_table(),
                     )
                     .map_err(Error::PreviouslyAssignedClass)?;
             }
@@ -261,7 +257,7 @@ impl<'a> FeatureWriter<'a> {
                 mark_base_builder.insert_base(
                     base.gid,
                     &mark_base.class,
-                    base.create_anchor_table(builder)?,
+                    base.create_anchor_table(),
                 )
             }
 
@@ -282,7 +278,7 @@ impl<'a> FeatureWriter<'a> {
                     .insert_mark1(
                         mark.gid,
                         mark_mark.class.clone(),
-                        mark.create_anchor_table(builder)?,
+                        mark.create_anchor_table(),
                     )
                     .map_err(Error::PreviouslyAssignedClass)?;
             }
@@ -291,7 +287,7 @@ impl<'a> FeatureWriter<'a> {
                 mark_mark_builder.insert_mark2(
                     base.gid,
                     &mark_mark.class,
-                    base.create_anchor_table(builder)?,
+                    base.create_anchor_table(),
                 );
             }
             mark_mark_lookups.push(builder.add_lookup(


### PR DESCRIPTION
Previously we used the `ValueRecord` and `AnchorTable` types in write-fonts. This had the complication that anytime you needed to include deltas you had to have access to a `VariationStoreBuilder`, which was a bottleneck for fontc.

With this change, we now just store the deltas inline in the record/anchor type, and only go and turn them into actual `write-fonts` types at the very end, after merging anything we've received from feature writers.

This patch makes the fewest changes outside fea-rs that were possible in order to get things working again; as follow up we can go and figure out how best to update the kerning/marks code to take advantage of this new model.

This requires https://github.com/googlefonts/fontations/pull/719; this includes a commit that patches Cargo.toml to point at that for the time being.