### PR TITLE
Split kerning by script

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ temp-env = "0.3.3"
 rstest = "0.18.2"
 
 [workspace]
-
 resolver = "2"
 
 members = [
@@ -52,3 +51,6 @@ members = [
     "layout-normalizer",
 ]
 
+[patch.crates-io]
+icu_properties = { version = "1.4", git = "https://github.com/unicode-org/icu4x.git", rev = "728eb44" }
+tinystr = { version = "0.7.5", git = "https://github.com/unicode-org/icu4x.git", rev = "728eb44" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,8 @@ members = [
     "layout-normalizer",
 ]
 
+# remove this when icu_properties 1.5 is released:
+# https://github.com/unicode-org/icu4x/issues?q=is%3Aopen+is%3Aissue+milestone%3A%221.5+Blocking+⟨P1⟩%22
 [patch.crates-io]
 icu_properties = { version = "1.4", git = "https://github.com/unicode-org/icu4x.git", rev = "728eb44" }
 tinystr = { version = "0.7.5", git = "https://github.com/unicode-org/icu4x.git", rev = "728eb44" }

--- a/fea-rs/src/common/glyph_class.rs
+++ b/fea-rs/src/common/glyph_class.rs
@@ -65,8 +65,14 @@ impl GlyphSet {
         self.0.iter().copied()
     }
 
-    pub(crate) fn len(&self) -> usize {
+    /// The number of glyphs in the set
+    pub fn len(&self) -> usize {
         self.0.len()
+    }
+
+    /// Returns `true` if the set contains no glyphs
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
     }
 }
 

--- a/fea-rs/src/compile/lookups.rs
+++ b/fea-rs/src/compile/lookups.rs
@@ -8,6 +8,7 @@ mod helpers;
 use std::{
     collections::{BTreeMap, HashMap},
     convert::TryInto,
+    fmt::Debug,
 };
 
 use smol_str::SmolStr;
@@ -182,7 +183,8 @@ pub(crate) struct LookupFlagInfo {
 }
 
 /// A feature associated with a particular script and language.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FeatureKey {
     pub(crate) feature: Tag,
     pub(crate) language: Tag,
@@ -1168,6 +1170,12 @@ impl FeatureKey {
             language,
             script,
         }
+    }
+}
+
+impl Debug for FeatureKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}/{}", self.feature, self.script, self.language)
     }
 }
 

--- a/fea-rs/src/compile/lookups/gpos_builders.rs
+++ b/fea-rs/src/compile/lookups/gpos_builders.rs
@@ -196,6 +196,17 @@ impl PairPosBuilder {
         self.pairs.0.is_empty() && self.classes.0.is_empty()
     }
 
