### PR TITLE
Correct case of subfamily name

### DIFF
--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -703,10 +703,10 @@ fn names(font_info: &norad::FontInfo) -> HashMap<NameKey, String> {
         NameId::SUBFAMILY_NAME,
         &font_info.style_map_style_name.as_ref().map(|s| {
             match s {
-                norad::fontinfo::StyleMapStyle::Regular => "regular",
-                norad::fontinfo::StyleMapStyle::Italic => "italic",
-                norad::fontinfo::StyleMapStyle::Bold => "bold",
-                norad::fontinfo::StyleMapStyle::BoldItalic => "bold italic",
+                norad::fontinfo::StyleMapStyle::Regular => "Regular",
+                norad::fontinfo::StyleMapStyle::Italic => "Italic",
+                norad::fontinfo::StyleMapStyle::Bold => "Bold",
+                norad::fontinfo::StyleMapStyle::BoldItalic => "Bold Italic",
             }
             .into()
         }),


### PR DESCRIPTION
Currently with a UFO like this:

```
    <key>familyName</key>
    <string>Noto Sans Balinese</string>
    <key>styleMapFamilyName</key>
    <string>Noto Sans Balinese</string>
    <key>styleMapStyleName</key>
    <string>bold</string>
    <key>styleName</key>
    <string>Bold</string>
    <key>trademark</key>
```

fontc produces a font like this:

```
    <namerecord nameID="1" platformID="3" platEncID="1" langID="0x409">
      Noto Sans Balinese
    </namerecord>
    <namerecord nameID="2" platformID="3" platEncID="1" langID="0x409">
      bold
    </namerecord>
    <namerecord nameID="3" platformID="3" platEncID="1" langID="0x409">
      2.005;GOOG;NotoSansBalinese-bold
    </namerecord>
    <namerecord nameID="4" platformID="3" platEncID="1" langID="0x409">
      Noto Sans Balinese bold
    </namerecord>
    <namerecord nameID="5" platformID="3" platEncID="1" langID="0x409">
      Version 2.005
    </namerecord>
    <namerecord nameID="6" platformID="3" platEncID="1" langID="0x409">
      NotoSansBalinese-bold
    </namerecord>
```

This is wrong (and worse, stops us comparing the files with diffenator2!). The stylemap names should be capitalised when used to create the Name ID 2 subfamily name.