### PR TITLE
[fontdrasil] Make piecewise_linear_map module private

### DIFF
--- a/fontdrasil/src/lib.rs
+++ b/fontdrasil/src/lib.rs
@@ -3,6 +3,6 @@
 pub mod coords;
 pub mod orchestration;
 pub mod paths;
-pub mod piecewise_linear_map;
+mod piecewise_linear_map;
 mod serde;
 pub mod types;


### PR DESCRIPTION
It is not actually used anywhere else currently, and making it private provides some benefits (specifically we will more warnings about unused methods/dead code)

(JMM)