### PR TITLE
Construct kerning/mark lookup builders direclty

### DIFF
--- a/fea-rs/src/compile/lookups/gpos_builders.rs
+++ b/fea-rs/src/compile/lookups/gpos_builders.rs
@@ -191,6 +191,11 @@ impl ClassPairPosSubtable {
 }
 
 impl PairPosBuilder {
+    /// Returns `true` if no rules have been added to this builder
+    pub fn is_empty(&self) -> bool {
+        self.pairs.0.is_empty() && self.classes.0.is_empty()
+    }
+
     /// Insert a new kerning pair
     pub fn insert_pair(
         &mut self,

--- a/fea-rs/src/compile/lookups/gpos_builders.rs
+++ b/fea-rs/src/compile/lookups/gpos_builders.rs
@@ -19,7 +19,8 @@ use crate::{
 
 use super::{Builder, ClassDefBuilder2};
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SinglePosBuilder {
     items: BTreeMap<GlyphId, ValueRecord>,
 }
@@ -324,7 +325,8 @@ impl Builder for ClassPairPosSubtable {
     }
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CursivePosBuilder {
     // (entry, exit)
     items: BTreeMap<GlyphId, (Option<Anchor>, Option<Anchor>)>,
@@ -356,7 +358,8 @@ impl Builder for CursivePosBuilder {
 }
 
 // shared between several tables
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 struct MarkList {
     // (class id, anchor)
     glyphs: BTreeMap<GlyphId, (u16, Anchor)>,
@@ -424,7 +427,8 @@ impl Builder for MarkList {
 }
 
 /// A builder for GPOS Lookup Type 4, Mark-to-Base
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MarkToBaseBuilder {
     marks: MarkList,
     bases: BTreeMap<GlyphId, Vec<(u16, Anchor)>>,
@@ -437,6 +441,19 @@ pub struct PreviouslyAssignedClass {
     pub glyph_id: GlyphId,
     /// The name of the previous class
     pub class: SmolStr,
+}
+
+impl std::error::Error for PreviouslyAssignedClass {}
+
+impl std::fmt::Display for PreviouslyAssignedClass {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Glyph '{}' was previously assigned to class '{}'",
+            self.glyph_id.to_u16(),
+            self.class
+        )
+    }
 }
 
 impl MarkToBaseBuilder {
@@ -499,7 +516,8 @@ impl Builder for MarkToBaseBuilder {
     }
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MarkToLigBuilder {
     marks: MarkList,
     ligatures: BTreeMap<GlyphId, Vec<BTreeMap<SmolStr, Anchor>>>,
@@ -569,7 +587,8 @@ impl Builder for MarkToLigBuilder {
 }
 
 /// A builder for GPOS Type 6 (Mark-to-Mark)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MarkToMarkBuilder {
     attaching_marks: MarkList,
     base_marks: BTreeMap<GlyphId, Vec<(u16, Anchor)>>,

--- a/fontbe/src/error.rs
+++ b/fontbe/src/error.rs
@@ -72,7 +72,7 @@ pub enum Error {
     #[error("No glyph class '{0}'")]
     MissingGlyphClass(GlyphName),
     #[error("Multiple assignments for class: {0:?}")]
-    PreviouslyAssignedClass(PreviouslyAssignedClass),
+    PreviouslyAssignedClass(#[from] PreviouslyAssignedClass),
 }
 
 #[derive(Debug)]

--- a/fontbe/src/features.rs
+++ b/fontbe/src/features.rs
@@ -18,7 +18,7 @@ use ordered_float::OrderedFloat;
 use fea_rs::{
     compile::{
         Compilation, FeatureBuilder, FeatureProvider, MarkToBaseBuilder, MarkToMarkBuilder,
-        PairPosBuilder, VariationInfo,
+        VariationInfo,
     },
     parse::{SourceLoadError, SourceResolver},
     Compiler,
@@ -197,15 +197,11 @@ impl<'a> FeatureWriter<'a> {
         if self.kerning.is_empty() {
             return Ok(());
         }
-        let mut ppos_subtables = PairPosBuilder::default();
-
-        for kern in self.kerning.kerns() {
-            kern.insert_into(&mut ppos_subtables);
-        }
+        let pairpos_subtables = self.kerning.lookups.clone();
 
         // now we have a builder for the pairpos subtables, so we can make
         // a lookup:
-        let lookups = vec![builder.add_lookup(LookupFlag::empty(), None, vec![ppos_subtables])];
+        let lookups = vec![builder.add_lookup(LookupFlag::empty(), None, pairpos_subtables)];
         builder.add_to_default_language_systems(Tag::new(b"kern"), &lookups);
 
         {

--- a/fontbe/src/features.rs
+++ b/fontbe/src/features.rs
@@ -16,10 +16,7 @@ use log::{debug, error, trace, warn};
 use ordered_float::OrderedFloat;
 
 use fea_rs::{
-    compile::{
-        Compilation, FeatureBuilder, FeatureProvider, MarkToBaseBuilder, MarkToMarkBuilder,
-        VariationInfo,
-    },
+    compile::{Compilation, FeatureBuilder, FeatureProvider, VariationInfo},
     parse::{SourceLoadError, SourceResolver},
     Compiler,
 };
@@ -238,58 +235,20 @@ impl<'a> FeatureWriter<'a> {
         let mut mark_mark_lookups = Vec::new();
 
         for mark_base in marks.mark_base.iter() {
-            let mut mark_base_builder = MarkToBaseBuilder::default();
-            for mark in mark_base.marks.iter() {
-                mark_base_builder
-                    .insert_mark(
-                        mark.gid,
-                        mark_base.class.clone(),
-                        mark.create_anchor_table(),
-                    )
-                    .map_err(Error::PreviouslyAssignedClass)?;
-            }
-
-            for base in mark_base.bases.iter() {
-                mark_base_builder.insert_base(
-                    base.gid,
-                    &mark_base.class,
-                    base.create_anchor_table(),
-                )
-            }
-
             // each mark to base it's own lookup, whch differs from fontmake
             mark_base_lookups.push(builder.add_lookup(
                 LookupFlag::default(),
                 None,
-                vec![mark_base_builder],
+                vec![mark_base.to_owned()],
             ));
         }
 
         // If a mark has anchors that are themselves marks what we got here is a mark to mark
         for mark_mark in marks.mark_mark.iter() {
-            let mut mark_mark_builder = MarkToMarkBuilder::default();
-
-            for mark in mark_mark.attaching_marks.iter() {
-                mark_mark_builder
-                    .insert_mark1(
-                        mark.gid,
-                        mark_mark.class.clone(),
-                        mark.create_anchor_table(),
-                    )
-                    .map_err(Error::PreviouslyAssignedClass)?;
-            }
-
-            for base in mark_mark.base_marks.iter() {
-                mark_mark_builder.insert_mark2(
-                    base.gid,
-                    &mark_mark.class,
-                    base.create_anchor_table(),
-                );
-            }
             mark_mark_lookups.push(builder.add_lookup(
                 LookupFlag::default(),
-                Some(mark_mark.filter_set.clone().into()),
-                vec![mark_mark_builder],
+                None,
+                vec![mark_mark.to_owned()],
             ));
         }
 

--- a/fontbe/src/orchestration.rs
+++ b/fontbe/src/orchestration.rs
@@ -282,30 +282,6 @@ pub enum Kern {
     },
 }
 
-impl Kern {
-    pub fn insert_into(&self, ppos_subtables: &mut PairPosBuilder) {
-        match self {
-            Kern::Pair {
-                glyph0,
-                glyph1,
-                x_advance,
-            } => {
-                ppos_subtables.insert_pair(*glyph0, x_advance.clone(), *glyph1, Default::default())
-            }
-            Kern::Class {
-                glyphs0,
-                glyphs1,
-                x_advance,
-            } => ppos_subtables.insert_classes(
-                glyphs0.clone(),
-                x_advance.clone(),
-                glyphs1.clone(),
-                Default::default(),
-            ),
-        }
-    }
-}
-
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(crate) struct MarkGroupName(pub(crate) SmolStr);
 
@@ -438,47 +414,12 @@ impl Persistable for Marks {
 /// [`fea_rs::compile::PairPosBuilder`] in advance.
 #[derive(Default, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Kerning {
-    deltas: Vec<Vec<(BeVariationRegion, i16)>>,
-    kerns: Vec<Kern>,
+    pub lookups: Vec<PairPosBuilder>,
 }
 
 impl Kerning {
     pub fn is_empty(&self) -> bool {
-        self.kerns.is_empty()
-    }
-
-    pub fn deltas(&self) -> impl Iterator<Item = &Vec<(BeVariationRegion, i16)>> {
-        self.deltas.iter()
-    }
-
-    pub fn kerns(&self) -> impl Iterator<Item = &Kern> {
-        self.kerns.iter()
-    }
-
-    pub fn add_deltas(&mut self, deltas: Vec<(BeVariationRegion, i16)>) -> usize {
-        self.deltas.push(deltas);
-        self.deltas.len() - 1
-    }
-
-    pub fn add_pair(&mut self, glyph0: GlyphId, x_advance: ValueRecordBuilder, glyph1: GlyphId) {
-        self.kerns.push(Kern::Pair {
-            glyph0,
-            glyph1,
-            x_advance,
-        })
-    }
-
-    pub fn add_class(
-        &mut self,
-        glyphs0: GlyphSet,
-        x_advance: ValueRecordBuilder,
-        glyphs1: GlyphSet,
-    ) {
-        self.kerns.push(Kern::Class {
-            glyphs0,
-            glyphs1,
-            x_advance,
-        })
+        self.lookups.is_empty()
     }
 }
 


### PR DESCRIPTION
This is followup to #598; since we don't need access to the feature builder in order to construct anchors or value records, we can now construct the various builders directly in the relevant tasks.