### PR TITLE
requirements.txt: update fontmake to 3.8.1

### DIFF
--- a/resources/scripts/requirements.txt
+++ b/resources/scripts/requirements.txt
@@ -1,7 +1,7 @@
 absl-py
 # keep fontmake version pinned to ensure output from ttx_diff.py is stable;
 # the 'repacker' option enables faster GSUB/GPOS serialization via uharfbuzz
-fontmake[repacker]==3.7.1
+fontmake[repacker]==3.8.1
 # technically fonttools is in turn a dependency of fontmake but a few of
 # our scripts import it directly, so we list it among the top-level requirements.
 fonttools


### PR DESCRIPTION
fontmake 3.8.0 (actually one of its deps i.e. ufo2ft v3) had a regression which has been fixed with this bugfix release:

https://github.com/googlefonts/ufo2ft/releases/tag/v3.0.1
https://github.com/googlefonts/fontmake/releases/tag/v3.8.1

Reverts #704 