### PR TITLE
[ttx_diff] Better handling of mark pos subtables

### DIFF
--- a/layout-normalizer/src/common.rs
+++ b/layout-normalizer/src/common.rs
@@ -178,6 +178,15 @@ impl GlyphSet {
         }
     }
 
+    #[cfg(test)]
+    pub(crate) fn iter(&self) -> impl Iterator<Item = GlyphId> + '_ {
+        let (left, right) = match self {
+            GlyphSet::Single(gid) => (Some(*gid), None),
+            GlyphSet::Multiple(gids) => (None, Some(gids.iter().copied())),
+        };
+        left.into_iter().chain(right.into_iter().flatten())
+    }
+
     pub(crate) fn printer<'a>(&'a self, names: &'a NameMap) -> impl Display + 'a {
         // A helper for printing one or more glyphs
         struct GlyphPrinter<'a> {

--- a/layout-normalizer/src/gpos/pairpos.rs
+++ b/layout-normalizer/src/gpos/pairpos.rs
@@ -255,6 +255,7 @@ mod tests {
 
     // to make our tests easier to read, have a special partialeq impl
     impl PartialEq<(u16, &[u16], i16)> for PairPosRule {
+        // (left gid, [right gids], x advance)
         fn eq(&self, other: &(u16, &[u16], i16)) -> bool {
             // bail early because the next comparison allocates -_-
             if self.first.to_u16() != other.0 {
@@ -311,6 +312,7 @@ mod tests {
         // sorted by first glyph
         rules.sort_unstable();
 
+        // (left gid, [right gids], x advance)
         let expected: &[(u16, &[u16], i16)] = &[
             (4, &[7, 8], -808), // from sub3
             (5, &[6], -7),      // sub1


### PR DESCRIPTION
As with pairpos, we will only skip a rule if the (base, mark) pair has already been seen in a preceding subtable.