### PR TITLE
[fea-rs] Remove use of Cell from Node

### DIFF
--- a/fea-rs/src/parse/context.rs
+++ b/fea-rs/src/parse/context.rs
@@ -199,7 +199,14 @@ impl ParseContext {
         }
 
         let mut map = SourceMap::default();
-        let root = self.generate_recurse(self.root_id(), &include_errors, &mut map, 0);
+        let mut root = self.generate_recurse(self.root_id(), &include_errors, &mut map, 0);
+        let needs_update_positions = self.parsed_files.len() > 1;
+        // we need to do this before updating positions, since it mutates and
+        // requires that there exist only one reference (via Arc) to the node
+        drop(self.parsed_files);
+        if needs_update_positions {
+            root.update_positions_from_root();
+        }
         (
             ParseTree {
                 root,

--- a/fea-rs/src/token_tree/cursor.rs
+++ b/fea-rs/src/token_tree/cursor.rs
@@ -19,11 +19,8 @@ struct NodeRef<'a> {
 
 impl<'a> Cursor<'a> {
     pub fn new(root: &'a Node) -> Self {
-        if let Some(child) = root.children.first() {
-            child.set_abs_pos(root.abs_pos.get() as usize);
-        }
         Cursor {
-            pos: root.abs_pos.get() as usize,
+            pos: root.abs_pos as usize,
             current: NodeRef {
                 node: root,
                 fresh: true,
@@ -66,9 +63,6 @@ impl<'a> Cursor<'a> {
         let len = self.current().map(NodeOrToken::text_len).unwrap_or(0);
         self.current.advance();
         self.pos += len;
-        if let Some(current) = self.current() {
-            current.set_abs_pos(self.pos);
-        }
     }
 
     /// Advance the cursor.
@@ -104,9 +98,6 @@ impl<'a> Cursor<'a> {
                 // after ascending, we need to advance
                 self.current.advance();
             }
-        }
-        if let Some(current) = self.current() {
-            current.set_abs_pos(self.pos);
         }
     }
 


### PR DESCRIPTION
This was part of a pattern I had copied from rust-analyzer but removing it has only a minor impact on performance and allow Node to be Sync, which we need in fontc.