### PR TITLE
Try spreading FE kerning across threads per location

### DIFF
--- a/fea-rs/src/compile/compile_ctx.rs
+++ b/fea-rs/src/compile/compile_ctx.rs
@@ -8,7 +8,7 @@ use std::{
     ops::Range,
 };
 
-use fontdrasil::coords::{DesignCoord, NormalizedCoord, NormalizedLocation, UserCoord};
+use fontdrasil::coords::{Coord, DesignCoord, NormalizedCoord, NormalizedLocation, UserCoord};
 use smol_str::SmolStr;
 use write_fonts::{
     tables::{

--- a/fea-rs/src/compile/variations.rs
+++ b/fea-rs/src/compile/variations.rs
@@ -86,7 +86,7 @@ pub enum AxisLocation {
 /// Create an axis where user coords == design coords
 #[cfg(any(test, feature = "test", feature = "cli"))]
 fn simple_axis(tag: Tag, min: i16, default: i16, max: i16) -> Axis {
-    use fontdrasil::coords::{CoordConverter, DesignCoord, UserCoord};
+    use fontdrasil::coords::{Coord, CoordConverter, DesignCoord, UserCoord};
 
     let min = UserCoord::new(min);
     let default = UserCoord::new(default);

--- a/fontbe/src/avar.rs
+++ b/fontbe/src/avar.rs
@@ -1,7 +1,7 @@
 //! Generates a [avar](https://learn.microsoft.com/en-us/typography/opentype/spec/avar) table.
 
 use fontdrasil::{
-    coords::{CoordConverter, DesignCoord, NormalizedCoord},
+    coords::{Coord, CoordConverter, DesignCoord, NormalizedCoord},
     orchestration::{Access, Work},
     types::Axis,
 };
@@ -123,7 +123,7 @@ impl Work<Context, AnyWorkId, Error> for AvarWork {
 #[cfg(test)]
 mod tests {
     use fontdrasil::{
-        coords::{CoordConverter, DesignCoord, UserCoord},
+        coords::{Coord, CoordConverter, DesignCoord, UserCoord},
         types::Axis,
     };
     use std::{cmp, str::FromStr};

--- a/fontbe/src/features.rs
+++ b/fontbe/src/features.rs
@@ -495,7 +495,7 @@ mod tests {
 
     use fea_rs::compile::VariationInfo;
     use fontdrasil::{
-        coords::{CoordConverter, DesignCoord, NormalizedCoord, UserCoord},
+        coords::{Coord, CoordConverter, DesignCoord, NormalizedCoord, UserCoord},
         types::Axis,
     };
     use fontir::ir::StaticMetadata;

--- a/fontbe/src/features.rs
+++ b/fontbe/src/features.rs
@@ -2,7 +2,7 @@
 
 use std::{
     cell::RefCell,
-    collections::{BTreeMap, HashMap},
+    collections::HashMap,
     ffi::{OsStr, OsString},
     fmt::Display,
     fs,
@@ -123,12 +123,12 @@ impl<'a> FeaVariationInfo<'a> {
 //except they have slightly different inputs?
 pub(crate) fn resolve_variable_metric(
     static_metadata: &StaticMetadata,
-    values: &BTreeMap<NormalizedLocation, OrderedFloat<f32>>,
+    values: impl IntoIterator<Item = (NormalizedLocation, OrderedFloat<f32>)>,
 ) -> Result<(i16, Vec<(VariationRegion, i16)>), Error> {
     let var_model = &static_metadata.variation_model;
 
     let point_seqs = values
-        .iter()
+        .into_iter()
         .map(|(pos, value)| (pos.to_owned(), vec![value.0 as f64]))
         .collect();
     let raw_deltas: Vec<_> = var_model

--- a/fontbe/src/features.rs
+++ b/fontbe/src/features.rs
@@ -121,9 +121,9 @@ impl<'a> FeaVariationInfo<'a> {
 
 //NOTE: this is basically identical to the same method on FeaVariationInfo,
 //except they have slightly different inputs?
-pub(crate) fn resolve_variable_metric(
+pub(crate) fn resolve_variable_metric<'a>(
     static_metadata: &StaticMetadata,
-    values: impl IntoIterator<Item = (NormalizedLocation, OrderedFloat<f32>)>,
+    values: impl Iterator<Item = &'a (NormalizedLocation, OrderedFloat<f32>)>,
 ) -> Result<(i16, Vec<(VariationRegion, i16)>), Error> {
     let var_model = &static_metadata.variation_model;
 

--- a/fontbe/src/glyphs.rs
+++ b/fontbe/src/glyphs.rs
@@ -903,7 +903,7 @@ mod tests {
     use super::*;
 
     use fontdrasil::{
-        coords::{NormalizedCoord, NormalizedLocation},
+        coords::{Coord, NormalizedCoord, NormalizedLocation},
         types::GlyphName,
     };
     use fontir::ir;

--- a/fontbe/src/kern.rs
+++ b/fontbe/src/kern.rs
@@ -93,7 +93,7 @@ impl Work<Context, AnyWorkId, Error> for KerningWork {
 
         // now for each kerning entry, directly add a rule to the builder:
         for ((left, right), values) in kerns {
-            let (default_value, deltas) = resolve_variable_metric(&static_metadata, values)?;
+            let (default_value, deltas) = resolve_variable_metric(&static_metadata, values.iter())?;
             let x_adv_record = ValueRecordBuilder::new()
                 .with_x_advance(default_value)
                 .with_x_advance_device(deltas);

--- a/fontbe/src/marks.rs
+++ b/fontbe/src/marks.rs
@@ -269,7 +269,7 @@ fn resolve_anchor(
     anchor: &fontir::ir::Anchor,
     static_metadata: &StaticMetadata,
 ) -> Result<fea_rs::compile::Anchor, Error> {
-    let (x_values, y_values) = anchor
+    let (x_values, y_values): (Vec<_>, Vec<_>) = anchor
         .positions
         .iter()
         .map(|(loc, pt)| {
@@ -281,9 +281,9 @@ fn resolve_anchor(
         .unzip();
 
     let (x_default, x_deltas) =
-        crate::features::resolve_variable_metric(static_metadata, &x_values)?;
+        crate::features::resolve_variable_metric(static_metadata, x_values)?;
     let (y_default, y_deltas) =
-        crate::features::resolve_variable_metric(static_metadata, &y_values)?;
+        crate::features::resolve_variable_metric(static_metadata, y_values)?;
     Ok(fea_rs::compile::Anchor::new(x_default, y_default)
         .with_x_device(x_deltas)
         .with_y_device(y_deltas))

--- a/fontbe/src/marks.rs
+++ b/fontbe/src/marks.rs
@@ -281,9 +281,9 @@ fn resolve_anchor(
         .unzip();
 
     let (x_default, x_deltas) =
-        crate::features::resolve_variable_metric(static_metadata, x_values)?;
+        crate::features::resolve_variable_metric(static_metadata, x_values.iter())?;
     let (y_default, y_deltas) =
-        crate::features::resolve_variable_metric(static_metadata, y_values)?;
+        crate::features::resolve_variable_metric(static_metadata, y_values.iter())?;
     Ok(fea_rs::compile::Anchor::new(x_default, y_default)
         .with_x_device(x_deltas)
         .with_y_device(y_deltas))

--- a/fontbe/src/orchestration.rs
+++ b/fontbe/src/orchestration.rs
@@ -678,7 +678,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use fontdrasil::coords::NormalizedCoord;
+    use fontdrasil::coords::{Coord, NormalizedCoord};
     use fontir::variations::{Tent, VariationRegion};
 
     use super::*;

--- a/fontbe/src/test_util.rs
+++ b/fontbe/src/test_util.rs
@@ -10,6 +10,8 @@ use write_fonts::types::Tag;
 
 #[cfg(test)]
 pub(crate) fn axis(min: f32, default: f32, max: f32) -> Axis {
+    use fontdrasil::coords::Coord;
+
     let mut mappings = Vec::new();
     if min < default {
         mappings.push((UserCoord::new(min), DesignCoord::new(min / 10.0)));

--- a/fontc/src/change_detector.rs
+++ b/fontc/src/change_detector.rs
@@ -123,7 +123,7 @@ impl ChangeDetector {
         let glyphs_deleted = prev_inputs
             .glyphs
             .keys()
-            .filter(|glyph_name| !current_inputs.glyphs.contains_key(glyph_name))
+            .filter(|glyph_name| !current_inputs.glyphs.contains_key(*glyph_name))
             .cloned()
             .collect();
 

--- a/fontc/src/change_detector.rs
+++ b/fontc/src/change_detector.rs
@@ -9,7 +9,7 @@ use fontbe::{
 };
 
 use crate::{create_timer, timing::JobTimer, work::AnyWork, workload::Workload, Config, Error};
-use fontdrasil::types::GlyphName;
+use fontdrasil::{coords::NormalizedLocation, types::GlyphName};
 use fontir::{
     orchestration::WorkId as FeWorkIdentifier,
     paths::Paths as IrPaths,
@@ -44,6 +44,10 @@ pub struct ChangeDetector {
     be_paths: BePaths,
     emit_ir: bool,
     skip_features: bool,
+    static_metadata_changed: bool,
+    glyph_order_changed: bool,
+    glyphs_changed: IndexSet<GlyphName>,
+    glyphs_deleted: IndexSet<GlyphName>,
 }
 
 impl Debug for ChangeDetector {
@@ -83,6 +87,46 @@ impl ChangeDetector {
             });
         }
 
+        let static_metadata_changed = current_inputs.static_metadata != prev_inputs.static_metadata
+            || !ir_paths
+                .target_file(&FeWorkIdentifier::StaticMetadata)
+                .is_file();
+
+        let glyph_order_changed = static_metadata_changed
+            || !ir_paths
+                .target_file(&FeWorkIdentifier::GlyphOrder)
+                .is_file();
+
+        let glyphs_changed = if static_metadata_changed || glyph_order_changed {
+            current_inputs.glyphs.keys().cloned().collect()
+        } else {
+            current_inputs
+                .glyphs
+                .iter()
+                .filter_map(
+                    |(glyph_name, curr_state)| match prev_inputs.glyphs.get(glyph_name) {
+                        Some(prev_state) => {
+                            // If the input changed or the output doesn't exist a rebuild is probably in order
+                            (prev_state != curr_state
+                                || !ir_paths
+                                    .target_file(&FeWorkIdentifier::Glyph(glyph_name.clone()))
+                                    .exists())
+                            .then_some(glyph_name)
+                        }
+                        None => Some(glyph_name),
+                    },
+                )
+                .cloned()
+                .collect()
+        };
+
+        let glyphs_deleted = prev_inputs
+            .glyphs
+            .keys()
+            .filter(|glyph_name| !current_inputs.glyphs.contains_key(glyph_name))
+            .cloned()
+            .collect();
+
         timer.add(time.complete());
 
         Ok(ChangeDetector {
@@ -94,6 +138,10 @@ impl ChangeDetector {
             be_paths,
             emit_ir: config.args.incremental,
             skip_features: config.args.skip_features,
+            static_metadata_changed,
+            glyph_order_changed,
+            glyphs_changed,
+            glyphs_deleted,
         })
     }
 
@@ -201,19 +249,11 @@ impl ChangeDetector {
     // TODO: could this be solved based on work id and also completes?
 
     pub fn static_metadata_ir_change(&self) -> bool {
-        self.current_inputs.static_metadata != self.prev_inputs.static_metadata
-            || !self
-                .ir_paths
-                .target_file(&FeWorkIdentifier::StaticMetadata)
-                .is_file()
+        self.static_metadata_changed
     }
 
     pub fn glyph_order_ir_change(&self) -> bool {
-        self.current_inputs.static_metadata != self.prev_inputs.static_metadata
-            || !self
-                .ir_paths
-                .target_file(&FeWorkIdentifier::GlyphOrder)
-                .is_file()
+        self.glyph_order_changed
     }
 
     pub fn global_metrics_ir_change(&self) -> bool {
@@ -233,7 +273,7 @@ impl ChangeDetector {
                 .is_file()
             || !self
                 .ir_paths
-                .target_file(&FeWorkIdentifier::Kerning)
+                .target_file(&FeWorkIdentifier::KerningGroups)
                 .is_file()
     }
 
@@ -249,7 +289,7 @@ impl ChangeDetector {
 
     pub fn mark_be_change(&self) -> bool {
         // Glyphs produce anchors and we need anchors
-        !self.glyphs_changed().is_empty()
+        !self.glyphs_changed.is_empty()
             || !self
                 .be_paths
                 .target_file(&BeWorkIdentifier::Marks)
@@ -257,20 +297,29 @@ impl ChangeDetector {
     }
 
     pub fn kerning_be_change(&self) -> bool {
-        self.kerning_ir_change()
+        self.kerning_groups_ir_change()
             || !self
                 .be_paths
                 .target_file(&BeWorkIdentifier::Kerning)
                 .is_file()
     }
 
-    pub fn kerning_ir_change(&self) -> bool {
+    pub fn kerning_groups_ir_change(&self) -> bool {
         self.static_metadata_ir_change()
             || self.glyph_order_ir_change()
             || self.current_inputs.features != self.prev_inputs.features
             || !self
                 .ir_paths
-                .target_file(&FeWorkIdentifier::Kerning)
+                .target_file(&FeWorkIdentifier::KerningGroups)
+                .is_file()
+    }
+
+    pub fn kerning_at_ir_change(&self, at: NormalizedLocation) -> bool {
+        self.kerning_groups_ir_change()
+            || self.current_inputs.features != self.prev_inputs.features
+            || !self
+                .ir_paths
+                .target_file(&FeWorkIdentifier::KerningAtLocation(at))
                 .is_file()
     }
 
@@ -295,38 +344,12 @@ impl ChangeDetector {
             || !self.be_paths.target_file(&BeWorkIdentifier::Post).is_file()
     }
 
-    pub fn glyphs_changed(&self) -> IndexSet<GlyphName> {
-        let glyph_iter = self.current_inputs.glyphs.iter();
-
-        if self.static_metadata_ir_change() || self.glyph_order_ir_change() {
-            return glyph_iter.map(|(name, _)| name).cloned().collect();
-        }
-        glyph_iter
-            .filter_map(
-                |(glyph_name, curr_state)| match self.prev_inputs.glyphs.get(glyph_name) {
-                    Some(prev_state) => {
-                        // If the input changed or the output doesn't exist a rebuild is probably in order
-                        (prev_state != curr_state
-                            || !self
-                                .ir_paths
-                                .target_file(&FeWorkIdentifier::Glyph(glyph_name.clone()))
-                                .exists())
-                        .then_some(glyph_name)
-                    }
-                    None => Some(glyph_name),
-                },
-            )
-            .cloned()
-            .collect()
+    pub fn glyphs_changed(&self) -> &IndexSet<GlyphName> {
+        &self.glyphs_changed
     }
 
-    pub fn glyphs_deleted(&self) -> IndexSet<GlyphName> {
-        self.prev_inputs
-            .glyphs
-            .keys()
-            .filter(|glyph_name| !self.current_inputs.glyphs.contains_key(*glyph_name))
-            .cloned()
-            .collect()
+    pub fn glyphs_deleted(&self) -> &IndexSet<GlyphName> {
+        &self.glyphs_deleted
     }
 
     pub fn finish_successfully(self) -> Result<(), Error> {

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -41,7 +41,7 @@ use fontbe::{
     stat::create_stat_work,
 };
 
-use fontdrasil::types::GlyphName;
+use fontdrasil::{coords::NormalizedLocation, types::GlyphName};
 use fontir::{glyph::create_glyph_order_work, source::DeleteWork};
 
 use fontbe::orchestration::Context as BeContext;
@@ -187,12 +187,25 @@ fn add_kerning_be_job(workload: &mut Workload) -> Result<(), Error> {
     Ok(())
 }
 
-fn add_kerning_ir_job(workload: &mut Workload) -> Result<(), Error> {
+fn add_kerning_group_ir_job(workload: &mut Workload) -> Result<(), Error> {
     let work = workload
         .change_detector
         .ir_source()
-        .create_kerning_ir_work(workload.change_detector.current_inputs())?;
-    workload.add(work.into(), workload.change_detector.kerning_ir_change());
+        .create_kerning_group_ir_work(workload.change_detector.current_inputs())?;
+    workload.add(
+        work.into(),
+        workload.change_detector.kerning_groups_ir_change(),
+    );
+    Ok(())
+}
+
+fn add_kerning_at_ir_job(workload: &mut Workload, at: NormalizedLocation) -> Result<(), Error> {
+    let work = workload
+        .change_detector
+        .ir_source()
+        .create_kerning_at_ir_work(workload.current_inputs(), at.clone())?
+        .into();
+    workload.add(work, workload.change_detector.kerning_at_ir_change(at));
     Ok(())
 }
 
@@ -208,7 +221,7 @@ fn add_glyph_ir_jobs(workload: &mut Workload) -> Result<(), Error> {
     let glyph_work = workload
         .change_detector
         .ir_source()
-        .create_glyph_ir_work(&glyphs_changed, workload.change_detector.current_inputs())?;
+        .create_glyph_ir_work(glyphs_changed, workload.change_detector.current_inputs())?;
     for work in glyph_work {
         workload.add(work.into(), true);
     }
@@ -219,7 +232,7 @@ fn add_glyph_ir_jobs(workload: &mut Workload) -> Result<(), Error> {
 fn add_glyph_be_jobs(workload: &mut Workload) -> Result<(), Error> {
     let glyphs_changed = workload.change_detector.glyphs_changed();
     for glyph_name in glyphs_changed {
-        add_glyph_be_job(workload, glyph_name);
+        add_glyph_be_job(workload, glyph_name.clone());
     }
     Ok(())
 }
@@ -356,7 +369,7 @@ pub fn create_workload(
 
     // FE: f(source) => IR
     add_feature_ir_job(&mut workload)?;
-    add_kerning_ir_job(&mut workload)?;
+    add_kerning_group_ir_job(&mut workload)?;
     add_glyph_ir_jobs(&mut workload)?;
     add_glyph_order_ir_job(&mut workload)?;
 
@@ -402,7 +415,7 @@ pub fn testdata_dir() -> PathBuf {
 mod tests {
 
     use std::{
-        collections::{HashSet, VecDeque},
+        collections::{HashMap, HashSet, VecDeque},
         fs::{self, File},
         io::Read,
         path::{Path, PathBuf},
@@ -415,9 +428,13 @@ mod tests {
     use fontbe::orchestration::{
         AnyWorkId, Context as BeContext, Glyph, LocaFormatWrapper, WorkId as BeWorkIdentifier,
     };
-    use fontdrasil::{coords::NormalizedCoord, paths::safe_filename, types::GlyphName};
+    use fontdrasil::{
+        coords::{norm_loc, NormalizedCoord},
+        paths::safe_filename,
+        types::GlyphName,
+    };
     use fontir::{
-        ir::{self, GlyphOrder, KernParticipant},
+        ir::{self, GlyphOrder, KernPair, KernParticipant},
         orchestration::{Context as FeContext, Persistable, WorkId as FeWorkIdentifier},
     };
     use indexmap::IndexSet;
@@ -525,8 +542,8 @@ mod tests {
                 build_dir,
                 args: config.args.clone(),
                 work_executed: HashSet::new(),
-                glyphs_changed: change_detector.glyphs_changed(),
-                glyphs_deleted: change_detector.glyphs_deleted(),
+                glyphs_changed: change_detector.glyphs_changed().clone(),
+                glyphs_deleted: change_detector.glyphs_deleted().clone(),
                 fe_context,
                 be_context,
                 raw_font: Vec::new(),
@@ -639,7 +656,9 @@ mod tests {
             FeWorkIdentifier::PreliminaryGlyphOrder.into(),
             FeWorkIdentifier::GlyphOrder.into(),
             FeWorkIdentifier::Features.into(),
-            FeWorkIdentifier::Kerning.into(),
+            FeWorkIdentifier::KerningGroups.into(),
+            FeWorkIdentifier::KerningAtLocation(norm_loc(&[("wght", 0.0)])).into(),
+            FeWorkIdentifier::KerningAtLocation(norm_loc(&[("wght", 1.0)])).into(),
             BeWorkIdentifier::Features.into(),
             BeWorkIdentifier::Avar.into(),
             BeWorkIdentifier::Cmap.into(),
@@ -774,7 +793,9 @@ mod tests {
         let result = TestCompile::compile_source("glyphs3/WghtVar.glyphs");
         assert!(result.work_executed.len() > 1);
 
-        fs::remove_file(result.build_dir.join("kerning.yml")).unwrap();
+        fs::remove_file(result.build_dir.join("kern_groups.yml")).unwrap();
+        fs::remove_file(result.build_dir.join("kern_wght_0.00.yml")).unwrap();
+        fs::remove_file(result.build_dir.join("kern_wght_1.00.yml")).unwrap();
 
         let result = TestCompile::compile_again(&result);
         let mut completed = result.work_executed.iter().cloned().collect::<Vec<_>>();
@@ -782,7 +803,9 @@ mod tests {
         assert_eq!(
             vec![
                 AnyWorkId::Fe(FeWorkIdentifier::Features),
-                FeWorkIdentifier::Kerning.into(),
+                FeWorkIdentifier::KerningGroups.into(),
+                FeWorkIdentifier::KerningAtLocation(norm_loc(&[("wght", 0.0)])).into(),
+                FeWorkIdentifier::KerningAtLocation(norm_loc(&[("wght", 1.0)])).into(),
                 BeWorkIdentifier::Features.into(),
                 BeWorkIdentifier::Font.into(),
                 BeWorkIdentifier::Gpos.into(),
@@ -887,7 +910,13 @@ mod tests {
         assert_eq!(
             vec![
                 AnyWorkId::Fe(FeWorkIdentifier::Features),
-                AnyWorkId::Fe(FeWorkIdentifier::Kerning),
+                AnyWorkId::Fe(FeWorkIdentifier::KerningGroups),
+                AnyWorkId::Fe(FeWorkIdentifier::KerningAtLocation(norm_loc(&[(
+                    "wght", 0.0
+                )]))),
+                AnyWorkId::Fe(FeWorkIdentifier::KerningAtLocation(norm_loc(&[(
+                    "wght", 1.0
+                )]))),
                 BeWorkIdentifier::Features.into(),
                 BeWorkIdentifier::Font.into(),
                 BeWorkIdentifier::Gpos.into(),
@@ -1747,9 +1776,9 @@ mod tests {
     fn assert_simple_kerning(source: &str) {
         let result = TestCompile::compile_source(source);
 
-        let kerning = result.fe_context.kerning.get();
+        let kerning_groups = result.fe_context.kerning_groups.get();
 
-        let mut groups: Vec<_> = kerning
+        let mut groups: Vec<_> = kerning_groups
             .groups
             .iter()
             .map(|(name, entries)| {
@@ -1760,25 +1789,36 @@ mod tests {
             .collect();
         groups.sort();
 
-        let mut kerns: Vec<_> = kerning
-            .kerns
-            .iter()
-            .map(|((side1, side2), values)| {
-                (
-                    side1,
-                    side2,
-                    values
-                        .iter()
-                        .map(|(loc, val)| {
-                            assert_eq!(loc.axis_tags().count(), 1, "Should be only wght");
-                            let (axis, pos) = loc.iter().next().unwrap();
-                            (format!("{axis} {}", pos.to_f32()), val.0)
-                        })
-                        .collect::<Vec<_>>(),
-                )
+        let wght = Tag::from_be_bytes(*b"wght");
+        let mut kerns: HashMap<KernPair, Vec<(String, f32)>> = HashMap::new();
+        for kern_loc in kerning_groups.locations.iter() {
+            assert_eq!(
+                vec![wght],
+                kern_loc.axis_tags().cloned().collect::<Vec<_>>()
+            );
+
+            let kerns_at = result
+                .fe_context
+                .kerning_at
+                .get(&FeWorkIdentifier::KerningAtLocation(kern_loc.clone()));
+            for (pair, adjustment) in kerns_at.kerns.iter() {
+                kerns.entry(pair.clone()).or_default().push((
+                    format!(
+                        "wght {}",
+                        kern_loc.iter().map(|(_, v)| *v).next().unwrap().to_f32()
+                    ),
+                    adjustment.0,
+                ));
+            }
+        }
+        let mut kerns: Vec<_> = kerns
+            .into_iter()
+            .map(|((left, right), mut values)| {
+                values.sort_by_key(|(s, _)| s.clone());
+                (left, right, values)
             })
             .collect();
-        kerns.sort_by_key(|(side1, side2, _)| (*side1, *side2));
+        kerns.sort_by_key(|(left, right, _)| (left.clone(), right.clone()));
 
         assert_eq!(
             (groups, kerns),
@@ -1791,42 +1831,42 @@ mod tests {
                 ],
                 vec![
                     (
-                        &KernParticipant::Glyph("bracketleft".into()),
-                        &KernParticipant::Glyph("bracketright".into()),
+                        KernParticipant::Glyph("bracketleft".into()),
+                        KernParticipant::Glyph("bracketright".into()),
                         vec![
                             ("wght 0".to_string(), -300.0),
                             ("wght 1".to_string(), -150.0)
                         ],
                     ),
                     (
-                        &KernParticipant::Glyph("exclam".into()),
-                        &KernParticipant::Glyph("exclam".into()),
+                        KernParticipant::Glyph("exclam".into()),
+                        KernParticipant::Glyph("exclam".into()),
                         vec![
                             ("wght 0".to_string(), -360.0),
                             ("wght 1".to_string(), -100.0)
                         ],
                     ),
                     (
-                        &KernParticipant::Glyph("exclam".into()),
-                        &KernParticipant::Glyph("hyphen".into()),
+                        KernParticipant::Glyph("exclam".into()),
+                        KernParticipant::Glyph("hyphen".into()),
                         vec![("wght 0".to_string(), 20.0),],
                     ),
                     (
-                        &KernParticipant::Glyph("exclam".into()),
-                        &KernParticipant::Group("public.kern2.bracketright_L".into()),
+                        KernParticipant::Glyph("exclam".into()),
+                        KernParticipant::Group("public.kern2.bracketright_L".into()),
                         vec![("wght 0".to_string(), -160.0),],
                     ),
                     (
-                        &KernParticipant::Glyph("hyphen".into()),
-                        &KernParticipant::Glyph("hyphen".into()),
+                        KernParticipant::Glyph("hyphen".into()),
+                        KernParticipant::Glyph("hyphen".into()),
                         vec![
                             ("wght 0".to_string(), -150.0),
                             ("wght 1".to_string(), -50.0)
                         ],
                     ),
                     (
-                        &KernParticipant::Group("public.kern1.bracketleft_R".into()),
-                        &KernParticipant::Glyph("exclam".into()),
+                        KernParticipant::Group("public.kern1.bracketleft_R".into()),
+                        KernParticipant::Glyph("exclam".into()),
                         vec![("wght 0".to_string(), -165.0),],
                     ),
                 ],

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -203,7 +203,7 @@ fn add_kerning_at_ir_job(workload: &mut Workload, at: NormalizedLocation) -> Res
     let work = workload
         .change_detector
         .ir_source()
-        .create_kerning_at_ir_work(workload.current_inputs(), at.clone())?
+        .create_kerning_instance_ir_work(workload.current_inputs(), at.clone())?
         .into();
     workload.add(work, workload.change_detector.kerning_at_ir_change(at));
     Ok(())
@@ -1793,7 +1793,7 @@ mod tests {
             .collect();
         groups.sort();
 
-        let wght = Tag::from_be_bytes(*b"wght");
+        let wght = Tag::new(b"wght");
         let mut kerns: HashMap<KernPair, Vec<(String, f32)>> = HashMap::new();
         for kern_loc in kerning_groups.locations.iter() {
             assert_eq!(

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -429,7 +429,7 @@ mod tests {
         AnyWorkId, Context as BeContext, Glyph, LocaFormatWrapper, WorkId as BeWorkIdentifier,
     };
     use fontdrasil::{
-        coords::{norm_loc, NormalizedCoord},
+        coords::{Coord, NormalizedCoord},
         paths::safe_filename,
         types::GlyphName,
     };
@@ -657,8 +657,10 @@ mod tests {
             FeWorkIdentifier::GlyphOrder.into(),
             FeWorkIdentifier::Features.into(),
             FeWorkIdentifier::KerningGroups.into(),
-            FeWorkIdentifier::KerningAtLocation(norm_loc(&[("wght", 0.0)])).into(),
-            FeWorkIdentifier::KerningAtLocation(norm_loc(&[("wght", 1.0)])).into(),
+            FeWorkIdentifier::KerningAtLocation(NormalizedLocation::for_pos(&[("wght", 0.0)]))
+                .into(),
+            FeWorkIdentifier::KerningAtLocation(NormalizedLocation::for_pos(&[("wght", 1.0)]))
+                .into(),
             BeWorkIdentifier::Features.into(),
             BeWorkIdentifier::Avar.into(),
             BeWorkIdentifier::Cmap.into(),
@@ -804,8 +806,10 @@ mod tests {
             vec![
                 AnyWorkId::Fe(FeWorkIdentifier::Features),
                 FeWorkIdentifier::KerningGroups.into(),
-                FeWorkIdentifier::KerningAtLocation(norm_loc(&[("wght", 0.0)])).into(),
-                FeWorkIdentifier::KerningAtLocation(norm_loc(&[("wght", 1.0)])).into(),
+                FeWorkIdentifier::KerningAtLocation(NormalizedLocation::for_pos(&[("wght", 0.0)]))
+                    .into(),
+                FeWorkIdentifier::KerningAtLocation(NormalizedLocation::for_pos(&[("wght", 1.0)]))
+                    .into(),
                 BeWorkIdentifier::Features.into(),
                 BeWorkIdentifier::Font.into(),
                 BeWorkIdentifier::Gpos.into(),
@@ -911,12 +915,12 @@ mod tests {
             vec![
                 AnyWorkId::Fe(FeWorkIdentifier::Features),
                 AnyWorkId::Fe(FeWorkIdentifier::KerningGroups),
-                AnyWorkId::Fe(FeWorkIdentifier::KerningAtLocation(norm_loc(&[(
-                    "wght", 0.0
-                )]))),
-                AnyWorkId::Fe(FeWorkIdentifier::KerningAtLocation(norm_loc(&[(
-                    "wght", 1.0
-                )]))),
+                AnyWorkId::Fe(FeWorkIdentifier::KerningAtLocation(
+                    NormalizedLocation::for_pos(&[("wght", 0.0)])
+                )),
+                AnyWorkId::Fe(FeWorkIdentifier::KerningAtLocation(
+                    NormalizedLocation::for_pos(&[("wght", 1.0)])
+                )),
                 BeWorkIdentifier::Features.into(),
                 BeWorkIdentifier::Font.into(),
                 BeWorkIdentifier::Gpos.into(),

--- a/fontc/src/timing.rs
+++ b/fontc/src/timing.rs
@@ -81,7 +81,12 @@ impl JobTimer {
                 let exec_pct =
                     100.0 * (timing.complete - timing.run).as_secs_f64() / end_time.as_secs_f64();
                 let fill = color(&timing.id);
-                writeln!(out, "  <g>").unwrap();
+                writeln!(
+                    out,
+                    "  <g work=\"{}\">",
+                    format!("{:?}", timing.id).replace('\"', "")
+                )
+                .unwrap();
                 writeln!(
                     out,
                     "    <rect x=\"{begin_pct:.2}%\" y=\"{box_top}\" width=\"{exec_pct:.2}%\" height=\"{line_height}\"  fill=\"{fill}\" stroke=\"black\" />"
@@ -122,7 +127,8 @@ fn short_name(id: &AnyWorkId) -> &'static str {
         AnyWorkId::Fe(FeWorkIdentifier::Glyph(..)) => "glyph",
         AnyWorkId::Fe(FeWorkIdentifier::GlyphIrDelete(..)) => "rm ir",
         AnyWorkId::Fe(FeWorkIdentifier::GlyphOrder) => "glyphorder",
-        AnyWorkId::Fe(FeWorkIdentifier::Kerning) => "kern",
+        AnyWorkId::Fe(FeWorkIdentifier::KerningGroups) => "kerngrps",
+        AnyWorkId::Fe(FeWorkIdentifier::KerningAtLocation(..)) => "kernat",
         AnyWorkId::Fe(FeWorkIdentifier::PreliminaryGlyphOrder) => "pre-go",
         AnyWorkId::Fe(FeWorkIdentifier::StaticMetadata) => "static-meta",
         AnyWorkId::Be(BeWorkIdentifier::Avar) => "avar",
@@ -141,7 +147,7 @@ fn short_name(id: &AnyWorkId) -> &'static str {
         AnyWorkId::Be(BeWorkIdentifier::Hhea) => "hhea",
         AnyWorkId::Be(BeWorkIdentifier::Hmtx) => "hmtx",
         AnyWorkId::Be(BeWorkIdentifier::Hvar) => "HVAR",
-        AnyWorkId::Be(BeWorkIdentifier::Kerning) => "Kern",
+        AnyWorkId::Be(BeWorkIdentifier::Kerning) => "kern-be",
         AnyWorkId::Be(BeWorkIdentifier::Loca) => "loca",
         AnyWorkId::Be(BeWorkIdentifier::LocaFormat) => "loca-fmt",
         AnyWorkId::Be(BeWorkIdentifier::Marks) => "Marks",
@@ -162,7 +168,8 @@ fn color(id: &AnyWorkId) -> &'static str {
         AnyWorkId::Fe(FeWorkIdentifier::Glyph(..)) => "#830356",
         AnyWorkId::Fe(FeWorkIdentifier::GlyphIrDelete(..)) => "gray",
         AnyWorkId::Fe(FeWorkIdentifier::GlyphOrder) => "gray",
-        AnyWorkId::Fe(FeWorkIdentifier::Kerning) => "gray",
+        AnyWorkId::Fe(FeWorkIdentifier::KerningGroups) => "gray",
+        AnyWorkId::Fe(FeWorkIdentifier::KerningAtLocation(..)) => "gray",
         AnyWorkId::Fe(FeWorkIdentifier::PreliminaryGlyphOrder) => "gray",
         AnyWorkId::Fe(FeWorkIdentifier::StaticMetadata) => "gray",
         AnyWorkId::Be(BeWorkIdentifier::Avar) => "gray",

--- a/fontdrasil/src/coords.rs
+++ b/fontdrasil/src/coords.rs
@@ -363,6 +363,21 @@ impl Debug for NormalizedLocation {
     }
 }
 
+/// For testing only
+#[doc(hidden)]
+pub fn norm_loc(positions: &[(&str, f32)]) -> NormalizedLocation {
+    positions
+        .iter()
+        .map(|(tag, value)| {
+            let tag = format!("{tag: <4}")
+                .as_bytes()
+                .try_into()
+                .unwrap_or_else(|_| panic!("Bad tag \"{tag}\""));
+            (Tag::new(&tag), NormalizedCoord::new(*value))
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use ordered_float::OrderedFloat;

--- a/fontdrasil/src/coords.rs
+++ b/fontdrasil/src/coords.rs
@@ -14,6 +14,12 @@ use write_fonts::types::{F2Dot14, Fixed, Tag};
 
 use crate::{piecewise_linear_map::PiecewiseLinearMap, serde::LocationSerdeRepr, types::Axis};
 
+/// A position on an axis
+pub trait Coord {
+    /// We do *not* provide From because we want conversion to be explicit
+    fn new(value: impl Into<OrderedFloat<f32>>) -> Self;
+}
+
 /// A coordinate in some arbitrary space the designer dreamed up.
 ///
 /// In .designspace, an xvalue. <https://fonttools.readthedocs.io/en/latest/designspaceLib/xml.html#dimension-element>.
@@ -135,11 +141,6 @@ impl CoordConverter {
 }
 
 impl DesignCoord {
-    /// We do *not* provide From because we want conversion to be explicit
-    pub fn new(value: impl Into<OrderedFloat<f32>>) -> DesignCoord {
-        DesignCoord(value.into())
-    }
-
     pub fn to_user(&self, converter: &CoordConverter) -> UserCoord {
         UserCoord::new(converter.design_to_user.map(self.0))
     }
@@ -153,12 +154,25 @@ impl DesignCoord {
     }
 }
 
-impl UserCoord {
-    /// We do *not* provide From because we want conversion to be explicit
-    pub fn new(value: impl Into<OrderedFloat<f32>>) -> UserCoord {
-        UserCoord(value.into())
+impl Coord for UserCoord {
+    fn new(value: impl Into<OrderedFloat<f32>>) -> Self {
+        Self(value.into())
     }
+}
 
+impl Coord for DesignCoord {
+    fn new(value: impl Into<OrderedFloat<f32>>) -> Self {
+        Self(value.into())
+    }
+}
+
+impl Coord for NormalizedCoord {
+    fn new(value: impl Into<OrderedFloat<f32>>) -> Self {
+        Self(value.into())
+    }
+}
+
+impl UserCoord {
     pub fn to_design(&self, converter: &CoordConverter) -> DesignCoord {
         DesignCoord::new(converter.user_to_design.map(self.0))
     }
@@ -179,11 +193,6 @@ impl From<UserCoord> for Fixed {
 }
 
 impl NormalizedCoord {
-    /// We do *not* provide From because we want conversion to be explicit
-    pub fn new(value: impl Into<OrderedFloat<f32>>) -> NormalizedCoord {
-        NormalizedCoord(value.into())
-    }
-
     pub fn to_design(&self, converter: &CoordConverter) -> DesignCoord {
         DesignCoord::new(converter.normalized_to_design.map(self.0))
     }
@@ -227,9 +236,24 @@ impl<T: Copy> From<Vec<(Tag, T)>> for Location<T> {
     }
 }
 
-impl<T: Copy> Location<T> {
+impl<T: Copy + Coord> Location<T> {
     pub fn new() -> Location<T> {
         Location(BTreeMap::new())
+    }
+
+    /// For testing only
+    #[doc(hidden)]
+    pub fn for_pos(positions: &[(&str, f32)]) -> Self {
+        positions
+            .iter()
+            .map(|(tag, value)| {
+                let tag = format!("{tag: <4}")
+                    .as_bytes()
+                    .try_into()
+                    .unwrap_or_else(|_| panic!("Bad tag \"{tag}\""));
+                (Tag::new(&tag), T::new(*value))
+            })
+            .collect()
     }
 
     pub fn insert(&mut self, tag: Tag, pos: T) -> &mut Location<T> {
@@ -361,21 +385,6 @@ impl Debug for NormalizedLocation {
         let it = self.0.iter().map(|(n, v)| (n, v.into_inner()));
         format_location("Normalized", f, it)
     }
-}
-
-/// For testing only
-#[doc(hidden)]
-pub fn norm_loc(positions: &[(&str, f32)]) -> NormalizedLocation {
-    positions
-        .iter()
-        .map(|(tag, value)| {
-            let tag = format!("{tag: <4}")
-                .as_bytes()
-                .try_into()
-                .unwrap_or_else(|_| panic!("Bad tag \"{tag}\""));
-            (Tag::new(&tag), NormalizedCoord::new(*value))
-        })
-        .collect()
 }
 
 #[cfg(test)]

--- a/fontdrasil/src/orchestration.rs
+++ b/fontdrasil/src/orchestration.rs
@@ -268,14 +268,14 @@ fn assert_access_many<I: Identifier>(
         AccessCheck::Any => ids.iter().any(|id| access.check(id)),
     };
     if !allow {
-        panic!("Illegal {desc} of {demand} {ids:?}");
+        panic!("Illegal {desc} of {demand} {ids:?}. {desc} access: {access:?}");
     }
 }
 
 fn assert_access_one<I: Identifier>(access: &Access<I>, id: &I, desc: &str) {
     let allow = access.check(id);
     if !allow {
-        panic!("Illegal {desc} of {id:?} per {access:?}");
+        panic!("Illegal {desc} of {id:?}. {desc} access: {access:?}");
     }
 }
 

--- a/fontir/src/glyph.rs
+++ b/fontir/src/glyph.rs
@@ -455,13 +455,8 @@ impl Work<Context, WorkId, WorkError> for GlyphOrderWork {
 mod tests {
     use std::{collections::HashSet, path::Path};
 
-    use fontdrasil::{
-        coords::{NormalizedCoord, NormalizedLocation},
-        orchestration::Access,
-        types::GlyphName,
-    };
+    use fontdrasil::{coords::norm_loc, orchestration::Access, types::GlyphName};
     use kurbo::{Affine, BezPath};
-    use write_fonts::types::Tag;
 
     use crate::{
         ir::{Component, Glyph, GlyphBuilder, GlyphInstance, GlyphOrder},
@@ -471,13 +466,6 @@ mod tests {
     };
 
     use super::*;
-
-    fn norm_loc(positions: &[(Tag, f32)]) -> NormalizedLocation {
-        positions
-            .iter()
-            .map(|(tag, value)| (*tag, NormalizedCoord::new(*value)))
-            .collect()
-    }
 
     fn component_instance() -> GlyphInstance {
         GlyphInstance {
@@ -561,10 +549,10 @@ mod tests {
     fn has_components_and_contours_false() {
         let mut glyph = GlyphBuilder::new("duck".into());
         glyph
-            .try_add_source(&norm_loc(&[(Tag::new(b"wght"), 0.0)]), component_instance())
+            .try_add_source(&norm_loc(&[("wght", 0.0)]), component_instance())
             .unwrap();
         glyph
-            .try_add_source(&norm_loc(&[(Tag::new(b"wght"), 1.0)]), contour_instance())
+            .try_add_source(&norm_loc(&[("wght", 1.0)]), contour_instance())
             .unwrap();
         let glyph = glyph.build().unwrap();
         assert!(!has_components_and_contours(&glyph));
@@ -575,7 +563,7 @@ mod tests {
         let mut glyph = GlyphBuilder::new("duck".into());
         glyph
             .try_add_source(
-                &norm_loc(&[(Tag::new(b"wght"), 0.0)]),
+                &norm_loc(&[("wght", 0.0)]),
                 contour_and_component_instance(),
             )
             .unwrap();
@@ -603,10 +591,10 @@ mod tests {
     fn contour_glyph(name: &str) -> Glyph {
         let mut glyph = GlyphBuilder::new(name.into());
         glyph
-            .try_add_source(&norm_loc(&[(Tag::new(b"wght"), 0.0)]), contour_instance())
+            .try_add_source(&norm_loc(&[("wght", 0.0)]), contour_instance())
             .unwrap();
         glyph
-            .try_add_source(&norm_loc(&[(Tag::new(b"wght"), 1.0)]), contour_instance())
+            .try_add_source(&norm_loc(&[("wght", 1.0)]), contour_instance())
             .unwrap();
         glyph.build().unwrap()
     }
@@ -618,10 +606,10 @@ mod tests {
         };
         let mut glyph = GlyphBuilder::new(name.into());
         glyph
-            .try_add_source(&norm_loc(&[(Tag::new(b"wght"), 0.0)]), component.clone())
+            .try_add_source(&norm_loc(&[("wght", 0.0)]), component.clone())
             .unwrap();
         glyph
-            .try_add_source(&norm_loc(&[(Tag::new(b"wght"), 1.0)]), component)
+            .try_add_source(&norm_loc(&[("wght", 1.0)]), component)
             .unwrap();
         glyph.build().unwrap()
     }
@@ -630,13 +618,13 @@ mod tests {
         let mut glyph = GlyphBuilder::new(name.into());
         glyph
             .try_add_source(
-                &norm_loc(&[(Tag::new(b"wght"), 0.0)]),
+                &norm_loc(&[("wght", 0.0)]),
                 contour_and_component_instance(),
             )
             .unwrap();
         glyph
             .try_add_source(
-                &norm_loc(&[(Tag::new(b"wght"), 1.0)]),
+                &norm_loc(&[("wght", 1.0)]),
                 contour_and_component_instance(),
             )
             .unwrap();
@@ -708,7 +696,7 @@ mod tests {
         let mut nested_components = GlyphBuilder::new("g".into());
         nested_components
             .try_add_source(
-                &norm_loc(&[(Tag::new(b"wght"), 0.0)]),
+                &norm_loc(&[("wght", 0.0)]),
                 GlyphInstance {
                     components: vec![
                         Component {
@@ -768,7 +756,7 @@ mod tests {
         let mut glyph = GlyphBuilder::new("g".into());
         glyph
             .try_add_source(
-                &norm_loc(&[(Tag::new(b"wght"), 0.0)]),
+                &norm_loc(&[("wght", 0.0)]),
                 GlyphInstance {
                     components: vec![Component {
                         base: reuse_me.name.clone(),

--- a/fontir/src/glyph.rs
+++ b/fontir/src/glyph.rs
@@ -455,7 +455,7 @@ impl Work<Context, WorkId, WorkError> for GlyphOrderWork {
 mod tests {
     use std::{collections::HashSet, path::Path};
 
-    use fontdrasil::{coords::norm_loc, orchestration::Access, types::GlyphName};
+    use fontdrasil::{orchestration::Access, types::GlyphName};
     use kurbo::{Affine, BezPath};
 
     use crate::{
@@ -549,10 +549,16 @@ mod tests {
     fn has_components_and_contours_false() {
         let mut glyph = GlyphBuilder::new("duck".into());
         glyph
-            .try_add_source(&norm_loc(&[("wght", 0.0)]), component_instance())
+            .try_add_source(
+                &NormalizedLocation::for_pos(&[("wght", 0.0)]),
+                component_instance(),
+            )
             .unwrap();
         glyph
-            .try_add_source(&norm_loc(&[("wght", 1.0)]), contour_instance())
+            .try_add_source(
+                &NormalizedLocation::for_pos(&[("wght", 1.0)]),
+                contour_instance(),
+            )
             .unwrap();
         let glyph = glyph.build().unwrap();
         assert!(!has_components_and_contours(&glyph));
@@ -563,7 +569,7 @@ mod tests {
         let mut glyph = GlyphBuilder::new("duck".into());
         glyph
             .try_add_source(
-                &norm_loc(&[("wght", 0.0)]),
+                &NormalizedLocation::for_pos(&[("wght", 0.0)]),
                 contour_and_component_instance(),
             )
             .unwrap();
@@ -591,10 +597,16 @@ mod tests {
     fn contour_glyph(name: &str) -> Glyph {
         let mut glyph = GlyphBuilder::new(name.into());
         glyph
-            .try_add_source(&norm_loc(&[("wght", 0.0)]), contour_instance())
+            .try_add_source(
+                &NormalizedLocation::for_pos(&[("wght", 0.0)]),
+                contour_instance(),
+            )
             .unwrap();
         glyph
-            .try_add_source(&norm_loc(&[("wght", 1.0)]), contour_instance())
+            .try_add_source(
+                &NormalizedLocation::for_pos(&[("wght", 1.0)]),
+                contour_instance(),
+            )
             .unwrap();
         glyph.build().unwrap()
     }
@@ -606,10 +618,13 @@ mod tests {
         };
         let mut glyph = GlyphBuilder::new(name.into());
         glyph
-            .try_add_source(&norm_loc(&[("wght", 0.0)]), component.clone())
+            .try_add_source(
+                &NormalizedLocation::for_pos(&[("wght", 0.0)]),
+                component.clone(),
+            )
             .unwrap();
         glyph
-            .try_add_source(&norm_loc(&[("wght", 1.0)]), component)
+            .try_add_source(&NormalizedLocation::for_pos(&[("wght", 1.0)]), component)
             .unwrap();
         glyph.build().unwrap()
     }
@@ -618,13 +633,13 @@ mod tests {
         let mut glyph = GlyphBuilder::new(name.into());
         glyph
             .try_add_source(
-                &norm_loc(&[("wght", 0.0)]),
+                &NormalizedLocation::for_pos(&[("wght", 0.0)]),
                 contour_and_component_instance(),
             )
             .unwrap();
         glyph
             .try_add_source(
-                &norm_loc(&[("wght", 1.0)]),
+                &NormalizedLocation::for_pos(&[("wght", 1.0)]),
                 contour_and_component_instance(),
             )
             .unwrap();
@@ -696,7 +711,7 @@ mod tests {
         let mut nested_components = GlyphBuilder::new("g".into());
         nested_components
             .try_add_source(
-                &norm_loc(&[("wght", 0.0)]),
+                &NormalizedLocation::for_pos(&[("wght", 0.0)]),
                 GlyphInstance {
                     components: vec![
                         Component {
@@ -756,7 +771,7 @@ mod tests {
         let mut glyph = GlyphBuilder::new("g".into());
         glyph
             .try_add_source(
-                &norm_loc(&[("wght", 0.0)]),
+                &NormalizedLocation::for_pos(&[("wght", 0.0)]),
                 GlyphInstance {
                     components: vec![Component {
                         base: reuse_me.name.clone(),

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -19,7 +19,7 @@ use write_fonts::{
 };
 
 use fontdrasil::{
-    coords::{NormalizedCoord, NormalizedLocation, UserLocation},
+    coords::{Coord, NormalizedCoord, NormalizedLocation, UserLocation},
     types::{AnchorName, Axis, GlyphName, GroupName},
 };
 

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -193,29 +193,39 @@ impl IntoIterator for GlyphOrder {
 pub type PostscriptNames = HashMap<GlyphName, GlyphName>;
 
 /// In logical (reading) order
-type KernPair = (KernParticipant, KernParticipant);
-type KernValues = BTreeMap<NormalizedLocation, OrderedFloat<f32>>;
+pub type KernPair = (KernParticipant, KernParticipant);
 
-/// IR representation of kerning.
+/// IR representation of kerning groups.
 ///
 /// In UFO terms, roughly [groups.plist](https://unifiedfontobject.org/versions/ufo3/groups.plist/)
-/// and [kerning.plist](https://unifiedfontobject.org/versions/ufo3/kerning.plist/) combined.
+/// plus the set of locations that can have kerning.
 #[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq, Eq)]
-pub struct Kerning {
+pub struct KerningGroups {
     pub groups: BTreeMap<GroupName, BTreeSet<GlyphName>>,
+    /// The locations that have kerning defined.
+    ///
+    /// Must be a subset of the master locations.
+    pub locations: BTreeSet<NormalizedLocation>,
+
+    /// Optional group renaming map, meant for [KerningAtLocation] to consume
+    ///
+    /// The rhs should be the name used in the groups map.
+    pub old_to_new_group_names: BTreeMap<GroupName, GroupName>,
+}
+
+/// IR representation of kerning for a location.
+///
+/// In UFO terms, roughly [kerning.plist](https://unifiedfontobject.org/versions/ufo3/kerning.plist/).
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq, Eq)]
+pub struct KerningAtLocation {
+    pub location: NormalizedLocation,
     /// An adjustment to the space *between* two glyphs in logical order.
     ///
     /// Maps (side1, side2) => a mapping location:adjustment.
     ///
     /// Used for both LTR and RTL. The BE application differs but the concept
     /// is the same.
-    pub kerns: BTreeMap<KernPair, KernValues>,
-}
-
-impl Kerning {
-    pub fn is_empty(&self) -> bool {
-        self.kerns.is_empty()
-    }
+    pub kerns: BTreeMap<KernPair, OrderedFloat<f32>>,
 }
 
 /// A participant in kerning, one of the entries in a kerning pair.
@@ -1106,13 +1116,29 @@ impl Persistable for Features {
     }
 }
 
-impl Persistable for Kerning {
+impl Persistable for KerningGroups {
     fn read(from: &mut dyn Read) -> Self {
         serde_yaml::from_reader(from).unwrap()
     }
 
     fn write(&self, to: &mut dyn std::io::Write) {
         serde_yaml::to_writer(to, self).unwrap();
+    }
+}
+
+impl Persistable for KerningAtLocation {
+    fn read(from: &mut dyn Read) -> Self {
+        serde_yaml::from_reader(from).unwrap()
+    }
+
+    fn write(&self, to: &mut dyn std::io::Write) {
+        serde_yaml::to_writer(to, self).unwrap();
+    }
+}
+
+impl IdAware<WorkId> for KerningAtLocation {
+    fn id(&self) -> WorkId {
+        WorkId::KerningAtLocation(self.location.clone())
     }
 }
 

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -207,7 +207,7 @@ pub struct KerningGroups {
     /// Must be a subset of the master locations.
     pub locations: BTreeSet<NormalizedLocation>,
 
-    /// Optional group renaming map, meant for [KerningAtLocation] to consume
+    /// Optional group renaming map, meant for [KerningInstance] to consume
     ///
     /// The rhs should be the name used in the groups map.
     pub old_to_new_group_names: BTreeMap<GroupName, GroupName>,
@@ -217,7 +217,7 @@ pub struct KerningGroups {
 ///
 /// In UFO terms, roughly [kerning.plist](https://unifiedfontobject.org/versions/ufo3/kerning.plist/).
 #[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq, Eq)]
-pub struct KerningAtLocation {
+pub struct KerningInstance {
     pub location: NormalizedLocation,
     /// An adjustment to the space *between* two glyphs in logical order.
     ///
@@ -1126,7 +1126,7 @@ impl Persistable for KerningGroups {
     }
 }
 
-impl Persistable for KerningAtLocation {
+impl Persistable for KerningInstance {
     fn read(from: &mut dyn Read) -> Self {
         serde_yaml::from_reader(from).unwrap()
     }
@@ -1136,7 +1136,7 @@ impl Persistable for KerningAtLocation {
     }
 }
 
-impl IdAware<WorkId> for KerningAtLocation {
+impl IdAware<WorkId> for KerningInstance {
     fn id(&self) -> WorkId {
         WorkId::KerningAtLocation(self.location.clone())
     }

--- a/fontir/src/orchestration.rs
+++ b/fontir/src/orchestration.rs
@@ -406,7 +406,7 @@ pub struct Context {
     pub glyphs: FeContextMap<ir::Glyph>,
     pub features: FeContextItem<ir::Features>,
     pub kerning_groups: FeContextItem<ir::KerningGroups>,
-    pub kerning_at: FeContextMap<ir::KerningAtLocation>,
+    pub kerning_at: FeContextMap<ir::KerningInstance>,
     pub anchors: FeContextMap<ir::GlyphAnchors>,
 }
 

--- a/fontir/src/orchestration.rs
+++ b/fontir/src/orchestration.rs
@@ -12,6 +12,7 @@ use std::{
 use crate::{error::WorkError, ir, paths::Paths, source::Input};
 use bitflags::bitflags;
 use fontdrasil::{
+    coords::NormalizedLocation,
     orchestration::{Access, AccessControlList, Identifier, IdentifierDiscriminant, Work},
     types::GlyphName,
 };
@@ -325,7 +326,8 @@ pub enum WorkId {
     /// The final glyph order. Most things that need glyph order should rely on this.
     GlyphOrder,
     Features,
-    Kerning,
+    KerningGroups,
+    KerningAtLocation(NormalizedLocation),
     Anchor(GlyphName),
 }
 
@@ -338,8 +340,9 @@ impl Identifier for WorkId {
             WorkId::GlyphIrDelete(..) => "IrGlyphDelete",
             WorkId::PreliminaryGlyphOrder => "IrPreliminaryGlyphOrder",
             WorkId::GlyphOrder => "IrGlyphOrder",
-            WorkId::Features => "Features",
-            WorkId::Kerning => "Kerning",
+            WorkId::Features => "IrFeatures",
+            WorkId::KerningGroups => "IrKerningGroups",
+            WorkId::KerningAtLocation(..) => "IrKernAtLoc",
             WorkId::Anchor(..) => "IrAnchor",
         }
     }
@@ -402,7 +405,8 @@ pub struct Context {
     pub global_metrics: FeContextItem<ir::GlobalMetrics>,
     pub glyphs: FeContextMap<ir::Glyph>,
     pub features: FeContextItem<ir::Features>,
-    pub kerning: FeContextItem<ir::Kerning>,
+    pub kerning_groups: FeContextItem<ir::KerningGroups>,
+    pub kerning_at: FeContextMap<ir::KerningAtLocation>,
     pub anchors: FeContextMap<ir::GlyphAnchors>,
 }
 
@@ -424,7 +428,8 @@ impl Context {
             global_metrics: self.global_metrics.clone_with_acl(acl.clone()),
             glyphs: self.glyphs.clone_with_acl(acl.clone()),
             features: self.features.clone_with_acl(acl.clone()),
-            kerning: self.kerning.clone_with_acl(acl.clone()),
+            kerning_groups: self.kerning_groups.clone_with_acl(acl.clone()),
+            kerning_at: self.kerning_at.clone_with_acl(acl.clone()),
             anchors: self.anchors.clone_with_acl(acl),
         }
     }
@@ -461,7 +466,12 @@ impl Context {
             ),
             glyphs: ContextMap::new(acl.clone(), persistent_storage.clone()),
             features: ContextItem::new(WorkId::Features, acl.clone(), persistent_storage.clone()),
-            kerning: ContextItem::new(WorkId::Kerning, acl.clone(), persistent_storage.clone()),
+            kerning_groups: ContextItem::new(
+                WorkId::KerningGroups,
+                acl.clone(),
+                persistent_storage.clone(),
+            ),
+            kerning_at: ContextMap::new(acl.clone(), persistent_storage.clone()),
             anchors: ContextMap::new(acl, persistent_storage),
         }
     }

--- a/fontir/src/paths.rs
+++ b/fontir/src/paths.rs
@@ -2,7 +2,7 @@
 
 use std::path::{Path, PathBuf};
 
-use fontdrasil::paths::safe_filename;
+use fontdrasil::{coords::NormalizedLocation, paths::safe_filename};
 
 use crate::orchestration::WorkId;
 
@@ -52,6 +52,17 @@ impl Paths {
         self.glyph_ir_dir.join(safe_filename(name, ".yml"))
     }
 
+    fn kern_ir_file(&self, location: &NormalizedLocation) -> PathBuf {
+        let filename = "kern_".to_string()
+            + &location
+                .iter()
+                .map(|(tag, pos)| format!("{tag}_{:.2}", pos.to_f32()))
+                .collect::<Vec<_>>()
+                .join("_")
+            + ".yml";
+        self.build_dir.join(filename)
+    }
+
     pub fn target_file(&self, id: &WorkId) -> PathBuf {
         match id {
             WorkId::Anchor(name) => self.anchor_ir_file(name.as_str()),
@@ -64,7 +75,8 @@ impl Paths {
                 self.build_dir.join(format!("delete-{}.yml", name.as_str()))
             }
             WorkId::Features => self.build_dir.join("features.yml"),
-            WorkId::Kerning => self.build_dir.join("kerning.yml"),
+            WorkId::KerningGroups => self.build_dir.join("kern_groups.yml"),
+            WorkId::KerningAtLocation(location) => self.kern_ir_file(location),
         }
     }
 }

--- a/fontir/src/source.rs
+++ b/fontir/src/source.rs
@@ -84,8 +84,8 @@ pub trait Source {
 
     /// Create a function that could be called to generate or identify kerning for a location.
     ///
-    /// When run work should update [Context] with [crate::ir::KerningAtLocation].
-    fn create_kerning_at_ir_work(
+    /// When run work should update [Context] with [crate::ir::KerningInstance].
+    fn create_kerning_instance_ir_work(
         &self,
         input: &Input,
         at: NormalizedLocation,

--- a/fontir/src/source.rs
+++ b/fontir/src/source.rs
@@ -6,7 +6,7 @@ use indexmap::IndexSet;
 use log::debug;
 use serde::{Deserialize, Serialize};
 
-use fontdrasil::{orchestration::Work, types::GlyphName};
+use fontdrasil::{coords::NormalizedLocation, orchestration::Work, types::GlyphName};
 
 use crate::{
     error::{Error, WorkError},
@@ -77,10 +77,19 @@ pub trait Source {
     /// When run work should update [Context] with [crate::ir::Features].
     fn create_feature_ir_work(&self, input: &Input) -> Result<Box<IrWork>, Error>;
 
-    /// Create a function that could be called to generate or identify kerning.
+    /// Create a function that could be called to produce kerning groups.
     ///
-    /// When run work should update [Context] with [crate::ir::Kerning].
-    fn create_kerning_ir_work(&self, input: &Input) -> Result<Box<IrWork>, Error>;
+    /// When run work should update [Context] with [crate::ir::KerningGroups].
+    fn create_kerning_group_ir_work(&self, input: &Input) -> Result<Box<IrWork>, Error>;
+
+    /// Create a function that could be called to generate or identify kerning for a location.
+    ///
+    /// When run work should update [Context] with [crate::ir::KerningAtLocation].
+    fn create_kerning_at_ir_work(
+        &self,
+        input: &Input,
+        at: NormalizedLocation,
+    ) -> Result<Box<IrWork>, Error>;
 }
 
 /// The files (in future non-file sources?) that drive various parts of IR

--- a/fontir/src/variations.rs
+++ b/fontir/src/variations.rs
@@ -765,7 +765,7 @@ mod tests {
     };
 
     use fontdrasil::{
-        coords::{CoordConverter, DesignCoord, NormalizedCoord, NormalizedLocation, UserCoord},
+        coords::{norm_loc, CoordConverter, DesignCoord, NormalizedLocation, UserCoord},
         types::Axis,
     };
     use kurbo::{Point, Vec2};
@@ -805,13 +805,6 @@ mod tests {
                 1,
             ),
         }
-    }
-
-    fn norm_loc(positions: &[(&str, f32)]) -> NormalizedLocation {
-        positions
-            .iter()
-            .map(|(tag, value)| (Tag::from_str(tag).unwrap(), NormalizedCoord::new(*value)))
-            .collect()
     }
 
     fn default_master_weight() -> Vec<(usize, OrderedFloat<f32>)> {

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -962,7 +962,7 @@ mod tests {
 
     use fontdrasil::{
         coords::{
-            CoordConverter, DesignCoord, NormalizedCoord, NormalizedLocation, UserCoord,
+            Coord, CoordConverter, DesignCoord, NormalizedCoord, NormalizedLocation, UserCoord,
             UserLocation,
         },
         orchestration::{Access, AccessBuilder},

--- a/glyphs2fontir/src/toir.rs
+++ b/glyphs2fontir/src/toir.rs
@@ -10,7 +10,7 @@ use ordered_float::OrderedFloat;
 use write_fonts::types::Tag;
 
 use fontdrasil::{
-    coords::{CoordConverter, DesignCoord, DesignLocation, NormalizedLocation, UserCoord},
+    coords::{Coord, CoordConverter, DesignCoord, DesignLocation, NormalizedLocation, UserCoord},
     types::GlyphName,
 };
 use fontir::{

--- a/glyphs2fontir/src/toir.rs
+++ b/glyphs2fontir/src/toir.rs
@@ -1,4 +1,7 @@
-use std::{collections::HashMap, str::FromStr};
+use std::{
+    collections::{HashMap, HashSet},
+    str::FromStr,
+};
 
 use kurbo::BezPath;
 use log::trace;
@@ -257,6 +260,8 @@ pub struct FontInfo {
     pub font: Font,
     /// Index by master id
     pub master_indices: HashMap<String, usize>,
+    // Master id => location
+    pub master_positions: HashMap<String, NormalizedLocation>,
     /// Axes values => location for every instance and master
     pub locations: HashMap<Vec<OrderedFloat<f64>>, NormalizedLocation>,
     pub axes: Vec<fontdrasil::types::Axis>,
@@ -300,9 +305,26 @@ impl TryFrom<Font> for FontInfo {
             }))
             .collect();
 
+        let variable_axes: HashSet<_> = axes
+            .iter()
+            .filter(|&a| (!a.is_point()))
+            .map(|a| a.tag)
+            .collect();
+        let master_positions: HashMap<_, _> = font
+            .masters
+            .iter()
+            .map(|m| (&m.id, locations.get(&m.axes_values).unwrap()))
+            .map(|(id, pos)| {
+                let mut pos = pos.clone();
+                pos.retain(|tag, _| variable_axes.contains(tag));
+                (id.clone(), pos)
+            })
+            .collect();
+
         Ok(FontInfo {
             font,
             master_indices,
+            master_positions,
             locations,
             axes,
             axis_indices,

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -7,7 +7,7 @@ use std::{
 
 use chrono::{DateTime, NaiveDateTime, Utc};
 use fontdrasil::{
-    coords::{DesignLocation, NormalizedLocation, UserCoord},
+    coords::{Coord, DesignLocation, NormalizedLocation, UserCoord},
     orchestration::{Access, AccessBuilder, Work},
     types::{GlyphName, GroupName},
 };

--- a/ufo2fontir/src/toir.rs
+++ b/ufo2fontir/src/toir.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, path::PathBuf, str::FromStr};
 
 use fontdrasil::{
-    coords::{CoordConverter, DesignCoord, DesignLocation, NormalizedLocation, UserCoord},
+    coords::{Coord, CoordConverter, DesignCoord, DesignLocation, NormalizedLocation, UserCoord},
     types::GlyphName,
 };
 use fontir::{


### PR DESCRIPTION
Step toward #639. Doesn't produce a speedup yet but I like the better threading. Basically breaks up the leftmost kern from https://github.com/googlefonts/fontc/issues/610#issuecomment-1833125480. 

![image](https://github.com/googlefonts/fontc/assets/6466432/8ce87660-71f7-4de5-a6ae-2978a53bab7d)

Things to poke in subsequent PRs:

1. Read file sooner, that has no need to block on glyph order etc
1. Looks like kern_at could have started sooner than it did
1. BE kerning spends a lot of time in a big loop, might be worth splitting up
   * GS has about 60k pairs to loop over, we could just break into N groups, say num CPUs or just a fixed value