### PR TITLE
Add release workflow to build and publish source and binary artifacts to Github and PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -217,6 +217,22 @@ jobs:
           pattern: binaries-*
           merge-multiple: true
 
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: wheels-*
+          merge-multiple: true
+          path: wheels
+
+      # this requirements.txt can be used to pip install fontc more securely
+      # https://pip.pypa.io/en/stable/topics/secure-installs/
+      - name: Generate requirements.txt with SHA256 hashes
+        run: |
+          echo fontc | pipx run --spec pip-tools pip-compile - --no-index --find-links wheels/ --no-emit-find-links --generate-hashes --pip-args '--only-binary=:all:' --no-annotate --no-header --output-file requirements.txt
+
+      - name: Compute checksums of release assets
+        run: |
+          sha256sum *.tar.gz *.zip requirements.txt > checksums.txt
+
       - name: Detect if tag is a pre-release
         id: set_prerelease
         env:
@@ -239,6 +255,8 @@ jobs:
           files: |
             *.tar.gz
             *.zip
+            checksums.txt
+            requirements.txt
           prerelease: ${{ steps.set_prerelease.outputs.is_prerelease }}
           generate_release_notes: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,3 +223,19 @@ jobs:
             *.zip
           prerelease: ${{ steps.set_prerelease.outputs.is_prerelease }}
           generate_release_notes: true
+
+  # TODO: Make sure fontc's Cargo.toml metadata are ok for publishing to crates.io,
+  # maybe publish it the first time manually to reserve a spot. Also store a token
+  # named CRATES_IO_TOKEN in the repository's secrets before un-commenting this:
+  # release-crates-io:
+  #   name: Publish source to crates.io
+  #   runs-on: ubuntu-latest
+  #   if: "startsWith(github.ref, 'refs/tags/v')"
+  #   needs: [release-github]
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: dtolnay/rust-toolchain@stable
+  #     - name: cargo login
+  #       run: cargo login ${{ secrets.CRATES_IO_TOKEN }}
+  #     - name: cargo publish
+  #       run: cargo publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,9 @@
 # Windows (i686 and x86_64) and macOS (universal2 'fat' binary supporting both
 # x86_64 and arm64 architectures), package these as Python wheels, and upload to PyPI.
 # The same fontc binaries are also uploaded as Github Release assets which can be used
-# with `cargo binstall` command. The fontc source is also uploded to crates.io.
-# The workflow runs automatically when a version tag (i.e. starting with 'v') gets
-# pushed, or can be manually triggered from Github Actions interface (in which case
+# with `cargo binstall` command.
+# The workflow runs automatically when a fontc version tag (i.e. starting with 'fontc-v')
+# gets pushed, or can be manually triggered from Github Actions interface (in which case
 # artifacts don't get published, just temporarily uploaded to Github Actions).
 
 name: Release
@@ -262,19 +262,3 @@ jobs:
             requirements.txt
           prerelease: ${{ steps.before_release.outputs.is_prerelease }}
           generate_release_notes: true
