### PR TITLE
[g2f] Use smolstr when parsing glyphs.app data

### DIFF
--- a/glyphs-reader/Cargo.toml
+++ b/glyphs-reader/Cargo.toml
@@ -20,6 +20,7 @@ env_logger.workspace = true
 regex.workspace = true
 
 chrono.workspace = true
+smol_str.workspace = true
 
 [dev-dependencies]
 pretty_assertions.workspace = true

--- a/glyphs-reader/src/plist.rs
+++ b/glyphs-reader/src/plist.rs
@@ -5,6 +5,7 @@ use kurbo::{Affine, Point};
 use ordered_float::OrderedFloat;
 
 use plist_derive::FromPlist;
+use smol_str::SmolStr;
 
 /// A plist dictionary
 pub type Dictionary = BTreeMap<String, Plist>;
@@ -747,6 +748,16 @@ impl FromPlist for String {
         match tokenizer.lex()? {
             Token::Atom(val) => Ok(val.to_string()),
             Token::String(val) => Ok(val.to_string()),
+            _ => Err(Error::ExpectedString),
+        }
+    }
+}
+
+impl FromPlist for SmolStr {
+    fn parse(tokenizer: &mut Tokenizer<'_>) -> Result<Self, Error> {
+        match tokenizer.lex()? {
+            Token::Atom(val) => Ok(val.into()),
+            Token::String(val) => Ok(val.into()),
             _ => Err(Error::ExpectedString),
         }
     }

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -690,13 +690,9 @@ impl Work<Context, WorkId, WorkError> for KerningGroupWork {
                 glyph
                     .right_kern
                     .iter()
-                    .map(|group| KernGroup::Side1(group.into()))
-                    .chain(
-                        glyph
-                            .left_kern
-                            .iter()
-                            .map(|group| KernGroup::Side2(group.into())),
-                    )
+                    .cloned()
+                    .map(KernGroup::Side1)
+                    .chain(glyph.left_kern.iter().cloned().map(KernGroup::Side2))
                     .map(|group| (group, GlyphName::from(glyph_name.as_str())))
             })
             .for_each(|(group_name, glyph_name)| {


### PR DESCRIPTION
Particularly for types that end up being SmolStr later on, like glyph names; it's inconvenient and inefficient to parse to String and then later convert to SmolStr, so this is a minor simplification.

Arguably the whole plist parsing process should be using smolstr, which should offer a reasonable speedup, but we can worry about that when we're thinking more generally about optimization.

----------

...looking at this again, maybe it would make sense to use `GlyphName` whenever we're dealing with a glyph name? that's the type we're going to want later anyway, and it would save us from needing to convert things later...