### PR TITLE
[ttx_diff] Better handling of pairpos subtables

### DIFF
--- a/fea-rs/src/compile.rs
+++ b/fea-rs/src/compile.rs
@@ -16,7 +16,7 @@ pub use compiler::Compiler;
 pub use feature_writer::{FeatureBuilder, FeatureProvider, NopFeatureProvider};
 pub use language_system::LanguageSystem;
 pub use lookups::{
-    FeatureKey, LookupId, MarkToBaseBuilder, MarkToMarkBuilder, PairPosBuilder,
+    Builder, FeatureKey, LookupId, MarkToBaseBuilder, MarkToMarkBuilder, PairPosBuilder,
     PreviouslyAssignedClass,
 };
 pub use metrics::{Anchor, ValueRecord};

--- a/fea-rs/src/compile/lookups.rs
+++ b/fea-rs/src/compile/lookups.rs
@@ -49,18 +49,26 @@ use gsub_builders::{
 };
 pub(crate) use helpers::ClassDefBuilder2;
 
-// A simple trait for building lookups
+/// A simple trait for building lookups
 // This exists because we use it to implement `LookupBuilder<T>`
-pub(crate) trait Builder {
+pub trait Builder {
+    /// The type produced by this builder.
+    ///
+    /// In the case of lookups, this is always a `Vec<Subtable>`, because a single
+    /// builder may produce multiple subtables in some instances.
     type Output;
-    // the var_store is only used in GPOS, but we pass it everywhere.
-    // This is annoying but feels like the lesser of two evils. It's easy to
-    // ignore this argument where it isn't used, and this makes the logic
-    // in LookupBuilder simpler, since it is identical for GPOS/GSUB.
-    //
-    // It would be nice if this could then be Option<&mut T>, but that type is
-    // annoying to work with, as Option<&mut _> doesn't impl Copy, so you need
-    // to do a dance anytime you use it.
+    /// Finalize the builder, producing the output.
+    ///
+    /// # Note:
+    ///
+    /// The var_store is only used in GPOS, but we pass it everywhere.
+    /// This is annoying but feels like the lesser of two evils. It's easy to
+    /// ignore this argument where it isn't used, and this makes the logic
+    /// in LookupBuilder simpler, since it is identical for GPOS/GSUB.
+    ///
+    /// It would be nice if this could then be Option<&mut T>, but that type is
+    /// annoying to work with, as Option<&mut _> doesn't impl Copy, so you need
+    /// to do a dance anytime you use it.
     fn build(self, var_store: &mut VariationStoreBuilder) -> Self::Output;
 }
 

--- a/layout-normalizer/Cargo.toml
+++ b/layout-normalizer/Cargo.toml
@@ -12,6 +12,9 @@ smol_str.workspace = true
 write-fonts.workspace = true
 indexmap.workspace = true
 
+[dev-dependencies]
+fea-rs = { path = "../fea-rs" }
+
 # cargo-release settings
 [package.metadata.release]
 release = false


### PR DESCRIPTION
This changes the logic around skipping rules to only skip if there is an entry for the _pair_, instead of for the first glyph.

Most of this PR is a test and a bunch of test-setup code which I hope to reuse.

This uses the builders in fea-rs, and doing that required me to make a trait in there public, but that seems fine.


- closes #657 
- progress on #643 