### PR TITLE
[ufo2fontir] Avoid duplicate loading of kerning groups

### DIFF
--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -1220,15 +1220,15 @@ impl Work<Context, WorkId, WorkError> for KerningWork {
             .enumerate()
             .filter(|(idx, source)| !is_glyph_only(source) && *idx != default_master_idx)
         {
-            for (name, entries) in kerning_groups_for(designspace_dir, &glyph_order, source)? {
-                let Some(real_name) = reverse_groups.get(&(KernSide::of(&name), &entries)) else {
+            for (name, entries) in &kerning.groups {
+                let Some(real_name) = reverse_groups.get(&(KernSide::of(name), &entries)) else {
                     warn!(
                         "{name} exists only in {} and will be ignored",
                         source.name.as_ref().unwrap()
                     );
                     continue;
                 };
-                if name == **real_name {
+                if name == *real_name {
                     continue;
                 }
                 warn!(
@@ -1236,7 +1236,7 @@ impl Work<Context, WorkId, WorkError> for KerningWork {
                     source.name.as_ref().unwrap(),
                     default_master.name.as_ref().unwrap()
                 );
-                old_to_new_group_name.insert(name, *real_name);
+                old_to_new_group_name.insert(name.to_owned(), *real_name);
             }
         }
 


### PR DESCRIPTION
we were calling the (very expensive) kerning_groups_for function twice, whene we can trivially reuse the results of the first call.

this looks to make a measurable difference before/after (in a profile this fn accounted for .6% of the total compile time)

```
Benchmark 1: target/release/fontc ../fontfiles/googlesans/source/GoogleSans/GoogleSans.designspace
  Time (mean ± σ):      4.327 s ±  0.060 s    [User: 6.830 s, System: 3.038 s]
  Range (min … max):    4.252 s …  4.443 s    10 runs


Benchmark 1: target/release/fontc ../fontfiles/googlesans/source/GoogleSans/GoogleSans.designspace
  Time (mean ± σ):      4.282 s ±  0.044 s    [User: 6.835 s, System: 3.034 s]
  Range (min … max):    4.218 s …  4.349 s    10 runs

```

(JMM)