### PR TITLE
Cleanup for the CoordConverter type

### DIFF
--- a/fontdrasil/src/coords.rs
+++ b/fontdrasil/src/coords.rs
@@ -116,7 +116,12 @@ impl CoordConverter {
 
     /// Walk the vertices of the mappings, viewing the user/design/normalized value at each stop.
     pub fn iter(&self) -> impl Iterator<Item = (UserCoord, DesignCoord, NormalizedCoord)> + '_ {
-        CoordConverterIter::new(self)
+        self.user_to_design.iter().map(|(user, design)| {
+            let user = UserCoord::new(user);
+            let design = DesignCoord::new(design);
+            let normalized = user.to_normalized(self);
+            (user, design, normalized)
+        })
     }
 
     /// How many mapping points exist
@@ -126,35 +131,6 @@ impl CoordConverter {
 
     pub fn is_empty(&self) -> bool {
         self.user_to_design.len() == 0
-    }
-}
-
-struct CoordConverterIter<'a> {
-    idx: usize,
-    converter: &'a CoordConverter,
-}
-
-impl<'a> CoordConverterIter<'a> {
-    fn new(converter: &'a CoordConverter) -> Self {
-        CoordConverterIter { idx: 0, converter }
-    }
-}
-
-impl<'a> Iterator for CoordConverterIter<'a> {
-    type Item = (UserCoord, DesignCoord, NormalizedCoord);
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.idx >= self.converter.user_to_design.len() {
-            return None;
-        }
-
-        let user = UserCoord::new(self.converter.user_to_design.from[self.idx]);
-        let design = DesignCoord::new(self.converter.user_to_design.to[self.idx]);
-        let normalized = user.to_normalized(self.converter);
-
-        let result = (user, design, normalized);
-        self.idx += 1;
-        Some(result)
     }
 }
 

--- a/fontdrasil/src/coords.rs
+++ b/fontdrasil/src/coords.rs
@@ -12,11 +12,7 @@ use ordered_float::OrderedFloat;
 use serde::{Deserialize, Serialize};
 use write_fonts::types::{F2Dot14, Fixed, Tag};
 
-use crate::{
-    piecewise_linear_map::PiecewiseLinearMap,
-    serde::{CoordConverterSerdeRepr, LocationSerdeRepr},
-    types::Axis,
-};
+use crate::{piecewise_linear_map::PiecewiseLinearMap, serde::LocationSerdeRepr, types::Axis};
 
 /// A coordinate in some arbitrary space the designer dreamed up.
 ///
@@ -58,7 +54,6 @@ pub type NormalizedLocation = Location<NormalizedCoord>;
 /// Stores [PiecewiseLinearMap]'s in several directions. Sources
 /// suggest <= 10 mappings is typical, we can afford the bytes.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
-#[serde(from = "CoordConverterSerdeRepr", into = "CoordConverterSerdeRepr")]
 pub struct CoordConverter {
     pub(crate) default_idx: usize,
     pub(crate) user_to_design: PiecewiseLinearMap,

--- a/fontdrasil/src/piecewise_linear_map.rs
+++ b/fontdrasil/src/piecewise_linear_map.rs
@@ -5,8 +5,9 @@
 //! xvalue to a userspace (fvar) value.
 
 use ordered_float::OrderedFloat;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PiecewiseLinearMap {
     pub(crate) from: Vec<OrderedFloat<f32>>, // sorted, ||'s to
     pub(crate) to: Vec<OrderedFloat<f32>>,   // sorted, ||'s from

--- a/fontdrasil/src/piecewise_linear_map.rs
+++ b/fontdrasil/src/piecewise_linear_map.rs
@@ -9,8 +9,9 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PiecewiseLinearMap {
-    pub(crate) from: Vec<OrderedFloat<f32>>, // sorted, ||'s to
-    pub(crate) to: Vec<OrderedFloat<f32>>,   // sorted, ||'s from
+    // these two mappings have identical lengths, by construction
+    from: Vec<OrderedFloat<f32>>, // sorted, ||'s to
+    to: Vec<OrderedFloat<f32>>,   // sorted, ||'s from
 }
 
 impl PiecewiseLinearMap {
@@ -33,6 +34,14 @@ impl PiecewiseLinearMap {
             .zip(self.from.iter().copied())
             .collect();
         PiecewiseLinearMap::new(mappings)
+    }
+
+    /// An iterator over (from, to) values.
+    pub(crate) fn iter(&self) -> impl Iterator<Item = (f32, f32)> + '_ {
+        self.from
+            .iter()
+            .zip(self.to.iter())
+            .map(|(from, to)| (from.0, to.0))
     }
 
     /// Based on <https://github.com/fonttools/fonttools/blob/5a0dc4bc8dfaa0c7da146cf902395f748b3cebe5/Lib/fontTools/varLib/models.py#L502>

--- a/fontdrasil/src/serde.rs
+++ b/fontdrasil/src/serde.rs
@@ -1,42 +1,9 @@
-use crate::coords::{CoordConverter, DesignCoord, Location, UserCoord};
+use crate::coords::Location;
 use serde::{Deserialize, Serialize};
 use write_fonts::types::Tag;
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub(crate) struct CoordConverterSerdeRepr {
-    default_idx: usize,
-    user_to_design: Vec<(f32, f32)>,
-}
-
 #[derive(Serialize, Deserialize, Debug)]
 pub(crate) struct LocationSerdeRepr<T>(Vec<(Tag, T)>);
-
-impl From<CoordConverterSerdeRepr> for CoordConverter {
-    fn from(from: CoordConverterSerdeRepr) -> Self {
-        let examples = from
-            .user_to_design
-            .into_iter()
-            .map(|(u, d)| (UserCoord::new(u), DesignCoord::new(d)))
-            .collect();
-        CoordConverter::new(examples, from.default_idx)
-    }
-}
-
-impl From<CoordConverter> for CoordConverterSerdeRepr {
-    fn from(from: CoordConverter) -> Self {
-        let user_to_design = from
-            .user_to_design
-            .from
-            .iter()
-            .zip(from.user_to_design.to)
-            .map(|(u, d)| (u.into_inner(), d.into_inner()))
-            .collect();
-        CoordConverterSerdeRepr {
-            default_idx: from.default_idx,
-            user_to_design,
-        }
-    }
-}
 
 impl<T: Clone> From<LocationSerdeRepr<T>> for Location<T> {
     fn from(src: LocationSerdeRepr<T>) -> Location<T> {


### PR DESCRIPTION
This contains two commits, one that removes the serde impl and one that removes the custom iterator in favour of `iter().map()`.


One other note here: it *feels* to me like `OrderedFloat` is basically an implementation detail, and that we shouldn't need to use it in public API, but I see that it is used in lots of places so I'm not totally sure. Does anyone remember the original motivation for using this type? was it just ensuring that we have `Eq` and `Ord`, for putting it in collections?

oh I also had another question: I noticed that the `PiecewiseLinearMap` stores floats instead of our `Coord` types... is this because we anticipated it being used in other places? If not I think the API would be clearer if we just used the coord types directly here. (edit: I think i can answer my own question here, and maybe it's just because we use this type to store various mappings in various coordinate spaces? but if we end up merging #632 then we can make the piecewise map generic over two coordinate spaces, which would be nice?)