### PR TITLE
[fontir] Start to refactor errors

### DIFF
--- a/fontc/src/config.rs
+++ b/fontc/src/config.rs
@@ -1,8 +1,8 @@
 //! State for a (possibly incremental) compiler job
 
-use std::{fs, io, path::PathBuf};
+use std::{fs, path::PathBuf};
 
-use fontir::{paths::Paths as IrPaths, source::Input, stateset::StateSet};
+use fontir::{error::TrackFileError, paths::Paths as IrPaths, source::Input, stateset::StateSet};
 use serde::{Deserialize, Serialize};
 
 use crate::{Args, Error};
@@ -21,9 +21,10 @@ pub struct Config {
 
 impl Config {
     /// Create a new config from the provided cli arguments
-    pub fn new(args: Args) -> Result<Config, io::Error> {
+    pub fn new(args: Args) -> Result<Config, TrackFileError> {
         let mut compiler = StateSet::new();
-        compiler.track_file(&std::env::current_exe()?)?;
+        compiler
+            .track_file(&std::env::current_exe().expect("could not get current executable path"))?;
         Ok(Config { args, compiler })
     }
 

--- a/fontc/src/error.rs
+++ b/fontc/src/error.rs
@@ -1,6 +1,7 @@
 use std::{io, path::PathBuf};
 
 use fontbe::orchestration::AnyWorkId;
+use fontir::error::TrackFileError;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -11,6 +12,8 @@ pub enum Error {
     YamlSerError(#[from] serde_yaml::Error),
     #[error("IO error: '{0}'")]
     IoError(#[from] io::Error),
+    #[error(transparent)]
+    TrackFile(#[from] TrackFileError),
     #[error("Font IR error: '{0}'")]
     FontIrError(#[from] fontir::error::Error),
     #[error("Unable to produce IR")]

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -15,7 +15,7 @@ use fontdrasil::{
     types::GlyphName,
 };
 use fontir::{
-    error::{Error, WorkError},
+    error::{BadSource, Error, WorkError},
     ir::{
         self, AnchorBuilder, AnchorKind, GdefCategories, GlobalMetric, GlobalMetrics,
         GlyphInstance, GlyphOrder, KernGroup, KernSide, KerningGroups, KerningInstance,
@@ -169,8 +169,8 @@ impl Source for GlyphsIrSource {
     fn inputs(&mut self) -> Result<Input, Error> {
         // We have to read the glyphs file then shred it to figure out if anything changed
         let font_info = FontInfo::try_from(Font::load(&self.glyphs_file).map_err(|e| {
-            Error::ParseError(
-                self.glyphs_file.clone(),
+            BadSource::parse(
+                &self.glyphs_file,
                 format!("Unable to read glyphs file: {e}"),
             )
         })?)?;


### PR DESCRIPTION
This is some initial cleanup of the errors in fontir; the next step is going to be to unify Error and WorkError.

- Replace various Error variants with a 'BadSource' error that packages up a particular error cause with the path of the problematic source
- Remove the general 'io error' variant from Error in favour of finer-grained errors that include additional context.
- get rid of `dyn Error`
