### PR TITLE
Add KernGroup type

### DIFF
--- a/fontbe/src/error.rs
+++ b/fontbe/src/error.rs
@@ -3,7 +3,8 @@ use std::{fmt::Display, io, path::PathBuf};
 use fea_rs::compile::error::CompilerError;
 use fontdrasil::{coords::NormalizedLocation, types::GlyphName};
 use fontir::{
-    error::VariationModelError, orchestration::WorkId as FeWorkId, variations::DeltaError,
+    error::VariationModelError, ir::KernGroup, orchestration::WorkId as FeWorkId,
+    variations::DeltaError,
 };
 use smol_str::SmolStr;
 use thiserror::Error;
@@ -84,6 +85,8 @@ pub enum Error {
     DeltaError(DeltaError),
     #[error("No glyph id for '{0}'")]
     MissingGlyphId(GlyphName),
+    #[error("Missing kern group {0:?}")]
+    MissingKernGroup(KernGroup),
 }
 
 #[derive(Debug)]

--- a/fontbe/src/kern.rs
+++ b/fontbe/src/kern.rs
@@ -191,11 +191,11 @@ impl Work<Context, AnyWorkId, Error> for KerningFragmentWork {
                 (KernParticipant::Group(left), KernParticipant::Group(right)) => {
                     let left = glyph_classes
                         .get(left)
-                        .ok_or_else(|| Error::MissingGlyphId(left.clone()))?
+                        .ok_or_else(|| Error::MissingKernGroup(left.clone()))?
                         .clone();
                     let right = glyph_classes
                         .get(right)
-                        .ok_or_else(|| Error::MissingGlyphId(right.clone()))?
+                        .ok_or_else(|| Error::MissingKernGroup(right.clone()))?
                         .clone();
                     kerns.push(PairPosEntry::Class(
                         left,
@@ -211,7 +211,7 @@ impl Work<Context, AnyWorkId, Error> for KerningFragmentWork {
                         .ok_or_else(|| Error::MissingGlyphId(left.clone()))?;
                     let right = glyph_classes
                         .get(right)
-                        .ok_or_else(|| Error::MissingGlyphId(right.clone()))?;
+                        .ok_or_else(|| Error::MissingKernGroup(right.clone()))?;
                     for gid1 in right.iter() {
                         kerns.push(PairPosEntry::Pair(
                             gid0,
@@ -224,7 +224,7 @@ impl Work<Context, AnyWorkId, Error> for KerningFragmentWork {
                 (KernParticipant::Group(left), KernParticipant::Glyph(right)) => {
                     let left = glyph_classes
                         .get(left)
-                        .ok_or_else(|| Error::MissingGlyphId(left.clone()))?;
+                        .ok_or_else(|| Error::MissingKernGroup(left.clone()))?;
                     let gid1 = gid(right)?;
                     for gid0 in left.iter() {
                         kerns.push(PairPosEntry::Pair(

--- a/fontbe/src/orchestration.rs
+++ b/fontbe/src/orchestration.rs
@@ -20,7 +20,7 @@ use fontdrasil::{
     types::GlyphName,
 };
 use fontir::{
-    ir::{Anchor, KernPair},
+    ir::{Anchor, KernGroup, KernPair},
     orchestration::{
         Context as FeContext, ContextItem, ContextMap, Flags, IdAware, Persistable,
         PersistentStorage, WorkId as FeWorkIdentifier,
@@ -423,7 +423,7 @@ pub type KernAdjustments = BTreeMap<NormalizedLocation, OrderedFloat<f32>>;
 /// Every kerning pair we have, taking from IR.
 #[derive(Default, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AllKerningPairs {
-    pub glyph_classes: BTreeMap<GlyphName, GlyphSet>,
+    pub glyph_classes: BTreeMap<KernGroup, GlyphSet>,
     pub adjustments: Vec<(KernPair, KernAdjustments)>,
 }
 

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -492,7 +492,7 @@ mod tests {
     };
     use fontdrasil::{coords::NormalizedCoord, paths::safe_filename, types::GlyphName};
     use fontir::{
-        ir::{self, GlyphOrder, KernPair, KernParticipant},
+        ir::{self, GlyphOrder, KernGroup, KernPair, KernParticipant},
         orchestration::{Context as FeContext, Persistable, WorkId as FeWorkIdentifier},
     };
     use indexmap::IndexSet;
@@ -1866,7 +1866,7 @@ mod tests {
             .map(|(name, entries)| {
                 let mut entries: Vec<_> = entries.iter().map(|e| e.as_str()).collect();
                 entries.sort();
-                (name.as_str(), entries)
+                (name.to_owned(), entries)
             })
             .collect();
         groups.sort();
@@ -1906,10 +1906,22 @@ mod tests {
             (groups, kerns),
             (
                 vec![
-                    ("public.kern1.bracketleft_R", vec!["bracketleft"],),
-                    ("public.kern1.bracketright_R", vec!["bracketright"],),
-                    ("public.kern2.bracketleft_L", vec!["bracketleft"],),
-                    ("public.kern2.bracketright_L", vec!["bracketright"],),
+                    (
+                        KernGroup::Side1("bracketleft_R".into()),
+                        vec!["bracketleft"],
+                    ),
+                    (
+                        KernGroup::Side1("bracketright_R".into()),
+                        vec!["bracketright"],
+                    ),
+                    (
+                        KernGroup::Side2("bracketleft_L".into()),
+                        vec!["bracketleft"],
+                    ),
+                    (
+                        KernGroup::Side2("bracketright_L".into()),
+                        vec!["bracketright"],
+                    ),
                 ],
                 vec![
                     (
@@ -1935,7 +1947,7 @@ mod tests {
                     ),
                     (
                         KernParticipant::Glyph("exclam".into()),
-                        KernParticipant::Group("public.kern2.bracketright_L".into()),
+                        KernParticipant::Group(KernGroup::Side2("bracketright_L".into())),
                         vec![("wght 0".to_string(), -160.0),],
                     ),
                     (
@@ -1947,12 +1959,12 @@ mod tests {
                         ],
                     ),
                     (
-                        KernParticipant::Group("public.kern1.bracketleft_R".into()),
+                        KernParticipant::Group(KernGroup::Side1("bracketleft_R".into())),
                         KernParticipant::Glyph("exclam".into()),
                         vec![("wght 0".to_string(), -165.0),],
                     ),
                 ],
-            ),
+            )
         );
     }
 

--- a/fontdrasil/src/types.rs
+++ b/fontdrasil/src/types.rs
@@ -73,7 +73,6 @@ impl std::borrow::Borrow<str> for GlyphName {
     }
 }
 
-pub type GroupName = GlyphName;
 pub type AnchorName = GlyphName;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]

--- a/fontir/Cargo.toml
+++ b/fontir/Cargo.toml
@@ -31,6 +31,7 @@ parking_lot.workspace = true
 write-fonts.workspace = true  # for pens
 
 chrono.workspace = true
+smol_str.workspace = true
 
 # unique to me!
 blake3 = "1.3.3"


### PR DESCRIPTION
This encodes in the type system the idea that kerning groups have an associated side, instead of having this be encoded as a prefix on a string.

This removes the need to hae separate `KernSide` enums, and removes possible complications around using the same type for glyph names and group names.


----

I was expecting this to be a smaller diff, but overall I think it's at least a modest improvement.