### PR TITLE
[fontbe] Fix incorrect feature deltas w/ sparse glyph sources

### DIFF
--- a/fontbe/src/features.rs
+++ b/fontbe/src/features.rs
@@ -1,6 +1,7 @@
 //! Feature binary compilation.
 
 use std::{
+    borrow::Cow,
     cell::RefCell,
     collections::{HashMap, HashSet},
     ffi::{OsStr, OsString},
@@ -160,16 +161,16 @@ pub(crate) fn resolve_variable_metric<'a>(
 
     // Try to reuse the global model, or make a new sub-model only with the locations we
     // are asked for so we can support sparseness
-    let local_model: VariationModel;
-    let var_model = if locations == global_locations {
-        &static_metadata.variation_model
+    let var_model: Cow<'_, VariationModel> = if locations == global_locations {
+        Cow::Borrowed(&static_metadata.variation_model)
     } else {
-        local_model = VariationModel::new(
-            locations.into_iter().cloned().collect(),
-            static_metadata.axes.clone(),
+        Cow::Owned(
+            VariationModel::new(
+                locations.into_iter().cloned().collect(),
+                static_metadata.axes.clone(),
+            )
+            .unwrap(),
         )
-        .unwrap();
-        &local_model
     };
 
     let raw_deltas: Vec<_> = var_model
@@ -295,16 +296,16 @@ impl<'a> VariationInfo for FeaVariationInfo<'a> {
 
         // Try to reuse the global model, or make a new sub-model only with the locations we
         // are asked for so we can support sparseness
-        let local_model: VariationModel;
-        let var_model = if locations == global_locations {
-            &self.static_metadata.variation_model
+        let var_model: Cow<'_, VariationModel> = if locations == global_locations {
+            Cow::Borrowed(&self.static_metadata.variation_model)
         } else {
-            local_model = VariationModel::new(
-                locations.into_iter().cloned().collect(),
-                self.static_metadata.axes.clone(),
+            Cow::Owned(
+                VariationModel::new(
+                    locations.into_iter().cloned().collect(),
+                    self.static_metadata.axes.clone(),
+                )
+                .unwrap(),
             )
-            .unwrap();
-            &local_model
         };
 
         // Only 1 value per region for our input

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -328,7 +328,7 @@ impl StaticMetadata {
         names: HashMap<NameKey, String>,
         axes: Vec<Axis>,
         named_instances: Vec<NamedInstance>,
-        glyph_locations: HashSet<NormalizedLocation>,
+        global_locations: HashSet<NormalizedLocation>,
         postscript_names: PostscriptNames,
         italic_angle: f64,
         gdef_categories: GdefCategories,
@@ -352,7 +352,7 @@ impl StaticMetadata {
                 key_to_name.insert(NameKey::new(name_id_gen.into(), name), name.clone());
             });
 
-        let variation_model = VariationModel::new(glyph_locations, variable_axes.clone())?;
+        let variation_model = VariationModel::new(global_locations, variable_axes.clone())?;
 
         let default_location = axes
             .iter()

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -351,7 +351,7 @@ impl Work<Context, WorkId, WorkError> for StaticMetadataWork {
                 })
             })
             .collect();
-        let glyph_locations = font
+        let global_locations = font
             .masters
             .iter()
             .map(|m| font_info.locations.get(&m.axes_values).cloned().unwrap())
@@ -387,7 +387,7 @@ impl Work<Context, WorkId, WorkError> for StaticMetadataWork {
             names(font),
             axes,
             named_instances,
-            glyph_locations,
+            global_locations,
             Default::default(), // TODO: impl reading PS names from Glyphs
             italic_angle,
             categories,

--- a/ufo2fontir/src/toir.rs
+++ b/ufo2fontir/src/toir.rs
@@ -89,14 +89,14 @@ fn to_ir_glyph_instance(glyph: &norad::Glyph) -> Result<ir::GlyphInstance, WorkE
 }
 
 /// Create a map from source filename (e.g. x.ufo) => normalized location
-pub fn master_locations(
+pub fn master_locations<'a>(
     axes: &[fontdrasil::types::Axis],
-    sources: &[designspace::Source],
+    sources: impl IntoIterator<Item = &'a designspace::Source>,
 ) -> HashMap<String, NormalizedLocation> {
     let tags_by_name: HashMap<_, _> = axes.iter().map(|a| (a.name.as_str(), a.tag)).collect();
     let axes = axes.iter().map(|a| (a.tag, a)).collect();
     sources
-        .iter()
+        .into_iter()
         .map(|s| {
             (
                 s.name.clone().unwrap(),


### PR DESCRIPTION
This fixes 'incorrect feature deltas when sparse' https://github.com/googlefonts/fontc/issues/407

The global StaticMetadata.variation_model now only includes 'full' masters (i.e. defining kerning) for both UFOs+DS and .glyphs input (previously this was the case only for the latter).

When we call `resolve_variable_metric` we make new sub-model when locations != global_model.locations(), or just reuse the global model when locations are equal -- which is currently basically always true for the common source formats (DS and glyphs) in the case of kerning, as the latter is meant to be "dense" and can only be specified for the "full" or globally-defined masters. However, we don't preclude the possibility that in the future other (or newer) source formats may define sparse kerning data, and our fontbe is ready for that.

I added a test file in #776, and verified locally that this patch fixes the issue #407, but ~~I haven't find the time to make an actual unit test yet. If I don't make it in time, you should be able connect the dots...~~

EDIT: I have added a test case #817 


