### PR TITLE
Correct ordering of transform coefficients

### DIFF
--- a/ufo2fontir/src/toir.rs
+++ b/ufo2fontir/src/toir.rs
@@ -60,6 +60,12 @@ fn to_ir_component(component: &norad::Component) -> ir::Component {
         base: component.base.as_str().into(),
         transform: Affine::new([
             component.transform.x_scale,
+            // For the 2nd and 3rd field of its 2x3 affine transformation, norad uses
+            // the same labels as fonttools' Transform, respectively `xy` and `yx`.
+            // Elsewhere (e.g. FreeType, Cairo or read-fonts Transform) these labels are
+            // inverted, but their meaning is still the same: i.e. the "y component of
+            // the î basis vector", and "x component of the ĵ basis vector".
+            // See https://github.com/googlefonts/fontc/pull/721
             component.transform.xy_scale,
             component.transform.yx_scale,
             component.transform.y_scale,

--- a/ufo2fontir/src/toir.rs
+++ b/ufo2fontir/src/toir.rs
@@ -292,19 +292,19 @@ mod tests {
             Affine::new([1.0, 0.0, 0.0, 1.0, 10.0, 10.0])
         );
 
-        // <component base="a" xScale="0.4366" xyScale="-0.4366" yScale="0.4415" yxScale="0.4415" xOffset="282" yOffset="5" identifier="5402E799"/>
+        // <component base="a" xScale="0.4366" xyScale="-0.4366" yScale="0.4425" yxScale="0.4415" xOffset="282" yOffset="5" identifier="5402E799"/>
         c.transform = AffineTransform {
             x_scale: 0.4366,
             xy_scale: -0.4366,
-            y_scale: 0.4415,
             yx_scale: 0.4415,
+            y_scale: 0.4425,
             x_offset: 282.0,
             y_offset: 5.0,
         };
         // Switchy switchy!
         assert_eq!(
             to_ir_component(&c).transform,
-            Affine::new([0.4366, -0.4366, 0.4415, 0.4415, 282.0, 5.0])
+            Affine::new([0.4366, -0.4366, 0.4415, 0.4425, 282.0, 5.0])
         );
     }
 }

--- a/ufo2fontir/src/toir.rs
+++ b/ufo2fontir/src/toir.rs
@@ -187,7 +187,7 @@ mod tests {
 
     use fontdrasil::coords::{NormalizedCoord, NormalizedLocation};
     use fontir::ir::AnchorBuilder;
-    use norad::ContourPoint;
+    use norad::{AffineTransform, Component, ContourPoint, Name};
 
     use super::*;
 
@@ -251,5 +251,54 @@ mod tests {
         )
         .unwrap();
         assert_eq!(HashSet::from([0x007C]), glyph.codepoints);
+    }
+
+    #[test]
+    pub fn component_transforms() {
+        let mut c = Component::new(
+            Name::new("A").unwrap(),
+            AffineTransform {
+                x_scale: 1.0,
+                xy_scale: 0.0,
+                yx_scale: 0.0,
+                y_scale: 1.0,
+                x_offset: 0.0,
+                y_offset: 0.0,
+            },
+            None,
+            None,
+        );
+        assert_eq!(
+            to_ir_component(&c).transform,
+            Affine::new([1.0, 0.0, 0.0, 1.0, 0.0, 0.0])
+        );
+
+        c.transform = AffineTransform {
+            x_scale: 1.0,
+            xy_scale: 0.0,
+            yx_scale: 0.0,
+            y_scale: 1.0,
+            x_offset: 10.0,
+            y_offset: 10.0,
+        };
+        assert_eq!(
+            to_ir_component(&c).transform,
+            Affine::new([1.0, 0.0, 0.0, 1.0, 10.0, 10.0])
+        );
+
+        // <component base="a" xScale="0.4366" xyScale="-0.4366" yScale="0.4415" yxScale="0.4415" xOffset="282" yOffset="5" identifier="5402E799"/>
+        c.transform = AffineTransform {
+            x_scale: 0.4366,
+            xy_scale: -0.4366,
+            y_scale: 0.4415,
+            yx_scale: 0.4415,
+            x_offset: 282.0,
+            y_offset: 5.0,
+        };
+        // Switchy switchy!
+        assert_eq!(
+            to_ir_component(&c).transform,
+            Affine::new([0.4366, -0.4366, 0.4415, 0.4415, 282.0, 5.0])
+        );
     }
 }

--- a/ufo2fontir/src/toir.rs
+++ b/ufo2fontir/src/toir.rs
@@ -60,8 +60,8 @@ fn to_ir_component(component: &norad::Component) -> ir::Component {
         base: component.base.as_str().into(),
         transform: Affine::new([
             component.transform.x_scale,
-            component.transform.yx_scale,
             component.transform.xy_scale,
+            component.transform.yx_scale,
             component.transform.y_scale,
             component.transform.x_offset,
             component.transform.y_offset,


### PR DESCRIPTION
Components with a xyScale and yxScale are currently broken. Noto Sans Balinese before this patch:

![shape](https://github.com/googlefonts/fontc/assets/106728/81d91add-1fe4-4a96-a8fc-057d144e08a1)

After:

![shape](https://github.com/googlefonts/fontc/assets/106728/7cf32059-95ce-4f2f-b68d-dc1a826bd187)

Comment explains why.