### PR TITLE
match ufo2ft's default ascender/descender settings

### DIFF
--- a/fontbe/src/os2.rs
+++ b/fontbe/src/os2.rs
@@ -864,7 +864,8 @@ mod tests {
     #[test]
     fn build_basic_os2() {
         let default_location = NormalizedLocation::new();
-        let mut global_metrics = GlobalMetrics::new(default_location.clone(), 1000, None, 0.0);
+        let mut global_metrics =
+            GlobalMetrics::new(default_location.clone(), 1000, None, None, None, 0.0);
 
         global_metrics.set(GlobalMetric::CapHeight, default_location.clone(), 37.5);
         global_metrics.set(GlobalMetric::XHeight, default_location.clone(), 112.2);

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -366,14 +366,16 @@ impl GlobalMetrics {
         default_location: NormalizedLocation,
         units_per_em: u16,
         x_height: Option<f32>,
+        ascender: Option<f32>,
+        descender: Option<f32>,
         italic_angle: f64,
     ) -> GlobalMetrics {
         let mut metrics = GlobalMetrics(HashMap::new());
         let mut set = |metric, value| metrics.set(metric, default_location.clone(), value);
 
         // https://github.com/googlefonts/ufo2ft/blob/fca66fe3ea1ea88ffb36f8264b21ce042d3afd05/Lib/ufo2ft/fontInfoData.py#L38-L45
-        let ascender = 0.8 * units_per_em as f32;
-        let descender = -0.2 * units_per_em as f32;
+        let ascender = ascender.unwrap_or(0.8 * units_per_em as f32);
+        let descender = descender.unwrap_or(-0.2 * units_per_em as f32);
         set(GlobalMetric::Ascender, ascender);
         set(GlobalMetric::Descender, descender);
 
@@ -387,7 +389,7 @@ impl GlobalMetrics {
         set(GlobalMetric::Os2TypoLineGap, typo_line_gap);
 
         // https://github.com/googlefonts/ufo2ft/blob/0d2688cd847d003b41104534d16973f72ef26c40/Lib/ufo2ft/fontInfoData.py#L215-L226
-        set(GlobalMetric::Os2TypoAscender, ascender + typo_line_gap);
+        set(GlobalMetric::Os2TypoAscender, ascender);
         set(GlobalMetric::Os2TypoDescender, descender);
 
         // https://github.com/googlefonts/ufo2ft/blob/0d2688cd847d003b41104534d16973f72ef26c40/Lib/ufo2ft/fontInfoData.py#L126-L130
@@ -397,8 +399,8 @@ impl GlobalMetrics {
         set(GlobalMetric::HheaLineGap, 0.0);
 
         // https://github.com/googlefonts/ufo2ft/blob/0d2688cd847d003b41104534d16973f72ef26c40/Lib/ufo2ft/fontInfoData.py#L241-L254
-        set(GlobalMetric::Os2WinAscent, ascender);
-        set(GlobalMetric::Os2WinDescent, descender);
+        set(GlobalMetric::Os2WinAscent, ascender + typo_line_gap);
+        set(GlobalMetric::Os2WinDescent, descender.abs());
 
         // https://github.com/googlefonts/ufo2ft/blob/fca66fe3ea1ea88ffb36f8264b21ce042d3afd05/Lib/ufo2ft/fontInfoData.py#L48-L55
         set(GlobalMetric::CapHeight, 0.7 * units_per_em as f32);

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -440,10 +440,13 @@ impl Work<Context, WorkId, WorkError> for GlobalMetricWork {
         );
 
         let static_metadata = context.static_metadata.get();
+        let default_master = font.default_master();
         let mut metrics = GlobalMetrics::new(
             static_metadata.default_location().clone(),
             static_metadata.units_per_em,
-            font.default_master().x_height().map(|v| v.0 as f32),
+            default_master.x_height().map(|v| v.0 as f32),
+            default_master.ascender().map(|v| v.0 as f32),
+            default_master.descender().map(|v| v.0 as f32),
             static_metadata.italic_angle.into_inner(),
         );
 
@@ -1481,13 +1484,13 @@ mod tests {
                 superscript_y_offset: 350.0.into(),
                 strikeout_position: 300.6.into(),
                 strikeout_size: 50.0.into(),
-                os2_typo_ascender: 1000.0.into(),
-                os2_typo_descender: (-200.0).into(),
-                os2_typo_line_gap: 200.0.into(),
-                os2_win_ascent: 800.0.into(),
-                os2_win_descent: (-200.0).into(),
-                hhea_ascender: 1000.0.into(),
-                hhea_descender: (-200.0).into(),
+                os2_typo_ascender: 737.0.into(),
+                os2_typo_descender: (-42.0).into(),
+                os2_typo_line_gap: 421.0.into(),
+                os2_win_ascent: 1158.0.into(),
+                os2_win_descent: 42.0.into(),
+                hhea_ascender: 1158.0.into(),
+                hhea_descender: (-42.0).into(),
                 hhea_line_gap: 0.0.into(),
                 underline_thickness: 50.0.into(),
                 underline_position: (-100.0).into(),

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -899,16 +899,16 @@ impl Work<Context, WorkId, WorkError> for GlobalMetricsWork {
             return Err(WorkError::NoDefaultMaster(self.designspace_file.clone()));
         };
 
+        let default_fontinfo = font_infos.get(&default_master.filename).ok_or_else(|| {
+            WorkError::FileExpected(designspace_dir.join(&default_master.filename))
+        })?;
+
         let mut metrics = GlobalMetrics::new(
             static_metadata.default_location().clone(),
             static_metadata.units_per_em,
-            font_infos
-                .get(&default_master.filename)
-                .ok_or_else(|| {
-                    WorkError::FileExpected(designspace_dir.join(&default_master.filename))
-                })?
-                .x_height
-                .map(|v| v as f32),
+            default_fontinfo.x_height.map(|v| v as f32),
+            default_fontinfo.ascender.map(|v| v as f32),
+            default_fontinfo.descender.map(|v| v as f32),
             static_metadata.italic_angle.into_inner(),
         );
         // ufo2ft default underline position differs from fontir/Glyphs.app's so


### PR DESCRIPTION
if the source file does provide generic ascender/descender values, we need to use those to derive the OS/2 and hhea values. We want to match ufo2ft defaults.

Surprisingly the code already contained urls to ufo2ft's source code but it didn't actually match the code it linked to.. 