### PR TITLE
[fontir] Unify Error & WorkError

### DIFF
--- a/fontbe/src/features/marks.rs
+++ b/fontbe/src/features/marks.rs
@@ -776,7 +776,7 @@ mod tests {
             let anchors = self
                 .anchors
                 .iter()
-                .map(|(name, anchors)| GlyphAnchors::new(name.clone(), anchors.clone()).unwrap())
+                .map(|(name, anchors)| GlyphAnchors::new(name.clone(), anchors.clone()))
                 .collect::<Vec<_>>();
             let anchorsref = anchors.iter().collect();
             let glyph_order = self.anchors.keys().cloned().collect();

--- a/fontc/src/work.rs
+++ b/fontc/src/work.rs
@@ -10,7 +10,7 @@ use fontbe::{
 };
 use fontdrasil::orchestration::{Access, AccessType};
 use fontir::{
-    error::WorkError as FeError,
+    error::Error as FeError,
     orchestration::{Context as FeContext, IrWork, WorkId},
 };
 

--- a/fontir/src/orchestration.rs
+++ b/fontir/src/orchestration.rs
@@ -9,7 +9,7 @@ use std::{
     sync::Arc,
 };
 
-use crate::{error::WorkError, ir, paths::Paths, source::Input};
+use crate::{error::Error, ir, paths::Paths, source::Input};
 use bitflags::bitflags;
 use fontdrasil::{
     coords::NormalizedLocation,
@@ -355,7 +355,7 @@ impl Identifier for WorkId {
     }
 }
 
-pub type IrWork = dyn Work<Context, WorkId, WorkError> + Send;
+pub type IrWork = dyn Work<Context, WorkId, Error> + Send;
 
 pub struct IrPersistentStorage {
     active: bool,

--- a/fontir/src/source.rs
+++ b/fontir/src/source.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use fontdrasil::{coords::NormalizedLocation, orchestration::Work, types::GlyphName};
 
 use crate::{
-    error::{Error, WorkError},
+    error::Error,
     orchestration::{Context, IrWork, WorkId},
     stateset::StateSet,
 };
@@ -26,16 +26,16 @@ impl DeleteWork {
     }
 }
 
-impl Work<Context, WorkId, WorkError> for DeleteWork {
+impl Work<Context, WorkId, Error> for DeleteWork {
     fn id(&self) -> WorkId {
         WorkId::GlyphIrDelete(self.glyph_name.clone())
     }
 
-    fn exec(&self, context: &Context) -> Result<(), WorkError> {
+    fn exec(&self, context: &Context) -> Result<(), Error> {
         let path = context.persistent_storage.paths.target_file(&self.id());
         debug!("Delete {:#?}", path);
         if path.exists() {
-            fs::remove_file(&path).map_err(WorkError::IoError)?
+            fs::remove_file(&path).map_err(|source| Error::DeleteFailed { path, source })?
         }
         Ok(())
     }

--- a/fontra2fontir/src/fontra.rs
+++ b/fontra2fontir/src/fontra.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use fontdrasil::{paths::string_to_filename, types::GlyphName};
-use fontir::error::{BadSource, Error};
+use fontir::error::{BadSource, PathConversionError};
 use serde::Deserialize;
 use write_fonts::types::Tag;
 
@@ -225,15 +225,16 @@ pub(crate) struct FontraPoint {
 impl FontraPoint {
     /// <https://github.com/googlefonts/fontra/blob/a4edd06837118e583804fd963c22ed806a315b04/src/fontra/core/path.py#L396-L406>
     #[allow(dead_code)] // TEMPORARY
-    pub(crate) fn point_type(&self) -> Result<PointType, Error> {
+    pub(crate) fn point_type(&self) -> Result<PointType, PathConversionError> {
         match (self.smooth, self.raw_type.as_deref()) {
             (false, Some("cubic")) => Ok(PointType::OffCurveCubic),
             (false, Some("quad")) => Ok(PointType::OffCurveQuad),
             (false, None) => Ok(PointType::OnCurve),
             (true, None) => Ok(PointType::OnCurveSmooth),
-            _ => Err(Error::InvalidInputData(format!(
-                "Unrecognized combination, smooth {}, type {:?}",
-                self.smooth, self.raw_type
+            _ => Err(PathConversionError::Parse(format!(
+                "Unrecognized combination, smooth {}, type '{}'",
+                self.smooth,
+                self.raw_type.clone().unwrap_or_default()
             ))),
         }
     }

--- a/fontra2fontir/src/source.rs
+++ b/fontra2fontir/src/source.rs
@@ -8,7 +8,7 @@ use std::{
 
 use fontdrasil::{orchestration::Work, types::GlyphName};
 use fontir::{
-    error::{BadSource, BadSourceKind, Error, WorkError},
+    error::{BadSource, BadSourceKind, Error},
     ir::StaticMetadata,
     orchestration::{Context, WorkId},
     source::{Input, Source},
@@ -211,14 +211,13 @@ struct StaticMetadataWork {
     glyph_info: Arc<BTreeMap<GlyphName, (PathBuf, Vec<u32>)>>,
 }
 
-fn create_static_metadata(fontdata_file: &Path) -> Result<StaticMetadata, WorkError> {
+fn create_static_metadata(fontdata_file: &Path) -> Result<StaticMetadata, Error> {
     debug!("Static metadata for {:#?}", fontdata_file);
-    let font_data = FontraFontData::from_file(fontdata_file)
-        .map_err(|e| WorkError::ParseError(fontdata_file.to_path_buf(), format!("{e}")))?;
+    let font_data = FontraFontData::from_file(fontdata_file)?;
     to_ir_static_metadata(&font_data)
 }
 
-impl Work<Context, WorkId, WorkError> for StaticMetadataWork {
+impl Work<Context, WorkId, Error> for StaticMetadataWork {
     fn id(&self) -> WorkId {
         WorkId::StaticMetadata
     }
@@ -227,7 +226,7 @@ impl Work<Context, WorkId, WorkError> for StaticMetadataWork {
         vec![WorkId::PreliminaryGlyphOrder]
     }
 
-    fn exec(&self, context: &Context) -> Result<(), WorkError> {
+    fn exec(&self, context: &Context) -> Result<(), Error> {
         debug!("Static metadata for {:#?}", self.fontdata_file);
         context
             .preliminary_glyph_order


### PR DESCRIPTION
This also makes errors more granular:

- errors related to finding, loading, or parsing a source file are their own 'BadSource' error type, which always preserves the path of the file in question;
- errors that occur during conversion of a specific glyph are now their own 'BadGlyph' error type, which means we always preserve the name of the glyph in question when such an error occurs.

A few other variants were removed or combined.