### PR TITLE
[ttx_diff] Less type erasure in layout-normalizer

### DIFF
--- a/layout-normalizer/src/gpos.rs
+++ b/layout-normalizer/src/gpos.rs
@@ -1,12 +1,11 @@
 use std::{
-    any::Any,
-    collections::BTreeMap,
     fmt::{Debug, Display},
     io,
 };
 
 use write_fonts::read::{
     tables::{
+        gdef::MarkGlyphSets,
         gpos::{AnchorTable, ExtensionSubtable, PositionLookup, PositionLookupList, ValueRecord},
         layout::{DeviceOrVariationIndex, LookupFlag},
     },
@@ -14,7 +13,7 @@ use write_fonts::read::{
 };
 
 use crate::{
-    common::{self, GlyphSet},
+    common::{self, GlyphSet, Lookup, PrintNames, SingleRule},
     error::Error,
     glyph_names::NameMap,
     variations::DeltaComputer,
@@ -55,41 +54,55 @@ pub(crate) fn print(f: &mut dyn io::Write, font: &FontRef, names: &NameMap) -> R
 
         // then for each feature/language/script we iterate through
         // all rules, split by the rule (lookup) type
-        for rule_set in lookup_rules.iter_rule_sets(&sys.lookups) {
-            writeln!(
-                f,
-                "# {} {} rules",
-                rule_set.rules.len(),
-                rule_set.lookup_type
-            )?;
-            let mut last_flag = None;
-            let mut last_filter_set = None;
-            for rule in rule_set.rules {
-                let (flags, filter_set_id) = rule.lookup_flags();
-                if last_flag != Some(flags) {
-                    writeln!(f, "# lookupflag {flags:?}")?;
-                    last_flag = Some(flags);
-                }
+        let pairpos = lookup_rules.pairpos_rules(&sys.lookups);
+        let markmark = lookup_rules.markmark_rules(&sys.lookups);
+        let markbase = lookup_rules.markbase_rules(&sys.lookups);
 
-                if filter_set_id != last_filter_set {
-                    if let Some(filter_id) = filter_set_id {
-                        let filter_set = mark_glyph_sets
-                            .as_ref()
-                            .map(|gsets| gsets.coverages().get(filter_id as usize))
-                            .transpose()
-                            .unwrap();
-                        let glyphs = filter_set.map(|cov| cov.iter().collect::<GlyphSet>());
-                        if let Some(glyphs) = glyphs {
-                            writeln!(f, "# filter glyphs: {}", glyphs.printer(names))?;
-                        }
-                    }
-                }
-                last_filter_set = filter_set_id;
-                writeln!(f, "{}", rule_printer(rule, names))?;
-            }
-        }
+        print_rules(f, "PairPos", &pairpos, names, mark_glyph_sets.as_ref())?;
+        print_rules(f, "MarkToBase", &markbase, names, mark_glyph_sets.as_ref())?;
+        print_rules(f, "MarkToMark", &markmark, names, mark_glyph_sets.as_ref())?;
     }
 
+    Ok(())
+}
+
+fn print_rules<T: PrintNames>(
+    f: &mut dyn io::Write,
+    type_name: &str,
+    rules: &[SingleRule<T>],
+    names: &NameMap,
+    mark_glyph_sets: Option<&MarkGlyphSets>,
+) -> Result<(), Error> {
+    if rules.is_empty() {
+        return Ok(());
+    }
+
+    writeln!(f, "# {} {type_name} rules", rules.len(),)?;
+    let mut last_flag = None;
+    let mut last_filter_set = None;
+    for rule in rules {
+        let (flags, filter_set_id) = rule.lookup_flags();
+        if last_flag != Some(flags) {
+            writeln!(f, "# lookupflag {flags:?}")?;
+            last_flag = Some(flags);
+        }
+
+        if filter_set_id != last_filter_set {
+            if let Some(filter_id) = filter_set_id {
+                let filter_set = mark_glyph_sets
+                    .as_ref()
+                    .map(|gsets| gsets.coverages().get(filter_id as usize))
+                    .transpose()
+                    .unwrap();
+                let glyphs = filter_set.map(|cov| cov.iter().collect::<GlyphSet>());
+                if let Some(glyphs) = glyphs {
+                    writeln!(f, "# filter glyphs: {}", glyphs.printer(names))?;
+                }
+            }
+        }
+        last_filter_set = filter_set_id;
+        writeln!(f, "{}", rule.printer(names))?;
+    }
     Ok(())
 }
 
@@ -217,158 +230,49 @@ impl ResolvedValue {
     }
 }
 
