### PR TITLE
[fontbe] make cu2qu tolerance relative to UPEM

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ tempfile = "3.3.0"
 more-asserts = "0.3.1"
 pretty_assertions = "1.3.0"
 temp-env = "0.3.3"
+rstest = "0.18.2"
 
 [workspace]
 

--- a/fontbe/Cargo.toml
+++ b/fontbe/Cargo.toml
@@ -43,3 +43,4 @@ ansi_term.workspace = true
 tempfile.workspace = true
 more-asserts.workspace = true
 temp-env.workspace = true
+rstest.workspace = true


### PR DESCRIPTION
Instead of hard-coding tolerance=1.0, we now use the same default tolerance as fontTools.cu2qu, which is relative to the font's UPEM, i.e. UPEM/1000

Fixes https://github.com/googlefonts/fontc/issues/474