### PR TITLE
[fontc_bulk] Call out to ttx_diff script

### DIFF
--- a/fontc_crater/Cargo.toml
+++ b/fontc_crater/Cargo.toml
@@ -11,6 +11,8 @@ readme = "README.md"
 fontc = { version = "0.0.1", path = "../fontc" }
 
 google-fonts-sources = "0.1.0"
+
+rayon.workspace = true
 write-fonts.workspace = true
 serde.workspace = true
 thiserror.workspace = true

--- a/fontc_crater/src/args.rs
+++ b/fontc_crater/src/args.rs
@@ -21,10 +21,13 @@ pub(super) struct Args {
     /// Optional path to write out results (as json)
     #[arg(short = 'o', long = "out")]
     pub(super) out_path: Option<PathBuf>,
+    /// for debugging, execute only a given number of fonts
+    #[arg(long)]
+    pub(super) n_fonts: Option<usize>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, ValueEnum)]
 pub(super) enum Tasks {
     Compile,
-    // this will expand to include at least 'ttx_diff'
+    Diff,
 }

--- a/fontc_crater/src/main.rs
+++ b/fontc_crater/src/main.rs
@@ -14,6 +14,7 @@ use write_fonts::types::Tag;
 mod args;
 mod error;
 mod sources;
+mod ttx_diff_runner;
 
 use sources::RepoList;
 
@@ -34,20 +35,76 @@ fn run(args: &Args) -> Result<(), Error> {
     }
     let sources = RepoList::get_or_create(&args.font_cache, args.fonts_repo.as_deref())?;
 
+    let pruned = args.n_fonts.map(|n| prune_sources(&sources.sources, n));
+    let inputs = pruned.as_ref().unwrap_or(&sources.sources);
+
     match args.command {
-        Tasks::Compile => {
-            compile_all(&sources.sources, &args.font_cache, args.out_path.as_deref())?
+        Tasks::Compile => run_all(
+            inputs,
+            &args.font_cache,
+            args.out_path.as_deref(),
+            compile_one,
+        )?,
+        Tasks::Diff => {
+            ttx_diff_runner::assert_can_run_script();
+            run_all(
+                inputs,
+                &args.font_cache,
+                args.out_path.as_deref(),
+                ttx_diff_runner::run_ttx_diff,
+            )?;
         }
     };
     sources.save(&args.font_cache)?;
     Ok(())
 }
 
+// only generic so I can write tests
+fn prune_sources<T: Clone>(sources: &[T], n_items: usize) -> Vec<T> {
+    if n_items == 0 || sources.is_empty() {
+        return Vec::new();
+    }
+
+    if n_items >= sources.len() {
+        return sources.to_owned();
+    }
+
+    // this is probably very dumb? I just want to use modular arithmetic to
+    // take a consistent subset of the input items, and I'm bad at math.
+    // I'm sure there is a better way to do this...
+
+    let ratio = (n_items as f32) / sources.len() as f32;
+    let modus = if ratio <= 0.5 {
+        // floor here and ceil below because we want to err on taking more items,
+        // since we will iter().take() the correct number below
+        (1. / ratio).floor() as usize
+    } else {
+        (1. / (1. - ratio)).ceil() as usize
+    };
+
+    let filter_fn = |n| {
+        // basically: if we want to take 1/8 of items we do n % 6 == 0,
+        // and if we want to take 7/8 of items we do n % 6 != 0
+        if ratio <= 0.5 {
+            n % modus == 0
+        } else {
+            n % modus != 0
+        }
+    };
+
+    sources
+        .iter()
+        .enumerate()
+        .filter_map(|(i, x)| filter_fn(i).then_some(x.clone()))
+        .take(n_items)
+        .collect()
+}
+
 /// Results of all runs