-
-  # TODO: Make sure fontc's Cargo.toml metadata are ok for publishing to crates.io,
-  # maybe publish it the first time manually to reserve a spot. Also store a token
-  # named CRATES_IO_TOKEN in the repository's secrets before un-commenting this:
-  # release-crates-io:
-  #   name: Publish source to crates.io
-  #   runs-on: ubuntu-latest
-  #   if: "startsWith(github.ref, 'refs/tags/v')"
-  #   needs: [release-github]
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: dtolnay/rust-toolchain@stable
-  #     - name: cargo login
-  #       run: cargo login ${{ secrets.CRATES_IO_TOKEN }}
-  #     - name: cargo publish
-  #       run: cargo publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,225 @@
+name: Release
+
+on:
+  # only run on version-tagged commits or manually
+  push:
+    tags: ["v*.*.*"]
+  # enables workflow to be run manually
+  # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch
+  workflow_dispatch:
+
+# read-only access to repo contents by default; specific jobs may override it
+# https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build ${{ matrix.platform.target }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            python-architecture: x64
+            archive: fontc-x86_64-apple-darwin.tar.gz
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            python-architecture: x64
+            archive: fontc-x86_64-pc-windows-msvc.zip
+          - target: i686-pc-windows-msvc
+            os: windows-latest
+            python-architecture: x86
+            archive: fontc-i686-pc-windows-msvc.zip
+    runs-on: ${{ matrix.platform.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          architecture: ${{ matrix.platform.python-architecture }}
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.platform.target }}
+
+      # Install gnu-tar because BSD tar is buggy
+      # https://github.com/actions/cache/issues/403
+      - name: Install GNU tar (macOS)
+        if: matrix.platform.os == 'macos-latest'
+        run: |
+          brew install gnu-tar
+          echo "/usr/local/opt/gnu-tar/libexec/gnubin" >> $GITHUB_PATH
+
+      - name: Build wheel (macOS universal2) and sdist
+        if: matrix.platform.target == 'x86_64-apple-darwin'
+        uses: PyO3/maturin-action@v1
+        with:
+          target: universal2-apple-darwin
+          args: --release -o dist --sdist
+
+      - name: Build wheel (without sdist)
+        if: matrix.platform.target != 'x86_64-apple-darwin'
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{matrix.platform.target}}
+          args: --release -o dist
+
+      - name: Install wheel
+        shell: bash
+        run: |
+          pip install --no-index --find-links dist/ --force-reinstall fontc
+          which fontc
+          fontc --version
+
+      - name: Check sdist metadata
+        if: matrix.platform.target == 'x86_64-apple-darwin'
+        run: pipx run twine check dist/*.tar.gz
+
+      - name: Archive binary
+        if: matrix.platform.os != 'windows-latest'
+        run: |
+          cd target/${{ matrix.platform.target }}/release
+          tar czvf ../../../${{ matrix.platform.archive }} fontc
+          cd -
+
+      - name: Archive binary (windows)
+        if: matrix.platform.os == 'windows-latest'
+        run: |
+          cd target/${{ matrix.platform.target }}/release
+          7z a ../../../${{ matrix.platform.archive }} fontc.exe
+          cd -
+
+      - name: Archive binary (macOS aarch64)
+        if: matrix.platform.os == 'macos-latest'
+        run: |
+          cd target/aarch64-apple-darwin/release
+          tar czvf ../../../fontc-aarch64-apple-darwin.tar.gz fontc
+          cd -
+
+      - name: Upload wheel artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.platform.target }}
+          path: dist
+
+      - name: Upload binary artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: binaries-${{ matrix.platform.target }}
+          path: |
+            *.tar.gz
+            *.zip
+
+  build_linux:
+    name: Build ${{ matrix.platform.target }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - target: "x86_64-unknown-linux-musl"
+            image_tag: "x86_64-musl"
+            compatibility: "manylinux2010 musllinux_1_1"
+          - target: "aarch64-unknown-linux-musl"
+            image_tag: "aarch64-musl"
+            compatibility: "manylinux2014 musllinux_1_1"
+    container:
+      image: docker://ghcr.io/rust-cross/rust-musl-cross:${{ matrix.platform.image_tag }}
+    steps:
+      # checkout@v3 doesn't work inside the manylinux container:
+      # https://github.com/actions/checkout/issues/1487
+      - uses: actions/checkout@v3
+
+      - name: Build Wheels
+        uses: PyO3/maturin-action@main
+        with:
+          target: ${{ matrix.platform.target }}
+          manylinux: ${{ matrix.platform.compatibility }}
+          container: off
+          args: --release -o dist
+
+      - name: Install x86_64 wheel
+        if: startsWith(matrix.platform.target, 'x86_64')
+        run: |
+          /usr/bin/python3 -m pip install --no-index --find-links dist/ --force-reinstall fontc
+          which fontc
+          fontc --version
+
+      - name: Archive binary
+        run: tar czvf target/release/fontc-${{ matrix.platform.target }}.tar.gz -C target/${{ matrix.platform.target }}/release fontc
+
+      - name: Upload wheel artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.platform.target }}
+          path: dist
+
+      - name: Upload binary artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: binaries-${{ matrix.platform.target }}
+          path: target/release/fontc-${{ matrix.platform.target }}.tar.gz
+
+  release-pypi:
+    name: Publish to PyPI
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [build, build_linux]
+    runs-on: ubuntu-latest
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      # https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/
+      id-token: write
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: wheels-*
+          # so that all artifacts are downloaded in the same directory specified by 'path'
+          merge-multiple: true
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true
+
+  release-github:
+    permissions:
+      # Needed to upload release artifacts.
+      contents: write
+    name: Publish to GitHub releases
+    runs-on: ubuntu-latest
+    if: "startsWith(github.ref, 'refs/tags/v')"
+    needs: [build, build_linux]
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: binaries-*
+          merge-multiple: true
+
+      - name: Detect if tag is a pre-release
+        id: set_prerelease
+        env:
+          # e.g. v0.1.0a1, v1.2.0b2 or v2.3.0rc3, but not v1.0.0
+          PRERELEASE_TAG_PATTERN: "v[[:digit:]]+\\.[[:digit:]]+\\.[[:digit:]]+([ab]|rc)[[:digit:]]+"
+        run: |
+          # strip leading 'refs/tags/' to get the tag name
+          TAG_NAME="${GITHUB_REF##*/}"
+          if egrep -q "$PRERELEASE_TAG_PATTERN" <<< "$TAG_NAME"; then
+            echo "Tag ${TAG_NAME} contains a pre-release suffix"
+            echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Tag ${TAG_NAME} does not contain a pre-release suffix"
+            echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            *.tar.gz
+            *.zip
+          prerelease: ${{ steps.set_prerelease.outputs.is_prerelease }}
+          generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,21 @@
+# This is heavily inspired on
+# https://github.com/PyO3/maturin/blob/main/.github/workflows/release.yml
+# Maturin is a tool to build Rust crates as Python packages with minimal configuration,
+# which uses cargo under the hood and ensures the binaries are compatible with a wide
+# array of platforms and architectures.
+# Although fontc itself is a pure Rust project and as such doesn't use Python,
+# making it available on PyPI as a binary wheel package suitable to be installed by pip
+# increases its reach among font developers accustomed to Python tools.
+#
+# The Release workflow uses maturin to build fontc for Linux (x86_64 and aarch64),
+# Windows (i686 and x86_64) and macOS (universal2 'fat' binary supporting both
+# x86_64 and arm64 architectures), package these as Python wheels, and upload to PyPI.
+# The same fontc binaries are also uploaded as Github Release assets which can be used
+# with `cargo binstall` command. The fontc source is also uploded to crates.io.
+# The workflow runs automatically when a version tag (i.e. starting with 'v') gets
+# pushed, or can be manually triggered from Github Actions interface (in which case
+# artifacts don't get published, just temporarily uploaded to Github Actions).
+
 name: Release
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,9 +19,9 @@
 name: Release
 
 on:
-  # only run on version-tagged commits or manually
+  # only run on fontc-specific, version-tagged commits or manually
   push:
-    tags: ["v*.*.*"]
+    tags: ["fontc-v*.*.*"]
   # enables workflow to be run manually
   # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch
   workflow_dispatch:
@@ -183,7 +183,7 @@ jobs:
 
   release-pypi:
     name: Publish to PyPI
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/fontc-v')
     needs: [build, build_linux]
     runs-on: ubuntu-latest
     permissions:
@@ -209,7 +209,7 @@ jobs:
       contents: write
     name: Publish to GitHub releases
     runs-on: ubuntu-latest
-    if: "startsWith(github.ref, 'refs/tags/v')"
+    if: "startsWith(github.ref, 'refs/tags/fontc-v')"
     needs: [build, build_linux]
     steps:
       - uses: actions/download-artifact@v4
@@ -237,7 +237,7 @@ jobs:
         id: set_prerelease
         env:
           # e.g. v0.1.0a1, v1.2.0b2 or v2.3.0rc3, but not v1.0.0
-          PRERELEASE_TAG_PATTERN: "v[[:digit:]]+\\.[[:digit:]]+\\.[[:digit:]]+([ab]|rc)[[:digit:]]+"
+          PRERELEASE_TAG_PATTERN: "fontc-v[[:digit:]]+\\.[[:digit:]]+\\.[[:digit:]]+([ab]|rc)[[:digit:]]+"
         run: |
           # strip leading 'refs/tags/' to get the tag name
           TAG_NAME="${GITHUB_REF##*/}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -234,7 +234,7 @@ jobs:
           sha256sum *.tar.gz *.zip requirements.txt > checksums.txt
 
       - name: Detect if tag is a pre-release
-        id: set_prerelease
+        id: before_release
         env:
           # e.g. v0.1.0a1, v1.2.0b2 or v2.3.0rc3, but not v1.0.0
           PRERELEASE_TAG_PATTERN: "fontc-v[[:digit:]]+\\.[[:digit:]]+\\.[[:digit:]]+([ab]|rc)[[:digit:]]+"
@@ -248,16 +248,19 @@ jobs:
             echo "Tag ${TAG_NAME} does not contain a pre-release suffix"
             echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
           fi