+#[derive(Clone, Debug, Default)]
 struct LookupRules {
+    pairpos: Vec<Lookup<PairPosRule>>,
+    markbase: Vec<Lookup<MarkAttachmentRule>>,
+    markmark: Vec<Lookup<MarkAttachmentRule>>,
     // decomposed rules for each lookup, in lookup order
-    rules: Vec<Vec<LookupRule>>,
-}
-
-#[derive(Clone, Debug)]
-#[allow(clippy::large_enum_variant)]
-enum LookupRule {
-    PairPos(PairPosRule),
-    MarkBase(MarkAttachmentRule),
-    MarkMark(MarkAttachmentRule),
-}
-
-// a collection of rules of a single type
-struct RuleSet<'a> {
-    lookup_type: LookupType,
-    rules: Vec<&'a dyn AnyRule>,
-}
-
-// a trait we use to type-erase our specific rules while printing
-trait AnyRule {
-    // The lookup flags plus the mark filter set id
-    fn lookup_flags(&self) -> (LookupFlag, Option<u16>);
-    fn lookup_type(&self) -> LookupType;
-    // write this rule into the provided stream
-    //
-    // this is passed in a map of gids to names, which are needed for printing
-    fn fmt_impl(&self, f: &mut std::fmt::Formatter<'_>, names: &NameMap) -> std::fmt::Result;
-
-    fn as_any(&self) -> &dyn Any;
-}
-
-fn rule_printer<'a>(rule: &'a dyn AnyRule, names: &'a NameMap) -> Printer<'a> {
-    Printer { rule, names }
-}
-
-// this code is annoying.
-//
-// basically: we have a bunch of different lookups, of different types. But when
-// we print the rules, we want to take a bunch of rules from different lookups
-// and print them in some canonical way. This means we need to be able to sort
-// them after we've collected them, at which point we don't know their actual
-// types anymore, so we do this dance. I'm sorry.
-impl<'a> Ord for &'a dyn AnyRule {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        match (self.lookup_type(), other.lookup_type()) {
-            (LookupType::PairPos, LookupType::PairPos) => self
-                .as_any()
-                .downcast_ref::<PairPosRule>()
-                .unwrap()
-                .cmp(other.as_any().downcast_ref::<PairPosRule>().unwrap()),
-            (LookupType::MarkToBase, LookupType::MarkToBase)
-            | (LookupType::MarkToMark, LookupType::MarkToMark) => self
-                .as_any()
-                .downcast_ref::<MarkAttachmentRule>()
-                .unwrap()
-                .cmp(other.as_any().downcast_ref::<MarkAttachmentRule>().unwrap()),
-            (self_type, other_type) => {
-                assert!(
-                    self_type != other_type,
-                    "you need to add a new branch in the Ord impl"
-                );
-                self_type.cmp(&other_type)
-            }
-        }
-    }
-}
-
-impl<'a> PartialOrd for &'a dyn AnyRule {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl<'a> PartialEq for &'a dyn AnyRule {
-    fn eq(&self, other: &Self) -> bool {
-        match (self.lookup_type(), other.lookup_type()) {
-            (LookupType::PairPos, LookupType::PairPos) => self
-                .as_any()
-                .downcast_ref::<PairPosRule>()
-                .unwrap()
-                .eq(other.as_any().downcast_ref::<PairPosRule>().unwrap()),
-            (LookupType::MarkToBase, LookupType::MarkToBase)
-            | (LookupType::MarkToMark, LookupType::MarkToMark) => self
-                .as_any()
-                .downcast_ref::<MarkAttachmentRule>()
-                .unwrap()
-                .eq(other.as_any().downcast_ref::<MarkAttachmentRule>().unwrap()),
-            (self_type, other_type) => {
-                assert!(
-                    self_type != other_type,
-                    "you need to add a new branch in the PartialEq impl"
-                );
-                false
-            }
-        }
-    }
-}
-
-impl<'a> Eq for &'a dyn AnyRule {}
-
-struct Printer<'a> {
-    rule: &'a dyn AnyRule,
-    names: &'a NameMap,
-}
-
-impl Display for Printer<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.rule.fmt_impl(f, self.names)
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
-enum LookupType {
-    //SinglePos = 1,
-    PairPos = 2,
-    MarkToBase,
-    MarkToMark,
-}
-
-impl LookupRule {
-    fn dyn_inner(&self) -> &dyn AnyRule {
-        match self {
-            LookupRule::PairPos(inner) => inner,
-            LookupRule::MarkBase(inner) => inner,
-            LookupRule::MarkMark(inner) => inner,
-        }
-    }
 }
 
 impl LookupRules {
-    /// returns all the rules in all the referenced lookups
-    fn iter_rule_sets<'a>(&'a self, lookups: &[u16]) -> impl Iterator<Item = RuleSet<'a>> {
-        let mut by_type = BTreeMap::new();
-        for lookup in lookups {
-            for rule in &self.rules[*lookup as usize] {
-                let as_dyn = rule.dyn_inner();
-                let lookup_type = as_dyn.lookup_type();
-                by_type
-                    .entry(lookup_type)
-                    .or_insert_with(|| RuleSet {
-                        lookup_type,
-                        rules: Vec::new(),
-                    })
-                    .rules
-                    .push(as_dyn);
-            }
-        }
-        by_type.into_values().map(|mut rules| {
-            rules.rules.sort_unstable();
-            rules
-        })
+    fn pairpos_rules<'a>(&'a self, lookups: &[u16]) -> Vec<SingleRule<'a, PairPosRule>> {
+        //TODO: in here we will do the normalizing of items that appear in multiple lookups
+        let mut all_rules = self
+            .pairpos
+            .iter()
+            .filter(|lookup| lookups.contains(&lookup.lookup_id))
+            .flat_map(|lookup| lookup.iter())
+            .collect::<Vec<_>>();
+        all_rules.sort_unstable();
+        all_rules
+    }
+
+    fn markbase_rules<'a>(&'a self, lookups: &[u16]) -> Vec<SingleRule<'a, MarkAttachmentRule>> {
+        //TODO: in here we will do the normalizing of items that appear in multiple lookups
+        let mut all_rules = self
+            .markbase
+            .iter()
+            .filter(|lookup| lookups.contains(&lookup.lookup_id))
+            .flat_map(|lookup| lookup.iter())
+            .collect::<Vec<_>>();
+        all_rules.sort_unstable();
+        all_rules
+    }
+
+    fn markmark_rules<'a>(&'a self, lookups: &[u16]) -> Vec<SingleRule<'a, MarkAttachmentRule>> {
+        //TODO: in here we will do the normalizing of items that appear in multiple lookups
+        let mut all_rules = self
+            .markmark
+            .iter()
+            .filter(|lookup| lookups.contains(&lookup.lookup_id))
+            .flat_map(|lookup| lookup.iter())
+            .collect::<Vec<_>>();
+        all_rules.sort_unstable();
+        all_rules
     }
 }
 
