### PR TITLE
[fontbe] Fixup errors for variable metrics

### DIFF
--- a/fontbe/src/error.rs
+++ b/fontbe/src/error.rs
@@ -3,7 +3,8 @@ use std::{fmt::Display, io, path::PathBuf};
 use fea_rs::compile::error::CompilerError;
 use fontdrasil::{coords::NormalizedLocation, types::GlyphName};
 use fontir::{
-    error::VariationModelError, orchestration::WorkId as FeWorkId, variations::DeltaError,
+    error::VariationModelError, ir::KernPair, orchestration::WorkId as FeWorkId,
+    variations::DeltaError,
 };
 use smol_str::SmolStr;
 use thiserror::Error;
@@ -53,6 +54,10 @@ pub enum Error {
     GlyphDeltaError(GlyphName, DeltaError),
     #[error("Unable to compute deltas for MVAR {0}: {1}")]
     MvarDeltaError(Tag, DeltaError),
+    #[error("Unable to compute deltas for anchor on '{0}': '{1}'")]
+    AnchorDeltaError(GlyphName, DeltaError),
+    #[error("Unable to compute deltas for kern pair '{}/{}': '{error}'", .pair.0, .pair.1)]
+    KernDeltaError { pair: KernPair, error: DeltaError },
     #[error("Unable to assemble gvar")]
     GvarError(#[from] GvarInputError),
     #[error("Unable to read")]

--- a/fontbe/src/features/kern.rs
+++ b/fontbe/src/features/kern.rs
@@ -327,7 +327,11 @@ impl Work<Context, AnyWorkId, Error> for KerningFragmentWork {
 
         let mut kerns = Vec::new();
         for ((left, right), values) in our_kerns {
-            let (default_value, deltas) = resolve_variable_metric(&static_metadata, values.iter())?;
+            let (default_value, deltas) = resolve_variable_metric(&static_metadata, values.iter())
+                .map_err(|error| Error::KernDeltaError {
+                    pair: (left.clone(), right.clone()),
+                    error,
+                })?;
 
             let mut x_adv_record = ValueRecordBuilder::new().with_x_advance(default_value);
             // only encode deltas if they aren't all zeros

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -253,6 +253,15 @@ pub enum KernParticipant {
     Group(KernGroup),
 }
 
+impl Display for KernParticipant {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            KernParticipant::Glyph(g) => Display::fmt(g, f),
+            KernParticipant::Group(name) => write!(f, "@{name}"),
+        }
+    }
+}
+
 impl Display for KernGroup {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {


### PR DESCRIPTION
There were a few giant FIXMEs in the resolve_variable_metric fn; if memory serves I think I'd initially written that patch as "just a sketch" and then it was merged to unblock other work.

In any case, this rationalizes things a bit, adding error variants for the case where we can't compute deltas for anchors & kerns.