### PR TITLE
[glypsh-reader] fix ParseIntError when custom param has unquoted string

### DIFF
--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -2402,6 +2402,18 @@ mod tests {
     }
 
     #[test]
+    fn vf_origin_unquoted_string() {
+        // the 'Variable Font Origin' custom parameter has the value `m01`,
+        // un un-quoted plist string, which happens to be the default master.id
+        // that Glyphs.app assigns to the predefined 'Regular' master that any
+        // "New Font" comes with when it is first crated.
+        // We just test that we do not crash attempting to parse the unquoted
+        // string as an integer.
+        let font = Font::load(&glyphs3_dir().join("CustomOrigin.glyphs")).unwrap();
+        assert_eq!(1, font.default_master_idx);
+    }
+
+    #[test]
     fn glyph_order_default_is_file_order() {
         let font = Font::load(&glyphs3_dir().join("WghtVar.glyphs")).unwrap();
         assert_eq!(

--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -355,6 +355,7 @@ impl CustomParameters {
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 enum CustomParameterValue {
     Int(i64),
+    Float(OrderedFloat<f64>),
     String(String),
     Axes(Vec<Axis>),
     AxesMappings(Vec<AxisMapping>),
@@ -393,22 +394,16 @@ impl FromPlist for CustomParameters {
                     "value" => {
                         let peek = tokenizer.peek()?;
                         match peek {
-                            // VendorID is a string but doesn't feel it needs quotes
-                            Token::Atom(..) if name == Some(String::from("vendorID")) => {
-                                let token = tokenizer.lex()?;
-                                let Token::Atom(val) = token else {
-                                    return Err(Error::UnexpectedDataType {
-                                        expected: "Atom",
-                                        found: token.name(),
-                                    });
-                                };
-                                value = Some(CustomParameterValue::String(val.to_string()));
-                            }
                             Token::Atom(..) => {
                                 let Token::Atom(val) = tokenizer.lex()? else {
                                     panic!("That shouldn't happen");
                                 };
-                                value = Some(CustomParameterValue::Int(val.parse().unwrap()));
+                                value = match Plist::parse(val)? {
+                                    Plist::Integer(i) => Some(CustomParameterValue::Int(i)),
+                                    Plist::Float(f) => Some(CustomParameterValue::Float(f)),
+                                    Plist::String(s) => Some(CustomParameterValue::String(s)),
+                                    _ => panic!("atom has to be int, float, or string"),
+                                };
                             }
                             Token::OpenBrace if name == Some(String::from("Axis Mappings")) => {
                                 let mappings: Vec<AxisMapping> = tokenizer

--- a/resources/testdata/glyphs3/CustomOrigin.glyphs
+++ b/resources/testdata/glyphs3/CustomOrigin.glyphs
@@ -1,0 +1,54 @@
+{
+.appVersion = "3227";
+.formatVersion = 3;
+axes = (
+{
+name = Weight;
+tag = wght;
+}
+);
+customParameters = (
+{
+name = "Variable Font Origin";
+value = m01;
+}
+);
+date = "2023-12-05 15:07:25 +0000";
+familyName = "WghtVar Custom Origin";
+fontMaster = (
+{
+axesValues = (
+100
+);
+id = "09676F4A-DA0D-41A4-A56F-3296CE3BD503";
+name = "Master 1";
+},
+{
+axesValues = (
+400
+);
+id = m01;
+name = "Master 2";
+}
+);
+glyphs = (
+{
+glyphname = space;
+lastChange = "2023-12-05 15:14:26 +0000";
+layers = (
+{
+layerId = m01;
+width = 200;
+},
+{
+layerId = "09676F4A-DA0D-41A4-A56F-3296CE3BD503";
+width = 300;
+}
+);
+unicode = 32;
+}
+);
+unitsPerEm = 1000;
+versionMajor = 1;
+versionMinor = 0;
+}


### PR DESCRIPTION
If you create a New Font from Glyphs.app and then add a 'Variable Font Origin' custom parameter (which we currently do support) and set this to the first and only master that the newly created font comes with (which Glyphs.app assigns the id of `m01` using an unquoted plist string), and then attempt to compile, you will get a ParseIntError when parsing the custom parameters, because glyphs-reader thinks that it is an integer.

I add a reproducer first, and follow up with the actual fix.

