### PR TITLE
[fontc] Use explicit threadpool

### DIFF
--- a/fontc/src/workload.rs
+++ b/fontc/src/workload.rs
@@ -451,9 +451,13 @@ impl<'a> Workload<'a> {
             AnyContext,
             Vec<Arc<AtomicUsize>>,
         )>::with_capacity(512)));
+        // use an explicit threadpool to avoid possible congestion if another
+        // library we use is using the global threadpool
+        let tp = rayon::ThreadPoolBuilder::new()
+            .build()
+            .expect("couldn't build threadpool");
 
-        // Do NOT assign custom thread names because it makes flamegraph root each thread individually
-        rayon::in_place_scope(|scope| {
+        tp.in_place_scope(|scope| {
             // Whenever a task completes see if it was the last incomplete dependency of other task(s)
             // and spawn them if it was
             // TODO timeout and die it if takes too long to make forward progress or we're spinning w/o progress


### PR DESCRIPTION
I ran into an issue where both fontc and fontc_crater (using fontc as a dependency) were using the implicit global threadpool, and this led to a deadlock where a new compilation operation was started on each available thread, which meant there were no threads available for the actual work to be done.

Using an explicit threadpool in fontc ensures this can't happen in the future.