-#[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
-struct Results {
-    success: BTreeSet<PathBuf>,
-    failure: BTreeMap<PathBuf, String>,
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+struct Results<T, E> {
+    success: BTreeMap<PathBuf, T>,
+    failure: BTreeMap<PathBuf, E>,
     panic: BTreeSet<PathBuf>,
     skipped: BTreeMap<PathBuf, SkipReason>,
 }
@@ -55,10 +112,10 @@ struct Results {
 /// The output of trying to run on one font.
 ///
 /// We don't use a normal Result because failure is okay, we will report it all at the end.
-enum RunResult {
+enum RunResult<T, E> {
     Skipped(SkipReason),
-    Success,
-    Fail(String),
+    Success(T),
+    Fail(E),
     Panic,
 }
 
@@ -71,18 +128,19 @@ enum SkipReason {
     NoConfig,
 }
 
-fn compile_all(
+fn run_all<T: serde::Serialize, E: serde::Serialize>(
     sources: &[RepoInfo],
     cache_dir: &Path,
     out_path: Option<&Path>,
+    runner: impl Fn(&Path) -> RunResult<T, E>,
 ) -> Result<(), Error> {
     let results = sources
         .iter()
         .flat_map(|info| {
             let font_dir = cache_dir.join(&info.repo_name);
-            fetch_and_run_repo(&font_dir, info)
+            fetch_and_run_repo(&font_dir, info, |p| runner(p))
         })
-        .collect::<Results>();
+        .collect::<Results<_, _>>();
 
     if let Some(path) = out_path {
         let as_json = serde_json::to_string_pretty(&results).map_err(Error::OutputJson)?;
@@ -97,7 +155,11 @@ fn compile_all(
 }
 
 // one repo can contain multiple sources, so we return a vec.
-fn fetch_and_run_repo(font_dir: &Path, repo: &RepoInfo) -> Vec<(PathBuf, RunResult)> {
+fn fetch_and_run_repo<T, E>(
+    font_dir: &Path,
+    repo: &RepoInfo,
+    runner: impl Fn(&Path) -> RunResult<T, E>,
+) -> Vec<(PathBuf, RunResult<T, E>)> {
     if !font_dir.exists() && clone_repo(font_dir, &repo.repo_url).is_err() {
         return vec![(font_dir.to_owned(), RunResult::Skipped(SkipReason::GitFail))];
     }
@@ -129,19 +191,19 @@ fn fetch_and_run_repo(font_dir: &Path, repo: &RepoInfo) -> Vec<(PathBuf, RunResu
     sources
         .into_iter()
         .map(|source| {
-            let result = compile_one(&source);
+            eprintln!("running {}", source.display());
+            let result = runner(&source);
             (source, result)
         })
         .collect()
 }
 
-fn compile_one(source_path: &Path) -> RunResult {
+fn compile_one(source_path: &Path) -> RunResult<(), String> {
     let tempdir = tempfile::tempdir().unwrap();
     let args = fontc::Args::new(tempdir.path(), source_path.to_owned());
     let timer = JobTimer::new(Instant::now());
-    eprintln!("compiling {}", source_path.display());
     match std::panic::catch_unwind(|| fontc::run(args, timer)) {
-        Ok(Ok(_)) => RunResult::Success,
+        Ok(Ok(_)) => RunResult::Success(()),
         Ok(Err(e)) => RunResult::Fail(e.to_string()),
         Err(_) => RunResult::Panic,
     }
@@ -187,16 +249,16 @@ fn load_config(config_path: &Path) -> Option<Config> {
     }
 }
 
-impl FromIterator<(PathBuf, RunResult)> for Results {
-    fn from_iter<T: IntoIterator<Item = (PathBuf, RunResult)>>(iter: T) -> Self {
+impl<T, E> FromIterator<(PathBuf, RunResult<T, E>)> for Results<T, E> {
+    fn from_iter<I: IntoIterator<Item = (PathBuf, RunResult<T, E>)>>(iter: I) -> Self {
         let mut out = Results::default();
         for (path, reason) in iter.into_iter() {
             match reason {
                 RunResult::Skipped(reason) => {
                     out.skipped.insert(path, reason);
                 }
-                RunResult::Success => {
-                    out.success.insert(path);
+                RunResult::Success(output) => {
+                    out.success.insert(path, output);
                 }
                 RunResult::Fail(reason) => {
                     out.failure.insert(path, reason);
@@ -210,7 +272,7 @@ impl FromIterator<(PathBuf, RunResult)> for Results {
     }
 }
 
-impl Results {
+impl<T, E> Results<T, E> {
     fn print_summary(&self) {
         let total = self.success.len() + self.failure.len() + self.panic.len() + self.skipped.len();
 
@@ -249,6 +311,17 @@ impl Results {
     }
 }
 
+impl<T, E> Default for Results<T, E> {
+    fn default() -> Self {
+        Self {
+            success: Default::default(),
+            failure: Default::default(),
+            panic: Default::default(),
+            skipped: Default::default(),
+        }
+    }
+}
+
 /// Google fonts config file ('config.yaml')
 #[derive(Clone, Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -270,5 +343,25 @@ impl std::fmt::Display for SkipReason {
             SkipReason::GitFail => f.write_str("Git checkout failed"),
             SkipReason::NoConfig => f.write_str("No config.yaml file found"),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prune_items_smoke_test() {
+        let items = (0usize..100).collect::<Vec<_>>();
+        assert_eq!(prune_sources(&items, 100).len(), 100);
+        assert_eq!(prune_sources(&items, 200).len(), 100);
+        assert_eq!(prune_sources(&items, 101).len(), 100);
+        assert_eq!(prune_sources(&items, 20).len(), 20);
+        assert_eq!(prune_sources(&items, 80).len(), 80);
+        assert_eq!(prune_sources(&items, 9).len(), 9);
+        assert_eq!(
+            prune_sources(&items, 9),
+            &[0, 11, 22, 33, 44, 55, 66, 77, 88]
+        );
     }
 }

--- a/fontc_crater/src/ttx_diff_runner.rs
+++ b/fontc_crater/src/ttx_diff_runner.rs
@@ -1,0 +1,165 @@
+use std::{collections::BTreeMap, path::Path, process::Command};
+
+use crate::RunResult;
+
+static SCRIPT_PATH: &str = "./resources/scripts/ttx_diff.py";
+
+pub(super) fn run_ttx_diff(source: &Path) -> RunResult<DiffOutput, DiffError> {
+    let output = match Command::new("python")
+        .arg(SCRIPT_PATH)
+        .args(["--compare", "default"])
+        .arg("--json")
+        .arg(source)
+        .output()
+    {
+        Err(e) => return RunResult::Fail(DiffError::Other(e.to_string())),
+        Ok(val) => val,
+    };
+
+    match output.status.code() {
+        // success, diffs are identical
+        Some(0) => RunResult::Success(DiffOutput::Identical),
+        // there are diffs, or one or more compilers did not finish
+        Some(2) => match serde_json::from_slice::<RawDiffOutput>(&output.stdout) {
+            Err(_) => {
+                let output = String::from_utf8_lossy(&output.stdout);
+                eprintln!("MALFORMED JSON? '{output}'");
+                std::process::exit(1);
+            }
+            Ok(RawDiffOutput::Success(success)) => {
+                if success.is_empty() {
+                    RunResult::Success(DiffOutput::Identical)
+                } else {
+                    RunResult::Success(DiffOutput::Diffs(success))
+                }
+            }
+            Ok(RawDiffOutput::Error(error)) => RunResult::Fail(DiffError::CompileFailed(error)),
+        },
+        // unhandled exception or sigterm
+        _ => {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            RunResult::Fail(DiffError::Other(format!("unknown error '{stderr}'")))
+        }
+    }
+}
+
+#[derive(Clone, Debug, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(super) enum DiffOutput {
+    Identical,
+    Diffs(BTreeMap<String, DiffValue>),
+}
+
+/// make sure we can find and execute ttx_diff script
+pub(super) fn assert_can_run_script() {
+    let path = Path::new(SCRIPT_PATH);
+    if !path.exists() {
+        eprintln!(
+            "cannot find script at {}",
+            path.canonicalize().as_deref().unwrap_or(path).display()
+        );
+        std::process::exit(1);
+    }
+    match Command::new("python")
+        .arg(SCRIPT_PATH)
+        .arg("--only_check_args")
+        .output()
+    {
+        Ok(output) if output.status.success() => return,
+        Ok(output) => {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            eprintln!("could not run ttx_diff.py. Have you setup your venv?");
+            if !stdout.is_empty() {
+                eprintln!("stdout: {stdout}");
+            }
+            if !stderr.is_empty() {
+                eprintln!("stderr: {stderr}");
+            }
+        }
+        Err(e) => eprintln!("Error executing ttx_diff script: '{e}'"),
+    }
+
+    std::process::exit(1)
+}
+
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum RawDiffOutput {
+    Success(BTreeMap<String, DiffValue>),
+    Error(CompileFailed),
+}
+
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum DiffError {
+    CompileFailed(CompileFailed),
+    Other(String),
+}
+
+/// One or both compilers failed to run
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) struct CompileFailed {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    fontc: Option<CompilerFailure>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    fontmake: Option<CompilerFailure>,
+}
+
+/// Info regarding the failure of a single compiler
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) struct CompilerFailure {
+    command: String,
+    stderr: String,
+}
+
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "snake_case", untagged)]
+pub(super) enum DiffValue {
+    Ratio(f32),
+    Only(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn basic_serde() {
+        fn expect_success(s: &str, expected: &[(&str, f32)]) -> bool {
+            let expected = expected
+                .iter()
+                .map(|(s, val)| (s.to_string(), DiffValue::Ratio(*val)))
+                .collect();
+            let result: RawDiffOutput = serde_json::from_str(s).unwrap();
+            match result {
+                RawDiffOutput::Error(CompileFailed { fontc, fontmake }) => {
+                    eprintln!("unexpected error: {fontc:?} '{fontmake:?}'");
+                    false
+                }
+                RawDiffOutput::Success(items) if items == expected => true,
+                RawDiffOutput::Success(items) => {
+                    eprintln!("wrong items: {items:?}");
+                    false
+                }
+            }
+        }
+
+        let success = "{\"success\": {\"GPOS\": 0.9995}}";
+        assert!(expect_success(success, &[("GPOS", 0.9995f32)]));
+        let success = "{\"success\": {}}";
+        assert!(expect_success(success, &[]));
+        let error = "{\"error\": {\"fontmake\": {\"command\": \"fontmake -o variable --output-path fontmake.ttf\", \"stderr\": \"oh no\"}}}";
+        let RawDiffOutput::Error(CompileFailed {
+            fontc: None,
+            fontmake: Some(CompilerFailure { command, stderr }),
+        }) = serde_json::from_str(error).unwrap()
+        else {
+            panic!("a quite unlikely success")
+        };
+        assert!(command.starts_with("fontmake -o"));
+        assert_eq!(stderr, "oh no");
+    }
+}

--- a/resources/scripts/check_no_println.sh
+++ b/resources/scripts/check_no_println.sh
@@ -94,6 +94,7 @@ allowlist+=("otl-normalizer")
 allowlist+=("glyphs-reader/build.rs")
 allowlist+=("fontdrasil/build.rs")
 allowlist+=("fontc_crater/src/main.rs")
+allowlist+=("fontc_crater/src/ttx_diff_runner.rs")
 
 allowlist=$(join "|" "${allowlist[@]}")
 echo grep -v "($allowlist)"

--- a/resources/scripts/ttx_diff.py
+++ b/resources/scripts/ttx_diff.py
@@ -17,8 +17,6 @@ Usage:
 JSON:
     If the `--json` flag is passed, this tool will output JSON.
 
-    If the script exits with a `0` status code, then `stdout` is a JSON dictionary.
-
     If both compilers ran successfully, this dictionary will have a single key,
     "success", which will contain a dictionary, where keys are the tags of tables
     (or another identifier) and the value is either a float representing the
@@ -29,11 +27,11 @@ JSON:
     means that the "GPOS" table was 99% similar, and only `fontmake` produced
     the "vmtx" table (and all other tables were identical).
 
-    If a compiler fails to exit successfully, we will return a dictionary with
-    the single key, "error", where the payload is a dictionary with "source" and
-    "message" fields; "source" is the name of the compiler that failed, and
-    "message" is the contents of stderr, e.g.:
-    `{"error": {"source": "fontmake", "message": "oh no!" }}`
+    If one or both of the compilers fail to exit successfully, we will return a
+    dictionary with the single key, "error", where the payload is a dictionary
+    where keys are the name of the compiler that failed, and the body is a
+    dictionary with "command" and "stderr" fields, where the "command" field
+    is the command that was used to run that compiler.
 """
 
 from absl import app
@@ -518,6 +516,7 @@ def main(argv):
                 "JSON output does not support multiple comparisons (try --compare default|gftools)")
         comparisons = (_COMPARE_DEFAULTS, _COMPARE_GFTOOLS)
 
+    no_diffs = True
     for compare in comparisons:
         build_dir = (root / "build" / compare).relative_to(root)
         build_dir.mkdir(parents=True, exist_ok=True)
@@ -545,11 +544,22 @@ def main(argv):
         assert fontc_ttf.is_file(), fontc_ttf
 
         output = generate_output(build_dir, fontmake_ttf, fontc_ttf)
+        if output["fontc"] == output["fontmake"]:
+            maybe_print("output is identical")
+            continue
+
+        no_diffs = False
+
         if not FLAGS.json:
             print_output(build_dir, output)
         else:
             output = jsonify_output(output)
             print_json(output)
+
+    if no_diffs:
+        sys.exit(0)
+    else:
+        sys.exit(2)
 
 
 if __name__ == "__main__":

--- a/resources/scripts/ttx_diff.py
+++ b/resources/scripts/ttx_diff.py
@@ -491,7 +491,6 @@ def report_errors_and_exit_if_there_were_any(errors: dict):
         print_json({"error": errors})
     sys.exit(2)
 
-
 def main(argv):
     if len(argv) != 2:
         sys.exit("Only one argument, a source file, is expected")


### PR DESCRIPTION
This adds the ability to diff lots of fonts and collect the aggregate results.

- this is based on #852, but also requires #860 and #861.

- This currently just outputs JSON, instead of fancier reports
- `fontmake` fails on a ton of sources, presumably because we are passing the wrong args? I think we should be using `gftools builder --generate` to generate recipes from config files or something? For instance we always pass `-o variable` to fontmake, even when we aren't building a variable font.
- but we get reasonable output for some fonts, and in that case it looks like,


```json
{
  "success": {
    "../gf_fonts/Advent/sources/AdventPro.designspace": {
      "diffs": {
        "GPOS": 1.0,
        "HVAR": 0.99195546,
        "OS_2": 0.9946581,
        "gasp": "fontmake",
        "glyf": 0.9999832,
        "gvar": 0.9998928,
        "head": 0.9967949,
        "hhea": 0.9981982
      }
    },
    "../gf_fonts/Briem-Hand/sources/BriemHand.glyphs": {
      "diffs": {
        "(mark/kern)": 0.99426824,
        "GDEF": 0.9837696,
        "GPOS": 0.9656813,
        "GSUB": 0.9259056,
        "OS_2": 0.99946666,
        "avar": 0.95606697,
        "fvar": 0.99673414,
        "glyf": 1.0,
        "gvar": 0.99999917,
        "head": 0.9984051,
        "maxp": 0.9983165,
        "name": 0.96020263
      }
    }
}
```

where the float values are a handwavey 'difference ratio' between the outputs, and if only one compiler generated a given table the value is that compiler's name. Identical tables are omitted (maybe they shouldn't be?).