### PR TITLE
[fontir] Remove custom serde impl for Kerning

### DIFF
--- a/fontdrasil/src/coords.rs
+++ b/fontdrasil/src/coords.rs
@@ -13,7 +13,9 @@ use serde::{Deserialize, Serialize};
 use write_fonts::types::{F2Dot14, Fixed, Tag};
 
 use crate::{
-    piecewise_linear_map::PiecewiseLinearMap, serde::CoordConverterSerdeRepr, types::Axis,
+    piecewise_linear_map::PiecewiseLinearMap,
+    serde::{CoordConverterSerdeRepr, LocationSerdeRepr},
+    types::Axis,
 };
 
 /// A coordinate in some arbitrary space the designer dreamed up.
@@ -43,7 +45,9 @@ pub struct NormalizedCoord(OrderedFloat<f32>);
 /// E.g. a user location is a `Location<UserCoord>`. Hashable so it can do things like be
 /// the key for a map of sources by location.
 #[derive(Serialize, Deserialize, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct Location<T>(BTreeMap<Tag, T>);
+#[serde(from = "LocationSerdeRepr<T>", into = "LocationSerdeRepr<T>")]
+// we need this trait bound here for our serde impl to work
+pub struct Location<T: Clone>(pub(crate) BTreeMap<Tag, T>);
 
 pub type DesignLocation = Location<DesignCoord>;
 pub type UserLocation = Location<UserCoord>;

--- a/fontdrasil/src/serde.rs
+++ b/fontdrasil/src/serde.rs
@@ -1,11 +1,15 @@
-use crate::coords::{CoordConverter, DesignCoord, UserCoord};
+use crate::coords::{CoordConverter, DesignCoord, Location, UserCoord};
 use serde::{Deserialize, Serialize};
+use write_fonts::types::Tag;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub(crate) struct CoordConverterSerdeRepr {
     default_idx: usize,
     user_to_design: Vec<(f32, f32)>,
 }
+
+#[derive(Serialize, Deserialize, Debug)]
+pub(crate) struct LocationSerdeRepr<T>(Vec<(Tag, T)>);
 
 impl From<CoordConverterSerdeRepr> for CoordConverter {
     fn from(from: CoordConverterSerdeRepr) -> Self {
@@ -31,5 +35,17 @@ impl From<CoordConverter> for CoordConverterSerdeRepr {
             default_idx: from.default_idx,
             user_to_design,
         }
+    }
+}
+
+impl<T: Clone> From<LocationSerdeRepr<T>> for Location<T> {
+    fn from(src: LocationSerdeRepr<T>) -> Location<T> {
+        Location(src.0.into_iter().collect())
+    }
+}
+
+impl<T: Clone> From<Location<T>> for LocationSerdeRepr<T> {
+    fn from(src: Location<T>) -> LocationSerdeRepr<T> {
+        LocationSerdeRepr(src.0.into_iter().collect())
     }
 }

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -27,8 +27,8 @@ use crate::{
     error::{PathConversionError, VariationModelError, WorkError},
     orchestration::{IdAware, Persistable, WorkId},
     serde::{
-        GlobalMetricsSerdeRepr, GlyphOrderSerdeRepr, GlyphSerdeRepr, KerningSerdeRepr,
-        MiscSerdeRepr, StaticMetadataSerdeRepr,
+        GlobalMetricsSerdeRepr, GlyphOrderSerdeRepr, GlyphSerdeRepr, MiscSerdeRepr,
+        StaticMetadataSerdeRepr,
     },
     variations::VariationModel,
 };
@@ -206,7 +206,6 @@ type KernValues = BTreeMap<NormalizedLocation, OrderedFloat<f32>>;
 /// In UFO terms, roughly [groups.plist](https://unifiedfontobject.org/versions/ufo3/groups.plist/)
 /// and [kerning.plist](https://unifiedfontobject.org/versions/ufo3/kerning.plist/) combined.
 #[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq, Eq)]
