### PR TITLE
Mark testing harness

### DIFF
--- a/fontbe/Cargo.toml
+++ b/fontbe/Cargo.toml
@@ -44,3 +44,5 @@ tempfile.workspace = true
 more-asserts.workspace = true
 temp-env.workspace = true
 rstest.workspace = true
+pretty_assertions.workspace = true
+layout-normalizer = { path = "../layout-normalizer" }

--- a/fontbe/src/features.rs
+++ b/fontbe/src/features.rs
@@ -126,13 +126,13 @@ impl Display for NoIncludePathError {
     }
 }
 
-struct FeaVariationInfo<'a> {
+pub(crate) struct FeaVariationInfo<'a> {
     axes: HashMap<Tag, (usize, &'a Axis)>,
     static_metadata: &'a StaticMetadata,
 }
 
 impl<'a> FeaVariationInfo<'a> {
-    fn new(static_metadata: &'a StaticMetadata) -> FeaVariationInfo<'a> {
+    pub(crate) fn new(static_metadata: &'a StaticMetadata) -> FeaVariationInfo<'a> {
         FeaVariationInfo {
             axes: static_metadata
                 .axes

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -2642,7 +2642,7 @@ mod tests {
                 .default_instance()
                 .components
                 .iter()
-                .any(|c| c.base == "hyphen".into()),
+                .any(|c| c.base == "hyphen"),
             "IR glyph should not reference hyphen {fe_hyphen_consumer:?}"
         );
         let be_hyphen_consumer = result

--- a/fontdrasil/src/types.rs
+++ b/fontdrasil/src/types.rs
@@ -47,6 +47,12 @@ impl From<&str> for GlyphName {
     }
 }
 
+impl From<SmolStr> for GlyphName {
+    fn from(value: SmolStr) -> Self {
+        GlyphName(value)
+    }
+}
+
 impl Debug for GlyphName {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(self.as_str())
@@ -70,6 +76,12 @@ impl AsRef<str> for GlyphName {
 impl std::borrow::Borrow<str> for GlyphName {
     fn borrow(&self) -> &str {
         self.0.borrow()
+    }
+}
+
+impl PartialEq<&str> for GlyphName {
+    fn eq(&self, other: &&str) -> bool {
+        self.as_str() == *other
     }
 }
 

--- a/layout-normalizer/src/common.rs
+++ b/layout-normalizer/src/common.rs
@@ -261,7 +261,7 @@ impl GlyphSet {
                 match self.glyphs {
                     GlyphSet::Single(single) => {
                         let name = self.names.get(*single);
-                        f.write_str(name)
+                        f.write_str(name.as_str())
                     }
                     GlyphSet::Multiple(glyphs) => {
                         f.write_str("[")?;
@@ -271,7 +271,7 @@ impl GlyphSet {
                             if !first {
                                 f.write_str(",")?;
                             }
-                            f.write_str(name)?;
+                            f.write_str(name.as_str())?;
                             first = false;
                         }
                         f.write_str("]")

--- a/layout-normalizer/src/gpos.rs
+++ b/layout-normalizer/src/gpos.rs
@@ -7,11 +7,11 @@ use std::{
 use write_fonts::{
     read::{
         tables::{
-            gdef::MarkGlyphSets,
-            gpos::{AnchorTable, PositionLookupList, PositionSubtables, ValueRecord},
+            gdef::{Gdef, MarkGlyphSets},
+            gpos::{AnchorTable, Gpos, PositionLookupList, PositionSubtables, ValueRecord},
             layout::DeviceOrVariationIndex,
         },
-        FontData, FontRef, ReadError, TableProvider,
+        FontData, ReadError,
     },
     types::GlyphId,
 };
@@ -35,13 +35,12 @@ use self::{
 };
 
 /// Print normalized GPOS layout rules for the provided font
-pub fn print(f: &mut dyn io::Write, font: &FontRef, names: &NameMap) -> Result<(), Error> {
-    writeln!(f, "# GPOS #")?;
-    let Some(table) = font.gpos().ok() else {
-        // no GPOS table, nothing to do
-        return Ok(());
-    };
-    let gdef = font.gdef().ok();
+pub fn print(
+    f: &mut dyn io::Write,
+    table: &Gpos,
+    gdef: Option<&Gdef>,
+    names: &NameMap,
+) -> Result<(), Error> {
     let var_store = gdef
         .as_ref()
         .and_then(|gdef| gdef.item_var_store())

--- a/layout-normalizer/src/gsub.rs
+++ b/layout-normalizer/src/gsub.rs
@@ -1,11 +1,16 @@
 use std::io;
 
-use write_fonts::read::FontRef;
+use write_fonts::read::tables::{gdef::Gdef, gsub::Gsub};
 
 use crate::{error::Error, glyph_names::NameMap};
 
 /// Print normalized GSUB layout rules for the provided font
-pub fn print(_f: &mut dyn io::Write, _font: &FontRef, _names: &NameMap) -> Result<(), Error> {
+pub fn print(
+    _f: &mut dyn io::Write,
+    _table: &Gsub,
+    _gdef: Option<&Gdef>,
+    _names: &NameMap,
+) -> Result<(), Error> {
     //TODO: do we *ever* want to support this? GPOS seems like the big one?
     Ok(())
 }


### PR DESCRIPTION
This adds a nice mechanism for testing our mark generation, based on `layout-normalizer`.


Basically this provides a builder where you can set up some set of glyphs + anchors + GDEF categories + user FEA, and then what feature code gets generated, in a normalized textual representation.

Getting this to work required a few tweaks in various places; I made it so that `layout-normalizer` can work only with the specific tables (instead of requiring a full font) and I also tweaked the `MarkLookupBuilder` so that our testing code more closely matches what we do during regular compilation.