### PR TITLE
[fontir] Rename SourceError::parse -> custom

### DIFF
--- a/fontir/src/error.rs
+++ b/fontir/src/error.rs
@@ -28,7 +28,7 @@ pub enum BadSourceKind {
     ExpectedParent,
     Io(io::Error),
     /// Payload is a message to print; this error can originate from various parsers
-    ParseFail(String),
+    Custom(String),
 }
 
 /// An error that occurs when trying to access a file during change tracking
@@ -235,8 +235,9 @@ impl BadSource {
         }
     }
 
-    pub fn parse(path: impl Into<PathBuf>, msg: impl Display) -> Self {
-        Self::new(path, BadSourceKind::ParseFail(msg.to_string()))
+    /// A catch-all constructor for additional kinds of errors, such as various parsing failures
+    pub fn custom(path: impl Into<PathBuf>, msg: impl Display) -> Self {
+        Self::new(path, BadSourceKind::Custom(msg.to_string()))
     }
 }
 
@@ -263,7 +264,7 @@ impl std::fmt::Display for BadSourceKind {
             BadSourceKind::UnrecognizedExtension => f.write_str("unknown file extension"),
             BadSourceKind::ExpectedParent => f.write_str("missing parent directory"),
             BadSourceKind::Io(e) => e.fmt(f),
-            BadSourceKind::ParseFail(e) => f.write_str(e),
+            BadSourceKind::Custom(e) => f.write_str(e),
         }
     }
 }

--- a/fontra2fontir/src/fontra.rs
+++ b/fontra2fontir/src/fontra.rs
@@ -25,7 +25,7 @@ where
     for<'a> T: Deserialize<'a>,
 {
     let raw = fs::read_to_string(p).map_err(|e| BadSource::new(p, e))?;
-    serde_json::from_str(&raw).map_err(|e| BadSource::parse(p, e))
+    serde_json::from_str(&raw).map_err(|e| BadSource::custom(p, e))
 }
 
 /// serde type used to load font-data.json

--- a/fontra2fontir/src/source.rs
+++ b/fontra2fontir/src/source.rs
@@ -75,11 +75,9 @@ impl FontraIrSource {
                 line.map_err(|e| BadSource::new(&self.glyphinfo_file, BadSourceKind::Io(e)))?;
             let parts: Vec<_> = line.split(';').collect();
             if parts.len() != 2 {
-                return Err(BadSource::new(
+                return Err(BadSource::custom(
                     &self.glyphinfo_file,
-                    BadSourceKind::ParseFail(format!(
-                        "Expected two parts in line {i} separated by ;"
-                    )),
+                    format!("Expected two parts in line {i} separated by ;"),
                 ));
             }
             let glyph_name = GlyphName::new(parts[0].trim());
@@ -91,13 +89,13 @@ impl FontraIrSource {
                         return None;
                     }
                     let Some(codepoint) = codepoint.strip_prefix("U+") else {
-                        return Some(Err(BadSource::parse(
+                        return Some(Err(BadSource::custom(
                             &self.glyphinfo_file,
                             format!("Unintelligible codepoint {codepoint:?} at line {i}"),
                         )));
                     };
                     Some(u32::from_str_radix(codepoint, 16).map_err(|e| {
-                        BadSource::parse(
+                        BadSource::custom(
                             &self.glyphinfo_file,
                             format!("Unintelligible codepoint {codepoint:?} at line {i}: {e}"),
                         )
@@ -113,7 +111,7 @@ impl FontraIrSource {
                 .insert(glyph_name.clone(), (glyph_file, codepoints))
                 .is_some()
             {
-                return Err(BadSource::parse(
+                return Err(BadSource::custom(
                     &self.glyphinfo_file,
                     format!("Multiple definitions of '{glyph_name}'"),
                 ));
@@ -129,7 +127,7 @@ impl FontraIrSource {
             let mut tracker = StateSet::new();
             tracker.track_file(glyph_file)?;
             if glyph_state.insert(glyph_name.clone(), tracker).is_some() {
-                Err(BadSource::parse(
+                Err(BadSource::custom(
                     &self.glyphinfo_file,
                     format!("Multiple definitions of '{glyph_name}'"),
                 ))?;

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -169,7 +169,7 @@ impl Source for GlyphsIrSource {
     fn inputs(&mut self) -> Result<Input, Error> {
         // We have to read the glyphs file then shred it to figure out if anything changed
         let font_info = FontInfo::try_from(Font::load(&self.glyphs_file).map_err(|e| {
-            BadSource::parse(
+            BadSource::custom(
                 &self.glyphs_file,
                 format!("Unable to read glyphs file: {e}"),
             )

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -96,8 +96,8 @@ fn glif_files(
     if !glyph_list_file.is_file() {
         return Err(BadSource::new(glyph_list_file, BadSourceKind::ExpectedFile).into());
     }
-    let result: BTreeMap<String, PathBuf> = plist::from_file(&glyph_list_file)
-        .map_err(|e| BadSource::new(&glyph_list_file, BadSourceKind::ParseFail(e.to_string())))?;
+    let result: BTreeMap<String, PathBuf> =
+        plist::from_file(&glyph_list_file).map_err(|e| BadSource::custom(&glyph_list_file, e))?;
 
     if result.is_empty() {
         warn!("{:?} is empty", glyph_list_file);
@@ -114,8 +114,8 @@ fn layer_contents(ufo_dir: &Path) -> Result<HashMap<GlyphName, PathBuf>, BadSour
     if !file.is_file() {
         return Ok(HashMap::new());
     }
-    let contents: Vec<(GlyphName, PathBuf)> = plist::from_file(&file)
-        .map_err(|e| BadSource::new(file, BadSourceKind::ParseFail(e.to_string())))?;
+    let contents: Vec<(GlyphName, PathBuf)> =
+        plist::from_file(&file).map_err(|e| BadSource::custom(file, e))?;
     Ok(contents.into_iter().collect())
 }
 
@@ -164,7 +164,7 @@ impl DesignSpaceIrSource {
             Some("designspace") => {
                 DesignSpaceDocument::load(&designspace_or_ufo).map_err(|e| match e {
                     norad::error::DesignSpaceLoadError::Io(e) => BadSourceKind::Io(e),
-                    other => BadSourceKind::ParseFail(other.to_string()),
+                    other => BadSourceKind::Custom(other.to_string()),
                 })?
             }
             Some("ufo") => {


### PR DESCRIPTION
per conversation in #855, 'parse' is a confusing name for a constructor. This renames that method for `SourceError`.

JMM