### PR TITLE
[fontir] Rename KernParticipant -> KernSide

### DIFF
--- a/fontbe/src/features/kern.rs
+++ b/fontbe/src/features/kern.rs
@@ -20,7 +20,7 @@ use fontdrasil::{
     types::GlyphName,
 };
 use fontir::{
-    ir::{self, Glyph, KernGroup, KernParticipant, KerningGroups, KerningInstance},
+    ir::{self, Glyph, KernGroup, KerningGroups, KerningInstance},
     orchestration::WorkId as FeWorkId,
 };
 use icu_properties::BidiClass;
@@ -182,11 +182,11 @@ impl Work<Context, AnyWorkId, Error> for GatherIrKerningWork {
             .filter(|((left, right), _)| {
                 for side in [left, right] {
                     match side {
-                        KernParticipant::Group(name) if !groups.contains_key(name) => {
+                        ir::KernSide::Group(name) if !groups.contains_key(name) => {
                             log::warn!("Unknown kern class '{name}' will be skipped");
                             return false;
                         }
-                        KernParticipant::Glyph(name) if glyph_order.glyph_id(name).is_none() => {
+                        ir::KernSide::Glyph(name) if glyph_order.glyph_id(name).is_none() => {
                             log::warn!("Unknown kern glyph '{name}' will be skipped");
                             return false;
                         }
@@ -265,14 +265,14 @@ fn lookup_kerning_value(
 ) -> OrderedFloat<f32> {
     // if already a group, return it, else look for group for glyph
     fn get_group_if_glyph(
-        side: &KernParticipant,
+        side: &ir::KernSide,
         map: &HashMap<&GlyphName, &KernGroup>,
-    ) -> Option<KernParticipant> {
+    ) -> Option<ir::KernSide> {
         match side {
-            KernParticipant::Glyph(glyph) => map
+            ir::KernSide::Glyph(glyph) => map
                 .get(&glyph)
-                .map(|group| KernParticipant::Group((*group).clone())),
-            KernParticipant::Group(_) => Some(side.to_owned()),
+                .map(|group| ir::KernSide::Group((*group).clone())),
+            ir::KernSide::Group(_) => Some(side.to_owned()),
         }
     }
 

--- a/fontbe/src/orchestration.rs
+++ b/fontbe/src/orchestration.rs
@@ -22,7 +22,7 @@ use fontdrasil::{
     types::GlyphName,
 };
 use fontir::{
-    ir::{self, Anchor, GlyphOrder, KernGroup, KernParticipant},
+    ir::{self, Anchor, GlyphOrder, KernGroup},
     orchestration::{
         Context as FeContext, ContextItem, ContextMap, Flags, IdAware, Persistable,
         PersistentStorage, WorkId as FeWorkIdentifier,
@@ -426,7 +426,7 @@ impl Persistable for AllKerningPairs {
 
 /// One side of a kerning pair, represented as glyph ids
 ///
-/// This parallels the [`KernParticipant`] IR type, with glyph names resolved
+/// This parallels the [`ir::KernSide`] type, with glyph names resolved
 /// to GIDs.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, PartialOrd, Eq, Ord)]
 pub(crate) enum KernSide {
@@ -458,13 +458,13 @@ impl KernSide {
 
     /// Convert from IR (which uses glyph names) to our representation (using ids)
     pub(crate) fn from_ir_side(
-        ir: &KernParticipant,
+        ir: &ir::KernSide,
         glyphs: &GlyphOrder,
         groups: &BTreeMap<KernGroup, GlyphSet>,
     ) -> Option<Self> {
         match ir {
-            KernParticipant::Glyph(name) => glyphs.glyph_id(name).map(Self::Glyph),
-            KernParticipant::Group(name) => groups.get(name).cloned().map(Self::Group),
+            ir::KernSide::Glyph(name) => glyphs.glyph_id(name).map(Self::Glyph),
+            ir::KernSide::Group(name) => groups.get(name).cloned().map(Self::Group),
         }
     }
 

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -495,7 +495,7 @@ mod tests {
     };
     use fontdrasil::{coords::NormalizedCoord, paths::safe_filename, types::GlyphName};
     use fontir::{
-        ir::{self, GlyphOrder, KernGroup, KernPair, KernParticipant},
+        ir::{self, GlyphOrder, KernGroup, KernPair, KernSide},
         orchestration::{Context as FeContext, Persistable, WorkId as FeWorkIdentifier},
     };
     use indexmap::IndexSet;
@@ -1928,42 +1928,42 @@ mod tests {
                 ],
                 vec![
                     (
-                        KernParticipant::Glyph("bracketleft".into()),
-                        KernParticipant::Glyph("bracketright".into()),
+                        KernSide::Glyph("bracketleft".into()),
+                        KernSide::Glyph("bracketright".into()),
                         vec![
                             ("wght 0".to_string(), -300.0),
                             ("wght 1".to_string(), -150.0)
                         ],
                     ),
                     (
-                        KernParticipant::Glyph("exclam".into()),
-                        KernParticipant::Glyph("exclam".into()),
+                        KernSide::Glyph("exclam".into()),
+                        KernSide::Glyph("exclam".into()),
                         vec![
                             ("wght 0".to_string(), -360.0),
                             ("wght 1".to_string(), -100.0)
                         ],
                     ),
                     (
-                        KernParticipant::Glyph("exclam".into()),
-                        KernParticipant::Glyph("hyphen".into()),
+                        KernSide::Glyph("exclam".into()),
+                        KernSide::Glyph("hyphen".into()),
                         vec![("wght 0".to_string(), 20.0),],
                     ),
                     (
-                        KernParticipant::Glyph("exclam".into()),
-                        KernParticipant::Group(KernGroup::Side2("bracketright_L".into())),
+                        KernSide::Glyph("exclam".into()),
+                        KernSide::Group(KernGroup::Side2("bracketright_L".into())),
                         vec![("wght 0".to_string(), -160.0),],
                     ),
                     (
-                        KernParticipant::Glyph("hyphen".into()),
-                        KernParticipant::Glyph("hyphen".into()),
+                        KernSide::Glyph("hyphen".into()),
+                        KernSide::Glyph("hyphen".into()),
                         vec![
                             ("wght 0".to_string(), -150.0),
                             ("wght 1".to_string(), -50.0)
                         ],
                     ),
                     (
-                        KernParticipant::Group(KernGroup::Side1("bracketleft_R".into())),
-                        KernParticipant::Glyph("exclam".into()),
+                        KernSide::Group(KernGroup::Side1("bracketleft_R".into())),
+                        KernSide::Glyph("exclam".into()),
                         vec![("wght 0".to_string(), -165.0),],
                     ),
                 ],

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -197,7 +197,7 @@ impl IntoIterator for GlyphOrder {
 pub type PostscriptNames = HashMap<GlyphName, GlyphName>;
 
 /// In logical (reading) order
-pub type KernPair = (KernParticipant, KernParticipant);
+pub type KernPair = (KernSide, KernSide);
 
 /// IR representation of kerning groups.
 ///
@@ -242,22 +242,20 @@ pub enum KernGroup {
     Side2(SmolStr),
 }
 
-/// A participant in kerning, one of the entries in a kerning pair.
-///
-/// Concretely, a glyph or a group of glyphs.
+/// One side of a kern pair, represented as a glyph or group name
 ///
 /// <https://unifiedfontobject.org/versions/ufo3/kerning.plist/#kerning-pair-types>
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum KernParticipant {
+pub enum KernSide {
     Glyph(GlyphName),
     Group(KernGroup),
 }
 
-impl Display for KernParticipant {
+impl Display for KernSide {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            KernParticipant::Glyph(g) => Display::fmt(g, f),
-            KernParticipant::Group(name) => write!(f, "@{name}"),
+            KernSide::Glyph(g) => Display::fmt(g, f),
+            KernSide::Group(name) => write!(f, "@{name}"),
         }
     }
 }
@@ -297,15 +295,15 @@ impl<'de> Deserialize<'de> for KernGroup {
     }
 }
 
-impl KernParticipant {
+impl KernSide {
     #[inline]
     pub fn is_glyph(&self) -> bool {
-        matches!(self, KernParticipant::Glyph(_))
+        matches!(self, KernSide::Glyph(_))
     }
 
     #[inline]
     pub fn is_group(&self) -> bool {
-        matches!(self, KernParticipant::Group(_))
+        matches!(self, KernSide::Group(_))
     }
 }
 

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -18,7 +18,7 @@ use fontir::{
     error::{Error, WorkError},
     ir::{
         self, AnchorBuilder, GlobalMetric, GlobalMetrics, GlyphInstance, GlyphOrder, KernGroup,
-        KernParticipant, KerningGroups, KerningInstance, NameBuilder, NameKey, NamedInstance,
+        KernSide, KerningGroups, KerningInstance, NameBuilder, NameKey, NamedInstance,
         StaticMetadata, DEFAULT_VENDOR_ID,
     },
     orchestration::{Context, IrWork, WorkId},
@@ -642,14 +642,14 @@ fn kern_participant(
     groups: &BTreeMap<KernGroup, BTreeSet<GlyphName>>,
     expect_prefix: &str,
     raw_side: &str,
-) -> Option<KernParticipant> {
+) -> Option<KernSide> {
     if let Some(group) = parse_kern_group(raw_side) {
         if !raw_side.starts_with(expect_prefix) {
             warn!("Invalid kern side: {raw_side}, should have prefix {expect_prefix}",);
             return None;
         }
         if groups.contains_key(&group) {
-            Some(KernParticipant::Group(group))
+            Some(KernSide::Group(group))
         } else {
             warn!("Invalid kern side: {raw_side}, no group {group:?}");
             None
@@ -657,7 +657,7 @@ fn kern_participant(
     } else {
         let name = GlyphName::from(raw_side);
         if glyph_order.contains(&name) {
-            Some(KernParticipant::Glyph(name))
+            Some(KernSide::Glyph(name))
         } else {
             warn!("Invalid kern side: {raw_side}, no such glyph");
             None

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -15,7 +15,7 @@ use fontir::{
     error::{Error, WorkError},
     ir::{
         AnchorBuilder, FeaturesSource, GlobalMetric, GlobalMetrics, GlyphOrder, KernGroup,
-        KernParticipant, KerningGroups, KerningInstance, NameBuilder, NameKey, NamedInstance,
+        KernSide, KerningGroups, KerningInstance, NameBuilder, NameKey, NamedInstance,
         PostscriptNames, StaticMetadata, DEFAULT_VENDOR_ID,
     },
     orchestration::{Context, Flags, IrWork, WorkId},
@@ -1408,14 +1408,14 @@ impl Work<Context, WorkId, WorkError> for KerningInstanceWork {
                     warn!("'{name}' is not a valid group name; ignored");
                     return None;
                 }
-                Some(KernParticipant::Group(group_name))
+                Some(KernSide::Group(group_name))
             } else {
                 let glyph_name = GlyphName::from(name.as_str());
                 if !glyph_order.contains(&glyph_name) {
                     warn!("'{name}' refers to a non-existent glyph; ignored");
                     return None;
                 }
-                Some(KernParticipant::Glyph(glyph_name))
+                Some(KernSide::Glyph(glyph_name))
             }
         };
 


### PR DESCRIPTION
We have a proliferation of names, and we are using the name KernSide to describe this role in fontbe. I think it's ultimately less confusing to have names duplicated between ir/be in places where the types are essentially equivalent.


(happy to be disagreed with on this, but thought i'd open the PR for discussion)