### PR TITLE
[fea-rs] Fixups for ttx_test util

### DIFF
--- a/fea-rs/src/bin/ttx_test.rs
+++ b/fea-rs/src/bin/ttx_test.rs
@@ -6,14 +6,13 @@ use std::path::{Path, PathBuf};
 use clap::Parser;
 use fea_rs::util::ttx;
 
-static TEST_DATA: &str = "./fea-rs/test-data/fonttools-tests";
 static WIP_DIFF_DIR: &str = "./wip";
 
 fn main() {
     env_logger::init();
     let args = Args::parse();
 
-    let results = ttx::run_all_tests(TEST_DATA, args.test_filter.as_ref());
+    let results = ttx::run_fonttools_tests(args.test_filter.as_ref());
 
     if let Some(to_compare) = args
         .compare

--- a/fea-rs/src/tests/compile.rs
+++ b/fea-rs/src/tests/compile.rs
@@ -13,14 +13,13 @@ static GOOD_DIR: &str = "good";
 static BAD_DIR: &str = "bad";
 static GLYPH_ORDER: &str = "glyph_order.txt";
 static BAD_OUTPUT_EXTENSION: &str = "ERR";
-static FONTTOOLS_TESTS: &str = "./test-data/fonttools-tests";
 static IMPORT_RESOLUTION_TEST: &str = "./test-data/include-resolution-tests/dir1/test1.fea";
 
 // tests taken directly from fonttools; these require some special handling.
 #[test]
 fn fonttools_tests() -> Result<(), Report> {
     test_utils::assert_has_ttx_executable();
-    test_utils::run_all_tests(FONTTOOLS_TESTS, None).into_error()
+    test_utils::run_fonttools_tests(None).into_error()
 }
 
 #[test]


### PR DESCRIPTION
This utility had broken a bit during the move from the old fea-rs repo into this new repo; in particular it would fail if you ran it from the `fea-rs` directory, which is annoying.

We will now attempt to figure out where we're running from when determining the path to the test data, instead of hardcoding paths.


JMM