### PR TITLE
[fea-rs] Match fontools merging of inline GSUB 1 rules

### DIFF
--- a/fea-rs/src/compile/lookups/contextual.rs
+++ b/fea-rs/src/compile/lookups/contextual.rs
@@ -187,16 +187,14 @@ impl ContextualLookupBuilder<SubstitutionLookup> {
                 SubstitutionLookup::Single(subtables) => subtables
                     .subtables
                     .iter()
-                    .all(|subt| target.iter().all(|t| !subt.contains_target(t))),
+                    .all(|subt| subt.can_add(&target, &replacement)),
                 _ => false,
             },
             |flags, mark_set| SubstitutionLookup::Single(LookupBuilder::new(flags, mark_set)),
         );
 
         let SubstitutionLookup::Single(subtables) = lookup else {
-            // we didn't panic here before my refactor but I don't think we
-            // want to fall through. let's find out?
-            panic!("I don't think this should happen?");
+            unreachable!("per logic above we only return this variant");
         };
         let sub = subtables.last_mut().unwrap();
         for (target, replacement) in target.iter().zip(replacement.into_iter_for_target()) {
@@ -222,9 +220,7 @@ impl ContextualLookupBuilder<SubstitutionLookup> {
         );
 
         let SubstitutionLookup::Multiple(subtables) = lookup else {
-            // we didn't panic here before my refactor but I don't think we
-            // want to fall through. let's find out?
-            panic!("I don't think this should happen?");
+            unreachable!("per logic above we only return this variant");
         };
         let sub = subtables.last_mut().unwrap();
         sub.insert(target, replacements);
@@ -248,7 +244,7 @@ impl ContextualLookupBuilder<SubstitutionLookup> {
         );
 
         let SubstitutionLookup::Ligature(subtables) = lookup else {
-            panic!("ahhhhhh");
+            unreachable!("per logic above we only return this variant");
         };
 
         let sub = subtables.last_mut().unwrap();

--- a/fea-rs/src/compile/lookups/gsub_builders.rs
+++ b/fea-rs/src/compile/lookups/gsub_builders.rs
@@ -7,6 +7,8 @@ use write_fonts::{
     types::{FixedSize, GlyphId},
 };
 
+use crate::common::GlyphOrClass;
+
 use super::Builder;
 
 #[derive(Clone, Debug, Default)]
@@ -32,8 +34,13 @@ impl SingleSubBuilder {
         self.items.insert(target, (replacement, delta));
     }
 
-    pub fn contains_target(&self, target: GlyphId) -> bool {
-        self.items.contains_key(&target)
+    pub(crate) fn can_add(&self, target: &GlyphOrClass, replacement: &GlyphOrClass) -> bool {
+        for (target, replacement) in target.iter().zip(replacement.iter()) {
+            if matches!(self.items.get(&target), Some(x) if x.0 != replacement) {
+                return false;
+            }
+        }
+        true
     }
 
     pub(crate) fn is_empty(&self) -> bool {

--- a/fea-rs/test-data/fonttools-tests/bug512.expected_diff
+++ b/fea-rs/test-data/fonttools-tests/bug512.expected_diff
@@ -1,9 +1,0 @@
-# generated automatically by fea-rs
-# this file represents an acceptable difference between the output of
-# fonttools and the output of fea-rs for a given input.
-L75
->                  <LookupListIndex value="1"/>
-L75
-<                  <LookupListIndex value="2"/>
-L97
-<            <Substitution in="H" out="H.swash"/>


### PR DESCRIPTION
In certain situations we were unnecessarily creating duplicate lookups. Matching fonttools here is another step towards eliminating the GSUB ttx diff for oswald.

- closes #541