### PR TITLE
[fontc] Tweak root error type

### DIFF
--- a/fontc/src/change_detector.rs
+++ b/fontc/src/change_detector.rs
@@ -357,7 +357,11 @@ impl ChangeDetector {
         if self.emit_ir {
             let current_sources =
                 serde_yaml::to_string(&self.current_inputs).map_err(Error::YamlSerError)?;
-            fs::write(self.ir_paths.ir_input_file(), current_sources).map_err(Error::IoError)
+            let out_path = self.ir_paths.ir_input_file();
+            fs::write(out_path, current_sources).map_err(|source| Error::FileIo {
+                path: out_path.to_owned(),
+                source,
+            })
         } else {
             Ok(())
         }

--- a/fontc/src/config.rs
+++ b/fontc/src/config.rs
@@ -49,7 +49,12 @@ impl Config {
                     .map_err(|_| Error::FileExpected(ir_input_file.to_owned()))?;
             }
             if self.args.incremental {
-                fs::write(config_file, serde_yaml::to_string(self)?)?;
+                fs::write(&config_file, serde_yaml::to_string(self)?).map_err(|source| {
+                    Error::FileIo {
+                        path: config_file,
+                        source,
+                    }
+                })?
             }
         };
 
@@ -57,7 +62,10 @@ impl Config {
             return Ok(Input::new());
         }
 
-        let yml = fs::read_to_string(ir_input_file)?;
+        let yml = fs::read_to_string(ir_input_file).map_err(|source| Error::FileIo {
+            path: ir_input_file.to_owned(),
+            source,
+        })?;
         serde_yaml::from_str(&yml).map_err(Into::into)
     }
 

--- a/fontc/src/error.rs
+++ b/fontc/src/error.rs
@@ -1,27 +1,34 @@
 use std::{io, path::PathBuf};
 
-use fontbe::orchestration::AnyWorkId;
 use fontir::error::TrackFileError;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum Error {
+    #[error("'{0}' exists but is not a directory")]
+    ExpectedDirectory(PathBuf),
+    #[error("io failed for '{path}': '{source}'")]
+    FileIo {
+        path: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+    #[error("failed to write to stdout or stderr: '{0}'")]
+    StdioWriteFail(#[source] io::Error),
     #[error("Unrecognized source {0}")]
     UnrecognizedSource(PathBuf),
-    #[error("yaml error: '{0}'")]
+    #[error(transparent)]
     YamlSerError(#[from] serde_yaml::Error),
-    #[error("IO error: '{0}'")]
-    IoError(#[from] io::Error),
     #[error(transparent)]
     TrackFile(#[from] TrackFileError),
     #[error("Font IR error: '{0}'")]
     FontIrError(#[from] fontir::error::Error),
-    #[error("Unable to produce IR")]
-    IrGenerationError,
+    #[error(transparent)]
+    Backend(#[from] fontbe::error::Error),
     #[error("Missing file '{0}'")]
     FileExpected(PathBuf),
-    #[error("Tasks failed: {0:?}")]
-    TasksFailed(Vec<(AnyWorkId, String)>),
     #[error("Unable to proceed; {0} jobs stuck pending")]
     UnableToProceed(usize),
+    #[error("A task panicked: '{0}'")]
+    Panic(String),
 }

--- a/fontc/src/work.rs
+++ b/fontc/src/work.rs
@@ -2,46 +2,11 @@
 //!
 //! Basically enums that can be a FeWhatever or a BeWhatever.
 
-use std::fmt::Display;
-
-use fontbe::{
-    error::Error as BeError,
-    orchestration::{AnyWorkId, BeWork, Context as BeContext},
-};
+use fontbe::orchestration::{AnyWorkId, BeWork, Context as BeContext};
 use fontdrasil::orchestration::{Access, AccessType};
-use fontir::{
-    error::Error as FeError,
-    orchestration::{Context as FeContext, IrWork, WorkId},
-};
+use fontir::orchestration::{Context as FeContext, IrWork, WorkId};
 
-#[derive(Debug)]
-pub enum AnyWorkError {
-    Fe(FeError),
-    Be(BeError),
-    Panic(String),
-}
-
-impl From<BeError> for AnyWorkError {
-    fn from(e: BeError) -> Self {
-        AnyWorkError::Be(e)
-    }
-}
-
-impl From<FeError> for AnyWorkError {
-    fn from(e: FeError) -> Self {
-        AnyWorkError::Fe(e)
-    }
-}
-
-impl Display for AnyWorkError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            AnyWorkError::Be(e) => e.fmt(f),
-            AnyWorkError::Fe(e) => e.fmt(f),
-            AnyWorkError::Panic(e) => write!(f, "Job panicked: '{e}'"),
-        }
-    }
-}
+use crate::Error;
 
 // Work of any type, FE, BE, ... some future pass, w/e
 #[derive(Debug)]
@@ -95,7 +60,7 @@ impl AnyWork {
         }
     }
 
-    pub fn exec(&self, context: AnyContext) -> Result<(), AnyWorkError> {
+    pub fn exec(&self, context: AnyContext) -> Result<(), Error> {
         match self {
             AnyWork::Be(work) => work.exec(context.unwrap_be()).map_err(|e| e.into()),
             AnyWork::Fe(work) => work.exec(context.unwrap_fe()).map_err(|e| e.into()),


### PR DESCRIPTION
The last little bit of error work, on top of #855.

- Removes AnyWorkError, and adds variants for BeError and and Panic to fontc::Error
- instead of returning a vec of errors when tasks fail, just return the first error we see (log the rest)
- Ensure that we always know the relevant path when we encounter an io::Error