+    /// The number of rules in the builder
+    pub fn len(&self) -> usize {
+        self.pairs.0.values().map(|vals| vals.len()).sum::<usize>()
+            + self
+                .classes
+                .0
+                .values()
+                .flat_map(|x| x.iter().map(|y| y.items.values().len()))
+                .sum::<usize>()
+    }
+
     /// Insert a new kerning pair
     pub fn insert_pair(
         &mut self,

--- a/fea-rs/src/compile/metrics.rs
+++ b/fea-rs/src/compile/metrics.rs
@@ -61,6 +61,16 @@ impl ValueRecord {
         Default::default()
     }
 
+    /// Duplicates the x-advance value to x-placement, required for RTL rules.
+    ///
+    /// This is only necessary when a record was originally created without
+    /// knowledge of the writing direction, and then later needs to be modified.
+    pub fn make_rtl_compatible(&mut self) {
+        if self.x_placement.is_none() {
+            self.x_placement = self.x_advance.clone();
+        }
+    }
+
     // these methods just match the existing builder methods on `ValueRecord`
     /// Builder style method to set the default x_placement value
     pub fn with_x_placement(mut self, val: i16) -> Self {

--- a/fea-rs/src/token_tree/typed.rs
+++ b/fea-rs/src/token_tree/typed.rs
@@ -420,17 +420,20 @@ impl ContextualRuleNode for Gsub8 {}
 impl ContextualRuleNode for IgnoreRule {}
 
 impl Root {
-    pub(crate) fn statements(&self) -> impl Iterator<Item = &NodeOrToken> {
+    /// Iterate over all top-level statements
+    pub fn statements(&self) -> impl Iterator<Item = &NodeOrToken> {
         self.iter().filter(|t| !t.kind().is_trivia())
     }
 }
 
 impl LanguageSystem {
-    pub(crate) fn script(&self) -> Tag {
+    /// The script tag
+    pub fn script(&self) -> Tag {
         self.inner.iter_children().find_map(Tag::cast).unwrap()
     }
 
-    pub(crate) fn language(&self) -> Tag {
+    /// The language tag
+    pub fn language(&self) -> Tag {
         self.inner
             .iter_children()
             .skip_while(|t| t.kind() != Kind::Tag)
@@ -451,7 +454,8 @@ impl Tag {
         self.inner.text.parse()
     }
 
-    pub(crate) fn to_raw(&self) -> write_fonts::types::Tag {
+    /// Convert this AST tag into a raw `Tag`
+    pub fn to_raw(&self) -> write_fonts::types::Tag {
         self.parse().expect("tag is exactly 4 bytes")
     }
 }

--- a/fontbe/Cargo.toml
+++ b/fontbe/Cargo.toml
@@ -14,10 +14,8 @@ categories = ["text-processing", "parsing", "graphics"]
 fontdrasil = { version = "0.0.1", path = "../fontdrasil" }
 fontir = { version = "0.0.1", path = "../fontir" }
 fea-rs = { version = "0.18.0", path = "../fea-rs", features = ["serde"] }
-#icu_properties = "1.4"
-icu_properties = { version = "1.4", path = "../../extern/icu4x/components/properties" }
-#tinystr = "0.7.5"
-tinystr = {version = "0.7.5", path = "../../extern/icu4x/utils/tinystr" }
+icu_properties = "1.4"
+tinystr = {version = "0.7.5", features = ["serde"] }
 
 serde.workspace = true
 bincode.workspace = true

--- a/fontbe/Cargo.toml
+++ b/fontbe/Cargo.toml
@@ -14,6 +14,10 @@ categories = ["text-processing", "parsing", "graphics"]
 fontdrasil = { version = "0.0.1", path = "../fontdrasil" }
 fontir = { version = "0.0.1", path = "../fontir" }
 fea-rs = { version = "0.18.0", path = "../fea-rs", features = ["serde"] }
+#icu_properties = "1.4"
+icu_properties = { version = "1.4", path = "../../extern/icu4x/components/properties" }
+#tinystr = "0.7.5"
+tinystr = {version = "0.7.5", path = "../../extern/icu4x/utils/tinystr" }
 
 serde.workspace = true
 bincode.workspace = true

--- a/fontbe/src/features.rs
+++ b/fontbe/src/features.rs
@@ -41,6 +41,8 @@ use crate::{
 
 mod kern;
 mod marks;
+mod properties;
+
 pub use kern::{create_gather_ir_kerning_work, create_kern_segment_work, create_kerns_work};
 pub use marks::create_mark_work;
 

--- a/fontbe/src/features.rs
+++ b/fontbe/src/features.rs
@@ -41,6 +41,7 @@ use crate::{
 
 mod kern;
 mod marks;
+mod ot_tags;
 mod properties;
 
 pub use kern::{create_gather_ir_kerning_work, create_kern_segment_work, create_kerns_work};

--- a/fontbe/src/features/kern.rs
+++ b/fontbe/src/features/kern.rs
@@ -1,10 +1,17 @@
 //! Generates an [FeaRsKerns] datastructure to be fed to fea-rs
 
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::{
+    borrow::Cow,
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
+};
 
 use fea_rs::{
-    compile::{PairPosBuilder, ValueRecord as ValueRecordBuilder},
-    GlyphSet,
+    compile::{
+        FeatureKey, NopFeatureProvider, NopVariationInfo, PairPosBuilder,
+        ValueRecord as ValueRecordBuilder,
+    },
+    typed::{AstNode, LanguageSystem},
+    GlyphMap, GlyphSet, Opts, ParseTree,
 };
 use fontdrasil::{
     coords::NormalizedLocation,
@@ -15,22 +22,38 @@ use fontir::{
     ir::{KernGroup, KernPair, KernParticipant, KerningGroups, KerningInstance},
     orchestration::WorkId as FeWorkId,
 };
+use icu_properties::BidiClass;
 use log::debug;
 use ordered_float::OrderedFloat;
-use write_fonts::types::GlyphId;
+use write_fonts::{
+    read::{tables::gsub::Gsub, FontRead, ReadError},
+    tables::gdef::GlyphClassDef,
+    types::{GlyphId, Tag},
+};
 
 use crate::{
     error::Error,
-    features::resolve_variable_metric,
+    features::{
+        properties::{ScriptDirection, UnicodeShortName, COMMON_SCRIPT, INHERITED_SCRIPT},
+        resolve_variable_metric,
+    },
     orchestration::{
         AllKerningPairs, AnyWorkId, BeWork, Context, FeaRsKerns, KernAdjustments, KernFragment,
         PairPosEntry, WorkId,
     },
 };
 
+use super::properties::CharMap;
+
 /// On Linux it took ~0.01 ms per loop, try to get enough to make fan out worthwhile
 /// based on empirical testing
 const KERNS_PER_BLOCK: usize = 2048;
+const KERN: Tag = Tag::new(b"kern");
+// we don't currently compile this feature, but we will, and it is referenced
+// in places because our impl is based on fonttools.
+const DIST: Tag = Tag::new(b"dist");
+const DFLT_SCRIPT: Tag = Tag::new(b"DFLT");
+const DFLT_LANG: Tag = Tag::new(b"dflt");
 
 /// Accumulation of all the kerning from IR
 #[derive(Debug)]
@@ -359,31 +382,645 @@ impl Work<Context, AnyWorkId, Error> for KerningGatherWork {
     fn exec(&self, context: &Context) -> Result<(), Error> {
         debug!("Gather be kerning");
         let arc_fragments = context.kern_fragments.all();
+        let ast = context.fea_ast.get();
+        let glyph_order = context.ir.glyph_order.get();
+        let glyph_map = glyph_order.iter().map(|g| g.clone().into_inner()).collect();
         let mut fragments: Vec<_> = arc_fragments
             .iter()
             .map(|(_, fragment)| fragment.as_ref())
             .collect();
         fragments.sort_by_key(|fragment| fragment.segment);
 
-        let mut builder = PairPosBuilder::default();
-
-        let mut entries = 0;
-        for ppe in fragments
+        let glyphs_and_gids = glyph_order
             .iter()
-            .flat_map(|fragment| fragment.kerns.iter())
-            .cloned()
-        {
-            ppe.add_to(&mut builder);
-            entries += 1;
-        }
-
-        debug!("{entries} be kerns gathered");
-        let mut kerns = FeaRsKerns::default();
-        if !builder.is_empty() {
-            kerns.lookups = vec![builder];
-        }
-        context.fea_rs_kerns.set(kerns);
-
+            .enumerate()
+            .map(|(i, glyphname)| {
+                (
+                    context.ir.glyphs.get(&FeWorkId::Glyph(glyphname.clone())),
+                    GlyphId::new(i as u16),
+                )
+            })
+            .collect::<Vec<_>>();
+        let lookups = self.finalize_kerning(&fragments, &ast.ast, &glyph_map, &glyphs_and_gids)?;
+        context.fea_rs_kerns.set(lookups);
         Ok(())
     }
+}
+
+impl KerningGatherWork {
+    //. take the kerning fragments and generate the kerning lookups.
+    ///
+    // This includes much of the logic from the ufo2ft KernFeatureWriter
+    fn finalize_kerning(
+        &self,
+        fragments: &[&KernFragment],
+        ast: &ParseTree,
+        glyph_map: &GlyphMap,
+        glyphs: &impl CharMap,
+    ) -> Result<FeaRsKerns, Error> {
+        // ignore diagnostics, they'll get logged during actual GSUB compilation
+        let (compilation, _) = fea_rs::compile::compile::<NopVariationInfo, NopFeatureProvider>(
+            ast,
+            glyph_map,
+            None,
+            None,
+            Opts::new().compile_gpos(false),
+        )
+        .map_err(|err| {
+            Error::FeaCompileError(fea_rs::compile::error::CompilerError::CompilationFail(err))
+        })?;
+
+        let gsub = compilation
+            .gsub
+            .as_ref()
+            .map(write_fonts::dump_table)
+            .transpose()
+            .expect("if this doesn't compile we will already panic when we try to add it to the context");
+        let gsub = gsub
+            .as_ref()
+            .map(|data| write_fonts::read::tables::gsub::Gsub::read(data.as_slice().into()))
+            .transpose()?;
+
+        let gdef = compilation.gdef_classes;
+
+        // serves as a standin for cmap in the fonttools impl
+
+        let pairs = fragments
+            .iter()
+            .flat_map(|frag| frag.kerns.iter())
+            .collect::<Vec<_>>();
+
+        let known_scripts = guess_font_scripts(ast, glyphs);
+        let split_ctx = KernSplitContext::new(glyphs, &known_scripts, gsub, gdef)?;
+
+        let lookups = split_ctx.make_lookups(&pairs);
+        let (lookups, features) = self.assign_lookups_to_scripts(lookups, ast, KERN);
+        Ok(FeaRsKerns { lookups, features })
+    }
+
+    /// returns a vec of lookups (as a vec of subtables), along with a map of features -> lookups
+    /// (by order in the first vec)
+    fn assign_lookups_to_scripts(
+        &self,
+        lookups: HashMap<BTreeSet<UnicodeShortName>, Vec<PairPosBuilder>>,
+        ast: &ParseTree,
+        // one of 'kern' or 'dist'
+        current_feature: Tag,
+    ) -> (Vec<Vec<PairPosBuilder>>, HashMap<FeatureKey, Vec<usize>>) {
+        let dflt_langs = vec![DFLT_LANG];
+
+        let is_kern_feature = current_feature == KERN;
+        assert!(is_kern_feature || current_feature == DIST);
+        // this is based on the _registerLookups fn, and this is where we should start typing
+        let mut lookups_by_script = HashMap::new();
+        let mut ordered_lookups = Vec::new();
+
+        let fea_langs_by_script: HashMap<_, _> = get_script_language_systems(ast)
+            .into_values()
+            .flat_map(|x| x.into_iter())
+            .collect();
+
+        // in python this part happens earlier, as part of splitKerning.
+        for (scripts, lookups) in lookups {
+            let idx = ordered_lookups.len();
+            ordered_lookups.push(lookups);
+            for script in scripts {
+                lookups_by_script
+                    .entry(script)
+                    .or_insert(Vec::new())
+                    .push(idx);
+            }
+        }
+
+        // now implement the logic from _registerLookups in KernFeatureWriter:
+        // <https://github.com/googlefonts/ufo2ft/blob/f6b4f42460b/Lib/ufo2ft/featureWriters/kernFeatureWriter.py#L772>
+        let mut default_lookups = Vec::new();
+        if let Some(common_lookups) = lookups_by_script
+            .get(&COMMON_SCRIPT)
+            .filter(|_| is_kern_feature)
+        {
+            log::debug!("found {} default lookups", common_lookups.len());
+            default_lookups.extend(common_lookups.iter().copied());
+        }
+
+        //inDesign bugfix:
+        let dist_enabled_scripts = super::properties::dist_feature_enabled_scripts();
+        let (mut ltr_lookups, mut rtl_lookups) = (Vec::new(), Vec::new());
+        for (script, lookups) in lookups_by_script
+            .iter()
+            .filter(|(script, _)| !dist_enabled_scripts.contains(script))
+        {
+            match ScriptDirection::for_script(script) {
+                ScriptDirection::LeftToRight => ltr_lookups.extend(lookups.iter().copied()),
+                ScriptDirection::RightToLeft => rtl_lookups.extend(lookups.iter().copied()),
+                ScriptDirection::Auto => (),
+            }
+        }
+
+        // if we have any LTR lookups, we add those to defaults, otherwise add RTL lookups
+        if !ltr_lookups.is_empty() {
+            default_lookups.extend(ltr_lookups);
+        } else {
+            default_lookups.extend(rtl_lookups);
+        }
+        default_lookups.sort_unstable();
+
+        let mut features = HashMap::new();
+        if !default_lookups.is_empty() {
+            let languages = fea_langs_by_script.get(&DFLT_SCRIPT).unwrap_or(&dflt_langs);
+            log::debug!("DFLT languages: {languages:?}");
+            for lang in languages {
+                features.insert(
+                    FeatureKey::new(KERN, *lang, DFLT_SCRIPT),
+                    default_lookups.clone(),
+                );
+            }
+        }
+
+        let common_lookups = lookups_by_script.remove(&COMMON_SCRIPT);
+        let inherited_lookups = lookups_by_script.remove(&INHERITED_SCRIPT);
+        let dflt_lookups = match (common_lookups, inherited_lookups) {
+            (Some(mut a), Some(b)) => {
+                a.extend(b);
+                a.sort_unstable();
+                a.dedup();
+                a
+            }
+            (Some(a), None) | (None, Some(a)) => a,
+            (None, None) => Vec::new(),
+        };
+
+        for (script, mut lookups) in lookups_by_script {
+            lookups.extend(dflt_lookups.iter().copied());
+
+            for tag in super::properties::script_to_ot_tags(&script) {
+                let languages = fea_langs_by_script.get(&tag).unwrap_or(&dflt_langs);
+                for lang in languages {
+                    log::info!("added {} lookups for {tag}/{lang}", lookups.len());
+                    features.insert(FeatureKey::new(KERN, *lang, tag), lookups.clone());
+                }
+            }
+        }
+
+        debug_ordered_lookups(&features, &ordered_lookups);
+        (ordered_lookups, features)
+    }
+}
+
+fn debug_ordered_lookups(
+    features: &HashMap<FeatureKey, Vec<usize>>,
+    lookups: &[Vec<PairPosBuilder>],
+) {
+    for (i, subtables) in lookups.iter().enumerate() {
+        let total_rules = subtables.iter().map(|x| x.len()).sum::<usize>();
+        log::debug!("lookup {i}, {total_rules} rules");
+    }
+
+    let mut feature_keys = features.keys().collect::<Vec<_>>();
+    feature_keys.sort();
+    for feature in feature_keys {
+        let indices = features.get(feature).unwrap();
+        log::debug!("feature {feature:?}, lookups {indices:?}");
+    }
+}
+
+/// All the state needed for splitting kern pairs by script & writing direction
+struct KernSplitContext {
+    gdef: Option<HashMap<GlyphId, GlyphClassDef>>,
+    glyph_scripts: HashMap<GlyphId, HashSet<UnicodeShortName>>,
+    bidi_glyphs: HashMap<BidiClass, HashSet<GlyphId>>,
+    opts: KernSplitOptions,
+    dflt_scripts: HashSet<UnicodeShortName>,
+    common_scripts: HashSet<UnicodeShortName>,
+}
+
+// unused for now, but included so that our impl can more closely follow fonttools
+struct KernSplitOptions {
+    ignore_marks: bool,
+}
+
+impl Default for KernSplitOptions {
+    fn default() -> Self {
+        Self { ignore_marks: true }
+    }
+}
+
+impl KernSplitContext {
+    fn new(
+        glyphs: &impl CharMap,
+        known_scripts: &HashSet<UnicodeShortName>,
+        gsub: Option<Gsub>,
+        gdef: Option<HashMap<GlyphId, GlyphClassDef>>,
+    ) -> Result<Self, ReadError> {
+        let glyph_scripts =
+            super::properties::scripts_by_glyph(glyphs, known_scripts, gsub.as_ref())?;
+        let bidi_glyphs = super::properties::glyphs_by_bidi_class(glyphs, gsub.as_ref())?;
+
+        Ok(Self {
+            gdef,
+            glyph_scripts,
+            bidi_glyphs,
+            opts: KernSplitOptions::default(),
+            dflt_scripts: HashSet::from([COMMON_SCRIPT, INHERITED_SCRIPT]),
+            common_scripts: HashSet::from([COMMON_SCRIPT]),
+        })
+    }
+
+    fn mark_glyph_ids(&self) -> HashSet<GlyphId> {
+        self.gdef
+            .as_ref()
+            .map(|classes| {
+                classes
+                    .iter()
+                    .filter_map(|(gid, cls)| (*cls == GlyphClassDef::Mark).then_some(*gid))
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    // <https://github.com/googlefonts/ufo2ft/blob/cea60d71dfc/Lib/ufo2ft/featureWriters/kernFeatureWriter.py#L242>
+    fn make_lookups(
+        &self,
+        pairs: &[&PairPosEntry],
+    ) -> HashMap<BTreeSet<UnicodeShortName>, Vec<PairPosBuilder>> {
+        if !self.opts.ignore_marks {
+            let pairs = pairs.iter().map(|x| Cow::Borrowed(*x)).collect::<Vec<_>>();
+            return self.make_split_script_kern_lookups(&pairs, false);
+        }
+
+        let (base_pairs, mark_pairs) = self.split_base_and_mark_pairs(pairs);
+        let mut result = HashMap::new();
+        if !base_pairs.is_empty() {
+            result = self.make_split_script_kern_lookups(&base_pairs, false);
+        }
+        if !mark_pairs.is_empty() {
+            for (scripts, lookups) in self.make_split_script_kern_lookups(&mark_pairs, true) {
+                result.entry(scripts).or_default().extend(lookups);
+            }
+        }
+        result
+    }
+
+    /// Split these pairpos rules into lookups based on script.
+    ///
+    /// Returns a map of scripts: `[lookup]`, where 'scripts' is a set of scripts
+    /// referencing the lookups.
+    ///
+    /// Although this method always/only returns a single lookup per unique set
+    /// of scripts, we wrap it in a vec because that is what we need at the
+    /// call site.
+    // <https://github.com/googlefonts/ufo2ft/blob/f6b4f42460b/Lib/ufo2ft/featureWriters/kernFeatureWriter.py#L694>
+    fn make_split_script_kern_lookups(
+        &self,
+        pairs: &[Cow<PairPosEntry>],
+        //TODO: handle marks
+        _are_marks: bool,
+    ) -> HashMap<BTreeSet<UnicodeShortName>, Vec<PairPosBuilder>> {
+        let mut lookups_by_script = HashMap::new();
+        let kerning_per_script = self.split_kerns(pairs);
+        let mut bidi_buf = HashSet::new(); // we can reuse this for each pair
+        for (scripts, pairs) in kerning_per_script {
+            let mut lookup = PairPosBuilder::default();
+            for mut pair in pairs {
+                bidi_buf.clear();
+                for (direction, glyphs) in &self.bidi_glyphs {
+                    if !pair.glyphs_are_disjoint(glyphs) {
+                        bidi_buf.insert(*direction);
+                    }
+                }
+                if bidi_buf.contains(&BidiClass::LeftToRight)
+                    && bidi_buf.contains(&BidiClass::RightToLeft)
+                {
+                    log::warn!(
+                        "skipping kern pair with ambigous direction: {}",
+                        pair.display_glyphs()
+                    );
+                    continue;
+                }
+
+                let script_direction = ScriptDirection::for_script(scripts.first().unwrap());
+                assert!(scripts
+                    .iter()
+                    .all(|x| ScriptDirection::for_script(x) == script_direction));
+                let script_is_rtl = matches!(script_direction, ScriptDirection::RightToLeft);
+                let pair_is_rtl = script_is_rtl && !bidi_buf.contains(&BidiClass::LeftToRight);
+                if pair_is_rtl {
+                    pair.make_rtl_compatible();
+                }
+                pair.add_to(&mut lookup);
+            }
+            lookups_by_script.insert(scripts, vec![lookup]);
+        }
+        lookups_by_script
+    }
+
+    // <https://github.com/googlefonts/ufo2ft/blob/f6b4f42460b/Lib/ufo2ft/featureWriters/kernFeatureWriter.py#L842>
+    fn split_kerns(
+        &self,
+        pairs: &[Cow<PairPosEntry>],
+    ) -> HashMap<BTreeSet<UnicodeShortName>, Vec<PairPosEntry>> {
+        let mut kerning_per_script = HashMap::new();
+        for pair in pairs {
+            for (scripts, pair) in self.partition_by_script(pair) {
+                kerning_per_script
+                    .entry(scripts)
+                    .or_insert(Vec::new())
+                    .push(pair);
+            }
+        }
+
+        kerning_per_script = merge_scripts(kerning_per_script);
+        for scripts in kerning_per_script.keys().filter(|x| x.len() > 1) {
+            log::info!("merging kerning lookups for {scripts:?}");
+        }
+
+        kerning_per_script
+    }
+
+    // <https://github.com/googlefonts/ufo2ft/blob/f6b4f42460b340c/Lib/ufo2ft/featureWriters/kernFeatureWriter.py#L865>
+    fn partition_by_script<'b>(
+        &self,
+        pair: &'b PairPosEntry,
+    ) -> impl Iterator<Item = (BTreeSet<UnicodeShortName>, PairPosEntry)> + 'b {
+        //TODO: we could definitely make a reusable context and save all this
+        //reallocation
+        let mut resolved_scripts = HashMap::new();
+        let mut side1_directions = HashMap::new();
+        let mut side2_directions = HashMap::new();
+        for glyph in pair.first_glyphs() {
+            let mut scripts = self.glyph_scripts.get(&glyph).unwrap_or(&self.dflt_scripts);
+            if !scripts.is_disjoint(&self.dflt_scripts) {
+                // if has any dflt script, just treat it as common
+                scripts = &self.common_scripts;
+            }
+            resolved_scripts.insert(glyph, scripts.to_owned());
+            for direction in scripts.iter().map(ScriptDirection::for_script) {
+                side1_directions
+                    .entry(direction)
+                    .or_insert(HashSet::new())
+                    .insert(glyph);
+            }
+        }
+
+        for glyph in pair.second_glyphs() {
+            let mut scripts = self.glyph_scripts.get(&glyph).unwrap_or(&self.dflt_scripts);
+            if !scripts.is_disjoint(&self.dflt_scripts) {
+                scripts = &self.common_scripts;
+            }
+            resolved_scripts.insert(glyph, scripts.to_owned());
+            for direction in scripts.iter().map(ScriptDirection::for_script) {
+                side2_directions
+                    .entry(direction)
+                    .or_insert(HashSet::new())
+                    .insert(glyph);
+            }
+        }
+
+        let mut product = side1_directions.into_iter().flat_map(move |s1d| {
+            side2_directions
+                .clone()
+                .into_iter()
+                .map(move |s2d| (s1d.clone(), s2d))
+        });
+
+        std::iter::from_fn(move || loop {
+            // we need to loop here so that we can skip some items
+
+            let ((side1_dir, side1_glyphs), (side2_dir, side2_glyphs)) = product.next()?;
+
+            let side1: GlyphSet = side1_glyphs.iter().copied().collect();
+            let side1_scripts = side1
+                .iter()
+                .flat_map(|gid| resolved_scripts.get(&gid).unwrap().iter().copied())
+                .collect::<HashSet<_>>();
+            let side2: GlyphSet = side2_glyphs.iter().copied().collect();
+            let side2_scripts = side2
+                .iter()
+                .flat_map(|gid| resolved_scripts.get(&gid).unwrap().iter().copied())
+                .collect::<HashSet<_>>();
+
+            if !side1_dir.plays_nicely_with(&side2_dir) {
+                log::warn!("skipping kerning pair {side1:?}/{side2:?} with mixed direction {side1_dir:?}/{side2_dir:?}");
+                continue;
+            }
+
+            let mut scripts = side1_scripts
+                .iter()
+                .copied()
+                .chain(side2_scripts.iter().copied())
+                .collect::<BTreeSet<_>>();
+            if ![side1_scripts, side2_scripts]
+                .iter()
+                .all(|x| x.contains(&COMMON_SCRIPT))
+            {
+                scripts.remove(&COMMON_SCRIPT);
+            }
+            return Some((scripts, pair.with_new_glyphs(side1, side2)));
+        })
+    }
+
+    /// returns vecs of base and mark pairs.
+    ///
+    /// Where possible the input items will be reused, but if a given entry contains
+    /// mixed items we will need to allocate new entries.
+    ///
+    /// see
+    /// <https://github.com/googlefonts/ufo2ft/blob/cea60d71dfc/Lib/ufo2ft/featureWriters/kernFeatureWriter.py#L441>
+    fn split_base_and_mark_pairs<'b>(
+        &self,
+        pairs: &[&'b PairPosEntry],
+    ) -> (Vec<Cow<'b, PairPosEntry>>, Vec<Cow<'b, PairPosEntry>>) {
+        enum GlyphSetContent {
+            Empty,
+            BasesOnly,
+            MarksOnly,
+            Mixed,
+        }
+
+        // little helper to tell us what's in a glyphset
+        fn classify_glyphset_contents(
+            glyph_set: &GlyphSet,
+            marks: &HashSet<GlyphId>,
+        ) -> GlyphSetContent {
+            glyph_set.iter().fold(GlyphSetContent::Empty, |val, gid| {
+                match (val, marks.contains(&gid)) {
+                    (GlyphSetContent::Empty, true) => GlyphSetContent::MarksOnly,
+                    (GlyphSetContent::Empty, false) => GlyphSetContent::BasesOnly,
+                    (GlyphSetContent::MarksOnly, true) => GlyphSetContent::MarksOnly,
+                    (GlyphSetContent::BasesOnly, false) => GlyphSetContent::BasesOnly,
+                    _ => GlyphSetContent::Mixed,
+                }
+            })
+        }
+
+        /// split a glyphset into (bases, marks)
+        fn split_glyphs(glyphs: &GlyphSet, marks: &HashSet<GlyphId>) -> (GlyphSet, GlyphSet) {
+            let (x, y): (Vec<_>, Vec<_>) = glyphs.iter().partition(|gid| !marks.contains(gid));
+            (x.into(), y.into())
+        }
+
+        let marks = self.mark_glyph_ids();
+        if marks.is_empty() {
+            return (
+                pairs.iter().map(|x| Cow::Borrowed(*x)).collect(),
+                Vec::new(),
+            );
+        }
+
+        let (mut base_pairs, mut mark_pairs) = (Vec::new(), Vec::new());
+
+        for pair in pairs {
+            match pair {
+                PairPosEntry::Pair(side1, _, side2, _)
+                    if !marks.contains(side1) && !marks.contains(side2) =>
+                {
+                    base_pairs.push(Cow::Borrowed(*pair))
+                }
+                PairPosEntry::Pair(..) => mark_pairs.push(Cow::Borrowed(*pair)),
+
+                // handle the case where all are marks or bases, first:
+                PairPosEntry::Class(side1, val1, side2, val2) => {
+                    let side1_cls = classify_glyphset_contents(side1, &marks);
+                    let side2_cls = classify_glyphset_contents(side2, &marks);
+
+                    match (side1_cls, side2_cls) {
+                        (GlyphSetContent::Empty, _) | (_, GlyphSetContent::Empty) => continue,
+                        (GlyphSetContent::BasesOnly, GlyphSetContent::BasesOnly) => {
+                            base_pairs.push(Cow::Borrowed(*pair));
+                            continue;
+                        }
+                        (GlyphSetContent::BasesOnly, GlyphSetContent::MarksOnly)
+                        | (GlyphSetContent::MarksOnly, GlyphSetContent::BasesOnly)
+                        | (GlyphSetContent::MarksOnly, GlyphSetContent::MarksOnly) => {
+                            mark_pairs.push(Cow::Borrowed(*pair));
+                            continue;
+                        }
+                        _ => {
+                            let (side1_bases, side1_marks) = split_glyphs(side1, &marks);
+                            let (side2_bases, side2_marks) = split_glyphs(side2, &marks);
+
+                            if !side1_bases.is_empty() && !side2_bases.is_empty() {
+                                base_pairs.push(Cow::Owned(PairPosEntry::Class(
+                                    side1_bases.clone(),
+                                    val1.clone(),
+                                    side2_bases.clone(),
+                                    val2.clone(),
+                                )));
+                            }
+                            // these various combos all go in the marks group
+                            for (side1, side2) in [
+                                (&side1_bases, &side2_marks),
+                                (&side1_marks, &side2_bases),
+                                (&side1_marks, &side2_marks),
+                            ] {
+                                if !side1.is_empty() && !side2.is_empty() {
+                                    base_pairs.push(Cow::Owned(PairPosEntry::Class(
+                                        side1.clone(),
+                                        val1.clone(),
+                                        side2.clone(),
+                                        val2.clone(),
+                                    )));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        (base_pairs, mark_pairs)
+    }
+}
+
+// <https://github.com/googlefonts/ufo2ft/blob/cea60d71dfcf0b1c/Lib/ufo2ft/featureWriters/baseFeatureWriter.py#L401>
+fn guess_font_scripts(ast: &ParseTree, glyphs: &impl CharMap) -> HashSet<UnicodeShortName> {
+    let mut scripts: HashSet<_> = glyphs
+        .iter_glyphs()
+        .filter_map(|(_, codepoint)| {
+            let mut scripts = super::properties::unicode_script_extensions(codepoint);
+            // only if a codepoint has a single script do know it is supported
+            match (scripts.next(), scripts.next()) {
+                (Some(script), None) => Some(script),
+                _ => None,
+            }
+        })
+        .collect();
+
+    // add scripts explicitly defined in fea
+    scripts.extend(get_script_language_systems(ast).keys().cloned());
+    scripts
+}
+
+// <https://github.com/googlefonts/ufo2ft/blob/cea60d71dfcf0b1c0fa4e133e/Lib/ufo2ft/featureWriters/ast.py#L23>
+/// returns a map of unicode script names to (ot_script, `[ot_lang]`)
+fn get_script_language_systems(ast: &ParseTree) -> HashMap<UnicodeShortName, Vec<(Tag, Vec<Tag>)>> {
+    let mut languages_by_script = HashMap::new();
+    for langsys in ast
+        .typed_root()
+        .statements()
+        .filter_map(LanguageSystem::cast)
+    {
+        languages_by_script
+            .entry(langsys.script().to_raw())
+            .or_insert(Vec::new())
+            .push(langsys.language().to_raw())
+    }
+
+    let mut unic_script_to_languages = HashMap::new();
+    for (ot_script, langs) in languages_by_script {
+        let Some(unicode_script) = super::properties::ot_tag_to_script(ot_script) else {
+            log::info!("no unicode script for OT script tag {ot_script}");
+            continue;
+        };
+        unic_script_to_languages
+            .entry(unicode_script)
+            .or_insert(Vec::new())
+            .push((ot_script, langs));
+    }
+
+    unic_script_to_languages
+}
+
+// <https://github.com/googlefonts/ufo2ft/blob/f6b4f42460b340c/Lib/ufo2ft/featureWriters/kernFeatureWriter.py#L946>
+fn merge_scripts(
+    kerning_per_script: HashMap<BTreeSet<UnicodeShortName>, Vec<PairPosEntry>>,
+) -> HashMap<BTreeSet<UnicodeShortName>, Vec<PairPosEntry>> {
+    let mut sets = kerning_per_script.keys().cloned().collect::<Vec<_>>();
+    let mut buf = Vec::with_capacity(sets.len());
+    let mut did_merge = true;
+
+    while did_merge {
+        did_merge = false;
+        while let Some(mut common) = sets.pop() {
+            sets.retain(|scripts| {
+                if scripts.is_disjoint(&common) {
+                    true
+                } else {
+                    common.extend(scripts.iter().copied());
+                    did_merge = true;
+                    false
+                }
+            });
+            buf.push(common);
+        }
+        // all items from sets were moved into buf; now move them back
+        std::mem::swap(&mut sets, &mut buf);
+        assert!(buf.is_empty());
+    }
+
+    let mut result = sets
+        .iter()
+        .map(|set| (set.clone(), Vec::new()))
+        .collect::<HashMap<_, _>>();
+
+    for (scripts, pairs) in kerning_per_script {
+        let merged_script = sets
+            .iter()
+            .find(|merged| !merged.is_disjoint(&scripts))
+            .unwrap();
+        result.get_mut(merged_script).unwrap().extend(pairs);
+    }
+
+    // sort all the pairs; fonttools does that after returning but here works?
+    result.values_mut().for_each(|pairs| pairs.sort_unstable());
+    result
 }

--- a/fontbe/src/features/ot_tags.rs
+++ b/fontbe/src/features/ot_tags.rs
@@ -1,0 +1,176 @@
+//! mapping opentype tags to unicode scripts
+//!
+//! based on
+//! <https://github.com/fonttools/fonttools/blob/8697f91cdc/Lib/fontTools/unicodedata/OTTags.py>
+
+use write_fonts::types::Tag;
+
+pub(crate) const DFLT_SCRIPT: Tag = Tag::new(b"DFLT");
+
+pub(crate) static SCRIPT_ALIASES: &[(Tag, Tag)] = &[(Tag::new(b"jamo"), Tag::new(b"hang"))];
+
+pub(crate) static SCRIPT_EXCEPTIONS: &[(&str, Tag)] = &[
+    ("Hira", Tag::new(b"kana")),
+    ("Hrkt", Tag::new(b"kana")),
+    ("Laoo", Tag::new(b"lao ")),
+    ("Nkoo", Tag::new(b"nko ")),
+    ("Vaii", Tag::new(b"vai ")),
+    ("Yiii", Tag::new(b"yi  ")),
+    ("Zinh", DFLT_SCRIPT),
+    ("Zmth", Tag::new(b"math")),
+    ("Zyyy", DFLT_SCRIPT),
+    ("Zzzz", DFLT_SCRIPT),
+];
+
+// 'math' is used as a script in opentype features:
+// <https://github.com/harfbuzz/harfbuzz/pull/3417>
+pub(crate) static SCRIPT_EXCEPTIONS_REVERSED: &[(Tag, &str)] = &[(Tag::new(b"math"), "Zmth")];
+
+pub(crate) static NEW_SCRIPTS: &[(Tag, &str)] = &[
+    (Tag::new(b"bng2"), "Beng"),
+    (Tag::new(b"dev2"), "Deva"),
+    (Tag::new(b"gjr2"), "Gujr"),
+    (Tag::new(b"gur2"), "Guru"),
+    (Tag::new(b"knd2"), "Knda"),
+    (Tag::new(b"mlm2"), "Mlym"),
+    (Tag::new(b"mym2"), "Mymr"),
+    (Tag::new(b"ory2"), "Orya"),
+    (Tag::new(b"tel2"), "Telu"),
+    (Tag::new(b"tml2"), "Taml"),
+];
+
+pub(crate) static NEW_SCRIPT_TAGS: &[(&str, Tag)] = &[
+    ("Beng", Tag::new(b"bng2")),
+    ("Deva", Tag::new(b"dev2")),
+    ("Gujr", Tag::new(b"gjr2")),
+    ("Guru", Tag::new(b"gur2")),
+    ("Kana", Tag::new(b"knd2")),
+    ("Mlym", Tag::new(b"mlm2")),
+    ("Mymr", Tag::new(b"mym2")),
+    ("Orya", Tag::new(b"ory2")),
+    ("Taml", Tag::new(b"tml2")),
+    ("Telu", Tag::new(b"tel2")),
+];
+
+pub(crate) static INDIC_SCRIPTS: &[&str] = &[
+    "Beng", // Bengali
+    "Deva", // Devanagari
+    "Gujr", // Gujarati
+    "Guru", // Gurmukhi
+    "Knda", // Kannada
+    "Mlym", // Malayalam
+    "Orya", // Oriya
+    "Sinh", // Sinhala
+    "Taml", // Tamil
+    "Telu", // Telugu
+];
+
+pub(crate) static USE_SCRIPTS: &[&str] = &[
+    // Correct as at Unicode 15.0
+    "Adlm", // Adlam
+    "Ahom", // Ahom
+    "Bali", // Balinese
+    "Batk", // Batak
+    "Brah", // Brahmi
+    "Bugi", // Buginese
+    "Buhd", // Buhid
+    "Cakm", // Chakma
+    "Cham", // Cham
+    "Chrs", // Chorasmian
+    "Cpmn", // Cypro Minoan
+    "Diak", // Dives Akuru
+    "Dogr", // Dogra
+    "Dupl", // Duployan
+    "Egyp", // Egyptian Hieroglyphs
+    "Elym", // Elymaic
+    "Gong", // Gunjala Gondi
+    "Gonm", // Masaram Gondi
+    "Gran", // Grantha
+    "Hano", // Hanunoo
+    "Hmng", // Pahawh Hmong
+    "Hmnp", // Nyiakeng Puachue Hmong
+    "Java", // Javanese
+    "Kali", // Kayah Li
+    "Kawi", // Kawi
+    "Khar", // Kharosthi
+    "Khoj", // Khojki
+    "Kits", // Khitan Small Script
+    "Kthi", // Kaithi
+    "Lana", // Tai Tham
+    "Lepc", // Lepcha
+    "Limb", // Limbu
+    "Mahj", // Mahajani
+    "Maka", // Makasar
+    "Mand", // Mandaic
+    "Mani", // Manichaean
+    "Marc", // Marchen
+    "Medf", // Medefaidrin
+    "Modi", // Modi
+    "Mong", // Mongolian
+    "Mtei", // Meetei Mayek
+    "Mult", // Multani
+    "Nagm", // Nag Mundari
+    "Nand", // Nandinagari
+    "Newa", // Newa
+    "Nhks", // Bhaiksuki
+    "Nko ", // Nko
+    "Ougr", // Old Uyghur
+    "Phag", // Phags Pa
+    "Phlp", // Psalter Pahlavi
+    "Plrd", // Miao
+    "Rjng", // Rejang
+    "Rohg", // Hanifi Rohingya
+    "Saur", // Saurashtra
+    "Shrd", // Sharada
+    "Sidd", // Siddham
+    "Sind", // Khudawadi
+    "Sogd", // Sogdian
+    "Sogo", // Old Sogdian
+    "Soyo", // Soyombo
+    "Sund", // Sundanese
+    "Sylo", // Syloti Nagri
+    "Tagb", // Tagbanwa
+    "Takr", // Takri
+    "Tale", // Tai Le
+    "Tavt", // Tai Viet
+    "Tfng", // Tifinagh
+    "Tglg", // Tagalog
+    "Tibt", // Tibetan
+    "Tirh", // Tirhuta
+    "Tnsa", // Tangsa
+    "Toto", // Toto
+    "Vith", // Vithkuqi
+    "Wcho", // Wancho
+    "Yezi", // Yezidi
+    "Zanb", // Zanabazar Square
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// we want to binary search these, so let's enforce that they are sorted,
+    /// to avoid future headaches
+    #[test]
+    fn const_arrays_are_sorted() {
+        fn get_original_and_sorted_items<T: Clone + Ord + Eq, U>(
+            items: &[(T, U)],
+        ) -> (Vec<T>, Vec<T>) {
+            let originals = items.iter().map(|(a, _)| a.clone()).collect::<Vec<_>>();
+            let mut sorted = originals.clone();
+            sorted.sort();
+            (originals, sorted)
+        }
+
+        let (actual, expected) = get_original_and_sorted_items(SCRIPT_ALIASES);
+        assert_eq!(actual, expected);
+        let (actual, expected) = get_original_and_sorted_items(SCRIPT_EXCEPTIONS_REVERSED);
+        assert_eq!(actual, expected);
+        let (actual, expected) = get_original_and_sorted_items(NEW_SCRIPTS);
+        assert_eq!(actual, expected);
+        let (actual, expected) = get_original_and_sorted_items(NEW_SCRIPT_TAGS);
+        assert_eq!(actual, expected);
+        let (actual, expected) = get_original_and_sorted_items(SCRIPT_EXCEPTIONS);
+        assert_eq!(actual, expected);
+    }
+}

--- a/fontbe/src/features/properties.rs
+++ b/fontbe/src/features/properties.rs
@@ -216,24 +216,23 @@ static SCRIPT_EXCEPTIONS: &[(&str, Tag)] = &[
     ("Zyyy", DFLT_SCRIPT),
     ("Zzzz", DFLT_SCRIPT),
 ];
-//TODO: python maps 'math' to 'Zmth' but 'Mathematical Notation'
-//is not a variant on icu4x's Script? But this is included in
-//some datafiles so might be an oversight? But it's actually not listed
-//in the official list of scripts, so idk?
-static SCRIPT_EXCEPTIONS_REVERSED: &[(Tag, Script)] = &[];
+
+// 'math' is used as a script in opentype features:
+// <https://github.com/harfbuzz/harfbuzz/pull/3417>
+static SCRIPT_EXCEPTIONS_REVERSED: &[(Tag, &str)] = &[(Tag::new(b"math"), "Zmth")];
 
 // I don't know what's going on here, just copying OTTags.py
-static NEW_SCRIPTS: &[(Tag, Script)] = &[
-    (Tag::new(b"bng2"), Script::Bengali),
-    (Tag::new(b"dev2"), Script::Devanagari),
-    (Tag::new(b"gjr2"), Script::Gujarati),
-    (Tag::new(b"gur2"), Script::Gurmukhi),
-    (Tag::new(b"knd2"), Script::Kannada),
-    (Tag::new(b"mlm2"), Script::Malayalam),
-    (Tag::new(b"mym2"), Script::Myanmar),
-    (Tag::new(b"ory2"), Script::Oriya),
-    (Tag::new(b"tel2"), Script::Telugu),
-    (Tag::new(b"tml2"), Script::Tamil),
+static NEW_SCRIPTS: &[(Tag, &str)] = &[
+    (Tag::new(b"bng2"), "Beng"),
+    (Tag::new(b"dev2"), "Deva"),
+    (Tag::new(b"gjr2"), "Gujr"),
+    (Tag::new(b"gur2"), "Guru"),
+    (Tag::new(b"knd2"), "Knda"),
+    (Tag::new(b"mlm2"), "Mlym"),
+    (Tag::new(b"mym2"), "Mymr"),
+    (Tag::new(b"ory2"), "Orya"),
+    (Tag::new(b"tel2"), "Telu"),
+    (Tag::new(b"tml2"), "Taml"),
 ];
 
 // I don't know what's going on here, just copying OTTags.py
@@ -384,8 +383,7 @@ pub(crate) fn ot_tag_to_script(script_tag: Tag) -> Option<UnicodeShortName> {
         .binary_search_exact(&tag)
         .or_else(|| NEW_SCRIPTS.binary_search_exact(&tag))
     {
-        let mapping = Script::enum_to_short_name_mapper();
-        return mapping.get(exception);
+        return Some(UnicodeShortName::from_str(exception).unwrap());
     }
 
     // finally, algorithmic conversion

--- a/fontbe/src/features/properties.rs
+++ b/fontbe/src/features/properties.rs
@@ -112,3 +112,117 @@ pub(crate) fn glyphs_by_bidi_class(
         gsub,
     )
 }
+static SCRIPT_ALIASES: &[(Tag, Tag)] = &[(Tag::new(b"jamo"), Tag::new(b"hang"))];
+
+//TODO: python maps 'math' to 'Zmth' but 'Mathematical Notation'
+//is not a variant on icu4x's Script? But this is included in
+//some datafiles so might be an oversight? But it's actually not listed
+//in the official list of scripts, so idk?
+static SCRIPT_EXCEPTIONS: &[(Tag, Script)] = &[];
+
+// I don't know what's going on here, just copying OTTags.py
+static NEW_SCRIPTS: &[(Tag, Script)] = &[
+    (Tag::new(b"bng2"), Script::Bengali),
+    (Tag::new(b"dev2"), Script::Devanagari),
+    (Tag::new(b"gjr2"), Script::Gujarati),
+    (Tag::new(b"gur2"), Script::Gurmukhi),
+    (Tag::new(b"knd2"), Script::Kannada),
+    (Tag::new(b"mlm2"), Script::Malayalam),
+    (Tag::new(b"mym2"), Script::Myanmar),
+    (Tag::new(b"ory2"), Script::Oriya),
+    (Tag::new(b"tel2"), Script::Telugu),
+    (Tag::new(b"tml2"), Script::Tamil),
+];
+
+// a little helper trait to handle binary searching an array of 2-tuples where
+// the first item is a key and the second a value
+trait BinarySearchExact<T, U> {
+    fn binary_search_exact(&self, needle: &T) -> Option<U>;
+}
+
+impl<T: Ord + Eq, U: Clone> BinarySearchExact<T, U> for &[(T, U)] {
+    fn binary_search_exact(&self, needle: &T) -> Option<U> {
+        self.binary_search_by(|probe| probe.0.cmp(&needle))
+            .ok()
+            .map(|idx| &self[idx].1)
+            .cloned()
+    }
+}
+
+/// Takes an OpenType script tag and returns a unicode script identifier
+///
+/// <https://github.com/fonttools/fonttools/blob/a7a0f41c90c0d/Lib/fontTools/unicodedata/__init__.py#L261>
+pub(crate) fn ot_tag_to_script(script_tag: Tag) -> Option<UnicodeShortName> {
+    const DFLT: Tag = Tag::new(b"DFLT");
+    if script_tag == DFLT {
+        return None;
+    }
+
+    let tag = SCRIPT_ALIASES
+        .binary_search_exact(&script_tag)
+        .unwrap_or(script_tag);
+
+    if let Some(exception) = SCRIPT_EXCEPTIONS
+        .binary_search_exact(&tag)
+        .or_else(|| NEW_SCRIPTS.binary_search_exact(&tag))
+    {
+        let mapping = Script::enum_to_short_name_mapper();
+        return mapping.get(exception);
+    }
+
+    // finally, algorithmic conversion
+    Some(ot_tag_to_unicode_short_name(tag))
+}
+
+// first char is uppercased; any trailing spaces are replaced with last non-space letter
+fn ot_tag_to_unicode_short_name(tag: Tag) -> UnicodeShortName {
+    const SPACE: u8 = b' ';
+
+    let tag_bytes = tag.into_bytes();
+    let mut out = [b'\0'; 4];
+    out[0] = tag_bytes[0].to_ascii_uppercase();
+    let mut last_non_space = tag_bytes[1];
+    for i in 1..=3 {
+        if tag_bytes[i] != SPACE {
+            out[i] = tag_bytes[i];
+            last_non_space = tag_bytes[i];
+        } else {
+            out[i] = last_non_space;
+        }
+    }
+
+    UnicodeShortName::try_from_raw(out).expect("cannot fail, as tag cannot have leading nul byte")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// we want to binary search these, so let's enforce that they are sorted,
+    /// to avoid future headaches
+    #[test]
+    fn const_arrays_are_sorted() {
+        fn get_original_and_sorted_items<T: Clone + Ord + Eq, U>(
+            items: &[(T, U)],
+        ) -> (Vec<T>, Vec<T>) {
+            let originals = items.iter().map(|(a, _)| a.clone()).collect::<Vec<_>>();
+            let mut sorted = originals.clone();
+            sorted.sort();
+            (originals, sorted)
+        }
+
+        let (actual, expected) = get_original_and_sorted_items(SCRIPT_ALIASES);
+        assert_eq!(actual, expected);
+        let (actual, expected) = get_original_and_sorted_items(SCRIPT_EXCEPTIONS);
+        assert_eq!(actual, expected);
+        let (actual, expected) = get_original_and_sorted_items(NEW_SCRIPTS);
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn raw_tag_conversion() {
+        assert_eq!(ot_tag_to_unicode_short_name(Tag::new(b"deva")), "Deva");
+        assert_eq!(ot_tag_to_unicode_short_name(Tag::new(b"yi  ")), "Yiii");
+        assert_eq!(ot_tag_to_unicode_short_name(Tag::new(b"nko ")), "Nkoo");
+    }
+}

--- a/fontbe/src/features/properties.rs
+++ b/fontbe/src/features/properties.rs
@@ -1,0 +1,114 @@
+use std::{
+    collections::{HashMap, HashSet},
+    hash::Hash,
+    sync::Arc,
+};
+
+use fontir::ir::Glyph;
+use icu_properties::{script::ScriptWithExtensionsBorrowed, BidiClass, Script};
+use write_fonts::{
+    read::{tables::gsub::Gsub, ReadError},
+    types::{GlyphId, Tag},
+};
+
+static SCRIPT_DATA: ScriptWithExtensionsBorrowed<'static> =
+    icu_properties::script::script_with_extensions();
+
+/// The type used by icu4x for script names
+pub type UnicodeShortName = tinystr::TinyAsciiStr<4>;
+
+/// Iterate over the unicode scripts + extensions for the provided codepoint
+///
+/// This returns the scripts as shortnames, because that's what python does.
+/// It would probably make more sense for us to use the Script type defined by
+/// icu4x, but I want to get a more direct port working first.
+pub(crate) fn unicode_script_extensions(
+    c: u32,
+) -> impl Iterator<Item = UnicodeShortName> + 'static {
+    let lookup = Script::enum_to_short_name_mapper();
+    SCRIPT_DATA
+        .get_script_extensions_val(c)
+        .iter()
+        .map(move |script| {
+            lookup
+                .get(script)
+                // if we get a script it is by definition a 4-char ascii string,
+                // so this unwrap should never fail
+                .expect("names should be available for all defined scripts")
+        })
+}
+
+fn unicode_bidi_type(c: u32) -> BidiClass {
+    icu_properties::maps::bidi_class().get32(c)
+}
+
+// equivalent to the 'classify' method in ufo2ft:
+// <https://github.com/googlefonts/ufo2ft/blob/cea60d71dfcf0b1c0f/Lib/ufo2ft/util.py#L287>
+fn classify<T, F, I>(
+    glyphs: &[(Arc<Glyph>, GlyphId)],
+    mut props_fn: F,
+    gsub: Option<&Gsub>,
+) -> Result<HashMap<T, HashSet<GlyphId>>, ReadError>
+where
+    T: Hash + Eq,
+    I: Iterator<Item = T>,
+    F: FnMut(u32) -> I,
+{
+    let mut sets = HashMap::new();
+    let mut neutral_glyphs = HashSet::new();
+    for (gid, unicode_value) in glyphs.iter().flat_map(|(glyph, gid)| {
+        glyph
+            .codepoints
+            .iter()
+            .copied()
+            .map(|codepoint| (*gid, codepoint))
+    }) {
+        let mut has_props = false;
+        for prop in props_fn(unicode_value) {
+            sets.entry(prop).or_insert(HashSet::new()).insert(gid);
+            has_props = true;
+        }
+        if !has_props {
+            neutral_glyphs.insert(gid);
+        }
+    }
+
+    if let Some(gsub) = gsub.as_ref() {
+        neutral_glyphs = gsub.closure_glyphs(neutral_glyphs)?;
+        for glyphs in sets.values_mut() {
+            let temp = glyphs
+                .union(&neutral_glyphs)
+                .copied()
+                .collect::<HashSet<_>>();
+            let temp = gsub.closure_glyphs(temp)?;
+            glyphs.extend(temp.difference(&neutral_glyphs).copied())
+        }
+    }
+    Ok(sets)
+}
+
+/// Returns a map of gids their scripts
+pub(crate) fn scripts_by_glyph(
+    glyphs: &[(Arc<Glyph>, GlyphId)],
+    gsub: Option<&Gsub>,
+) -> Result<HashMap<GlyphId, HashSet<UnicodeShortName>>, ReadError> {
+    let mut result = HashMap::with_capacity(glyphs.len());
+    for (script, glyphs) in classify(glyphs, |cp| unicode_script_extensions(cp), gsub)? {
+        for glyph in glyphs {
+            result.entry(glyph).or_insert(HashSet::new()).insert(script);
+        }
+    }
+    Ok(result)
+}
+
+/// A map of bidi class to glyphs in that class.
+pub(crate) fn glyphs_by_bidi_class(
+    glyphs: &[(Arc<Glyph>, GlyphId)],
+    gsub: Option<&Gsub>,
+) -> Result<HashMap<BidiClass, HashSet<GlyphId>>, ReadError> {
+    classify(
+        glyphs,
+        |codepoint| Some(unicode_bidi_type(codepoint)).into_iter(),
+        gsub,
+    )
+}

--- a/fontbe/src/features/properties.rs
+++ b/fontbe/src/features/properties.rs
@@ -1,3 +1,4 @@
+//! Properties and constants related to unicode data
 use std::{
     collections::{HashMap, HashSet},
     hash::Hash,
@@ -11,11 +12,74 @@ use write_fonts::{
     types::{GlyphId, Tag},
 };
 
+// SAFETY: we can easily verify that neither of these strings contains a nul byte.
+// (this is the only way we can declare these as constants)
+pub const COMMON_SCRIPT: UnicodeShortName =
+    unsafe { UnicodeShortName::from_bytes_unchecked(*b"Zyyy") };
+pub const INHERITED_SCRIPT: UnicodeShortName =
+    unsafe { UnicodeShortName::from_bytes_unchecked(*b"Zinh") };
+
 static SCRIPT_DATA: ScriptWithExtensionsBorrowed<'static> =
     icu_properties::script::script_with_extensions();
 
 /// The type used by icu4x for script names
 pub type UnicodeShortName = tinystr::TinyAsciiStr<4>;
+
+/// The writing direction of a script
+#[derive(Clone, Debug, Copy, Hash, PartialEq, Eq)]
+pub enum ScriptDirection {
+    /// any direction, for the 'common' script
+    Auto,
+    LeftToRight,
+    RightToLeft,
+}
+
+/// A trait for mapping glyph ids to unicode values
+///
+/// This lets us write functions that don't need to know the concrete types we're
+/// using, which is an implementation detail. It also makes it easier for us to
+/// write tests.
+pub trait CharMap {
+    /// Iterate over all the defined (gid, unicode value) pairs.
+    ///
+    /// Note that a single glyph may appear multiple times, with different
+    /// unicode values.
+    fn iter_glyphs(&self) -> impl Iterator<Item = (GlyphId, u32)>;
+}
+
+impl CharMap for Vec<(Arc<Glyph>, GlyphId)> {
+    fn iter_glyphs(&self) -> impl Iterator<Item = (GlyphId, u32)> {
+        self.iter()
+            .flat_map(|(glyph, gid)| glyph.codepoints.iter().map(|uv| (*gid, *uv)))
+    }
+}
+
+impl ScriptDirection {
+    /// Returns the writing direction for the provided script
+    pub(crate) fn for_script(script: &UnicodeShortName) -> Self {
+        match script.as_str() {
+            "Zyyy" => ScriptDirection::Auto,
+            "Arab" | "Hebr" | "Syrc" | "Thaa" | "Cprt" | "Khar" | "Phnx" | "Nkoo" | "Lydi"
+            | "Avst" | "Armi" | "Phli" | "Prti" | "Sarb" | "Orkh" | "Samr" | "Mand" | "Merc"
+            | "Mero" | "Mani" | "Mend" | "Nbat" | "Narb" | "Palm" | "Phlp" | "Hatr" | "Hung"
+            | "Adlm" | "Rohg" | "Sogo" | "Sogd" | "Elym" | "Chrs" | "Yezi" | "Ougr" => {
+                ScriptDirection::RightToLeft
+            }
+            _ => ScriptDirection::LeftToRight,
+        }
+    }
+
+    /// true if either side is auto, or both sides are equal
+    pub(crate) fn plays_nicely_with(&self, other: &ScriptDirection) -> bool {
+        matches!(
+            (self, other),
+            (ScriptDirection::Auto, _)
+                | (_, ScriptDirection::Auto)
+                | (ScriptDirection::LeftToRight, ScriptDirection::LeftToRight)
+                | (ScriptDirection::RightToLeft, ScriptDirection::RightToLeft)
+        )
+    }
+}
 
 /// Iterate over the unicode scripts + extensions for the provided codepoint
 ///
@@ -38,14 +102,22 @@ pub(crate) fn unicode_script_extensions(
         })
 }
 
-fn unicode_bidi_type(c: u32) -> BidiClass {
-    icu_properties::maps::bidi_class().get32(c)
+// <https://github.com/googlefonts/ufo2ft/blob/f6b4f42460b340c/Lib/ufo2ft/featureWriters/kernFeatureWriter.py#L49>
+/// returns none for neutral characters
+fn unicode_bidi_type(c: u32) -> Option<BidiClass> {
+    match icu_properties::maps::bidi_class().get32(c) {
+        BidiClass::RightToLeft | BidiClass::ArabicLetter => Some(BidiClass::RightToLeft),
+        BidiClass::LeftToRight | BidiClass::ArabicNumber | BidiClass::EuropeanNumber => {
+            Some(BidiClass::LeftToRight)
+        }
+        _ => None,
+    }
 }
 
 // equivalent to the 'classify' method in ufo2ft:
 // <https://github.com/googlefonts/ufo2ft/blob/cea60d71dfcf0b1c0f/Lib/ufo2ft/util.py#L287>
-fn classify<T, F, I>(
-    glyphs: &[(Arc<Glyph>, GlyphId)],
+fn classify<T, F, I, CM>(
+    char_map: &CM,
     mut props_fn: F,
     gsub: Option<&Gsub>,
 ) -> Result<HashMap<T, HashSet<GlyphId>>, ReadError>
@@ -53,16 +125,11 @@ where
     T: Hash + Eq,
     I: Iterator<Item = T>,
     F: FnMut(u32) -> I,
+    CM: CharMap,
 {
     let mut sets = HashMap::new();
     let mut neutral_glyphs = HashSet::new();
-    for (gid, unicode_value) in glyphs.iter().flat_map(|(glyph, gid)| {
-        glyph
-            .codepoints
-            .iter()
-            .copied()
-            .map(|codepoint| (*gid, codepoint))
-    }) {
+    for (gid, unicode_value) in char_map.iter_glyphs() {
         let mut has_props = false;
         for prop in props_fn(unicode_value) {
             sets.entry(prop).or_insert(HashSet::new()).insert(gid);
@@ -87,13 +154,33 @@ where
     Ok(sets)
 }
 
-/// Returns a map of gids their scripts
+/// Returns a map of gids to their scripts
 pub(crate) fn scripts_by_glyph(
-    glyphs: &[(Arc<Glyph>, GlyphId)],
+    glyphs: &impl CharMap,
+    known_scripts: &HashSet<UnicodeShortName>,
     gsub: Option<&Gsub>,
 ) -> Result<HashMap<GlyphId, HashSet<UnicodeShortName>>, ReadError> {
-    let mut result = HashMap::with_capacity(glyphs.len());
-    for (script, glyphs) in classify(glyphs, |cp| unicode_script_extensions(cp), gsub)? {
+    let mut result = HashMap::new();
+    for (script, glyphs) in classify(
+        glyphs,
+        |cp| {
+            // we need to write this in such a way as to return a single concrete type;
+            // this is basically two branches, one or the other option is always `None`
+            let common = known_scripts.is_empty().then_some(COMMON_SCRIPT);
+            let other_branch = if known_scripts.is_empty() {
+                None
+            } else {
+                Some(unicode_script_extensions(cp).filter(|script| {
+                    *script == COMMON_SCRIPT
+                        || *script == INHERITED_SCRIPT
+                        || known_scripts.contains(script)
+                }))
+            };
+
+            common.into_iter().chain(other_branch.into_iter().flatten())
+        },
+        gsub,
+    )? {
         for glyph in glyphs {
             result.entry(glyph).or_insert(HashSet::new()).insert(script);
         }
@@ -103,22 +190,37 @@ pub(crate) fn scripts_by_glyph(
 
 /// A map of bidi class to glyphs in that class.
 pub(crate) fn glyphs_by_bidi_class(
-    glyphs: &[(Arc<Glyph>, GlyphId)],
+    glyphs: &impl CharMap,
     gsub: Option<&Gsub>,
 ) -> Result<HashMap<BidiClass, HashSet<GlyphId>>, ReadError> {
     classify(
         glyphs,
-        |codepoint| Some(unicode_bidi_type(codepoint)).into_iter(),
+        |codepoint| unicode_bidi_type(codepoint).into_iter(),
         gsub,
     )
 }
+
+const DFLT_SCRIPT: Tag = Tag::new(b"DFLT");
+
 static SCRIPT_ALIASES: &[(Tag, Tag)] = &[(Tag::new(b"jamo"), Tag::new(b"hang"))];
 
+static SCRIPT_EXCEPTIONS: &[(&str, Tag)] = &[
+    ("Hira", Tag::new(b"kana")),
+    ("Hrkt", Tag::new(b"kana")),
+    ("Laoo", Tag::new(b"lao ")),
+    ("Nkoo", Tag::new(b"nko ")),
+    ("Vaii", Tag::new(b"vai ")),
+    ("Yiii", Tag::new(b"yi  ")),
+    ("Zinh", DFLT_SCRIPT),
+    ("Zmth", Tag::new(b"math")),
+    ("Zyyy", DFLT_SCRIPT),
+    ("Zzzz", DFLT_SCRIPT),
+];
 //TODO: python maps 'math' to 'Zmth' but 'Mathematical Notation'
 //is not a variant on icu4x's Script? But this is included in
 //some datafiles so might be an oversight? But it's actually not listed
 //in the official list of scripts, so idk?
-static SCRIPT_EXCEPTIONS: &[(Tag, Script)] = &[];
+static SCRIPT_EXCEPTIONS_REVERSED: &[(Tag, Script)] = &[];
 
 // I don't know what's going on here, just copying OTTags.py
 static NEW_SCRIPTS: &[(Tag, Script)] = &[
@@ -134,6 +236,122 @@ static NEW_SCRIPTS: &[(Tag, Script)] = &[
     (Tag::new(b"tml2"), Script::Tamil),
 ];
 
+// I don't know what's going on here, just copying OTTags.py
+static NEW_SCRIPT_TAGS: &[(&str, Tag)] = &[
+    ("Beng", Tag::new(b"bng2")),
+    ("Deva", Tag::new(b"dev2")),
+    ("Gujr", Tag::new(b"gjr2")),
+    ("Guru", Tag::new(b"gur2")),
+    ("Kana", Tag::new(b"knd2")),
+    ("Mlym", Tag::new(b"mlm2")),
+    ("Mymr", Tag::new(b"mym2")),
+    ("Orya", Tag::new(b"ory2")),
+    ("Taml", Tag::new(b"tml2")),
+    ("Telu", Tag::new(b"tel2")),
+];
+
+static INDIC_SCRIPTS: &[&str] = &[
+    "Beng", // Bengali
+    "Deva", // Devanagari
+    "Gujr", // Gujarati
+    "Guru", // Gurmukhi
+    "Knda", // Kannada
+    "Mlym", // Malayalam
+    "Orya", // Oriya
+    "Sinh", // Sinhala
+    "Taml", // Tamil
+    "Telu", // Telugu
+];
+
+static USE_SCRIPTS: &[&str] = &[
+    // Correct as at Unicode 15.0
+    "Adlm", // Adlam
+    "Ahom", // Ahom
+    "Bali", // Balinese
+    "Batk", // Batak
+    "Brah", // Brahmi
+    "Bugi", // Buginese
+    "Buhd", // Buhid
+    "Cakm", // Chakma
+    "Cham", // Cham
+    "Chrs", // Chorasmian
+    "Cpmn", // Cypro Minoan
+    "Diak", // Dives Akuru
+    "Dogr", // Dogra
+    "Dupl", // Duployan
+    "Egyp", // Egyptian Hieroglyphs
+    "Elym", // Elymaic
+    "Gong", // Gunjala Gondi
+    "Gonm", // Masaram Gondi
+    "Gran", // Grantha
+    "Hano", // Hanunoo
+    "Hmng", // Pahawh Hmong
+    "Hmnp", // Nyiakeng Puachue Hmong
+    "Java", // Javanese
+    "Kali", // Kayah Li
+    "Kawi", // Kawi
+    "Khar", // Kharosthi
+    "Khoj", // Khojki
+    "Kits", // Khitan Small Script
+    "Kthi", // Kaithi
+    "Lana", // Tai Tham
+    "Lepc", // Lepcha
+    "Limb", // Limbu
+    "Mahj", // Mahajani
+    "Maka", // Makasar
+    "Mand", // Mandaic
+    "Mani", // Manichaean
+    "Marc", // Marchen
+    "Medf", // Medefaidrin
+    "Modi", // Modi
+    "Mong", // Mongolian
+    "Mtei", // Meetei Mayek
+    "Mult", // Multani
+    "Nagm", // Nag Mundari
+    "Nand", // Nandinagari
+    "Newa", // Newa
+    "Nhks", // Bhaiksuki
+    "Nko ", // Nko
+    "Ougr", // Old Uyghur
+    "Phag", // Phags Pa
+    "Phlp", // Psalter Pahlavi
+    "Plrd", // Miao
+    "Rjng", // Rejang
+    "Rohg", // Hanifi Rohingya
+    "Saur", // Saurashtra
+    "Shrd", // Sharada
+    "Sidd", // Siddham
+    "Sind", // Khudawadi
+    "Sogd", // Sogdian
+    "Sogo", // Old Sogdian
+    "Soyo", // Soyombo
+    "Sund", // Sundanese
+    "Sylo", // Syloti Nagri
+    "Tagb", // Tagbanwa
+    "Takr", // Takri
+    "Tale", // Tai Le
+    "Tavt", // Tai Viet
+    "Tfng", // Tifinagh
+    "Tglg", // Tagalog
+    "Tibt", // Tibetan
+    "Tirh", // Tirhuta
+    "Tnsa", // Tangsa
+    "Toto", // Toto
+    "Vith", // Vithkuqi
+    "Wcho", // Wancho
+    "Yezi", // Yezidi
+    "Zanb", // Zanabazar Square
+];
+
+pub(crate) fn dist_feature_enabled_scripts() -> HashSet<UnicodeShortName> {
+    INDIC_SCRIPTS
+        .iter()
+        .chain(USE_SCRIPTS)
+        .chain(["Khmr", "Mymr"].iter())
+        .map(|s| UnicodeShortName::from_str(s).unwrap())
+        .collect()
+}
+
 // a little helper trait to handle binary searching an array of 2-tuples where
 // the first item is a key and the second a value
 trait BinarySearchExact<T, U> {
@@ -142,7 +360,7 @@ trait BinarySearchExact<T, U> {
 
 impl<T: Ord + Eq, U: Clone> BinarySearchExact<T, U> for &[(T, U)] {
     fn binary_search_exact(&self, needle: &T) -> Option<U> {
-        self.binary_search_by(|probe| probe.0.cmp(&needle))
+        self.binary_search_by(|probe| probe.0.cmp(needle))
             .ok()
             .map(|idx| &self[idx].1)
             .cloned()
@@ -162,7 +380,7 @@ pub(crate) fn ot_tag_to_script(script_tag: Tag) -> Option<UnicodeShortName> {
         .binary_search_exact(&script_tag)
         .unwrap_or(script_tag);
 
-    if let Some(exception) = SCRIPT_EXCEPTIONS
+    if let Some(exception) = SCRIPT_EXCEPTIONS_REVERSED
         .binary_search_exact(&tag)
         .or_else(|| NEW_SCRIPTS.binary_search_exact(&tag))
     {
@@ -194,6 +412,21 @@ fn ot_tag_to_unicode_short_name(tag: Tag) -> UnicodeShortName {
     UnicodeShortName::try_from_raw(out).expect("cannot fail, as tag cannot have leading nul byte")
 }
 
+/// a script can correspond to one or two tags, because
+pub(crate) fn script_to_ot_tags(script: &UnicodeShortName) -> impl Iterator<Item = Tag> {
+    let mut out = [None, None];
+    if let Some(tag) = SCRIPT_EXCEPTIONS.binary_search_exact(&script.as_str()) {
+        out[0] = Some(tag);
+    } else if Script::name_to_enum_mapper().get_strict(script).is_none() {
+        out[0] = Some(DFLT_SCRIPT);
+    } else {
+        out[0] = NEW_SCRIPT_TAGS.binary_search_exact(&script.as_str());
+        out[1] = Some(Tag::new(script.to_owned().to_ascii_lowercase().all_bytes()));
+    }
+
+    out.into_iter().flatten()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -213,9 +446,13 @@ mod tests {
 
         let (actual, expected) = get_original_and_sorted_items(SCRIPT_ALIASES);
         assert_eq!(actual, expected);
-        let (actual, expected) = get_original_and_sorted_items(SCRIPT_EXCEPTIONS);
+        let (actual, expected) = get_original_and_sorted_items(SCRIPT_EXCEPTIONS_REVERSED);
         assert_eq!(actual, expected);
         let (actual, expected) = get_original_and_sorted_items(NEW_SCRIPTS);
+        assert_eq!(actual, expected);
+        let (actual, expected) = get_original_and_sorted_items(NEW_SCRIPT_TAGS);
+        assert_eq!(actual, expected);
+        let (actual, expected) = get_original_and_sorted_items(SCRIPT_EXCEPTIONS);
         assert_eq!(actual, expected);
     }
 

--- a/fontbe/src/orchestration.rs
+++ b/fontbe/src/orchestration.rs
@@ -1,7 +1,7 @@
 //! Helps coordinate the graph execution for BE
 
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{BTreeMap, HashSet},
     fmt::Display,
     fs::File,
     io::{self, BufReader, BufWriter, Read, Write},
@@ -377,7 +377,7 @@ pub struct FeaRsKerns {
     /// ordered!
     pub lookups: Vec<Vec<PairPosBuilder>>,
     /// each value is a set of lookups, referenced by their order in array above
-    pub features: HashMap<FeatureKey, Vec<usize>>,
+    pub features: BTreeMap<FeatureKey, Vec<usize>>,
 }
 
 /// The abstract syntax tree of any user FEA.

--- a/fontc/src/workload.rs
+++ b/fontc/src/workload.rs
@@ -318,6 +318,9 @@ impl<'a> Workload<'a> {
                 .expect("Gather BE Kerning has to be pending")
                 .read_access = AccessBuilder::<AnyWorkId>::new()
                 .variant(BeWorkIdentifier::KernFragment(0))
+                .variant(BeWorkIdentifier::FeaturesAst)
+                .variant(FeWorkIdentifier::Glyph(GlyphName::NOTDEF))
+                .variant(FeWorkIdentifier::StaticMetadata)
                 .build()
                 .into();
         }


### PR DESCRIPTION
This patch is imperfect, but I think it is worth getting something committed that we can iterate from.

- modulo a very small number of differences, this matches the output of fontmake on Oswald.
- this does not correctly set the lookup flags (or mark filtering set); I'll do that as a followup
- this does not handle the 'dist' feature
- the testing here is anemic. I have at least figured out *how* to write tests against this, and I see that there are some ideas at https://github.com/googlefonts/ufo2ft/blob/cea60d71dfcf0b1c0fa4e133ec4231ba06fe0da0/tests/featureWriters/kernFeatureWriter_test.py that look worth porting, but I think it makes sense to focus on this as I continue to refine.