### PR TITLE
set lookupflag and mark filtering set for kerning lookups

### DIFF
--- a/fontbe/src/features.rs
+++ b/fontbe/src/features.rs
@@ -39,11 +39,13 @@ use crate::{
     orchestration::{AnyWorkId, BeWork, Context, FeaAst, FeaRsKerns, FeaRsMarks, WorkId},
 };
 
+mod common;
 mod kern;
 mod marks;
 mod ot_tags;
 mod properties;
 
+pub(crate) use common::PendingLookup;
 pub use kern::{create_gather_ir_kerning_work, create_kern_segment_work, create_kerns_work};
 pub use marks::create_mark_work;
 
@@ -219,7 +221,13 @@ impl<'a> FeatureWriter<'a> {
             .kerning
             .lookups
             .iter()
-            .map(|lookups| builder.add_lookup(LookupFlag::empty(), None, lookups.to_owned()))
+            .map(|lookup| {
+                builder.add_lookup(
+                    lookup.flags,
+                    lookup.mark_filter_set.clone(),
+                    lookup.subtables.clone(),
+                )
+            })
             .collect::<Vec<_>>();
 
         for (feature, ids) in &self.kerning.features {

--- a/fontbe/src/features/common.rs
+++ b/fontbe/src/features/common.rs
@@ -1,0 +1,26 @@
+use fea_rs::GlyphSet;
+use write_fonts::tables::layout::LookupFlag;
+
+/// A lookup generated outside of user FEA
+///
+/// This will be merged into any user-provided features during compilation.
+#[derive(Debug, Default, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct PendingLookup<T> {
+    pub(crate) subtables: Vec<T>,
+    pub(crate) flags: LookupFlag,
+    pub(crate) mark_filter_set: Option<GlyphSet>,
+}
+
+impl<T> PendingLookup<T> {
+    pub(crate) fn new(
+        subtables: Vec<T>,
+        flags: LookupFlag,
+        mark_filter_set: Option<GlyphSet>,
+    ) -> Self {
+        Self {
+            subtables,
+            flags,
+            mark_filter_set,
+        }
+    }
+}

--- a/fontbe/src/orchestration.rs
+++ b/fontbe/src/orchestration.rs
@@ -64,7 +64,7 @@ use write_fonts::{
     FontWrite,
 };
 
-use crate::{error::Error, paths::Paths};
+use crate::{error::Error, features::PendingLookup, paths::Paths};
 
 /// What exactly is being assembled from glyphs?
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -375,7 +375,7 @@ impl Persistable for FeaRsMarks {
 #[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq)]
 pub struct FeaRsKerns {
     /// ordered!
-    pub lookups: Vec<Vec<PairPosBuilder>>,
+    pub lookups: Vec<PendingLookup<PairPosBuilder>>,
     /// each value is a set of lookups, referenced by their order in array above
     pub features: BTreeMap<FeatureKey, Vec<usize>>,
 }


### PR DESCRIPTION
This adds a `PendingLookup` type so that we can compute and store the lookup flag and the mark filtering sets when we generate the kerning lookups.

based on #731, which should go in first.