### PR TITLE
[fontbe] Minor marks cleanup

### DIFF
--- a/fontbe/src/features/marks.rs
+++ b/fontbe/src/features/marks.rs
@@ -8,7 +8,7 @@ use std::{
 use fea_rs::compile::{MarkToBaseBuilder, MarkToMarkBuilder, PreviouslyAssignedClass};
 use fontdrasil::{
     orchestration::{Access, AccessBuilder, Work},
-    types::GlyphName,
+    types::{AnchorName, GlyphName},
 };
 
 use ordered_float::OrderedFloat;
@@ -16,7 +16,7 @@ use smol_str::SmolStr;
 
 use crate::{
     error::Error,
-    orchestration::{AnyWorkId, BeWork, Context, FeaRsMarks, MarkGroup, MarkGroupName, WorkId},
+    orchestration::{AnyWorkId, BeWork, Context, FeaRsMarks, MarkGroup, WorkId},
 };
 use fontir::{
     ir::{GlyphAnchors, GlyphOrder, StaticMetadata},
@@ -30,7 +30,10 @@ pub fn create_mark_work() -> Box<BeWork> {
     Box::new(MarkWork {})
 }
 
-/// The type of an anchor, used when generating mark features
+/// The canonical name shared for a given mark/base pair, e.g. `top` for `top`/`_top`
+type MarkGroupName = SmolStr;
+
+/// The type of a mark anchor, used when generating mark features
 #[derive(Clone, Debug, PartialEq, PartialOrd, Eq, Ord)]
 pub(crate) enum AnchorInfo {
     Base(MarkGroupName),
@@ -38,12 +41,12 @@ pub(crate) enum AnchorInfo {
 }
 
 impl AnchorInfo {
-    pub(crate) fn new(name: &GlyphName) -> AnchorInfo {
+    pub(crate) fn new(name: &AnchorName) -> AnchorInfo {
         // _ prefix means mark. This convention appears to come from FontLab and is now everywhere.
-        if name.as_str().starts_with('_') {
-            AnchorInfo::Mark(MarkGroupName(name.as_str()[1..].into()))
+        if let Some(group) = name.as_str().strip_prefix('_') {
+            AnchorInfo::Mark(group.into())
         } else {
-            AnchorInfo::Base(MarkGroupName(name.as_str().into()))
+            AnchorInfo::Base(name.as_str().into())
         }
     }
 
@@ -214,14 +217,14 @@ impl Work<Context, AnyWorkId, Error> for MarkWork {
                     let gid = gid(mark_name)?;
                     let anchor = resolve_anchor(mark_anchor, &static_metadata, mark_name)?;
                     mark_base
-                        .insert_mark(gid, group_name.0.clone(), anchor)
-                        .map_err(|err| map_prev_class_error(err, &group_name.0, mark_name))?;
+                        .insert_mark(gid, group_name.clone(), anchor)
+                        .map_err(|err| map_prev_class_error(err, group_name, mark_name))?;
                 }
 
                 for (base_name, base_anchor) in group.bases.iter() {
                     let gid = gid(base_name)?;
                     let anchor = resolve_anchor(base_anchor, &static_metadata, base_name)?;
-                    mark_base.insert_base(gid, &group_name.0, anchor);
+                    mark_base.insert_base(gid, group_name, anchor);
                 }
 
                 all_marks.mark_base.push(mark_base);
@@ -238,13 +241,13 @@ impl Work<Context, AnyWorkId, Error> for MarkWork {
             for (mark_name, mark_anchor) in marks {
                 let anchor = resolve_anchor(mark_anchor, &static_metadata, mark_name)?;
                 mark_mark
-                    .insert_mark1(gid(mark_name)?, group_name.0.clone(), anchor)
-                    .map_err(|err| map_prev_class_error(err, &group_name.0, mark_name))?;
+                    .insert_mark1(gid(mark_name)?, group_name.clone(), anchor)
+                    .map_err(|err| map_prev_class_error(err, group_name, mark_name))?;
             }
 
             for (base_name, base_anchor) in bases {
                 let anchor = resolve_anchor(base_anchor, &static_metadata, base_name)?;
-                mark_mark.insert_mark2(gid(base_name)?, &group_name.0, anchor);
+                mark_mark.insert_mark2(gid(base_name)?, group_name, anchor);
             }
             all_marks.mark_mark.push(mark_mark);
         }

--- a/fontbe/src/orchestration.rs
+++ b/fontbe/src/orchestration.rs
@@ -34,7 +34,6 @@ use log::trace;
 use ordered_float::OrderedFloat;
 use serde::{Deserialize, Serialize};
 
-use smol_str::SmolStr;
 use write_fonts::{
     dump_table,
     read::{FontData, FontRead},
@@ -318,9 +317,6 @@ impl TupleBuilder {
         )
     }
 }
-
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub(crate) struct MarkGroupName(pub(crate) SmolStr);
 
 #[derive(Default, Clone, Serialize, Deserialize, PartialEq)]
 pub(crate) struct MarkGroup {

--- a/fontdrasil/src/types.rs
+++ b/fontdrasil/src/types.rs
@@ -73,7 +73,8 @@ impl std::borrow::Borrow<str> for GlyphName {
     }
 }
 
-pub type AnchorName = GlyphName;
+/// The name of a glyph anchor, direct from the font source
+pub type AnchorName = SmolStr;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct Axis {

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -1012,6 +1012,7 @@ impl Anchor {
     }
 }
 
+/// A type for building glyph anchors, reused by different backends
 #[derive(Debug, Clone)]
 pub struct AnchorBuilder {
     glyph_name: GlyphName,


### PR DESCRIPTION
I'm making sense of the existing code, and cleaning up a few little inconsistencies.

- the MarkGroupName struct wasn't really part of any public api and was being used as a type alias
- the AnchorName type was aliased to 'GlyphName'

In both these cases I think it's simpler for us to just use SmolStr directly for now, and we can introduce stronger types if there is any confusion.