### PR TITLE
Fix the order of BE kern gathering

### DIFF
--- a/fontbe/src/kern.rs
+++ b/fontbe/src/kern.rs
@@ -253,10 +253,7 @@ impl Work<Context, AnyWorkId, Error> for KerningGatherWork {
     }
 
     fn read_access(&self) -> Access<AnyWorkId> {
-        AccessBuilder::new()
-            .variant(WorkId::GatherIrKerning) // until this runs there are no kern fragments to await
-            .variant(WorkId::KernFragment(0))
-            .build()
+        Access::Unknown // https://github.com/googlefonts/fontc/issues/647: don't enable until KernFragment's spawn
     }
 
     fn exec(&self, context: &Context) -> Result<(), Error> {

--- a/fontc/src/workload.rs
+++ b/fontc/src/workload.rs
@@ -311,6 +311,15 @@ impl<'a> Workload<'a> {
             for work in create_kern_segment_work(&kern_pairs) {
                 self.add(work.into(), true);
             }
+
+            // https://github.com/googlefonts/fontc/issues/647: it is now safe to set read access on segment gathering
+            self.jobs_pending
+                .get_mut(&AnyWorkId::Be(BeWorkIdentifier::GatherBeKerning))
+                .expect("Gather BE Kerning has to be pending")
+                .read_access = AccessBuilder::<AnyWorkId>::new()
+                .variant(BeWorkIdentifier::KernFragment(0))
+                .build()
+                .into();
         }
 
         if let AnyWorkId::Fe(FeWorkIdentifier::Glyph(glyph_name)) = success {


### PR DESCRIPTION
I believe this resolves the issue described at https://github.com/googlefonts/fontc/issues/647#issuecomment-1889793531 by applying the same fix as #655 to the second scatter/gather we do on kerning.

I have filed #677 to track making this simpler as it's definitely harder than it shoudl be.

The following produces observably unstable output on main, usually in 2-4 builds, and is stable through 20 cycles after the fix:

```shell
$ rm -f *.ttxl threads*.svg && for i in {0..19}; do echo "CYCLE $i" && rm -rf build/ && cargo run ../googlesans/source/GoogleSans/GoogleSans.designspace --emit-timing && cp build/threads.svg ./threads_$i.svg && ttx -l build/font.ttf > run$i.ttxl && grep GPOS *.ttxl; done

# Unstable: GPOS occasionally dramatically smaller
# because gather ran before the tasks that produce what it gathers
CYCLE 2
    Finished dev [unoptimized + debuginfo] target(s) in 0.19s
     Running `target/debug/fontc ../googlesans/source/GoogleSans/GoogleSans.designspace --emit-timing`
run0.ttxl:    GPOS  0x19131F6A   4364690     19000
run1.ttxl:    GPOS  0x19131F6A   4364690     19000
run2.ttxl:    GPOS  0x4F3B316D    106928     15264  # MUCH BADNESS
```

JMM if happy.