### PR TITLE
Stable name order

### DIFF
--- a/fea-rs/src/compile/features.rs
+++ b/fea-rs/src/compile/features.rs
@@ -31,7 +31,7 @@ pub(crate) struct AllFeatures {
     required_features: HashSet<FeatureKey>,
     pub(crate) size: Option<SizeFeature>,
     pub(crate) aalt: Option<AaltFeature>,
-    pub(crate) stylistic_sets: HashMap<Tag, Vec<NameSpec>>,
+    pub(crate) stylistic_sets: BTreeMap<Tag, Vec<NameSpec>>,
     pub(crate) character_variants: HashMap<Tag, CvParams>,
 }
 


### PR DESCRIPTION
Helps with #647. After this change GSUB and gvar are the same size, binary different, and ttx equal. Previously ttx had a diff about UINameValue.

```shell
# Prior diffs looked like this
           <FeatureParamsStylisticSet>
             <Version value="0"/>
-            <UINameID value="264"/>  <!-- Text Bold -->
+            <UINameID value="259"/>  <!-- Regular -->
           </FeatureParamsStylisticSet>

# Now ttx is the same but tables aren't a binary match
$ f=../googlesans/source/GoogleSans/GoogleSans.designspace; \
export SOURCE_DATE_EPOCH=$(date +%s); \
cargo build --release && rm -rf build/ \
&& target/release/fontc $f && cp build/font.ttf build/first.ttf \
&& target/release/fontc $f && cp build/font.ttf build/second.ttf \
&& diff -u <(fonttools ttx -o - -l build/first.ttf | tail -n +2) <(fonttools ttx -o - -l build/second.ttf | tail -n +2)
...
     ----  ----------  --------  --------
     GDEF  0x264FC9B0     18586       300
     GPOS  0xF380817A   4384362     18888
-    GSUB  0x7065E658    116846   4403252
+    GSUB  0x57181E07    116846   4403252
     HVAR  0x48F9517C     22831   4520100
     OS/2  0xC339AE91        96   4542932
     STAT  0x31361D50        44   4543028
@@ -10,7 +10,7 @@
     cmap  0xBEBC9FD3     10444   4543132
     fvar  0x47F5205B       172   4553576
     glyf  0x6C2897A1   1083450   4553748
-    gvar  0x81F1F8AB   2791136   5637200
+    gvar  0xA9AECAF6   2791136   5637200
     head  0x1F490158        54   8428336
     hhea  0x0CCB293F        36   8428392
     hmtx  0x5D80687A     30484   8428428

$ diff -u <(fonttools ttx -o - -t GSUB -q build/first.ttf | tail -n +2) <(fonttools ttx -o - -t GSUB -q build/font.ttf | tail -n +2)
<no output>
$ diff -u <(fonttools ttx -o - -t gvar -q build/first.ttf | tail -n +2) <(fonttools ttx -o - -t gvar -q build/font.ttf | tail -n +2)
<no output>
```