### PR TITLE
[fea-rs] Parse useExtension keyword in lookups

### DIFF
--- a/fea-rs/src/parse/grammar/mod.rs
+++ b/fea-rs/src/parse/grammar/mod.rs
@@ -112,7 +112,9 @@ fn table(parser: &mut Parser) {
 //or     lookup <label>;
 fn lookup_block_or_reference(parser: &mut Parser, recovery: TokenSet) {
     assert!(parser.matches(0, Kind::LookupKw));
-    if parser.matches(2, Kind::LBrace) {
+    if parser.matches(2, Kind::LBrace)
+        || (parser.matches(2, Kind::UseExtensionKw) && parser.matches(3, Kind::LBrace))
+    {
         feature::lookup_block(parser, recovery.union(TokenSet::STATEMENT));
     } else if parser.matches(2, Kind::Semi) {
         parser.in_node(AstKind::LookupRefNode, |parser| {

--- a/fea-rs/test-data/compile-tests/mini-latin/good/lookup_extension.fea
+++ b/fea-rs/test-data/compile-tests/mini-latin/good/lookup_extension.fea
@@ -1,0 +1,3 @@
+lookup what useExtension {
+    sub a by b;
+} what;

--- a/fea-rs/test-data/compile-tests/mini-latin/good/lookup_extension.ttx
+++ b/fea-rs/test-data/compile-tests/mini-latin/good/lookup_extension.ttx
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont>
+
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=0 -->
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=0 -->
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=1 -->
+      <Lookup index="0">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0">
+          <Substitution in="a" out="b"/>
+        </SingleSubst>
+      </Lookup>
+    </LookupList>
+  </GSUB>
+
+</ttFont>


### PR DESCRIPTION
I've never seen this syntax in the wild before, and apparently it wasn't covered by our tests. Now it is.

JMM