### PR TITLE
Add an error type to the VariationInfo trait

### DIFF
--- a/fea-rs/src/bin/compile.rs
+++ b/fea-rs/src/bin/compile.rs
@@ -7,7 +7,7 @@ use fea_rs::{
     compile::{
         self,
         error::{FontGlyphOrderError, GlyphOrderError, UfoGlyphOrderError},
-        Compiler, MockVariationInfo, Opts,
+        Compiler, MockVariationInfo, NopFeatureProvider, Opts,
     },
     GlyphMap,
 };
@@ -34,7 +34,7 @@ fn run() -> Result<(), Error> {
 
     let var_info = args.get_var_info().transpose()?;
 
-    let mut compiler =
+    let mut compiler: Compiler<'_, NopFeatureProvider, MockVariationInfo> =
         Compiler::new(fea, &glyph_names).with_opts(Opts::new().make_post_table(args.post));
     if let Some(var_info) = var_info.as_ref() {
         log::info!("compiling with {} mock variation axes", var_info.axes.len());

--- a/fea-rs/src/compile.rs
+++ b/fea-rs/src/compile.rs
@@ -13,7 +13,7 @@ use self::{
 use self::error::UfoGlyphOrderError;
 
 pub use compiler::Compiler;
-pub use feature_writer::{FeatureBuilder, FeatureProvider};
+pub use feature_writer::{FeatureBuilder, FeatureProvider, NopFeatureProvider};
 pub use language_system::LanguageSystem;
 pub use lookups::{
     FeatureKey, LookupId, MarkToBaseBuilder, MarkToMarkBuilder, PairPosBuilder,
@@ -22,7 +22,7 @@ pub use lookups::{
 pub use metrics::{Anchor, ValueRecord};
 pub use opts::Opts;
 pub use output::Compilation;
-pub use variations::{AxisLocation, VariationInfo};
+pub use variations::{AxisLocation, NopVariationInfo, VariationInfo};
 
 #[cfg(any(test, feature = "test", feature = "cli"))]
 pub use variations::MockVariationInfo;
@@ -44,10 +44,10 @@ mod validate;
 mod variations;
 
 /// Run the validation pass, returning any diagnostics.
-pub(crate) fn validate(
+pub(crate) fn validate<V: VariationInfo>(
     node: &ParseTree,
     glyph_map: &GlyphMap,
-    fvar: Option<&dyn VariationInfo>,
+    fvar: Option<&V>,
 ) -> Vec<Diagnostic> {
     let mut ctx = validate::ValidationCtx::new(node.source_map(), glyph_map, fvar);
     ctx.validate_root(&node.typed_root());

--- a/fea-rs/src/compile/compile_ctx.rs
+++ b/fea-rs/src/compile/compile_ctx.rs
@@ -62,12 +62,12 @@ use super::{
 /// - call `CompilationCtx::build`. This checks if any errors were encountered
 ///   during compilation, and if not converts the accumulated internal state into
 ///   the final output, ready to be written to binary.
-pub struct CompilationCtx<'a> {
+pub struct CompilationCtx<'a, F: FeatureProvider, V: VariationInfo> {
     glyph_map: &'a GlyphMap,
     reverse_glyph_map: BTreeMap<GlyphId, GlyphIdent>,
     source_map: &'a SourceMap,
-    variation_info: Option<&'a dyn VariationInfo>,
-    feature_writer: Option<&'a dyn FeatureProvider>,
+    variation_info: Option<&'a V>,
+    feature_writer: Option<&'a F>,
     /// Any errors or warnings generated during compilation.
     pub errors: Vec<Diagnostic>,
     /// Stores any [specified table values][tables] in the input FEA.
@@ -93,12 +93,12 @@ pub struct CompilationCtx<'a> {
     mark_filter_sets: HashMap<GlyphSet, FilterSetId>,
 }
 
-impl<'a> CompilationCtx<'a> {
+impl<'a, F: FeatureProvider, V: VariationInfo> CompilationCtx<'a, F, V> {
     pub(crate) fn new(
         glyph_map: &'a GlyphMap,
         source_map: &'a SourceMap,
-        variation_info: Option<&'a dyn VariationInfo>,
-        feature_writer: Option<&'a dyn FeatureProvider>,
+        variation_info: Option<&'a V>,
+        feature_writer: Option<&'a F>,
     ) -> Self {
         CompilationCtx {
             glyph_map,

--- a/fea-rs/src/compile/compiler.rs
+++ b/fea-rs/src/compile/compiler.rs
@@ -23,27 +23,27 @@ const DEFAULT_N_MESSAGES_TO_PRINT: usize = 100;
 /// This is intended as the principal public API for this crate.
 ///
 /// ```no_run
-/// # use fea_rs::Compiler;
+/// # use fea_rs::{Compiler, compile::{NopFeatureProvider, NopVariationInfo}};
 /// # fn make_glyph_map() -> fea_rs::GlyphMap { todo!() }
 /// let glyph_map = make_glyph_map();
-/// let my_font_bytes = Compiler::new("path/to/features.fea", &glyph_map)
+/// let my_font_bytes = Compiler::<'_, NopFeatureProvider, NopVariationInfo>::new("path/to/features.fea", &glyph_map)
 ///     .verbose(true)
 ///     .compile_binary().unwrap();
 /// ```
-pub struct Compiler<'a> {
+pub struct Compiler<'a, F: FeatureProvider, V: VariationInfo> {
     root_path: OsString,
     project_root: Option<PathBuf>,
     glyph_map: &'a GlyphMap,
     // variable fonts only
-    var_info: Option<&'a dyn VariationInfo>,
-    feature_writer: Option<&'a dyn FeatureProvider>,
+    var_info: Option<&'a V>,
+    feature_writer: Option<&'a F>,
     print_warnings: bool,
     max_n_errors: usize,
     opts: Opts,
     resolver: Option<Box<dyn SourceResolver>>,
 }
 
-impl<'a> Compiler<'a> {
+impl<'a, F: FeatureProvider, V: VariationInfo> Compiler<'a, F, V> {
     /// Configure a new compilation run with a root source and a glyph map.
     ///
     /// In the general case, `root_path` will be a path to a feature file on disk;
@@ -73,13 +73,13 @@ impl<'a> Compiler<'a> {
     }
 
     /// Provide [`VariationInfo`], necessary when compiling features for a variable font.
-    pub fn with_variable_info(mut self, var_info: &'a dyn VariationInfo) -> Self {
+    pub fn with_variable_info(mut self, var_info: &'a V) -> Self {
         self.var_info = Some(var_info);
         self
     }
 
     /// Provide [`FeatureProvider`] to provide additional features during compilation
-    pub fn with_feature_writer(mut self, feature_writer: &'a dyn FeatureProvider) -> Self {
+    pub fn with_feature_writer(mut self, feature_writer: &'a F) -> Self {
         self.feature_writer = Some(feature_writer);
         self
     }

--- a/fea-rs/src/compile/feature_writer.rs
+++ b/fea-rs/src/compile/feature_writer.rs
@@ -19,6 +19,13 @@ pub trait FeatureProvider {
     fn add_features(&self, builder: &mut FeatureBuilder);
 }
 
+/// A nop implementation of [FeatureProvider]
+pub struct NopFeatureProvider;
+
+impl FeatureProvider for NopFeatureProvider {
+    fn add_features(&self, _: &mut FeatureBuilder) {}
+}
+
 /// A structure that allows client code to add additional features to the compilation.
 pub struct FeatureBuilder<'a> {
     pub(crate) language_systems: &'a DefaultLanguageSystems,

--- a/fea-rs/src/compile/validate.rs
+++ b/fea-rs/src/compile/validate.rs
@@ -27,11 +27,11 @@ use crate::{
     Diagnostic, GlyphMap, Kind, NodeOrToken,
 };
 
-pub struct ValidationCtx<'a> {
+pub struct ValidationCtx<'a, V: VariationInfo> {
     pub errors: Vec<Diagnostic>,
     glyph_map: &'a GlyphMap,
     source_map: &'a SourceMap,
-    variation_info: Option<&'a dyn VariationInfo>,
+    variation_info: Option<&'a V>,
     default_lang_systems: HashSet<(SmolStr, SmolStr)>,
     seen_non_default_script: bool,
     lookup_defs: HashMap<SmolStr, Token>,
@@ -46,11 +46,11 @@ pub struct ValidationCtx<'a> {
     all_features: HashSet<Tag>,
 }
 
-impl<'a> ValidationCtx<'a> {
+impl<'a, V: VariationInfo> ValidationCtx<'a, V> {
     pub(crate) fn new(
         source_map: &'a SourceMap,
         glyph_map: &'a GlyphMap,
-        variation_info: Option<&'a dyn VariationInfo>,
+        variation_info: Option<&'a V>,
     ) -> Self {
         ValidationCtx {
             glyph_map,

--- a/fea-rs/src/compile/variations.rs
+++ b/fea-rs/src/compile/variations.rs
@@ -1,10 +1,15 @@
 //! compiling variable fonts
 
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    fmt::{Debug, Display},
+};
 
 use fontdrasil::{coords::NormalizedLocation, types::Axis};
 use ordered_float::OrderedFloat;
 use write_fonts::{tables::variations::VariationRegion, types::Tag};
+
+type DefaultAndVariations = (i16, Vec<(VariationRegion, i16)>);
 
 /// A trait for providing variable font information to the compiler.
 ///
@@ -14,6 +19,9 @@ use write_fonts::{tables::variations::VariationRegion, types::Tag};
 ///
 /// This trait abstracts over that info.
 pub trait VariationInfo {
+    /// The error type
+    type Error: Debug + Display;
+
     /// If the tag is an axis in this font, it's fvar index and it's [`Axis`] data.
     fn axis(&self, axis_tag: Tag) -> Option<(usize, &Axis)>;
 
@@ -24,10 +32,26 @@ pub trait VariationInfo {
     fn resolve_variable_metric(
         &self,
         locations: &HashMap<NormalizedLocation, i16>,
-    ) -> Result<(i16, Vec<(VariationRegion, i16)>), AnyError>;
+    ) -> Result<DefaultAndVariations, Self::Error>;
 }
 
-pub type AnyError = Box<dyn std::error::Error>;
+/// Inert variation info
+pub struct NopVariationInfo;
+
+impl VariationInfo for NopVariationInfo {
+    type Error = &'static str;
+
+    fn axis(&self, _: Tag) -> Option<(usize, &Axis)> {
+        None
+    }
+
+    fn resolve_variable_metric(
+        &self,
+        _: &HashMap<NormalizedLocation, i16>,
+    ) -> Result<DefaultAndVariations, Self::Error> {
+        Ok((0, Default::default()))
+    }
+}
 
 /// A type that implements [`VariationInfo`], for testing and debugging.
 #[derive(Clone, Debug, Default)]
@@ -148,6 +172,8 @@ impl MockVariationInfo {
 }
 
 impl VariationInfo for MockVariationInfo {
+    type Error = u32;
+
     fn axis(&self, axis_tag: Tag) -> Option<(usize, &Axis)> {
         self.axes.iter().enumerate().find_map(|(i, axis)| {
             if axis_tag == axis.tag {
@@ -161,7 +187,7 @@ impl VariationInfo for MockVariationInfo {
     fn resolve_variable_metric(
         &self,
         _locations: &HashMap<NormalizedLocation, i16>,
-    ) -> Result<(i16, Vec<(VariationRegion, i16)>), Box<(dyn std::error::Error + 'static)>> {
+    ) -> Result<(i16, Vec<(VariationRegion, i16)>), Self::Error> {
         Ok(Default::default())
     }
 }

--- a/fea-rs/src/tests/compile.rs
+++ b/fea-rs/src/tests/compile.rs
@@ -3,7 +3,7 @@
 use std::path::{Path, PathBuf};
 
 use crate::{
-    compile::{error::CompilerError, Compiler, MockVariationInfo, Opts},
+    compile::{error::CompilerError, Compiler, MockVariationInfo, NopFeatureProvider, Opts},
     util::ttx::{self as test_utils, Report, TestCase, TestResult},
     GlyphMap, GlyphName,
 };
@@ -106,9 +106,10 @@ fn bad_test_body(
     glyph_map: &GlyphMap,
     var_info: &MockVariationInfo,
 ) -> Result<(), TestResult> {
-    let mut compiler = Compiler::new(path, glyph_map)
-        .print_warnings(std::env::var(crate::util::VERBOSE).is_ok())
-        .with_opts(Opts::new().make_post_table(true));
+    let mut compiler: Compiler<'_, NopFeatureProvider, MockVariationInfo> =
+        Compiler::new(path, glyph_map)
+            .print_warnings(std::env::var(crate::util::VERBOSE).is_ok())
+            .with_opts(Opts::new().make_post_table(true));
     if test_utils::is_variable(path) {
         compiler = compiler.with_variable_info(var_info);
     }

--- a/fea-rs/src/util/ttx.rs
+++ b/fea-rs/src/util/ttx.rs
@@ -13,7 +13,7 @@ use std::{
 use crate::{
     compile::{
         error::{CompilerError, DiagnosticSet},
-        Compiler, MockVariationInfo, Opts,
+        Compiler, MockVariationInfo, NopFeatureProvider, Opts,
     },
     Diagnostic, GlyphIdent, GlyphMap, ParseTree,
 };
@@ -238,9 +238,10 @@ pub(crate) fn run_test(
     fvar: &MockVariationInfo,
 ) -> Result<PathBuf, TestCase> {
     match std::panic::catch_unwind(|| {
-        let mut compiler = Compiler::new(&path, glyph_map)
-            .print_warnings(std::env::var(super::VERBOSE).is_ok())
-            .with_opts(Opts::new().make_post_table(true));
+        let mut compiler: Compiler<'_, NopFeatureProvider, MockVariationInfo> =
+            Compiler::new(&path, glyph_map)
+                .print_warnings(std::env::var(super::VERBOSE).is_ok())
+                .with_opts(Opts::new().make_post_table(true));
         if is_variable(&path) {
             compiler = compiler.with_variable_info(fvar);
         }

--- a/fontbe/src/error.rs
+++ b/fontbe/src/error.rs
@@ -1,7 +1,7 @@
 use std::{fmt::Display, io, path::PathBuf};
 
 use fea_rs::compile::error::CompilerError;
-use fontdrasil::types::GlyphName;
+use fontdrasil::{coords::NormalizedLocation, types::GlyphName};
 use fontir::{
     error::VariationModelError, orchestration::WorkId as FeWorkId, variations::DeltaError,
 };
@@ -78,6 +78,10 @@ pub enum Error {
         new_class: SmolStr,
         glyph: GlyphName,
     },
+    #[error("No variation model for '{0:?}'")]
+    NoVariationModel(NormalizedLocation),
+    #[error("Delta error '{0:?}'")]
+    DeltaError(DeltaError),
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Drop a dyn while we're at it as any given use of the compiler seems likely to use a specific type. Maybe we should do that to source resolver too?

Fixes #535.