### PR TITLE
[ci] Fail CI if docs contain broken links

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,8 +29,11 @@ jobs:
       - name: rustfmt check
         run: cargo fmt --all -- --check
 
+      # ensure that docs are sane (links are reachable etc)
       - name: cargo doc
         run: cargo doc --all-features --document-private-items --no-deps
+        env:
+          RUSTDOCFLAGS: -D warnings
 
       - name: check no println! or eprintln! statements
         run: resources/scripts/check_no_println.sh

--- a/fontbe/src/kern.rs
+++ b/fontbe/src/kern.rs
@@ -1,4 +1,4 @@
-//! Generates a [Kerning] datastructure to be fed to fea-rs
+//! Generates an [FeaRsKerns] datastructure to be fed to fea-rs
 
 use std::collections::{BTreeMap, HashMap};
 

--- a/fontbe/src/marks.rs
+++ b/fontbe/src/marks.rs
@@ -1,4 +1,4 @@
-//! Generates a [Marks] datastructure to be fed to fea-rs
+//! Generates a [FeaRsMarks] datastructure to be fed to fea-rs
 
 use std::{
     collections::{BTreeMap, BTreeSet},

--- a/fontdrasil/src/coords.rs
+++ b/fontdrasil/src/coords.rs
@@ -140,9 +140,8 @@ convert_convenience_methods!(UserSpace, to_user);
 convert_convenience_methods!(DesignSpace, to_design);
 
 /// Converts between Design, User, and Normalized coordinates.
-///
-/// Stores `PiecewiseLinearMap`s in several directions. Sources
-/// suggest <= 10 mappings is typical, we can afford the bytes.
+// Stores `PiecewiseLinearMap`'s in several directions. Sources
+// suggest <= 10 mappings is typical, we can afford the bytes.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct CoordConverter {
     pub(crate) default_idx: usize,


### PR DESCRIPTION
This also fixes some existing broken links.

locally I'm getting warnings printed everytime I run the pre-push checks, so we should be catching this in CI.


JMM