### PR TITLE
bump write-fonts to 0.21.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ clap = { version = "4.0.32", features = ["derive"] }
 rayon = "1.6"
 
 # fontations etc
-write-fonts = { version = "0.21.0", features = ["serde", "read"] }
+write-fonts = { version = "0.21.1", features = ["serde", "read"] }
 skrifa = "0.15.0"
 norad = "0.12"
 


### PR DESCRIPTION
required for https://github.com/googlefonts/fontc/issues/647