### PR TITLE
[DO NOT SUBMIT] Try to reproduce and fix inconsistent GPOS

### DIFF
--- a/fea-rs/src/compile/lookups/gpos_builders.rs
+++ b/fea-rs/src/compile/lookups/gpos_builders.rs
@@ -115,13 +115,15 @@ fn cmp_coverage_key(coverage: &CoverageTable) -> impl Ord {
 #[derive(Clone, Debug, Default, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PairPosBuilder {
-    pairs: GlyphPairPosBuilder,
-    classes: ClassPairPosBuilder,
+    /// meh
+    pub pairs: GlyphPairPosBuilder,
+    /// meh
+    pub classes: ClassPairPosBuilder,
 }
 
 #[derive(Clone, Debug, Default, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-struct GlyphPairPosBuilder(BTreeMap<GlyphId, BTreeMap<GlyphId, (ValueRecord, ValueRecord)>>);
+pub struct GlyphPairPosBuilder(BTreeMap<GlyphId, BTreeMap<GlyphId, (ValueRecord, ValueRecord)>>);
 
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -143,7 +145,7 @@ impl Default for ClassPairPosSubtable {
 
 #[derive(Clone, Debug, Default, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-struct ClassPairPosBuilder(BTreeMap<(ValueFormat, ValueFormat), Vec<ClassPairPosSubtable>>);
+pub struct ClassPairPosBuilder(BTreeMap<(ValueFormat, ValueFormat), Vec<ClassPairPosSubtable>>);
 
 impl ClassPairPosBuilder {
     fn insert(

--- a/fontbe/Cargo.toml
+++ b/fontbe/Cargo.toml
@@ -35,6 +35,8 @@ smol_str.workspace = true
 
 chrono.workspace = true
 
+pretty_assertions.workspace = true
+
 [dev-dependencies]
 diff.workspace = true
 ansi_term.workspace = true

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -211,6 +211,9 @@ pub struct KerningGroups {
     ///
     /// The rhs should be the name used in the groups map.
     pub old_to_new_group_names: BTreeMap<GroupName, GroupName>,
+
+    // TEMPORARY
+    pub complete_kerning: BTreeMap<KernPair, BTreeMap<NormalizedLocation, OrderedFloat<f32>>>,
 }
 
 /// IR representation of kerning for a location.


### PR DESCRIPTION
Problem noted in #647 

This branch rolls back to just after the addition of || ir (that is, before the || be), builds the IR kerning with and without ||ism, and compares the result.