### PR TITLE
Add repeatable-builds.sh and test Oswald as well

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -202,9 +202,6 @@ jobs:
           repository: googlefonts/OswaldFont
           path: oswald
 
-      - name: Pin SOURCE_DATE_EPOCH
-        run: echo "SOURCE_DATE_EPOCH=$(date +%s)" >> "$GITHUB_ENV"
-
       - name: Compile GS Roman twice
         run: ./resources/scripts/repeatable-builds.sh googlesans/source/GoogleSans/GoogleSans.designspace
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -219,3 +219,8 @@ jobs:
 
       - name: OTS tests, Oswald
         run: ots-9.1.0-Linux/ots-sanitize build/Oswald.ttf
+
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          path: build/*.ttf

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -189,24 +189,36 @@ jobs:
           which ttx
           ttx --version
 
-      - name: Check out font project source repository
+      - name: Check out GS source repository
         uses: actions/checkout@v4
         with:
           repository: googlefonts/googlesans
           path: googlesans
           token: ${{ secrets.GS_READ_FONTC }}
 
+      - name: Check out Oswald source repository
+        uses: actions/checkout@v4
+        with:
+          repository: googlefonts/OswaldFont
+          path: oswald
+
       - name: Pin SOURCE_DATE_EPOCH
         run: echo "SOURCE_DATE_EPOCH=$(date +%s)" >> "$GITHUB_ENV"
 
-      - name: Compile Roman twice
+      - name: Compile GS Roman twice
         run: ./resources/scripts/repeatable-builds.sh googlesans/source/GoogleSans/GoogleSans.designspace
 
-      - name: Compile Italic twice
+      - name: Compile GS Italic twice
         run: ./resources/scripts/repeatable-builds.sh googlesans/source/GoogleSans/GoogleSans-Italic.designspace
 
-      - name: OTS tests, Roman
+      - name: Compile Oswald twice
+        run: ./resources/scripts/repeatable-builds.sh oswald/sources/Oswald.glyphs
+
+      - name: OTS tests, GS Roman
         run: ots-9.1.0-Linux/ots-sanitize build/GoogleSans.ttf
 
-      - name: OTS tests, Italic
+      - name: OTS tests, GS Italic
         run: ots-9.1.0-Linux/ots-sanitize build/GoogleSans-Italic.ttf
+
+      - name: OTS tests, Oswald
+        run: ots-9.1.0-Linux/ots-sanitize build/Oswald.ttf

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,7 +13,7 @@ name: Continuous integration
 # https://github.com/googlefonts/fontations/blob/main/.github/workflows/rust.yml.
 # other than the list of crates for cargo check no std
 
-jobs:  
+jobs:
   check:
     name: Rustfmt
     runs-on: ubuntu-latest
@@ -178,55 +178,35 @@ jobs:
       - name: Build and install fontc (release mode)
         run: cd fontc && pwd && cargo install --path .
 
-      - name: Check out font project source repository
-        uses: actions/checkout@v4
-        with:
-          repository: googlefonts/googlesans
-          token: ${{ secrets.GS_READ_FONTC }}
-
-      - name: Pin SOURCE_DATE_EPOCH
-        run: echo "SOURCE_DATE_EPOCH=$(date +%s)" >> "$GITHUB_ENV"
-
-      - name: Compile me once, shame on you
-        run: |
-          rm -rf build
-          fontc source/GoogleSans/GoogleSans.designspace
-          cp build/font.ttf ./first-roman.ttf
-          rm -rf build
-          fontc source/GoogleSans/GoogleSans-Italic.designspace
-          cp build/font.ttf ./first-italic.ttf
-
       - name: Fetch OTS
         run: |
             curl -OL "https://github.com/khaledhosny/ots/releases/download/v9.1.0/ots-9.1.0-Linux.zip"
             unzip "ots-9.1.0-Linux.zip" "ots-9.1.0-Linux/ots-sanitize"
 
-      - name: OTS tests, Roman
-        run: ots-9.1.0-Linux/ots-sanitize build/font.ttf
-
-      - name: OTS tests, Italic
-        run: ots-9.1.0-Linux/ots-sanitize build/font.ttf
-
-      - name: Compile me twice, shame on me
-        run: |
-          rm -rf build
-          fontc source/GoogleSans/GoogleSans.designspace
-          cp build/font.ttf ./second-roman.ttf
-          rm -rf build
-          fontc source/GoogleSans/GoogleSans-Italic.designspace
-          cp build/font.ttf ./second-italic.ttf
-
-      - name: ttx, it might be handy to troubleshoot
-        # tail -n +2 to skip past the first line because it emits the filename
+      - name: Install ttx
         run: |
           pipx install fonttools
           which ttx
           ttx --version
-          diff -u <(ttx -l first-roman.ttf | tail -n +2) <(ttx -l second-roman.ttf | tail -n +2)
-          diff -u <(ttx -l first-italic.ttf | tail -n +2) <(ttx -l second-italic.ttf | tail -n +2)
 
-      - name: Stable Roman?
-        run: cmp first-roman.ttf second-roman.ttf
+      - name: Check out font project source repository
+        uses: actions/checkout@v4
+        with:
+          repository: googlefonts/googlesans
+          path: googlesans
+          token: ${{ secrets.GS_READ_FONTC }}
 
-      - name: Stable Italic?
-        run: cmp first-italic.ttf second-italic.ttf
+      - name: Pin SOURCE_DATE_EPOCH
+        run: echo "SOURCE_DATE_EPOCH=$(date +%s)" >> "$GITHUB_ENV"
+
+      - name: Compile Roman twice
+        run: ./resources/scripts/repeatable-builds.sh googlesans/source/GoogleSans/GoogleSans.designspace
+
+      - name: Compile Italic twice
+        run: ./resources/scripts/repeatable-builds.sh googlesans/source/GoogleSans/GoogleSans-Italic.designspace
+
+      - name: OTS tests, Roman
+        run: ots-9.1.0-Linux/ots-sanitize build/GoogleSans.ttf
+
+      - name: OTS tests, Italic
+        run: ots-9.1.0-Linux/ots-sanitize build/GoogleSans-Italic.ttf

--- a/resources/scripts/repeatable-builds.sh
+++ b/resources/scripts/repeatable-builds.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# This script is used to test that fontc produces repeatable builds.
+
+if [ -z "$1" ]; then
+  echo "Usage: repeatable-builds.sh FONTFILE [NUM_TIMES]"
+  exit 1
+fi
+
+INPUT_SOURCE="$1"
+filename=$(basename "$INPUT_SOURCE")
+first="build/${filename%.*}.ttf"
+# this is to ensure head.modified does not change
+export SOURCE_DATE_EPOCH=$(date +%s)
+
+build_font() {
+  echo "$ fontc $1 -o $2"
+  fontc "$1" -o "$2"
+  if [ $? -ne 0 ]; then
+    echo "Error: building $1 failed"
+    exit 1
+  fi
+}
+
+compare_fonts() {
+  echo "$ cmp $1 $2"
+  cmp "$1" "$2"
+  if [ $? -ne 0 ]; then
+    # tail -n +2 to skip past the first line because it emits the filename
+    diff -u <(ttx -l "$1" | tail -n +2) <(ttx -l "$2" | tail -n +2)
+    echo "Error: $1 and $2 are different"
+    exit 1
+  fi
+}
+
+echo "$ which fontc"
+which fontc
+
+build_font "$INPUT_SOURCE" "$first"
+
+for i in $(seq 1 ${2:-1})
+do
+  ith="build/${filename%.*}#$i.ttf"
+  build_font "$INPUT_SOURCE" "$ith"
+  compare_fonts $first $ith
+done
+
+echo "Success: all fonts are identical"


### PR DESCRIPTION
This PR adds a new shell script to help debugging repeatable builds locally, and adds Oswald to the CI testing repeatable builds (the gvar randomness about order of shared tuples would only trigger when building Oswald, not GS somehow).
Finally, I added a step to upload the built ttfs as CI artifacts if any failure occurs, also useful for remote debugging.