@@ -376,55 +280,45 @@ fn get_lookup_rules(
     lookups: &PositionLookupList,
     delta_computer: Option<&DeltaComputer>,
 ) -> LookupRules {
-    let mut result = Vec::new();
-    for (_i, lookup) in lookups.lookups().iter().enumerate() {
+    let mut result = LookupRules::default();
+    for (id, lookup) in lookups.lookups().iter().enumerate() {
         let lookup = lookup.unwrap();
+        let (flag, mark_filter_id) = get_flags_and_filter_set_id(&lookup);
         match lookup {
             PositionLookup::Pair(lookup) => {
-                let flag = lookup.lookup_flag();
                 let subs = lookup
                     .subtables()
                     .iter()
                     .flat_map(|sub| sub.ok())
                     .collect::<Vec<_>>();
-                let rules = pairpos::get_pairpos_rules(&subs, flag, delta_computer).unwrap();
-                result.push(rules);
+                let rules = pairpos::get_pairpos_rules(&subs, delta_computer).unwrap();
+                result.pairpos.push(Lookup::new(id, rules, flag, None));
             }
             PositionLookup::MarkToBase(lookup) => {
-                let flag = lookup.lookup_flag();
-                let mark_filter_id = flag
-                    .use_mark_filtering_set()
-                    .then(|| lookup.mark_filtering_set());
                 let subs: Vec<_> = lookup
                     .subtables()
                     .iter()
                     .flat_map(|subt| subt.ok())
                     .collect();
-                let rules = marks::get_mark_base_rules(&subs, flag, mark_filter_id, delta_computer)
-                    .unwrap();
-                result.push(rules);
+                let rules = marks::get_mark_base_rules(&subs, delta_computer).unwrap();
+                result
+                    .markbase
+                    .push(Lookup::new(id, rules, flag, mark_filter_id));
             }
             PositionLookup::MarkToMark(lookup) => {
-                let flag = lookup.lookup_flag();
-                let mark_filter_id = flag
-                    .use_mark_filtering_set()
-                    .then(|| lookup.mark_filtering_set());
                 let subs: Vec<_> = lookup
                     .subtables()
                     .iter()
                     .flat_map(|subt| subt.ok())
                     .collect();
-                let rules = marks::get_mark_mark_rules(&subs, flag, mark_filter_id, delta_computer)
-                    .unwrap();
-                result.push(rules)
+                let rules = marks::get_mark_mark_rules(&subs, delta_computer).unwrap();
+                result
+                    .markmark
+                    .push(Lookup::new(id, rules, flag, mark_filter_id));
             }
             PositionLookup::Extension(lookup) => {
-                let flag = lookup.lookup_flag();
-                let mark_filter_id = flag
-                    .use_mark_filtering_set()
-                    .then(|| lookup.mark_filtering_set());
                 let first_sub = lookup.subtables().get(0).ok();
-                let rules = match first_sub {
+                match first_sub {
                     Some(ExtensionSubtable::MarkToBase(_)) => {
                         let subs = lookup
                             .subtables()
@@ -434,8 +328,10 @@ fn get_lookup_rules(
                                 _ => None,
                             })
                             .collect::<Vec<_>>();
-                        marks::get_mark_base_rules(&subs, flag, mark_filter_id, delta_computer)
-                            .unwrap()
+                        let rules = marks::get_mark_base_rules(&subs, delta_computer).unwrap();
+                        result
+                            .markbase
+                            .push(Lookup::new(id, rules, flag, mark_filter_id));
                     }
                     Some(ExtensionSubtable::MarkToMark(_)) => {
                         let subs = lookup
@@ -446,8 +342,10 @@ fn get_lookup_rules(
                                 _ => None,
                             })
                             .collect::<Vec<_>>();
-                        marks::get_mark_mark_rules(&subs, flag, mark_filter_id, delta_computer)
-                            .unwrap()
+                        let rules = marks::get_mark_mark_rules(&subs, delta_computer).unwrap();
+                        result
+                            .markmark
+                            .push(Lookup::new(id, rules, flag, mark_filter_id));
                     }
                     Some(ExtensionSubtable::Pair(_)) => {
                         let subs = lookup
@@ -458,19 +356,35 @@ fn get_lookup_rules(
                                 _ => None,
                             })
                             .collect::<Vec<_>>();
-                        pairpos::get_pairpos_rules(&subs, flag, delta_computer).unwrap()
+                        let rules = pairpos::get_pairpos_rules(&subs, delta_computer).unwrap();
+                        result
+                            .pairpos
+                            .push(Lookup::new(id, rules, flag, mark_filter_id));
                     }
-                    _ => Vec::new(),
+                    _ => (),
                 };
-                result.push(rules);
             }
-            _other => {
-                // we always want to have as many sets as we have lookups
-                result.push(Vec::new());
-            }
+            _ => (),
         }
     }
