### PR TITLE
Update fontations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ clap = { version = "4.0.32", features = ["derive"] }
 rayon = "1.6"
 
 # fontations etc
-write-fonts = { version = "0.19.0", features = ["serde", "read"] }
-skrifa = "0.14.0"
+write-fonts = { version = "0.20.1", features = ["serde", "read"] }
+skrifa = "0.15.0"
 norad = "0.12"
 
 # dev dependencies


### PR DESCRIPTION
Meant to help with #647 as a packing indeteriminism was fixed by https://github.com/googlefonts/fontations/pull/738.

Unfortunately this seems to exhibit a new bug, I'm seeing errors like

```shell
thread 'tests::intermediate_layer_in_designspace' panicked at ./.cargo/registry/src/index.crates.io-6f17d22bba15001f/read-fonts-0.15.0/src/array.rs:27:19:
attempt to divide by zero
stack backtrace:
   0: rust_begin_unwind
             at /rustc/a28077b28a02b92985b3a3faecf92813155f1ea1/library/std/src/panicking.rs:597:5
   1: core::panicking::panic_fmt
             at /rustc/a28077b28a02b92985b3a3faecf92813155f1ea1/library/core/src/panicking.rs:72:14
   2: core::panicking::panic
             at /rustc/a28077b28a02b92985b3a3faecf92813155f1ea1/library/core/src/panicking.rs:127:5
   3: read_fonts::array::ComputedArray<T>::new
             at ./.cargo/registry/src/index.crates.io-6f17d22bba15001f/read-fonts-0.15.0/src/array.rs:27:19
   4: <read_fonts::array::ComputedArray<T> as read_fonts::read::FontReadWithArgs>::read_with_args
             at ./.cargo/registry/src/index.crates.io-6f17d22bba15001f/read-fonts-0.15.0/src/array.rs:55:12
   5: read_fonts::font_data::FontData::read_with_args::{{closure}}
             at ./.cargo/registry/src/index.crates.io-6f17d22bba15001f/read-fonts-0.15.0/src/font_data.rs:95:30
   6: core::result::Result<T,E>::and_then
             at /rustc/a28077b28a02b92985b3a3faecf92813155f1ea1/library/core/src/result.rs:1320:22
   7: read_fonts::font_data::FontData::read_with_args
             at ./.cargo/registry/src/index.crates.io-6f17d22bba15001f/read-fonts-0.15.0/src/font_data.rs:93:9
   8: read_fonts::tables::variations::<impl read_fonts::table_ref::TableRef<read_fonts::tables::variations::VariationRegionListMarker>>::variation_regions
             at ./.cargo/registry/src/index.crates.io-6f17d22bba15001f/read-fonts-0.15.0/src/tables/../../generated/generated_variations.rs:793:9
```