### PR TITLE
[kerning] Delay decomposing kern rules

### DIFF
--- a/fea-rs/src/common/glyph_class.rs
+++ b/fea-rs/src/common/glyph_class.rs
@@ -36,13 +36,11 @@ pub(crate) struct GlyphClass(Vec<GlyphId>);
 pub struct GlyphSet(Vec<GlyphId>);
 
 impl GlyphClass {
+    /// An empty glyph class
+    pub const EMPTY: Self = GlyphClass(Vec::new());
+
     pub(crate) fn items(&self) -> &[GlyphId] {
         &self.0
-    }
-
-    /// Return a new, empty glyph class
-    pub fn empty() -> Self {
-        Self(Default::default())
     }
 
     /// Return a `GlyphSet` containing the unique glyphs in this class.
@@ -60,6 +58,9 @@ impl GlyphClass {
 }
 
 impl GlyphSet {
+    /// The empty glyph set
+    pub const EMPTY: Self = GlyphSet(Vec::new());
+
     /// Iterate over the glyphs in this class
     pub fn iter(&self) -> impl Iterator<Item = GlyphId> + '_ {
         self.0.iter().copied()
@@ -131,7 +132,7 @@ impl From<GlyphOrClass> for GlyphClass {
         match src {
             GlyphOrClass::Class(class) => class,
             GlyphOrClass::Glyph(id) => id.into(),
-            GlyphOrClass::Null => GlyphClass::empty(),
+            GlyphOrClass::Null => GlyphClass::EMPTY,
         }
     }
 }


### PR DESCRIPTION
This reworks how we do kerning in order to preserve information about whether rules included a glyph class until we are ready to do the final compilation.

Preserving this information lets us match the behaviour of FEA in ordering these rules, where we put (glyph, glyph) first, followed by (glyph, class), (class, glyph) and finally (class, class).

---

With this patch `ttx_diff` is producing identical output to oswald for generated kerning.