### PR TITLE
[fea-rs] Remove ClassId, add gdef classes to output

### DIFF
--- a/fea-rs/src/compile/lookups.rs
+++ b/fea-rs/src/compile/lookups.rs
@@ -14,6 +14,7 @@ use smol_str::SmolStr;
 
 use write_fonts::{
     tables::{
+        gdef::GlyphClassDef,
         gpos::{self as write_gpos},
         gsub as write_gsub,
         layout::{
@@ -33,7 +34,7 @@ use crate::{
     Kind, Opts,
 };
 
-use super::{features::AllFeatures, metrics::Anchor, tables::ClassId, tags};
+use super::{features::AllFeatures, metrics::Anchor, tags};
 
 use contextual::{
     ContextualLookupBuilder, PosChainContextBuilder, PosContextBuilder, ReverseChainBuilder,
@@ -506,19 +507,27 @@ impl AllLookups {
         )));
     }
 
-    pub(crate) fn infer_glyph_classes(&self, mut f: impl FnMut(GlyphId, ClassId)) {
+    pub(crate) fn infer_glyph_classes(&self, mut f: impl FnMut(GlyphId, GlyphClassDef)) {
         for lookup in &self.gpos {
             match lookup {
                 PositionLookup::MarkToBase(lookup) => {
                     for subtable in &lookup.subtables {
-                        subtable.base_glyphs().for_each(|k| f(k, ClassId::Base));
-                        subtable.mark_glyphs().for_each(|k| f(k, ClassId::Mark));
+                        subtable
+                            .base_glyphs()
+                            .for_each(|k| f(k, GlyphClassDef::Base));
+                        subtable
+                            .mark_glyphs()
+                            .for_each(|k| f(k, GlyphClassDef::Mark));
                     }
                 }
                 PositionLookup::MarkToLig(lookup) => {
                     for subtable in &lookup.subtables {
-                        subtable.lig_glyphs().for_each(|k| f(k, ClassId::Ligature));
-                        subtable.mark_glyphs().for_each(|k| f(k, ClassId::Mark));
+                        subtable
+                            .lig_glyphs()
+                            .for_each(|k| f(k, GlyphClassDef::Ligature));
+                        subtable
+                            .mark_glyphs()
+                            .for_each(|k| f(k, GlyphClassDef::Mark));
                     }
                 }
                 PositionLookup::MarkToMark(lookup) => {
@@ -526,7 +535,7 @@ impl AllLookups {
                         subtable
                             .mark1_glyphs()
                             .chain(subtable.mark2_glyphs())
-                            .for_each(|k| f(k, ClassId::Mark));
+                            .for_each(|k| f(k, GlyphClassDef::Mark));
                     }
                 }
                 _ => (),

--- a/fea-rs/src/compile/output.rs
+++ b/fea-rs/src/compile/output.rs
@@ -1,7 +1,10 @@
 //! The result of a compilation
 
+use std::collections::HashMap;
+
 use write_fonts::{
-    tables::{self as wtables, maxp::Maxp},
+    tables::{self as wtables, gdef::GlyphClassDef, maxp::Maxp},
+    types::GlyphId,
     BuilderError, FontBuilder,
 };
 
@@ -42,6 +45,11 @@ pub struct Compilation {
     pub gsub: Option<wtables::gsub::Gsub>,
     /// The `GPOS` table, if one was generated
     pub gpos: Option<wtables::gpos::Gpos>,
+    /// Any *explicit* gdef classes declared in the FEA.
+    ///
+    /// This is provided so that the user can reference them if they are going
+    /// to manually generate kerning or markpos lookups.
+    pub gdef_classes: Option<HashMap<GlyphId, GlyphClassDef>>,
 }
 
 impl Compilation {

--- a/fea-rs/src/compile/tables.rs
+++ b/fea-rs/src/compile/tables.rs
@@ -27,7 +27,7 @@ mod os2;
 mod stat;
 
 pub(crate) use base::{BaseBuilder, ScriptRecord};
-pub(crate) use gdef::{ClassId, GdefBuilder};
+pub(crate) use gdef::{GdefBuilder, GlyphClassDefExt};
 pub(crate) use name::{NameBuilder, NameSpec};
 pub(crate) use os2::{CodePageRange, Os2Builder};
 pub(crate) use stat::{AxisLocation, AxisRecord, AxisValue, StatBuilder, StatFallbackName};


### PR DESCRIPTION
- ClassId was a pre-write-fonts enum standing in for the GlyphClassDef enum, which we can now juse use directly
- passing any explicit GDEF classes through to the output feels like the simplest way to expose these to manual feature generation code, since that code needs to compile anyway to get the GSUB table.


The motivation here was that I want the explicit classes in a more user-friendly format, instead of having to go muck about in the compiled GDEF ClassDef table/recheck the AST to figure out if it was inferred or not, etc.
