### PR TITLE
[kerning] Pre-validate kerning groups & pairs

### DIFF
--- a/fontbe/src/error.rs
+++ b/fontbe/src/error.rs
@@ -3,8 +3,7 @@ use std::{fmt::Display, io, path::PathBuf};
 use fea_rs::compile::error::CompilerError;
 use fontdrasil::{coords::NormalizedLocation, types::GlyphName};
 use fontir::{
-    error::VariationModelError, ir::KernGroup, orchestration::WorkId as FeWorkId,
-    variations::DeltaError,
+    error::VariationModelError, orchestration::WorkId as FeWorkId, variations::DeltaError,
 };
 use smol_str::SmolStr;
 use thiserror::Error;
@@ -86,8 +85,6 @@ pub enum Error {
     DeltaError(DeltaError),
     #[error("No glyph id for '{0}'")]
     MissingGlyphId(GlyphName),
-    #[error("Missing kern group {0:?}")]
-    MissingKernGroup(KernGroup),
     #[error("Error making CMap: {0}")]
     CmapConflict(#[from] CmapConflict),
 }

--- a/fontbe/src/orchestration.rs
+++ b/fontbe/src/orchestration.rs
@@ -403,10 +403,21 @@ impl Persistable for FeaAst {
 pub type KernAdjustments = BTreeMap<NormalizedLocation, OrderedFloat<f32>>;
 
 /// Every kerning pair we have, taking from IR.
+///
+/// It is an invariant that every group referenced in an adjustment exists in the
+/// groups mapping, and every glyph in a rule (including in all groups) is defined
+/// in the glyph order.
 #[derive(Default, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AllKerningPairs {
-    pub glyph_classes: BTreeMap<KernGroup, GlyphSet>,
+    /// A mapping from named kern groups to the appropriate set of glyphs
+    pub groups: BTreeMap<KernGroup, GlyphSet>,
     pub adjustments: Vec<(KernPair, KernAdjustments)>,
+}
+
+impl AllKerningPairs {
+    pub(crate) fn get_group(&self, group: &KernGroup) -> Option<&GlyphSet> {
+        self.groups.get(group)
+    }
 }
 
 impl Persistable for AllKerningPairs {


### PR DESCRIPTION
Following the general principle of "validate data as early as possible.


This validates the raw kerning data when it is assembled from the IR, which means that subsequent code can use that data without needing to handle error conditions.

In particular, we ensure that:
- all glyphs and groups referenced in a rule exist
- all glyphs referenced in a group exist
- groups are non-empty

Missing items are filtered, and a warning is logged.
