### PR TITLE
Generate MarkToLig lookups, take two

### DIFF
--- a/fea-rs/src/compile.rs
+++ b/fea-rs/src/compile.rs
@@ -16,8 +16,8 @@ pub use compiler::Compiler;
 pub use feature_writer::{FeatureBuilder, FeatureProvider, NopFeatureProvider, PendingLookup};
 pub use language_system::LanguageSystem;
 pub use lookups::{
-    Builder, FeatureKey, LookupId, MarkToBaseBuilder, MarkToMarkBuilder, PairPosBuilder,
-    PreviouslyAssignedClass,
+    Builder, FeatureKey, LookupId, MarkToBaseBuilder, MarkToLigBuilder, MarkToMarkBuilder,
+    PairPosBuilder, PreviouslyAssignedClass,
 };
 pub use metrics::{Anchor, ValueRecord};
 pub use opts::Opts;

--- a/fea-rs/src/compile/compile_ctx.rs
+++ b/fea-rs/src/compile/compile_ctx.rs
@@ -964,7 +964,7 @@ impl<'a, F: FeatureProvider, V: VariationInfo> CompilationCtx<'a, F, V> {
             .unwrap()
             .with_gpos_type_5(|subtable| {
                 for base in base_ids.iter() {
-                    subtable.add_lig(base, components.clone());
+                    subtable.add_ligature_components(base, components.clone());
                 }
             })
     }

--- a/fea-rs/src/compile/lookups.rs
+++ b/fea-rs/src/compile/lookups.rs
@@ -42,9 +42,9 @@ use contextual::{
     SubChainContextBuilder, SubContextBuilder,
 };
 
-use gpos_builders::{CursivePosBuilder, MarkToLigBuilder, SinglePosBuilder};
+use gpos_builders::{CursivePosBuilder, SinglePosBuilder};
 pub use gpos_builders::{
-    MarkToBaseBuilder, MarkToMarkBuilder, PairPosBuilder, PreviouslyAssignedClass,
+    MarkToBaseBuilder, MarkToLigBuilder, MarkToMarkBuilder, PairPosBuilder, PreviouslyAssignedClass,
 };
 use gsub_builders::{
     AlternateSubBuilder, LigatureSubBuilder, MultipleSubBuilder, SingleSubBuilder,
@@ -124,6 +124,7 @@ macro_rules! impl_into_pos_lookup {
 impl_into_pos_lookup!(PairPosBuilder, Pair);
 impl_into_pos_lookup!(MarkToBaseBuilder, MarkToBase);
 impl_into_pos_lookup!(MarkToMarkBuilder, MarkToMark);
+impl_into_pos_lookup!(MarkToLigBuilder, MarkToLig);
 
 #[derive(Clone, Debug)]
 pub(crate) enum SubstitutionLookup {

--- a/fontbe/src/orchestration.rs
+++ b/fontbe/src/orchestration.rs
@@ -11,8 +11,8 @@ use std::{
 
 use fea_rs::{
     compile::{
-        FeatureKey, MarkToBaseBuilder, MarkToMarkBuilder, PairPosBuilder, PendingLookup,
-        ValueRecord as ValueRecordBuilder,
+        FeatureKey, MarkToBaseBuilder, MarkToLigBuilder, MarkToMarkBuilder, PairPosBuilder,
+        PendingLookup, ValueRecord as ValueRecordBuilder,
     },
     GlyphMap, GlyphSet, ParseTree,
 };
@@ -332,6 +332,7 @@ pub struct FeaRsMarks {
     pub(crate) glyphmap: GlyphMap,
     pub(crate) mark_base: Vec<PendingLookup<MarkToBaseBuilder>>,
     pub(crate) mark_mark: Vec<PendingLookup<MarkToMarkBuilder>>,
+    pub(crate) mark_lig: Vec<PendingLookup<MarkToLigBuilder>>,
 }
 
 impl Persistable for FeaRsMarks {


### PR DESCRIPTION
This is a rewrite of the initial implementation in #794 to more closely match fontmake (and pass the basic tests there).

- ~Several tests in this PR will fail until it is rebased onto #803; these failures are the result of issues in the normalizer.~
- ~also requires #802.~