### PR TITLE
[fea-rs] Stop printing ttx version in test

### DIFF
--- a/fea-rs/src/util/ttx.rs
+++ b/fea-rs/src/util/ttx.rs
@@ -6,7 +6,7 @@ use std::{
     ffi::OsStr,
     fmt::{Debug, Display, Write},
     path::{Path, PathBuf},
-    process::Command,
+    process::{Command, Stdio},
     time::SystemTime,
 };
 
@@ -112,6 +112,7 @@ pub fn assert_has_ttx_executable() {
     assert!(
         Command::new("ttx")
             .arg("--version")
+            .stdout(Stdio::null())
             .status()
             .map(|s| s.success())
             .unwrap_or(false),


### PR DESCRIPTION
This was an accident: in order to check that the 'ttx' executable is present we check the output of `ttx --version`, but this was causing the output of that command being printed to stdout. This suppresses that.


(If  you ever saw a line that said like `4.48.1` in the list of tests when running them, it was because of this)