-#[serde(from = "KerningSerdeRepr", into = "KerningSerdeRepr")]
 pub struct Kerning {
     pub groups: BTreeMap<GroupName, BTreeSet<GlyphName>>,
     /// An adjustment to the space *between* two glyphs in logical order.

--- a/fontir/src/serde.rs
+++ b/fontir/src/serde.rs
@@ -12,9 +12,8 @@ use write_fonts::{tables::os2::SelectionFlags, types::Tag};
 
 use crate::{
     ir::{
-        GlobalMetric, GlobalMetrics, Glyph, GlyphBuilder, GlyphInstance, GlyphOrder,
-        KernParticipant, Kerning, MiscMetadata, NameKey, NamedInstance, PostscriptNames,
-        StaticMetadata,
+        GlobalMetric, GlobalMetrics, Glyph, GlyphBuilder, GlyphInstance, GlyphOrder, MiscMetadata,
+        NameKey, NamedInstance, PostscriptNames, StaticMetadata,
     },
     stateset::{FileState, MemoryState, State, StateIdentifier, StateSet},
 };
@@ -73,88 +72,6 @@ impl From<GlyphOrderSerdeRepr> for GlyphOrder {
 impl From<GlyphOrder> for GlyphOrderSerdeRepr {
     fn from(value: GlyphOrder) -> Self {
         GlyphOrderSerdeRepr(value.into_iter().map(|v| v.to_string()).collect())
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub(crate) struct KerningSerdeRepr {
-    pub groups: Vec<KerningGroupSerdeRepr>,
-    pub kerns: Vec<KernSerdeRepr>,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub(crate) struct KerningGroupSerdeRepr {
-    name: String,
-    glyphs: Vec<String>,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub(crate) struct KernSerdeRepr {
-    side1: KernParticipant,
-    side2: KernParticipant,
-    values: Vec<(NormalizedLocation, f32)>,
-}
-
-impl From<Kerning> for KerningSerdeRepr {
-    fn from(from: Kerning) -> Self {
-        KerningSerdeRepr {
-            groups: from
-                .groups
-                .into_iter()
-                .map(|(name, glyphs)| {
-                    let name = name.to_string();
-                    let mut glyphs: Vec<_> = glyphs.iter().map(|g| g.to_string()).collect();
-                    glyphs.sort();
-                    KerningGroupSerdeRepr { name, glyphs }
-                })
-                .collect(),
-            kerns: from
-                .kerns
-                .into_iter()
-                .map(|((side1, side2), values)| {
-                    let mut values: Vec<_> = values
-                        .into_iter()
-                        .map(|(pos, adjustment)| (pos, adjustment.0))
-                        .collect();
-                    values.sort_by_key(|(pos, _)| pos.clone());
-                    KernSerdeRepr {
-                        side1,
-                        side2,
-                        values,
-                    }
-                })
-                .collect(),
-        }
-    }
-}
-
-impl From<KerningSerdeRepr> for Kerning {
-    fn from(from: KerningSerdeRepr) -> Self {
-        Kerning {
-            groups: from
-                .groups
-                .into_iter()
-                .map(|g| {
-                    (
-                        g.name.into(),
-                        g.glyphs.into_iter().map(|n| n.into()).collect(),
-                    )
-                })
-                .collect(),
-            kerns: from
-                .kerns
-                .into_iter()
-                .map(|k| {
-                    (
-                        (k.side1, k.side2),
-                        k.values
-                            .into_iter()
-                            .map(|(pos, value)| (pos, value.into()))
-                            .collect(),
-                    )
-                })
-                .collect(),
-        }
     }
 }
 


### PR DESCRIPTION
The problem was that serde_yaml doesn't like it when BTreeMap is used as the key to a collection. Since this is only the case in `Location`, it's much simpler to just have a cusom serde impl for that type.

I expect this will lead to further simplification, although I will leave that for additional PRs.

progress towards #495