### PR TITLE
Add test files to reproduce issue #407

### DIFF
--- a/resources/testdata/designspace_from_glyphs/IntermediateLayer-Black.ufo/kerning.plist
+++ b/resources/testdata/designspace_from_glyphs/IntermediateLayer-Black.ufo/kerning.plist
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>i</key>
+    <dict>
+      <key>i</key>
+      <integer>-400</integer>
+    </dict>
+  </dict>
+</plist>

--- a/resources/testdata/designspace_from_glyphs/IntermediateLayer-Regular.ufo/kerning.plist
+++ b/resources/testdata/designspace_from_glyphs/IntermediateLayer-Regular.ufo/kerning.plist
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>i</key>
+    <dict>
+      <key>i</key>
+      <integer>-50</integer>
+    </dict>
+  </dict>
+</plist>

--- a/resources/testdata/designspace_from_glyphs/IntermediateLayer.designspace
+++ b/resources/testdata/designspace_from_glyphs/IntermediateLayer.designspace
@@ -40,6 +40,14 @@
       </location>
     </source>
   </sources>
+  <variable-fonts>
+    <variable-font name="Regular" filename="IntermediateLayerVF">
+      <axis-subsets>
+        <axis-subset name="Cap Height"/>
+        <axis-subset name="Weight"/>
+      </axis-subsets>
+    </variable-font>
+  </variable-fonts>
   <instances>
     <instance name="Intermediate Layer Regular" familyname="Intermediate Layer" stylename="Regular" filename="../instance_ufo/IntermediateLayer-Regular.ufo" stylemapfamilyname="Intermediate Layer" stylemapstylename="regular">
       <location>

--- a/resources/testdata/glyphs2/IntermediateLayer.glyphs
+++ b/resources/testdata/glyphs2/IntermediateLayer.glyphs
@@ -1,5 +1,9 @@
 {
-.appVersion = "3226";
+.appVersion = "3300";
+DisplayStrings = (
+I,
+ii
+);
 customParameters = (
 {
 name = "Disable Last Change";
@@ -674,6 +678,18 @@ name = "Tall Caps Black";
 weightClass = Black;
 }
 );
+kerning = {
+"F969B945-4602-464F-B67C-A69BED6E6A4A" = {
+i = {
+i = -50;
+};
+};
+m01 = {
+i = {
+i = -400;
+};
+};
+};
 unitsPerEm = 1000;
 userData = {
 GSDontShowVersionAlert = 1;

--- a/resources/testdata/glyphs3/IntermediateLayer.glyphs
+++ b/resources/testdata/glyphs3/IntermediateLayer.glyphs
@@ -1,6 +1,10 @@
 {
-.appVersion = "3226";
+.appVersion = "3300";
 .formatVersion = 3;
+DisplayStrings = (
+I,
+ii
+);
 axes = (
 {
 name = "Cap Height";
@@ -752,6 +756,18 @@ name = "Tall Caps Black";
 weightClass = 900;
 }
 );
+kerningLTR = {
+"F969B945-4602-464F-B67C-A69BED6E6A4A" = {
+i = {
+i = -50;
+};
+};
+m01 = {
+i = {
+i = -400;
+};
+};
+};
 metrics = (
 {
 type = ascender;


### PR DESCRIPTION
I modified an existing test file that contained intermediate glyph layers. These only contribute sources for the glyph outlines and are expected to be ignored for other global font metrics or kerning.
I added a kerning pair between 'i' and 'i', defined at Regular and Black masters.

The expectaction is that these intermediate locations don't participate in kerning variations; however because we currently use a single VariationModel initialized from the union of all the _glyphs_ locations for generating deltas for the OpenType Layout features (see #407), the regions' min or max for variable kerning are computed incorrectly: in this particular example, instead of expected 0.0 (normalized Regular) and 1.0 (normalzied Black), the support's min is somewhere in between (0.6), which is where the unrelated intermediate layer happens to be, so the kerning will not vary at all between 0.0 and 0.6.

In the recording below, the top font is the incorrect one that fontc builds, the one below is the correct expected one:

https://github.com/googlefonts/fontc/assets/6939968/a26653fb-b2fb-4038-b09a-649d906cbb78

