### PR TITLE
[ttx_diff]: Normalize kern rules

### DIFF
--- a/layout-normalizer/src/common.rs
+++ b/layout-normalizer/src/common.rs
@@ -65,7 +65,7 @@ where
     // this is one of rare times that Cow makes sense; the vast majority of
     // the time this is borrowed from a lookup unchanged, but *occasionally* if
     // there is overlap between two lookups we need to clone and mutate it.
-    pub rule: Cow<'a, Rule>,
+    rule: Cow<'a, Rule>,
     pub lookup_id: u16,
     flag: LookupFlag,
     filter_set: Option<u16>,
@@ -293,6 +293,14 @@ impl<Rule> Lookup<Rule> {
 impl<T: Clone> SingleRule<'_, T> {
     pub fn lookup_flags(&self) -> (LookupFlag, Option<u16>) {
         (self.flag, self.filter_set)
+    }
+
+    pub fn rule(&self) -> &T {
+        self.rule.as_ref()
+    }
+
+    pub fn rule_mut(&mut self) -> &mut T {
+        self.rule.to_mut()
     }
 }
 

--- a/layout-normalizer/src/common.rs
+++ b/layout-normalizer/src/common.rs
@@ -1,6 +1,7 @@
 //! general common utilities and types
 
 use std::{
+    borrow::Cow,
     collections::{BTreeSet, HashMap},
     fmt::Display,
     io,
@@ -34,7 +35,7 @@ pub(crate) struct Feature {
 }
 
 /// A type to represent either one or multiple glyphs
-#[derive(Clone, Debug, PartialEq, PartialOrd, Eq, Ord)]
+#[derive(Clone, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub(crate) enum GlyphSet {
     Single(GlyphId),
     Multiple(BTreeSet<GlyphId>),
@@ -57,8 +58,14 @@ pub(crate) struct Lookup<Rule> {
 
 /// a single rule, carrying along info stored in its parent lookup
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
-pub(crate) struct SingleRule<'a, Rule> {
-    pub rule: &'a Rule,
+pub(crate) struct SingleRule<'a, Rule>
+where
+    Rule: Clone,
+{
+    // this is one of rare times that Cow makes sense; the vast majority of
+    // the time this is borrowed from a lookup unchanged, but *occasionally* if
+    // there is overlap between two lookups we need to clone and mutate it.
+    pub rule: Cow<'a, Rule>,
     pub lookup_id: u16,
     flag: LookupFlag,
     filter_set: Option<u16>,
@@ -184,16 +191,16 @@ impl GlyphSet {
         }
     }
 
-    pub(crate) fn combine(&mut self, other: GlyphSet) {
+    pub(crate) fn combine(&mut self, other: &GlyphSet) {
         self.make_set();
         let GlyphSet::Multiple(gids) = self else {
             unreachable!()
         };
         match other {
             GlyphSet::Single(gid) => {
-                gids.insert(gid);
+                gids.insert(*gid);
             }
-            GlyphSet::Multiple(mut multi) => gids.append(&mut multi),
+            GlyphSet::Multiple(multi) => gids.extend(multi.iter().copied()),
         }
     }
 
@@ -270,23 +277,26 @@ impl<Rule> Lookup<Rule> {
         }
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = SingleRule<Rule>> + '_ {
+    pub fn iter(&self) -> impl Iterator<Item = SingleRule<Rule>> + '_
+    where
+        Rule: Clone,
+    {
         self.rules.iter().map(|rule| SingleRule {
             lookup_id: self.lookup_id,
             flag: self.flag,
             filter_set: self.filter_set,
-            rule,
+            rule: Cow::Borrowed(rule),
         })
     }
 }
 
-impl<T> SingleRule<'_, T> {
+impl<T: Clone> SingleRule<'_, T> {
     pub fn lookup_flags(&self) -> (LookupFlag, Option<u16>) {
         (self.flag, self.filter_set)
     }
 }
 
-impl<T: PrintNames> SingleRule<'_, T> {
+impl<T: PrintNames + Clone> SingleRule<'_, T> {
     pub fn printer<'a>(&'a self, names: &'a NameMap) -> impl std::fmt::Display + 'a {
         struct Printer<'a, T> {
             names: &'a NameMap,
@@ -301,7 +311,7 @@ impl<T: PrintNames> SingleRule<'_, T> {
 
         Printer {
             names,
-            item: self.rule,
+            item: self.rule.as_ref(),
         }
     }
 }

