### PR TITLE
add support for cargo binstall in fontc/Cargo.toml

### DIFF
--- a/fontc/Cargo.toml
+++ b/fontc/Cargo.toml
@@ -52,3 +52,20 @@ chrono.workspace = true
 
 [build-dependencies]
 vergen = { version = "8.2.6", features = ["build", "cargo", "git", "gitcl", "rustc"] }
+
+# Support for `cargo binstall fontc`.
+# The default Github download URL template used by cargo-binstall doesn't work
+# because our tag is named `fontc-v{version}` instead of just `v{version}`.
+# https://github.com/cargo-bins/cargo-binstall/blob/main/SUPPORT.md
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/{ name }-v{ version }/{ name }-{ target }{ archive-suffix }"
+# Our binary archives contain just the `fontc` executable, no sub-folders
+bin-dir = "{ bin }{ binary-ext }"
+# We use .tar.gz for Linux/Mac binary archives, .zip for Windows
+pkg-fmt = "tgz"
+
+[package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
+pkg-fmt = "zip"
+
+[package.metadata.binstall.overrides.i686-pc-windows-msvc]
+pkg-fmt = "zip"


### PR DESCRIPTION
there's this nice cargo sub-command called https://github.com/cargo-bins/cargo-binstall which allows one to install pre-compiled binaries for one's own platform/architecture that are hosted on Github Releases.

This is particularly useful e.g. for https://github.com/googlefonts/fontc-action where one would like to install fontc the quickest way possible instead of building from source.

Usually cargo binstall just works and it requires no configuation, but in our particular case, because we push prefixed tags like `fontc-v{version}` instead of bare `v{version}`, then cargo binstall cannot automatically find the github releases download URL, and falls back to the slower `cargo install` (from source).

This little change to fontc/Cargo.toml should make sure the correct URL will be used.