-    LookupRules { rules: result }
+    result
+}
+
+fn get_flags_and_filter_set_id(lookup: &PositionLookup) -> (LookupFlag, Option<u16>) {
+    let (flag, filter_id) = match lookup {
+        PositionLookup::Single(lookup) => (lookup.lookup_flag(), lookup.mark_filtering_set()),
+        PositionLookup::Pair(lookup) => (lookup.lookup_flag(), lookup.mark_filtering_set()),
+        PositionLookup::Cursive(lookup) => (lookup.lookup_flag(), lookup.mark_filtering_set()),
+        PositionLookup::MarkToBase(lookup) => (lookup.lookup_flag(), lookup.mark_filtering_set()),
+        PositionLookup::MarkToLig(lookup) => (lookup.lookup_flag(), lookup.mark_filtering_set()),
+        PositionLookup::MarkToMark(lookup) => (lookup.lookup_flag(), lookup.mark_filtering_set()),
+        PositionLookup::Contextual(lookup) => (lookup.lookup_flag(), lookup.mark_filtering_set()),
+        PositionLookup::ChainContextual(lookup) => {
+            (lookup.lookup_flag(), lookup.mark_filtering_set())
+        }
+        PositionLookup::Extension(lookup) => (lookup.lookup_flag(), lookup.mark_filtering_set()),
+    };
+    (flag, flag.use_mark_filtering_set().then_some(filter_id))
 }
 
 impl From<i16> for ResolvedValue {
@@ -479,17 +393,6 @@ impl From<i16> for ResolvedValue {
             default: src,
             device_or_deltas: None,
         }
-    }
-}
-
-impl Display for LookupType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let name = match self {
-            LookupType::PairPos => "PairPos",
-            LookupType::MarkToBase => "MarkToBase",
-            LookupType::MarkToMark => "MarkToMark",
-        };
-        f.write_str(name)
     }
 }
 


### PR DESCRIPTION
This is just a refactor, with no functional changes.

This is ultimately just a better, simpler implementation. It preserves more information about lookup order, which will be helpful as we try to do things like unify overlapping rules across lookup boundaries.