### PR TITLE
[ttx_diff] Add a 'total diff' number to json output

### DIFF
--- a/resources/scripts/ttx_diff.py
+++ b/resources/scripts/ttx_diff.py
@@ -415,17 +415,29 @@ def jsonify_output(output: dict[str, dict[str, str]]):
     fontmake = output["fontmake"]
     all_tags = set(fontc.keys()) | set(fontmake.keys())
     out = dict()
+    same_lines = 0
+    different_lines = 0
     for tag in all_tags:
         if tag not in fontc:
+            different_lines += len(fontmake[tag])
             out[tag] = "fontmake"
         elif tag not in fontmake:
+            different_lines += len(fontc[tag])
             out[tag] = "fontc"
         else:
             s1 = fontc[tag]
             s2 = fontmake[tag]
             if s1 != s2:
                 ratio = diff_ratio(s1, s2)
+                n_lines = max(len(s1), len(s2))
+                same_lines += int(n_lines * ratio)
+                different_lines += int( n_lines * (1 - ratio))
                 out[tag] = ratio
+            else:
+                same_lines += len(s1)
+
+    overall_diff_ratio = same_lines / (same_lines + different_lines)
+    out["total"] = overall_diff_ratio
     return {"success": out}
 
 


### PR DESCRIPTION
This tries to quantify the total size of the difference across all tables in a font, based on the total number of lines that differ in the ttx/otl-normalizer output.

This is not hugely scientific, but will give us a single number that we can track per-font.