### PR TITLE
Update env-logger

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ smol_str = { version = "0.2.0", features = ["serde"] }
 regex = "1.7.1"
 thiserror = "1.0.37"
 log = "0.4"
-env_logger = "0.10.0"
+env_logger = "0.11.0"
 parking_lot = "0.12.1"
 clap = { version = "4.0.32", features = ["derive"] }
 rayon = "1.6"

--- a/fea-lsp/Cargo.toml
+++ b/fea-lsp/Cargo.toml
@@ -10,7 +10,7 @@ lspower = "1.1.0"
 tokio = { version = "1.3", features = ["io-std", "io-util", "macros", "net", "rt-multi-thread", "sync", "time"] }
 serde_json = "1.0"
 anyhow = "1.0"
-env_logger = "0.10"
+env_logger.workspace = true
 
 # cargo-release settings
 [package.metadata.release]

--- a/fontc/src/main.rs
+++ b/fontc/src/main.rs
@@ -35,14 +35,13 @@ fn run() -> Result<(), Error> {
     env_logger::builder()
         .format(|buf, record| {
             let ts = buf.timestamp_micros();
+            let style = buf.default_level_style(record.level());
             writeln!(
                 buf,
-                "[{ts} {} {} {}] {}",
-                // we manually assign all threads a name
-                std::thread::current().name().unwrap_or("unknown"),
+                "[{ts} {:?} {} {style}{}{style:#}] {}",
+                std::thread::current().id(),
                 record.target(),
-                buf.default_level_style(record.level())
-                    .value(record.level()),
+                record.level(),
                 record.args()
             )
         })


### PR DESCRIPTION
The API changed a bit, so needed to fix that up. Also noticed that our logs were never actually printing a thread name, and this doesn't seem super useful given that the threading isn't something we manage, so I've just removed that bit of the log preamble for the time being.