### PR TITLE
[ttx_diff] Normalize marks

### DIFF
--- a/layout-normalizer/src/gpos/marks.rs
+++ b/layout-normalizer/src/gpos/marks.rs
@@ -15,7 +15,7 @@ use super::{PrintNames, ResolvedAnchor};
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) struct MarkAttachmentRule {
-    base: GlyphId,
+    pub base: GlyphId,
     base_anchor: ResolvedAnchor,
     marks: BTreeMap<ResolvedAnchor, GlyphSet>,
 }
@@ -35,8 +35,25 @@ impl PrintNames for MarkAttachmentRule {
     }
 }
 
-#[cfg(test)]
 impl MarkAttachmentRule {
+    pub(crate) fn iter_base_mark_pairs(&self) -> impl Iterator<Item = (GlyphId, GlyphId)> + '_ {
+        self.marks
+            .values()
+            .flat_map(|set| set.iter())
+            .map(|mark| (self.base, mark))
+    }
+
+    // returns `true` if we have marks remaining after removing this set
+    pub(crate) fn remove_marks(&mut self, marks: &[GlyphId]) -> bool {
+        self.marks.retain(|_, v| {
+            v.remove_glyphs(marks);
+            !v.is_empty()
+        });
+
+        !self.marks.is_empty()
+    }
+
+    #[cfg(test)]
     pub(crate) fn iter_simple_rules(
         &self,
     ) -> impl Iterator<Item = super::test_helpers::SimpleAnchorRule> + '_ {

--- a/layout-normalizer/src/gpos/test_helpers.rs
+++ b/layout-normalizer/src/gpos/test_helpers.rs
@@ -1,3 +1,5 @@
+use std::fmt::Debug;
+
 use fea_rs::compile::{Anchor, Builder, MarkToBaseBuilder, PairPosBuilder, ValueRecord};
 use write_fonts::{
     tables::{
@@ -68,7 +70,7 @@ impl SimpleMarkBaseBuilder for MarkToBaseBuilder {
 }
 
 // further decomposed for testing, so we just see one mark per entry
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SimpleAnchorRule {
     pub base_gid: GlyphId,
     pub mark_gid: GlyphId,
@@ -85,6 +87,19 @@ impl PartialEq<(u16, RawAnchor, u16, RawAnchor)> for SimpleAnchorRule {
             && self.base_anchor == base_anchor
             && self.mark_gid.to_u16() == mark_id
             && self.mark_anchor == mark_anchor
+    }
+}
+
+impl Debug for SimpleAnchorRule {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let base = self.base_gid.to_u16();
+        let mark = self.mark_gid.to_u16();
+        let (base_x, base_y) = self.base_anchor;
+        let (mark_x, mark_y) = self.mark_anchor;
+        write!(
+            f,
+            "({base}, ({base_x}, {base_y}), {mark}, ({mark_x}, {mark_y}))"
+        )
     }
 }
 


### PR DESCRIPTION
This is conceptually simple, although the implementation is a bit hairy: basically we want to track the last time we see each (base, mark) pair, and then we want to go through all the rules and remove any pairs that are going to be included later on.