### PR TITLE
[kerning] Remove second record from PairPosEntry

### DIFF
--- a/fontbe/src/features/kern.rs
+++ b/fontbe/src/features/kern.rs
@@ -307,17 +307,11 @@ impl Work<Context, AnyWorkId, Error> for KerningFragmentWork {
             if deltas.iter().any(|v| v.1 != 0) {
                 x_adv_record = x_adv_record.with_x_advance_device(deltas);
             }
-            let empty = ValueRecordBuilder::new();
 
             match (left, right) {
                 (KernParticipant::Glyph(left), KernParticipant::Glyph(right)) => {
                     let (left, right) = (gid(left)?, gid(right)?);
-                    kerns.push(PairPosEntry::Pair(
-                        left,
-                        x_adv_record.clone(),
-                        right,
-                        empty.clone(),
-                    ));
+                    kerns.push(PairPosEntry::Pair(left, x_adv_record.clone(), right));
                 }
                 (KernParticipant::Group(left), KernParticipant::Group(right)) => {
                     let left = glyph_classes
@@ -328,12 +322,7 @@ impl Work<Context, AnyWorkId, Error> for KerningFragmentWork {
                         .get(right)
                         .ok_or_else(|| Error::MissingKernGroup(right.clone()))?
                         .clone();
-                    kerns.push(PairPosEntry::Class(
-                        left,
-                        x_adv_record.clone(),
-                        right,
-                        empty.clone(),
-                    ));
+                    kerns.push(PairPosEntry::Class(left, x_adv_record.clone(), right));
                 }
                 // if groups are mixed with glyphs then we enumerate the group
                 (KernParticipant::Glyph(left), KernParticipant::Group(right)) => {
@@ -344,12 +333,7 @@ impl Work<Context, AnyWorkId, Error> for KerningFragmentWork {
                         .get(right)
                         .ok_or_else(|| Error::MissingKernGroup(right.clone()))?;
                     for gid1 in right.iter() {
-                        kerns.push(PairPosEntry::Pair(
-                            gid0,
-                            x_adv_record.clone(),
-                            gid1,
-                            empty.clone(),
-                        ));
+                        kerns.push(PairPosEntry::Pair(gid0, x_adv_record.clone(), gid1));
                     }
                 }
                 (KernParticipant::Group(left), KernParticipant::Glyph(right)) => {
@@ -358,12 +342,7 @@ impl Work<Context, AnyWorkId, Error> for KerningFragmentWork {
                         .ok_or_else(|| Error::MissingKernGroup(left.clone()))?;
                     let gid1 = gid(right)?;
                     for gid0 in left.iter() {
-                        kerns.push(PairPosEntry::Pair(
-                            gid0,
-                            x_adv_record.clone(),
-                            gid1,
-                            empty.clone(),
-                        ));
+                        kerns.push(PairPosEntry::Pair(gid0, x_adv_record.clone(), gid1));
                     }
                 }
             }
@@ -920,7 +899,7 @@ impl KernSplitContext {
 
         for pair in pairs {
             match pair {
-                PairPosEntry::Pair(side1, _, side2, _)
+                PairPosEntry::Pair(side1, _, side2)
                     if !self.mark_glyphs.contains_key(side1)
                         && !self.mark_glyphs.contains_key(side2) =>
                 {
@@ -929,7 +908,7 @@ impl KernSplitContext {
                 PairPosEntry::Pair(..) => mark_pairs.push(Cow::Borrowed(*pair)),
 
                 // handle the case where all are marks or bases, first:
-                PairPosEntry::Class(side1, val1, side2, val2) => {
+                PairPosEntry::Class(side1, value, side2) => {
                     let side1_cls = classify_glyphset_contents(side1, &self.mark_glyphs);
                     let side2_cls = classify_glyphset_contents(side2, &self.mark_glyphs);
 
@@ -952,9 +931,8 @@ impl KernSplitContext {
                             if !side1_bases.is_empty() && !side2_bases.is_empty() {
                                 base_pairs.push(Cow::Owned(PairPosEntry::Class(
                                     side1_bases.clone(),
-                                    val1.clone(),
+                                    value.clone(),
                                     side2_bases.clone(),
-                                    val2.clone(),
                                 )));
                             }
                             // these various combos all go in the marks group
@@ -966,9 +944,8 @@ impl KernSplitContext {
                                 if !side1.is_empty() && !side2.is_empty() {
                                     mark_pairs.push(Cow::Owned(PairPosEntry::Class(
                                         side1.clone(),
-                                        val1.clone(),
+                                        value.clone(),
                                         side2.clone(),
-                                        val2.clone(),
                                     )));
                                 }
                             }
@@ -1100,19 +1077,13 @@ mod tests {
                 self.get(left),
                 ValueRecordBuilder::new().with_x_advance(val),
                 self.get(right),
-                ValueRecordBuilder::new(),
             )
         }
 
         fn make_class_rule(&self, left: &[char], right: &[char], val: i16) -> PairPosEntry {
             let left = left.iter().map(|c| self.get(*c)).collect();
             let right = right.iter().map(|c| self.get(*c)).collect();
-            PairPosEntry::Class(
-                left,
-                ValueRecordBuilder::new().with_x_advance(val),
-                right,
-                ValueRecordBuilder::new(),
-            )
+            PairPosEntry::Class(left, ValueRecordBuilder::new().with_x_advance(val), right)
         }
 
         fn get(&self, c: char) -> GlyphId {

--- a/fontbe/src/orchestration.rs
+++ b/fontbe/src/orchestration.rs
@@ -444,8 +444,8 @@ impl Persistable for AllKerningPairs {
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, PartialOrd, Eq, Ord)]
 pub enum PairPosEntry {
-    Pair(GlyphId, ValueRecordBuilder, GlyphId, ValueRecordBuilder),
-    Class(GlyphSet, ValueRecordBuilder, GlyphSet, ValueRecordBuilder),
+    Pair(GlyphId, ValueRecordBuilder, GlyphId),
+    Class(GlyphSet, ValueRecordBuilder, GlyphSet),
 }
 
 impl PairPosEntry {
@@ -456,18 +456,18 @@ impl PairPosEntry {
     /// any knowledge of writing direction.
     pub(crate) fn make_rtl_compatible(&mut self) {
         let record = match self {
-            PairPosEntry::Pair(_, record, _, _) => record,
-            PairPosEntry::Class(_, record, _, _) => record,
+            PairPosEntry::Pair(_, record, _) => record,
+            PairPosEntry::Class(_, record, _) => record,
         };
         record.make_rtl_compatible();
     }
     pub(crate) fn add_to(self, builder: &mut PairPosBuilder) {
         match self {
-            PairPosEntry::Pair(gid0, rec0, gid1, rec1) => {
-                builder.insert_pair(gid0, rec0, gid1, rec1)
+            PairPosEntry::Pair(gid0, rec0, gid1) => {
+                builder.insert_pair(gid0, rec0, gid1, Default::default())
             }
-            PairPosEntry::Class(set0, rec0, set1, rec1) => {
-                builder.insert_classes(set0, rec0, set1, rec1)
+            PairPosEntry::Class(set0, rec0, set1) => {
+                builder.insert_classes(set0, rec0, set1, Default::default())
             }
         }
     }
@@ -481,20 +481,19 @@ impl PairPosEntry {
 
     /// a helper used when splitting kerns based on script direction
     pub(crate) fn with_new_glyphs(&self, side1: GlyphSet, side2: GlyphSet) -> Self {
-        let (val1, val2) = match self {
-            PairPosEntry::Pair(_, val1, _, val2) => (val1, val2),
-            PairPosEntry::Class(_, val1, _, val2) => (val1, val2),
+        let value = match self {
+            PairPosEntry::Pair(_, value, _) => value,
+            PairPosEntry::Class(_, value, _) => value,
         };
 
         if side1.len() == 1 && side2.len() == 1 {
             Self::Pair(
                 side1.iter().next().unwrap(),
-                val1.clone(),
+                value.clone(),
                 side2.iter().next().unwrap(),
-                val2.clone(),
             )
         } else {
-            Self::Class(side1, val1.clone(), side2, val2.clone())
+            Self::Class(side1, value.clone(), side2)
         }
     }
 
@@ -511,8 +510,8 @@ impl PairPosEntry {
 
     pub(crate) fn second_glyphs(&self) -> impl Iterator<Item = GlyphId> + '_ {
         let (first, second) = match self {
-            PairPosEntry::Pair(_, _, gid1, _) => (Some(*gid1), None),
-            PairPosEntry::Class(_, _, set1, _) => (None, Some(set1)),
+            PairPosEntry::Pair(_, _, gid1) => (Some(*gid1), None),
+            PairPosEntry::Class(_, _, set1) => (None, Some(set1)),
         };
 
         first
@@ -556,8 +555,8 @@ impl PairPosEntry {
         }
 
         match self {
-            PairPosEntry::Pair(one, _, two, _) => DisplayGlyphs::Pair(*one, *two),
-            PairPosEntry::Class(one, _, two, _) => DisplayGlyphs::Class(one, two),
+            PairPosEntry::Pair(one, _, two) => DisplayGlyphs::Pair(*one, *two),
+            PairPosEntry::Class(one, _, two) => DisplayGlyphs::Class(one, two),
         }
     }
 }


### PR DESCRIPTION
Generated kerning only ever sets one value record, so we don't need to define both in our IR.