### PR TITLE
Add fontra2fontir without an actual implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@
 bincode = "1.3.3"
 serde = {version = "1.0", features = ["derive"] }
 serde_yaml = "0.9.14"
+serde_json = "1.0.113"
 bitflags = "2.0"
 chrono = { version = "0.4.24", features = ["serde"] }
 filetime = "0.2.18"
@@ -43,6 +44,7 @@ members = [
     "fontir",
     "glyphs-reader",
     "glyphs2fontir",
+    "fontra2fontir",
     "ufo2fontir",
     "fontc",
     "fea-rs",

--- a/fontc/Cargo.toml
+++ b/fontc/Cargo.toml
@@ -16,6 +16,7 @@ fontdrasil = { version = "0.0.1", path = "../fontdrasil" }
 fontbe = { version = "0.0.1", path = "../fontbe" }
 fontir = { version = "0.0.1", path = "../fontir" }
 glyphs2fontir = { version = "0.0.1", path = "../glyphs2fontir" }
+fontra2fontir = { version = "0.0.1", path = "../fontra2fontir" }
 ufo2fontir = { version = "0.0.1", path = "../ufo2fontir" }
 
 bitflags.workspace = true

--- a/fontc/src/change_detector.rs
+++ b/fontc/src/change_detector.rs
@@ -7,6 +7,7 @@ use fontbe::{
     orchestration::{AnyWorkId, WorkId as BeWorkIdentifier},
     paths::Paths as BePaths,
 };
+use fontra2fontir::source::FontraIrSource;
 
 use crate::{create_timer, timing::JobTimer, work::AnyWork, workload::Workload, Config, Error};
 use fontdrasil::{coords::NormalizedLocation, types::GlyphName};
@@ -375,6 +376,7 @@ fn ir_source(source: &Path) -> Result<Box<dyn Source>, Error> {
         "designspace" => Ok(Box::new(DesignSpaceIrSource::new(source.to_path_buf())?)),
         "glyphs" => Ok(Box::new(GlyphsIrSource::new(source.to_path_buf()))),
         "glyphspackage" => Ok(Box::new(GlyphsIrSource::new(source.to_path_buf()))),
+        "fontra" => Ok(Box::new(FontraIrSource::new(source.to_path_buf()))),
         _ => Err(Error::UnrecognizedSource(source.to_path_buf())),
     }
 }

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -149,7 +149,7 @@ impl GlyphOrder {
     }
 
     pub fn remove(&mut self, name: &GlyphName) -> bool {
-        self.0.remove(name)
+        self.0.shift_remove(name)
     }
 
     pub fn difference<'a>(

--- a/fontra2fontir/Cargo.toml
+++ b/fontra2fontir/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "fontra2fontir"
+version = "0.0.1"
+edition = "2021"
+license = "MIT/Apache-2.0"
+description = "Converts fontra.xyz/ files to font ir for compilation."
+repository = "https://github.com/googlefonts/fontmake-rs"
+readme = "README.md"
+categories = ["text-processing", "parsing", "graphics"]
+
+[features]
+
+[dependencies]
+fontdrasil = { version = "0.0.1", path = "../fontdrasil" }
+fontir = { version = "0.0.1", path = "../fontir" }
+
+log.workspace = true
+env_logger.workspace = true
+
+thiserror.workspace = true
+
+kurbo.workspace = true
+ordered-float.workspace = true
+indexmap.workspace = true
+
+write-fonts.workspace = true
+
+chrono.workspace = true
+
+serde_json.workspace = true
+
+[dev-dependencies]
+diff.workspace = true
+ansi_term.workspace = true
+tempfile.workspace = true
+pretty_assertions.workspace = true

--- a/fontra2fontir/README.md
+++ b/fontra2fontir/README.md
@@ -1,0 +1,6 @@
+# fontra2fontir
+
+This crate is a frontend for compilation of Fontra json sources. It converts from .fontra to the fontc
+internal representation.
+
+It should be referenced only by fontc.

