### PR TITLE
[ttx_diff] Group language systems with identical lookups

### DIFF
--- a/layout-normalizer/src/gpos.rs
+++ b/layout-normalizer/src/gpos.rs
@@ -51,7 +51,7 @@ pub(crate) fn print(f: &mut dyn io::Write, font: &FontRef, names: &NameMap) -> R
     // so first we iterate through each feature/language/script set
     for sys in &lang_systems {
         writeln!(f,)?;
-        writeln!(f, "# {}: {}/{} #", sys.feature, sys.script, sys.lang)?;
+        sys.fmt_header(f)?;
 
         // then for each feature/language/script we iterate through
         // all rules, split by the rule (lookup) type


### PR DESCRIPTION
Sometimes a given feature has a common set of lookups, which are shared between multiple language systems. In this case, we will now just print rules once.

For a large font this brought our output size down from 400+ mb to ~30mb, which is still too much but isn't *insane*.

(we didn't notice this problem before because fonts with a large number of rules/lookups/systems are likely using extension lookups, and we were just skipping those)