### PR TITLE
Generate mark2lig lookups

### DIFF
--- a/fea-rs/src/compile.rs
+++ b/fea-rs/src/compile.rs
@@ -16,8 +16,8 @@ pub use compiler::Compiler;
 pub use feature_writer::{FeatureBuilder, FeatureProvider, NopFeatureProvider, PendingLookup};
 pub use language_system::LanguageSystem;
 pub use lookups::{
-    Builder, FeatureKey, LookupId, MarkToBaseBuilder, MarkToMarkBuilder, PairPosBuilder,
-    PreviouslyAssignedClass,
+    Builder, FeatureKey, LookupId, MarkToBaseBuilder, MarkToLigBuilder, MarkToMarkBuilder,
+    PairPosBuilder, PreviouslyAssignedClass,
 };
 pub use metrics::{Anchor, ValueRecord};
 pub use opts::Opts;

--- a/fea-rs/src/compile/lookups.rs
+++ b/fea-rs/src/compile/lookups.rs
@@ -42,9 +42,9 @@ use contextual::{
     SubChainContextBuilder, SubContextBuilder,
 };
 
-use gpos_builders::{CursivePosBuilder, MarkToLigBuilder, SinglePosBuilder};
+use gpos_builders::{CursivePosBuilder, SinglePosBuilder};
 pub use gpos_builders::{
-    MarkToBaseBuilder, MarkToMarkBuilder, PairPosBuilder, PreviouslyAssignedClass,
+    MarkToBaseBuilder, MarkToLigBuilder, MarkToMarkBuilder, PairPosBuilder, PreviouslyAssignedClass,
 };
 use gsub_builders::{
     AlternateSubBuilder, LigatureSubBuilder, MultipleSubBuilder, SingleSubBuilder,
@@ -124,6 +124,7 @@ macro_rules! impl_into_pos_lookup {
 impl_into_pos_lookup!(PairPosBuilder, Pair);
 impl_into_pos_lookup!(MarkToBaseBuilder, MarkToBase);
 impl_into_pos_lookup!(MarkToMarkBuilder, MarkToMark);
+impl_into_pos_lookup!(MarkToLigBuilder, MarkToLig);
 
 #[derive(Clone, Debug)]
 pub(crate) enum SubstitutionLookup {

--- a/fea-rs/src/compile/lookups/gpos_builders.rs
+++ b/fea-rs/src/compile/lookups/gpos_builders.rs
@@ -532,6 +532,7 @@ impl Builder for MarkToBaseBuilder {
     }
 }
 
+/// A builder for GPOS Lookup Type 5, Mark-to-Ligature
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MarkToLigBuilder {
@@ -540,6 +541,10 @@ pub struct MarkToLigBuilder {
 }
 
 impl MarkToLigBuilder {
+    /// Add a new mark glyph.
+    ///
+    /// If this glyph already exists in another mark class, we return the
+    /// previous class; this is likely an error.
     pub fn insert_mark(
         &mut self,
         glyph: GlyphId,
@@ -549,14 +554,21 @@ impl MarkToLigBuilder {
         self.marks.insert(glyph, class, anchor)
     }
 
+    /// Add a ligature base, providing a set of anchors for each component.
+    ///
+    /// There must be an item in the vec for each component in the ligature glyph,
+    /// but the anchors can be sparse; null anchors will be added for any classes
+    /// that are missing.
     pub fn add_lig(&mut self, glyph: GlyphId, components: Vec<BTreeMap<SmolStr, Anchor>>) {
         self.ligatures.insert(glyph, components);
     }
 
+    /// Returns an iterator over all of the mark glyphs
     pub fn mark_glyphs(&self) -> impl Iterator<Item = GlyphId> + Clone + '_ {
         self.marks.glyphs()
     }
 
+    /// Returns an iterator over all of the ligature glyphs
     pub fn lig_glyphs(&self) -> impl Iterator<Item = GlyphId> + Clone + '_ {
         self.ligatures.keys().copied()
     }

--- a/fontbe/src/features.rs
+++ b/fontbe/src/features.rs
@@ -241,6 +241,7 @@ impl<'a> FeatureWriter<'a> {
                 .borrow_mut()
                 .push(("Start add marks", Instant::now()));
         }
+
         self.marks.add_features(builder);
 
         {

--- a/fontbe/src/orchestration.rs
+++ b/fontbe/src/orchestration.rs
@@ -11,8 +11,8 @@ use std::{
 
 use fea_rs::{
     compile::{
-        FeatureKey, MarkToBaseBuilder, MarkToMarkBuilder, PairPosBuilder, PendingLookup,
-        ValueRecord as ValueRecordBuilder,
+        FeatureKey, MarkToBaseBuilder, MarkToLigBuilder, MarkToMarkBuilder, PairPosBuilder,
+        PendingLookup, ValueRecord as ValueRecordBuilder,
     },
     GlyphMap, GlyphSet, ParseTree,
 };
@@ -332,6 +332,7 @@ pub struct FeaRsMarks {
     pub(crate) glyphmap: GlyphMap,
     pub(crate) mark_base: Vec<PendingLookup<MarkToBaseBuilder>>,
     pub(crate) mark_mark: Vec<PendingLookup<MarkToMarkBuilder>>,
+    pub(crate) mark_lig: Vec<PendingLookup<MarkToLigBuilder>>,
 }
 
 impl Persistable for FeaRsMarks {

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -1116,6 +1116,14 @@ impl Anchor {
     pub fn is_mark(&self) -> bool {
         matches!(self.kind, AnchorKind::Mark(_))
     }
+
+    /// If this is a ligature anchor, return the index
+    pub fn ligature_index(&self) -> Option<usize> {
+        match self.kind {
+            AnchorKind::Ligature { index, .. } => Some(index),
+            _ => None,
+        }
+    }
 }
 
 /// A type for building glyph anchors, reused by different backends

--- a/layout-normalizer/src/gpos.rs
+++ b/layout-normalizer/src/gpos.rs
@@ -343,12 +343,14 @@ impl LookupRules {
     }
 
     fn markliga_rules<'a>(&'a self, lookups: &[u16]) -> Vec<SingleRule<'a, MarkLigaRule>> {
-        self.markliga
+        let mut rules = self
+            .markliga
             .iter()
             .filter(|lookup| lookups.contains(&lookup.lookup_id))
-            .inspect(|lookup| eprintln!("liga lookup id {}", lookup.lookup_id))
             .flat_map(|lookup| lookup.iter())
-            .collect()
+            .collect::<Vec<_>>();
+        rules.sort_unstable();
+        rules
     }
 }
 
@@ -445,10 +447,8 @@ fn get_lookup_rules(
                     .push(Lookup::new(id, rules, flag, mark_filter_id));
             }
             PositionSubtables::MarkToLig(subs) => {
-                eprintln!("get lookup rules id {id}");
                 let subs = subs.iter().flat_map(|sub| sub.ok()).collect::<Vec<_>>();
                 let rules = marks::get_mark_liga_rules(&subs, delta_computer).unwrap();
-                eprintln!("got {} rules", rules.len());
                 result
                     .markliga
                     .push(Lookup::new(id, rules, flag, mark_filter_id));


### PR DESCRIPTION
*This is based on #793, which should go in first.*

This is the last major remaining piece that we were missing in order to be able to match oswald.


This code *is* generating the same lookups as fontmake for oswald, but it is pretty naive; in particular it's just generating one big lookup and assuming that anchors don't collide (that is, that the same glyph is not part of multiple mark classes) whereas I believe the markFeatureWriter does the same sort of splitting for mark2lig that it does for mark2base, where it generates one lookup for each mark class?


This raises the bigger question of testing: there's currently no good way to test our feature generating code in isolation. I started working on this a bit for kerning but ran into some issues, but I think now it's worth spending some time to figure that problem out, since I think that the "last 10%" of layout is going to be much more test driven (isolate some funny quirk, write a test case, write a fix)