### PR TITLE
[fea-rs] More reuse of lookups for inline multisub rules

### DIFF
--- a/fea-rs/src/compile/compile_ctx.rs
+++ b/fea-rs/src/compile/compile_ctx.rs
@@ -692,8 +692,6 @@ impl<'a, F: FeatureProvider, V: VariationInfo> CompilationCtx<'a, F, V> {
                     .collect::<Vec<_>>();
                 let replacement = self.resolve_glyph(&rule.replacement_glyphs().next().unwrap());
                 let lookup = self.ensure_current_lookup_type(Kind::GsubType6);
-                //FIXME: we should check that the whole sequence is not present
-                // in the lookup before adding.. (https://github.com/cmyr/fea-rs/issues/207)
                 let mut to_return = None;
                 for target in sequence_enumerator(&target) {
                     to_return = Some(

--- a/fea-rs/src/compile/lookups/contextual.rs
+++ b/fea-rs/src/compile/lookups/contextual.rs
@@ -213,7 +213,7 @@ impl ContextualLookupBuilder<SubstitutionLookup> {
                 SubstitutionLookup::Multiple(subtables) => subtables
                     .subtables
                     .iter()
-                    .all(|subt| !subt.contains_target(target)),
+                    .all(|subt| subt.can_add(target, &replacements)),
                 _ => false,
             },
             |flags, mark_set| SubstitutionLookup::Multiple(LookupBuilder::new(flags, mark_set)),

--- a/fea-rs/src/compile/lookups/gsub_builders.rs
+++ b/fea-rs/src/compile/lookups/gsub_builders.rs
@@ -170,8 +170,11 @@ impl MultipleSubBuilder {
         self.items.insert(target, replacement);
     }
 
-    pub fn contains_target(&self, target: GlyphId) -> bool {
-        self.items.contains_key(&target)
+    pub fn can_add(&self, target: GlyphId, replacement: &[GlyphId]) -> bool {
+        match self.items.get(&target) {
+            None => true,
+            Some(thing) => thing == replacement,
+        }
     }
 }
 

--- a/fea-rs/test-data/compile-tests/mini-latin/glyph_order.txt
+++ b/fea-rs/test-data/compile-tests/mini-latin/glyph_order.txt
@@ -112,3 +112,7 @@ seven.osf
 eight.osf
 nine.osf
 zero.slash
+acutecomb
+brevecomb
+ogonekcomb
+dotbelowcomb

--- a/fea-rs/test-data/compile-tests/mini-latin/good/contextual_format_2.fea
+++ b/fea-rs/test-data/compile-tests/mini-latin/good/contextual_format_2.fea
@@ -1,0 +1,16 @@
+# reduced from the ccmp feature in oswald
+feature ccmp {
+    lookup ccmp_Other_1 {
+        @CombiningTopAccents = [acutecomb brevecomb];
+        @CombiningNonTopAccents = [dotbelowcomb ogonekcomb];
+        lookupflag UseMarkFilteringSet @CombiningTopAccents;
+        # we should only generate two lookups; one contextual and one multiple sub,
+        # containing 'sub a by I dotbelowcomb' and 'sub i by I ogonekcomb'
+        sub a' @CombiningTopAccents by I dotbelowcomb;
+        sub i' @CombiningTopAccents by I ogonekcomb;
+        sub a' @CombiningNonTopAccents @CombiningTopAccents by I dotbelowcomb;
+        sub i' @CombiningNonTopAccents @CombiningTopAccents by I ogonekcomb;
+    } ccmp_Other_1;
+} ccmp;
+
+

--- a/fea-rs/test-data/compile-tests/mini-latin/good/contextual_format_2.ttx
+++ b/fea-rs/test-data/compile-tests/mini-latin/good/contextual_format_2.ttx
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont>
+
+  <GDEF>
+    <Version value="0x00010002"/>
+    <MarkGlyphSetsDef>
+      <MarkSetTableFormat value="1"/>
+      <!-- MarkSetCount=1 -->
+      <Coverage index="0">
+        <Glyph value="acutecomb"/>
+        <Glyph value="brevecomb"/>
+      </Coverage>
+    </MarkGlyphSetsDef>
+  </GDEF>
+
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=1 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="ccmp"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=2 -->
+      <Lookup index="0">
+        <LookupType value="6"/>
+        <LookupFlag value="16"/><!-- useMarkFilteringSet -->
+        <!-- SubTableCount=1 -->
+        <ChainContextSubst index="0" Format="2">
+          <Coverage>
+            <Glyph value="a"/>
+            <Glyph value="i"/>
+          </Coverage>
+          <BacktrackClassDef>
+          </BacktrackClassDef>
+          <InputClassDef>
+            <ClassDef glyph="a" class="1"/>
+            <ClassDef glyph="i" class="2"/>
+          </InputClassDef>
+          <LookAheadClassDef>
+            <ClassDef glyph="acutecomb" class="1"/>
+            <ClassDef glyph="brevecomb" class="1"/>
+            <ClassDef glyph="dotbelowcomb" class="2"/>
+            <ClassDef glyph="ogonekcomb" class="2"/>
+          </LookAheadClassDef>
+          <!-- ChainSubClassSetCount=3 -->
+          <ChainSubClassSet index="0" empty="1"/>
+          <ChainSubClassSet index="1">
+            <!-- ChainSubClassRuleCount=2 -->
+            <ChainSubClassRule index="0">
+              <!-- BacktrackGlyphCount=0 -->
+              <!-- InputGlyphCount=1 -->
+              <!-- LookAheadGlyphCount=1 -->
+              <LookAhead index="0" value="1"/>
+              <!-- SubstCount=1 -->
+              <SubstLookupRecord index="0">
+                <SequenceIndex value="0"/>
+                <LookupListIndex value="1"/>
+              </SubstLookupRecord>
+            </ChainSubClassRule>
+            <ChainSubClassRule index="1">
+              <!-- BacktrackGlyphCount=0 -->
+              <!-- InputGlyphCount=1 -->
+              <!-- LookAheadGlyphCount=2 -->
+              <LookAhead index="0" value="2"/>
+              <LookAhead index="1" value="1"/>
+              <!-- SubstCount=1 -->
+              <SubstLookupRecord index="0">
+                <SequenceIndex value="0"/>
+                <LookupListIndex value="1"/>
+              </SubstLookupRecord>
+            </ChainSubClassRule>
+          </ChainSubClassSet>
+          <ChainSubClassSet index="2">
+            <!-- ChainSubClassRuleCount=2 -->
+            <ChainSubClassRule index="0">
+              <!-- BacktrackGlyphCount=0 -->
+              <!-- InputGlyphCount=1 -->
+              <!-- LookAheadGlyphCount=1 -->
+              <LookAhead index="0" value="1"/>
+              <!-- SubstCount=1 -->
+              <SubstLookupRecord index="0">
+                <SequenceIndex value="0"/>
+                <LookupListIndex value="1"/>
+              </SubstLookupRecord>
+            </ChainSubClassRule>
+            <ChainSubClassRule index="1">
+              <!-- BacktrackGlyphCount=0 -->
+              <!-- InputGlyphCount=1 -->
+              <!-- LookAheadGlyphCount=2 -->
+              <LookAhead index="0" value="2"/>
+              <LookAhead index="1" value="1"/>
+              <!-- SubstCount=1 -->
+              <SubstLookupRecord index="0">
+                <SequenceIndex value="0"/>
+                <LookupListIndex value="1"/>
+              </SubstLookupRecord>
+            </ChainSubClassRule>
+          </ChainSubClassSet>
+        </ChainContextSubst>
+        <MarkFilteringSet value="0"/>
+      </Lookup>
+      <Lookup index="1">
+        <LookupType value="2"/>
+        <LookupFlag value="16"/><!-- useMarkFilteringSet -->
+        <!-- SubTableCount=1 -->
+        <MultipleSubst index="0">
+          <Substitution in="a" out="I,dotbelowcomb"/>
+          <Substitution in="i" out="I,ogonekcomb"/>
+        </MultipleSubst>
+        <MarkFilteringSet value="0"/>
+      </Lookup>
+    </LookupList>
+  </GSUB>
+
+</ttFont>


### PR DESCRIPTION
With this change, if an existing lookup already contains the substitution that are trying to add, we will just reuse that lookup.

Our behaviour here was already slightly different from fonttools; this is a further optimization. I've opened https://github.com/fonttools/fonttools/issues/3551 there, and believe fonttools should match this behaviour.