### PR TITLE
Move anchor name parsing into fontir

### DIFF
--- a/fontdrasil/src/types.rs
+++ b/fontdrasil/src/types.rs
@@ -73,9 +73,6 @@ impl std::borrow::Borrow<str> for GlyphName {
     }
 }
 
-/// The name of a glyph anchor, direct from the font source
-pub type AnchorName = SmolStr;
-
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct Axis {
     pub name: String,

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -952,11 +952,11 @@ mod tests {
             UserLocation,
         },
         orchestration::{Access, AccessBuilder},
-        types::{AnchorName, GlyphName},
+        types::GlyphName,
     };
     use fontir::{
         error::WorkError,
-        ir::{GlobalMetricsInstance, GlyphOrder, NameKey},
+        ir::{AnchorKind, GlobalMetricsInstance, GlyphOrder, NameKey},
         orchestration::{Context, Flags, WorkId},
         paths::Paths,
         source::Source,
@@ -1585,17 +1585,17 @@ mod tests {
         let mark = context.anchors.get(&WorkId::Anchor(mark_name));
 
         assert_eq!(
-            vec![AnchorName::from("top")],
+            vec![AnchorKind::Base("top".into())],
             base.anchors
                 .iter()
-                .map(|a| a.name.clone())
+                .map(|a| a.kind.clone())
                 .collect::<Vec<_>>()
         );
         assert_eq!(
-            vec![AnchorName::from("_top")],
+            vec![AnchorKind::Mark("top".into())],
             mark.anchors
                 .iter()
-                .map(|a| a.name.clone())
+                .map(|a| a.kind.clone())
                 .collect::<Vec<_>>()
         );
     }

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -1524,10 +1524,10 @@ mod tests {
     use fontdrasil::{
         coords::{DesignCoord, DesignLocation, NormalizedCoord, NormalizedLocation, UserCoord},
         orchestration::{Access, AccessBuilder},
-        types::{AnchorName, GlyphName},
+        types::GlyphName,
     };
     use fontir::{
-        ir::{GlobalMetricsInstance, GlyphOrder, NameKey, PostscriptNames},
+        ir::{AnchorKind, GlobalMetricsInstance, GlyphOrder, NameKey, PostscriptNames},
         orchestration::{Context, Flags, WorkId},
         paths::Paths,
         source::{Input, Source},
@@ -2034,17 +2034,17 @@ mod tests {
         let mark = context.anchors.get(&WorkId::Anchor(mark_name));
 
         assert_eq!(
-            vec![AnchorName::from("top")],
+            vec![AnchorKind::Base("top".into())],
             base.anchors
                 .iter()
-                .map(|a| a.name.clone())
+                .map(|a| a.kind.clone())
                 .collect::<Vec<_>>()
         );
         assert_eq!(
-            vec![AnchorName::from("_top")],
+            vec![AnchorKind::Mark("top".into())],
             mark.anchors
                 .iter()
-                .map(|a| a.name.clone())
+                .map(|a| a.kind.clone())
                 .collect::<Vec<_>>()
         );
     }


### PR DESCRIPTION
This is shared between frontends, and doing this in ir simplifies backend code.