### PR TITLE
[fea-rs] Allow negative values in LigatureCaretByPos

### DIFF
--- a/fea-rs/src/compile/validate.rs
+++ b/fea-rs/src/compile/validate.rs
@@ -534,7 +534,7 @@ impl<'a, V: VariationInfo> ValidationCtx<'a, V> {
                 //to resolve glyphs here in order to track that.
                 typed::GdefTableItem::LigatureCaret(node) => {
                     self.validate_glyph_or_class(&node.target());
-                    if let typed::LigatureCaretValue::Pos(node) = node.values() {
+                    if let typed::LigatureCaretValue::Index(node) = node.values() {
                         for idx in node.values() {
                             if idx.parse_unsigned().is_none() {
                                 self.error(idx.range(), "contourpoint index must be non-negative");

--- a/fea-rs/test-data/compile-tests/mini-latin/bad/negative_lig_caret_idx.ERR
+++ b/fea-rs/test-data/compile-tests/mini-latin/bad/negative_lig_caret_idx.ERR
@@ -1,0 +1,5 @@
+error: contourpoint index must be non-negative
+in ./test-data/compile-tests/mini-latin/bad/negative_lig_caret_idx.fea at 3:29
+  | 
+3 |     LigatureCaretByIndex f_f -100;
+  |                              ^^^^

--- a/fea-rs/test-data/compile-tests/mini-latin/bad/negative_lig_caret_idx.fea
+++ b/fea-rs/test-data/compile-tests/mini-latin/bad/negative_lig_caret_idx.fea
@@ -1,0 +1,4 @@
+table GDEF {
+    # indices cannot be negative
+    LigatureCaretByIndex f_f -100;
+} GDEF;

--- a/fea-rs/test-data/compile-tests/mini-latin/good/negative_lig_caret_pos.fea
+++ b/fea-rs/test-data/compile-tests/mini-latin/good/negative_lig_caret_pos.fea
@@ -1,0 +1,4 @@
+table GDEF {
+    # positions can be negative, unlike indices
+    LigatureCaretByPos f_f -100;
+} GDEF;

--- a/fea-rs/test-data/compile-tests/mini-latin/good/negative_lig_caret_pos.ttx
+++ b/fea-rs/test-data/compile-tests/mini-latin/good/negative_lig_caret_pos.ttx
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont>
+
+  <GDEF>
+    <Version value="0x00010000"/>
+    <LigCaretList>
+      <Coverage>
+        <Glyph value="f_f"/>
+      </Coverage>
+      <!-- LigGlyphCount=1 -->
+      <LigGlyph index="0">
+        <!-- CaretCount=1 -->
+        <CaretValue index="0" Format="1">
+          <Coordinate value="-100"/>
+        </CaretValue>
+      </LigGlyph>
+    </LigCaretList>
+  </GDEF>
+
+</ttFont>


### PR DESCRIPTION
When validating ligature caret statements I had the logic reversed, and was disallowing negative positions (which are fine) but allowing negative indices (which are not).

The fix is simple, and this adds some test coverage for this case.


- fixes #838 