--- a/layout-normalizer/src/gpos.rs
+++ b/layout-normalizer/src/gpos.rs
@@ -277,13 +277,13 @@ impl LookupRules {
             .filter(|lookup| lookups.contains(&lookup.lookup_id))
             .flat_map(|lookup| lookup.iter())
         {
-            match pairmap.entry((rule.rule.first, rule.rule.second.clone())) {
+            match pairmap.entry((rule.rule().first, rule.rule().second.clone())) {
                 hash_map::Entry::Vacant(entry) => {
                     entry.insert(rule);
                 }
                 hash_map::Entry::Occupied(mut entry) => {
-                    let prev_rule = entry.get_mut().rule.to_mut();
-                    prev_rule.merge(&rule.rule);
+                    let prev_rule = entry.get_mut().rule_mut();
+                    prev_rule.merge(rule.rule());
                 }
             };
         }
@@ -293,9 +293,9 @@ impl LookupRules {
         let mut seen = HashMap::<_, _>::new();
         for rule in pairmap.into_values() {
             match seen.entry((
-                rule.rule.first,
-                rule.rule.record1.clone(),
-                rule.rule.record2.clone(),
+                rule.rule().first,
+                rule.rule().record1.clone(),
+                rule.rule().record2.clone(),
             )) {
                 hash_map::Entry::Vacant(entry) => {
                     entry.insert(rule);
@@ -303,10 +303,9 @@ impl LookupRules {
                 hash_map::Entry::Occupied(mut entry) => {
                     entry
                         .get_mut()
-                        .rule
-                        .to_mut()
+                        .rule_mut()
                         .second
-                        .combine(&rule.rule.second);
+                        .combine(&rule.rule().second);
                 }
             }
         }
@@ -555,7 +554,7 @@ mod tests {
         let our_rules = rules
             .pairpos_rules(&[0, 1])
             .into_iter()
-            .map(|r| r.rule.as_ref().to_owned())
+            .map(|r| r.rule().to_owned())
             .collect::<Vec<_>>();
 
         // (left gid, [right gids], x advance)

--- a/layout-normalizer/src/gpos.rs
+++ b/layout-normalizer/src/gpos.rs
@@ -19,10 +19,13 @@ use crate::{
     variations::DeltaComputer,
 };
 
-use self::{marks::MarkAttachmentRule, pairpos::PairPosRule};
-
 mod marks;
 mod pairpos;
+
+#[cfg(test)]
+mod test_helpers;
+
+use self::{marks::MarkAttachmentRule, pairpos::PairPosRule};
 
 pub(crate) fn print(f: &mut dyn io::Write, font: &FontRef, names: &NameMap) -> Result<(), Error> {
     writeln!(f, "# GPOS #")?;

--- a/layout-normalizer/src/gpos.rs
+++ b/layout-normalizer/src/gpos.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::HashMap,
     fmt::{Debug, Display},
     io,
 };
@@ -69,7 +70,7 @@ pub(crate) fn print(f: &mut dyn io::Write, font: &FontRef, names: &NameMap) -> R
     Ok(())
 }
 
-fn print_rules<T: PrintNames>(
+fn print_rules<T: PrintNames + Clone>(
     f: &mut dyn io::Write,
     type_name: &str,
     rules: &[SingleRule<T>],
@@ -185,6 +186,13 @@ impl ResolvedValueRecord {
             && self.y_placement.is_zero()
             && self.x_placement.is_zero()
     }
+
+    fn add_in_place(&mut self, other: &Self) {
+        self.x_advance.add_in_place(&other.x_advance);
+        self.y_advance.add_in_place(&other.y_advance);
+        self.x_placement.add_in_place(&other.x_placement);
+        self.y_placement.add_in_place(&other.y_placement);
+    }
 }
 
 impl ResolvedAnchor {
@@ -231,6 +239,22 @@ impl ResolvedValue {
     fn is_zero(&self) -> bool {
         self.default == 0 && self.device_or_deltas.is_none()
     }
+
+    fn add_in_place(&mut self, other: &ResolvedValue) {
+        self.default += other.default;
+        // note: in theory there could be Device tables here, in which case
+        // we are just dropping the second one; in practice Device tables are
+        // basically unused, and are completely unused in Google Fonts fonts
+        if let (Some(DeviceOrDeltas::Deltas(d1)), Some(DeviceOrDeltas::Deltas(d2))) = (
+            self.device_or_deltas.as_mut(),
+            other.device_or_deltas.as_ref(),
+        ) {
+            // these aren't deltas, but rather the resolved value at each
+            // defined master location, so they should always be equal.
+            assert_eq!(d1.len(), d2.len());
+            d1.iter_mut().zip(d2.iter()).for_each(|(d1, d2)| *d1 += d2)
+        }
+    }
 }
 
 #[derive(Clone, Debug, Default)]
@@ -243,15 +267,52 @@ struct LookupRules {
 
 impl LookupRules {
     fn pairpos_rules<'a>(&'a self, lookups: &[u16]) -> Vec<SingleRule<'a, PairPosRule>> {
-        //TODO: in here we will do the normalizing of items that appear in multiple lookups
-        let mut all_rules = self
+        use std::collections::hash_map;
+        // so these rules are currently decomposed, (each rule is for a
+        // single pair of glyphs) so we want to normalize them and then combine.
+        let mut pairmap = HashMap::<_, _>::new();
+        for rule in self
             .pairpos
             .iter()
             .filter(|lookup| lookups.contains(&lookup.lookup_id))
             .flat_map(|lookup| lookup.iter())
-            .collect::<Vec<_>>();
-        all_rules.sort_unstable();
-        all_rules
+        {
+            match pairmap.entry((rule.rule.first, rule.rule.second.clone())) {
+                hash_map::Entry::Vacant(entry) => {
+                    entry.insert(rule);
+                }
+                hash_map::Entry::Occupied(mut entry) => {
+                    let prev_rule = entry.get_mut().rule.to_mut();
+                    prev_rule.merge(&rule.rule);
+                }
+            };
+        }
+
+        // now for any given first glyph + adjustment if there are multiple
+        // second glyphs we combine these
+        let mut seen = HashMap::<_, _>::new();
+        for rule in pairmap.into_values() {
+            match seen.entry((
+                rule.rule.first,
+                rule.rule.record1.clone(),
+                rule.rule.record2.clone(),
+            )) {
+                hash_map::Entry::Vacant(entry) => {
+                    entry.insert(rule);
+                }
+                hash_map::Entry::Occupied(mut entry) => {
+                    entry
+                        .get_mut()
+                        .rule
+                        .to_mut()
+                        .second
+                        .combine(&rule.rule.second);
+                }
+            }
+        }
+        let mut result: Vec<_> = seen.into_values().collect();
+        result.sort_unstable();
+        result
     }
 
     fn markbase_rules<'a>(&'a self, lookups: &[u16]) -> Vec<SingleRule<'a, MarkAttachmentRule>> {
@@ -450,5 +511,61 @@ impl Display for ResolvedValue {
 impl Display for ResolvedAnchor {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "@(x: {}, y: {})", self.x, self.y)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use fea_rs::compile::PairPosBuilder;
+
+    use super::test_helpers::SimplePairPosBuilder;
+    use super::*;
+    use write_fonts::{
+        read::FontRead,
+        tables::{gpos as wgpos, layout as wlayout},
+    };
+
+    fn make_lookup(subtable: wgpos::PairPos) -> wgpos::PositionLookup {
+        wgpos::PositionLookup::Pair(wlayout::Lookup::new(LookupFlag::empty(), vec![subtable], 0))
+    }
+
+    #[test]
+    fn merge_pairpos_lookups() {
+        let mut sub1 = PairPosBuilder::default();
+        sub1.add_pair(1, 4, 20);
+        sub1.add_pair(1, 5, -10);
+        let sub1 = sub1.build_exactly_one_subtable();
+
+        let mut sub2 = PairPosBuilder::default();
+        // this class overlaps with the previous for the pair (1, 4)
+        sub2.add_class(&[1, 2], &[3, 4], 7);
+        let sub2 = sub2.build_exactly_one_subtable();
+
+        let lookup1 = make_lookup(sub1);
+        let lookup2 = make_lookup(sub2);
+        let lookup_list = wlayout::LookupList::new(vec![lookup1, lookup2]);
+        let lookup_list = write_fonts::dump_table(&lookup_list).unwrap();
+        let lookup_list = write_fonts::read::tables::gpos::PositionLookupList::read(
+            lookup_list.as_slice().into(),
+        )
+        .unwrap();
+
+        let rules = get_lookup_rules(&lookup_list, None);
+
+        let our_rules = rules
+            .pairpos_rules(&[0, 1])
+            .into_iter()
+            .map(|r| r.rule.as_ref().to_owned())
+            .collect::<Vec<_>>();
+
+        // (left gid, [right gids], x advance)
+        let expected: &[(u16, &[u16], i16)] = &[
+            (1, &[3], 7),
+            (1, &[4], 27),
+            (1, &[5], -10),  // sub1
+            (2, &[3, 4], 7), // sub2
+        ];
+
+        assert_eq!(our_rules, expected);
     }
 }

--- a/layout-normalizer/src/gpos/pairpos.rs
+++ b/layout-normalizer/src/gpos/pairpos.rs
@@ -3,7 +3,6 @@ use std::{
     fmt::Debug,
 };
 
-use indexmap::IndexMap;
 use write_fonts::read::{
     tables::gpos::{PairPos, PairPosFormat1, PairPosFormat2, ValueRecord},
     types::GlyphId,
@@ -16,10 +15,17 @@ use super::{PrintNames, ResolvedValueRecord};
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub(super) struct PairPosRule {
-    first: GlyphId,
-    second: GlyphSet,
-    record1: ResolvedValueRecord,
-    record2: ResolvedValueRecord,
+    pub first: GlyphId,
+    pub second: GlyphSet,
+    pub record1: ResolvedValueRecord,
+    pub record2: ResolvedValueRecord,
+}
+
+impl PairPosRule {
+    pub fn merge(&mut self, other: &Self) {
+        self.record1.add_in_place(&other.record1);
+        self.record2.add_in_place(&other.record2);
+    }
 }
 
 impl PrintNames for PairPosRule {
@@ -46,22 +52,6 @@ impl Debug for PairPosRule {
     }
 }
 
-// combine any rules where the first glyph and the value records are identical.
-fn combine_rules(rules: Vec<PairPosRule>) -> Vec<PairPosRule> {
-    let mut seen = IndexMap::<_, PairPosRule>::new();
-    for rule in rules {
-        match seen.entry((rule.first, rule.record1.clone(), rule.record2.clone())) {
-            indexmap::map::Entry::Occupied(mut entry) => {
-                entry.get_mut().second.combine(rule.second)
-            }
-            indexmap::map::Entry::Vacant(entry) => {
-                entry.insert(rule);
-            }
-        }
-    }
-    seen.into_values().collect()
-}
-
 pub(super) fn get_pairpos_rules(
     subtables: &[PairPos],
     delta_computer: Option<&DeltaComputer>,
@@ -80,7 +70,7 @@ pub(super) fn get_pairpos_rules(
             }
         }
     }
-    Ok(combine_rules(result))
+    Ok(result)
 }
 
 // okay so we want to return some heterogeneous type here hmhm
@@ -244,11 +234,12 @@ mod tests {
 
         // (left gid, [right gids], x advance)
         let expected: &[(u16, &[u16], i16)] = &[
-            (4, &[7, 8], -808), // from sub3
-            (5, &[6], -7),      // sub1
-            (5, &[7], -30),     // sub2
-            (5, &[8], -808),    // sub3
-            (10, &[11], 1011),  //sub 1
+            (4, &[7], -808),   // from sub3
+            (4, &[8], -808),   // from sub3
+            (5, &[6], -7),     // sub1
+            (5, &[7], -30),    // sub2
+            (5, &[8], -808),   // sub3
+            (10, &[11], 1011), //sub 1
         ];
 
         assert_eq!(rules, expected);

--- a/layout-normalizer/src/gpos/pairpos.rs
+++ b/layout-normalizer/src/gpos/pairpos.rs
@@ -178,45 +178,12 @@ fn append_pairpos_f2_rules(
 mod tests {
 
     use std::collections::BTreeSet;
+    use write_fonts::read::FontRead;
+
+    use super::super::test_helpers::SimplePairPosBuilder;
+    use fea_rs::compile::PairPosBuilder;
 
     use super::*;
-    use fea_rs::compile::{Builder, PairPosBuilder, ValueRecord};
-    use write_fonts::{
-        read::FontRead,
-        tables::{gpos::PairPos, variations::ivs_builder::VariationStoreBuilder},
-    };
-
-    // a way to bolt a simpler API onto the PairPosBuilder from fea-rs
-    trait SimplePairPosBuilder {
-        fn add_pair(&mut self, gid1: u16, gid2: u16, x_adv: i16);
-        fn add_class(&mut self, class1: &[u16], class2: &[u16], x_adv: i16);
-        fn build_exactly_one_subtable(self) -> PairPos;
-    }
-
-    impl SimplePairPosBuilder for PairPosBuilder {
-        fn add_pair(&mut self, gid1: u16, gid2: u16, x_adv: i16) {
-            self.insert_pair(
-                GlyphId::new(gid1),
-                ValueRecord::new().with_x_advance(x_adv),
-                GlyphId::new(gid2),
-                ValueRecord::new(),
-            )
-        }
-
-        fn add_class(&mut self, class1: &[u16], class2: &[u16], x_adv: i16) {
-            let class1 = class1.iter().copied().map(GlyphId::new).collect();
-            let class2 = class2.iter().copied().map(GlyphId::new).collect();
-            let record1 = ValueRecord::new().with_x_advance(x_adv);
-            self.insert_classes(class1, record1, class2, ValueRecord::new())
-        }
-
-        fn build_exactly_one_subtable(self) -> PairPos {
-            let mut varstore = VariationStoreBuilder::new(0);
-            let subs = self.build(&mut varstore);
-            assert_eq!(subs.len(), 1);
-            subs.into_iter().next().unwrap()
-        }
-    }
 
     // to make our tests easier to read, have a special partialeq impl
     impl PartialEq<(u16, &[u16], i16)> for PairPosRule {

--- a/layout-normalizer/src/gpos/test_helpers.rs
+++ b/layout-normalizer/src/gpos/test_helpers.rs
@@ -1,0 +1,99 @@
+use fea_rs::compile::{Anchor, Builder, MarkToBaseBuilder, PairPosBuilder, ValueRecord};
+use write_fonts::{
+    tables::{
+        gpos::{MarkBasePosFormat1, PairPos},
+        variations::ivs_builder::VariationStoreBuilder,
+    },
+    types::GlyphId,
+};
+
+use crate::gpos::MarkAttachmentRule;
+
+// a way to bolt a simpler API onto the PairPosBuilder from fea-rs
+pub trait SimplePairPosBuilder {
+    fn add_pair(&mut self, gid1: u16, gid2: u16, x_adv: i16);
+    fn add_class(&mut self, class1: &[u16], class2: &[u16], x_adv: i16);
+    fn build_exactly_one_subtable(self) -> PairPos;
+}
+
+impl SimplePairPosBuilder for PairPosBuilder {
+    fn add_pair(&mut self, gid1: u16, gid2: u16, x_adv: i16) {
+        self.insert_pair(
+            GlyphId::new(gid1),
+            ValueRecord::new().with_x_advance(x_adv),
+            GlyphId::new(gid2),
+            ValueRecord::new(),
+        )
+    }
+
+    fn add_class(&mut self, class1: &[u16], class2: &[u16], x_adv: i16) {
+        let class1 = class1.iter().copied().map(GlyphId::new).collect();
+        let class2 = class2.iter().copied().map(GlyphId::new).collect();
+        let record1 = ValueRecord::new().with_x_advance(x_adv);
+        self.insert_classes(class1, record1, class2, ValueRecord::new())
+    }
+
+    fn build_exactly_one_subtable(self) -> PairPos {
+        let mut varstore = VariationStoreBuilder::new(0);
+        let subs = self.build(&mut varstore);
+        assert_eq!(subs.len(), 1);
+        subs.into_iter().next().unwrap()
+    }
+}
+
+pub trait SimpleMarkBaseBuilder {
+    fn add_mark(&mut self, gid: u16, class: &str, anchor: (i16, i16));
+    fn add_base(&mut self, gid: u16, class: &str, anchor: (i16, i16));
+    fn build_exactly_one_subtable(self) -> MarkBasePosFormat1;
+}
+
+impl SimpleMarkBaseBuilder for MarkToBaseBuilder {
+    fn add_mark(&mut self, gid: u16, class: &str, anchor: (i16, i16)) {
+        let anchor = Anchor::new(anchor.0, anchor.1);
+        self.insert_mark(GlyphId::new(gid), class.into(), anchor)
+            .unwrap();
+    }
+
+    fn add_base(&mut self, gid: u16, class: &str, anchor: (i16, i16)) {
+        let anchor = Anchor::new(anchor.0, anchor.1);
+        self.insert_base(GlyphId::new(gid), &class.into(), anchor)
+    }
+
+    fn build_exactly_one_subtable(self) -> MarkBasePosFormat1 {
+        let mut varstore = VariationStoreBuilder::new(0);
+        let subs = self.build(&mut varstore);
+        assert_eq!(subs.len(), 1);
+        subs.into_iter().next().unwrap()
+    }
+}
+
+// further decomposed for testing, so we just see one mark per entry
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct SimpleAnchorRule {
+    pub base_gid: GlyphId,
+    pub mark_gid: GlyphId,
+    pub base_anchor: (i16, i16),
+    pub mark_anchor: (i16, i16),
+}
+
+pub type RawAnchor = (i16, i16);
+
+impl PartialEq<(u16, RawAnchor, u16, RawAnchor)> for SimpleAnchorRule {
+    fn eq(&self, other: &(u16, RawAnchor, u16, RawAnchor)) -> bool {
+        let (base_id, base_anchor, mark_id, mark_anchor) = *other;
+        self.base_gid.to_u16() == base_id
+            && self.base_anchor == base_anchor
+            && self.mark_gid.to_u16() == mark_id
+            && self.mark_anchor == mark_anchor
+    }
+}
+
+impl SimpleAnchorRule {
+    // convert from the enum back to the specific pairpos type.
+    pub fn from_mark_rules(rules: &[MarkAttachmentRule]) -> Vec<Self> {
+        rules
+            .iter()
+            .flat_map(|rule| rule.iter_simple_rules())
+            .collect()
+    }
+}


### PR DESCRIPTION
This adds the proper normalization logic for pairpos rules: basically we will now sum the values in subsequent lookups that apply to the same pairs.


this PR also involves moving some test helpers to a common `test_helpers` module, since they're needed by different tests that live in different places.


There's one question inline: basically I'm not sure how we should think about merging of device tables, or if we should care. Also I'm assuming that if deltas are provided there should be the same number of deltas in each master, and we can just sum them individually?