### PR TITLE
Use italic_angle to set default hhea caret slope/run

### DIFF
--- a/fontbe/src/metrics_and_limits.rs
+++ b/fontbe/src/metrics_and_limits.rs
@@ -302,18 +302,19 @@ impl Work<Context, AnyWorkId, Error> for MetricAndLimitWork {
             ascender: FWord::new(default_metrics.hhea_ascender.into_inner().ot_round()),
             descender: FWord::new(default_metrics.hhea_descender.into_inner().ot_round()),
             line_gap: FWord::new(default_metrics.hhea_line_gap.into_inner().ot_round()),
-            caret_slope_rise: default_metrics.caret_slope_rise.into_inner().ot_round(),
             advance_width_max: glyph_limits.advance_width_max.into(),
             min_left_side_bearing,
             min_right_side_bearing,
             x_max_extent,
+            caret_slope_rise: default_metrics.caret_slope_rise.into_inner().ot_round(),
+            caret_slope_run: default_metrics.caret_slope_run.into_inner().ot_round(),
+            caret_offset: default_metrics.caret_offset.into_inner().ot_round(),
             number_of_long_metrics: long_metrics.len().try_into().map_err(|_| {
                 Error::OutOfBounds {
                     what: "number_of_long_metrics".into(),
                     value: format!("{}", long_metrics.len()),
                 }
             })?,
-            ..Default::default()
         };
         context.hhea.set_unconditionally(hhea.into());
 

--- a/fontbe/src/os2.rs
+++ b/fontbe/src/os2.rs
@@ -864,7 +864,7 @@ mod tests {
     #[test]
     fn build_basic_os2() {
         let default_location = NormalizedLocation::new();
-        let mut global_metrics = GlobalMetrics::new(default_location.clone(), 1000, None);
+        let mut global_metrics = GlobalMetrics::new(default_location.clone(), 1000, None, 0.0);
 
         global_metrics.set(GlobalMetric::CapHeight, default_location.clone(), 37.5);
         global_metrics.set(GlobalMetric::XHeight, default_location.clone(), 112.2);

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -2525,4 +2525,28 @@ mod tests {
     fn italic_angle_in_designspace() {
         assert_post_italic_angle("designspace_from_glyphs/SlantedFont.designspace", -12.0);
     }
+
+    fn assert_hhea_caret_slope(source: &str, expected_slope_rise: i16, expected_slope_run: i16) {
+        let compile = TestCompile::compile_source(source);
+        let hhea = compile.font().hhea().unwrap();
+
+        assert_eq!(expected_slope_rise, hhea.caret_slope_rise());
+        assert_eq!(expected_slope_run, hhea.caret_slope_run());
+        assert_eq!(0, hhea.caret_offset());
+    }
+
+    #[test]
+    fn default_caret_slope_in_glyphs2() {
+        assert_hhea_caret_slope("glyphs2/SlantedFont.glyphs", 1000, 213);
+    }
+
+    #[test]
+    fn default_caret_slope_in_glyphs3() {
+        assert_hhea_caret_slope("glyphs3/SlantedFont.glyphs", 1000, 213);
+    }
+
+    #[test]
+    fn default_caret_slope_in_designspace() {
+        assert_hhea_caret_slope("designspace_from_glyphs/SlantedFont.designspace", 1000, 213);
+    }
 }

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -448,6 +448,7 @@ impl Work<Context, WorkId, WorkError> for GlobalMetricWork {
             static_metadata.default_location().clone(),
             static_metadata.units_per_em,
             font.default_master().x_height().map(|v| v.0 as f32),
+            static_metadata.italic_angle.into_inner(),
         );
 
         for master in font.masters.iter() {

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -921,6 +921,7 @@ impl Work<Context, WorkId, WorkError> for GlobalMetricsWork {
                 })?
                 .x_height
                 .map(|v| v as f32),
+            static_metadata.italic_angle.into_inner(),
         );
         for source in self
             .designspace
@@ -935,11 +936,6 @@ impl Work<Context, WorkId, WorkError> for GlobalMetricsWork {
 
             metrics.set_if_some(GlobalMetric::Ascender, pos.clone(), font_info.ascender);
             metrics.set_if_some(GlobalMetric::Descender, pos.clone(), font_info.descender);
-            metrics.set_if_some(
-                GlobalMetric::CaretSlopeRise,
-                pos.clone(),
-                font_info.open_type_hhea_caret_slope_rise.map(|v| v as f64),
-            );
             metrics.set_if_some(GlobalMetric::CapHeight, pos.clone(), font_info.cap_height);
             metrics.set_if_some(GlobalMetric::XHeight, pos.clone(), font_info.x_height);
             metrics.set_if_some(
@@ -981,6 +977,21 @@ impl Work<Context, WorkId, WorkError> for GlobalMetricsWork {
                 GlobalMetric::HheaLineGap,
                 pos.clone(),
                 font_info.open_type_hhea_line_gap.map(|v| v as f64),
+            );
+            metrics.set_if_some(
+                GlobalMetric::CaretSlopeRise,
+                pos.clone(),
+                font_info.open_type_hhea_caret_slope_rise.map(|v| v as f64),
+            );
+            metrics.set_if_some(
+                GlobalMetric::CaretSlopeRun,
+                pos.clone(),
+                font_info.open_type_hhea_caret_slope_run.map(|v| v as f64),
+            );
+            metrics.set_if_some(
+                GlobalMetric::CaretOffset,
+                pos.clone(),
+                font_info.open_type_hhea_caret_offset.map(|v| v as f64),
             );
         }
 


### PR DESCRIPTION
using the same logic as in ufo2ft.fontInfoData.

Also read the respective fields for caret rise/run in UFO fontinfo.plist and apply them if present.
For Glyphs sources, the caret slope rise/run cannot be overridden, only indirectly via the italic angle it seems to be able to control them.