### PR TITLE
[marks] Move marks logic into a context struct

### DIFF
--- a/fontbe/src/error.rs
+++ b/fontbe/src/error.rs
@@ -79,6 +79,7 @@ pub enum Error {
     #[error("No glyph class '{0}'")]
     MissingGlyphClass(GlyphName),
     #[error("Mark glyph '{glyph}' in conflicting classes '{old_class}' and '{new_class}'")]
+    //FIXME: this can be deleted eventually, we will manually ensure classes are disjoint
     PreviouslyAssignedMarkClass {
         old_class: SmolStr,
         new_class: SmolStr,

--- a/fontbe/src/orchestration.rs
+++ b/fontbe/src/orchestration.rs
@@ -22,7 +22,7 @@ use fontdrasil::{
     types::GlyphName,
 };
 use fontir::{
-    ir::{self, Anchor, GlyphOrder, KernGroup},
+    ir::{self, GlyphOrder, KernGroup},
     orchestration::{
         Context as FeContext, ContextItem, ContextMap, Flags, IdAware, Persistable,
         PersistentStorage, WorkId as FeWorkIdentifier,
@@ -316,12 +316,6 @@ impl TupleBuilder {
             Tuple::new(self.max),
         )
     }
-}
-
-#[derive(Default, Clone, Serialize, Deserialize, PartialEq)]
-pub(crate) struct MarkGroup {
-    pub(crate) bases: Vec<(GlyphName, Anchor)>,
-    pub(crate) marks: Vec<(GlyphName, Anchor)>,
 }
 
 /// Marks, ready to feed to fea-rs in the form it expects

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -1078,6 +1078,16 @@ impl Anchor {
             .map(|(_, p)| *p)
             .unwrap()
     }
+
+    /// If this is a mark, base, or ligature anchor, return the group name
+    pub fn mark_group_name(&self) -> Option<&SmolStr> {
+        match &self.kind {
+            AnchorKind::Base(group_name)
+            | AnchorKind::Mark(group_name)
+            | AnchorKind::Ligature { group_name, .. } => Some(group_name),
+            _ => None,
+        }
+    }
 }
 
 /// A type for building glyph anchors, reused by different backends


### PR DESCRIPTION
This patch just matches the existing behaviour, but it will be improved to match the behaviour of fontmake.


no functional change, diffs are all the same etc; just thought this would be a good checkpoint that will reduce the size of subsequent diffs.