+          # strip the redundant 'fontc-v' prefix from the Github Release title
+          echo "release_title=${TAG_NAME#fontc-v}" >> "$GITHUB_OUTPUT"
 
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
+          name: ${{ steps.before_release.outputs.release_title }}
           files: |
             *.tar.gz
             *.zip
             checksums.txt
             requirements.txt
-          prerelease: ${{ steps.set_prerelease.outputs.is_prerelease }}
+          prerelease: ${{ steps.before_release.outputs.is_prerelease }}
           generate_release_notes: true
 
   # TODO: Make sure fontc's Cargo.toml metadata are ok for publishing to crates.io,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,32 @@
+[build-system]
+requires = ["maturin>=0.12"]
+build-backend = "maturin"
+
+[tool.maturin]
+# maturin needs a manifest with a [package], can't just use the workspace's Cargo.toml
+manifest-path = "fontc/Cargo.toml"
+# treat the project as a Rust binary application: https://www.maturin.rs/bindings#bin
+bindings = "bin"
+# somehow these standard files aren't included automatically in the sdist,
+# it's better to keep them in there
+include = [
+  { path = "README.md", format = "sdist" },
+  { path = "LICENSE", format = "sdist" },
+]
+# without this exclude, maturin installs all fontc/*.rs source files in the
+# site-packages which is useless (maybe it expects to find *.py in there?)
+exclude = [
+  { path = "fontc/**/*", format = "wheel" },
+]
+
+# maturin merges the metadata from Cargo.toml with the pyproject.toml's below,
+# which takes precedence and overrides Cargo.toml
+[project]
+# 'name' key is required for [project]
+name = "fontc"
+# comment out 'version' to use the same as Cargo.toml, only override if needed
+# (e.g. for a post-release to fix some packaging issues with a previous release)
+# version = "0.0.1.post1"
+# Ensure we use the workspace's top-level README.md for the sdist/wheel metadata
+# not the fontc crate's specific README.md
+readme = "README.md"


### PR DESCRIPTION
For the Glyphs.app fontc export plugin (#684) we need to make precompiled binaries of fontc available to download and run without requiring to build from source. Glyphs.app already comes with Python, which in turn comes with an established and secure way to distribute and install binary packages via the Python Package Index (PyPI) and the pip installer.
With the help of a tool called maturin (see [source](https://github.com/PyO3/maturin) and [docs](https://www.maturin.rs/)) it's super easy to make Python wheels out of any Rust crate, including binary-only ones like fontc. Maturin itself is written in Rust, uses cargo under the hood, and it's primarily used to package up hybrid Python/Rust projects -- which fontc technically is not (but who knows, it may in the future get a python API as well); but that's ok, ours would not be the first project on PyPI that doesn't contain any Python itself but is simply an executable that gets unpacked to the environment's bin/ or Scripts/ directories (e.g. ther's also stuff like ninja or cmake). And we have used maturin in the past to package stuff like resvg or pngquant for nanoemoji, for example.
Maturin is great because I don't have to deal with the complications of making sure the binaries works on, e.g., both intel or Apple Silicon macs, or some random linux distro. I'm sure other, more expert Rust devs in here would know how do deal with all that, and may sniff at any snakes creeping in.. but I hope they will accept this as a pragmatic, first-time attempt :)

PS:  While this is more of a side effect than the primary goal, allowing one to `pip install fontc` would increase its reach among font editors (Glyphs.app, Robofont, fontra either expose Python API/Macros or are themselves writtein in it) as well as many font developers who are already accustomed to Python (think fontTools, fontmake, afdko, etc.).

This PR adds a new release.yml Github Actions workflow that is triggered automatically on git tags (actually tags conventionally start with 'v' e.g. `v1.0.0`) or manually from the Actions interface.
It builds the wheels for Mac, Linux and Windows and pushes them to PyPI, where they will be available at https://pypi.org/project/fontc/
It also compresses and publish the same `fontc` binaries that maturin has built for the Python wheels as simple .tar.gz archives and uploads them to a new Github Release, as downloadable assets. Besides allowing one to just curl, unzip and run, this also makes them ready to be installed with the nifty `cargo binstall` (https://github.com/cargo-bins/cargo-binstall), which can automatically finds the Github release associated with a given crate on crates.io and download precompiled binaries from it.
Finally, I added a block that automatically publishes fontc to crates.io but have not enabled that yet, because I think we first need to check we have all the required metatada and maybe we need to make the first cargo publish manually to reserve our spot and make sure everying works.

EDIT: I removed the automatic upload to crates.io, since we decided to publish source crates manually instead like we do in fontations.