### PR TITLE
Revert "use the latest fontmake 3.8.0"

### DIFF
--- a/resources/scripts/requirements.txt
+++ b/resources/scripts/requirements.txt
@@ -1,7 +1,7 @@
 absl-py
 # keep fontmake version pinned to ensure output from ttx_diff.py is stable;
 # the 'repacker' option enables faster GSUB/GPOS serialization via uharfbuzz
-fontmake[repacker]==3.8.0
+fontmake[repacker]==3.7.1
 # technically fonttools is in turn a dependency of fontmake but a few of
 # our scripts import it directly, so we list it among the top-level requirements.
 fonttools


### PR DESCRIPTION
Reverts googlefonts/fontc#702

Found a bug in ufo2ft v3 (used by fontmake 3.8.0) related to --drop-implied-oncurves (which we use in ttx_diff.py):
https://github.com/googlefonts/ufo2ft/pull/817

The Oswald glyf/gvar tables that we build with fontmake 3.8 with --drop-implied-oncurves option enabled is invalid because of it, thus it shows spurious diffs when compared against the respective fontc tables.

We may want to revert until it gets fixed (hopefully tomorrow once I add a test to that PR so we won't regress again)