--- a/fontra2fontir/README.md
+++ b/fontra2fontir/README.md
@@ -1,6 +1,6 @@
 # fontra2fontir
 
-This crate is a frontend for compilation of Fontra json sources. It converts from .fontra to the fontc
+This crate is a frontend for compilation of [Fontra](https://fontra.xyz/) json sources. It converts from .fontra to the fontc
 internal representation.
 
 It should be referenced only by fontc.

--- a/fontra2fontir/src/lib.rs
+++ b/fontra2fontir/src/lib.rs
@@ -1,0 +1,3 @@
+//! Loads fontra source and converts it to fontc IR
+
+pub mod source;

--- a/fontra2fontir/src/source.rs
+++ b/fontra2fontir/src/source.rs
@@ -1,0 +1,63 @@
+use std::path::PathBuf;
+
+use fontir::source::Source;
+
+pub struct FontraIrSource {
+    fontra_dir: PathBuf,
+}
+
+impl FontraIrSource {
+    pub fn new(fontra_dir: PathBuf) -> Self {
+        FontraIrSource { fontra_dir }
+    }
+}
+
+impl Source for FontraIrSource {
+    fn inputs(&mut self) -> Result<fontir::source::Input, fontir::error::Error> {
+        todo!()
+    }
+
+    fn create_static_metadata_work(
+        &self,
+        _input: &fontir::source::Input,
+    ) -> Result<Box<fontir::orchestration::IrWork>, fontir::error::Error> {
+        todo!()
+    }
+
+    fn create_global_metric_work(
+        &self,
+        _input: &fontir::source::Input,
+    ) -> Result<Box<fontir::orchestration::IrWork>, fontir::error::Error> {
+        todo!()
+    }
+
+    fn create_glyph_ir_work(
+        &self,
+        _glyph_names: &indexmap::IndexSet<fontdrasil::types::GlyphName>,
+        _input: &fontir::source::Input,
+    ) -> Result<Vec<Box<fontir::orchestration::IrWork>>, fontir::error::Error> {
+        todo!()
+    }
+
+    fn create_feature_ir_work(
+        &self,
+        _input: &fontir::source::Input,
+    ) -> Result<Box<fontir::orchestration::IrWork>, fontir::error::Error> {
+        todo!()
+    }
+
+    fn create_kerning_group_ir_work(
+        &self,
+        _input: &fontir::source::Input,
+    ) -> Result<Box<fontir::orchestration::IrWork>, fontir::error::Error> {
+        todo!()
+    }
+
+    fn create_kerning_instance_ir_work(
+        &self,
+        _input: &fontir::source::Input,
+        _at: fontdrasil::coords::NormalizedLocation,
+    ) -> Result<Box<fontir::orchestration::IrWork>, fontir::error::Error> {
+        todo!()
+    }
+}

--- a/fontra2fontir/src/source.rs
+++ b/fontra2fontir/src/source.rs
@@ -3,12 +3,14 @@ use std::path::PathBuf;
 use fontir::source::Source;
 
 pub struct FontraIrSource {
-    fontra_dir: PathBuf,
+    _fontra_dir: PathBuf,
 }
 
 impl FontraIrSource {
     pub fn new(fontra_dir: PathBuf) -> Self {
-        FontraIrSource { fontra_dir }
+        FontraIrSource {
+            _fontra_dir: fontra_dir,
+        }
     }
 }
 


### PR DESCRIPTION
Fontra source can describe varc so having an IR source for it seems like it will be handy.
Per discussion with Just we will want to ingress their json format, not .rcjk.

Fontra json examples can be found in https://github.com/notofonts/noto-cjk-varco action runs, e.g. https://github.com/notofonts/noto-cjk-varco/actions/runs/7714671850. In subsequent PRs I will add sample sources to resources.