### PR TITLE
[glyphs] Ignore unknown glyph categories

### DIFF
--- a/glyphs-reader/src/error.rs
+++ b/glyphs-reader/src/error.rs
@@ -1,6 +1,5 @@
 use std::{io, num::TryFromIntError, path::PathBuf};
 
-use smol_str::SmolStr;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -21,6 +20,4 @@ pub enum Error {
     NotAGlyphsPackage(PathBuf),
     #[error("Invalid plist")]
     WorstPlistEver(#[from] crate::plist::Error),
-    #[error("Unknown glyph category '{category}' for glyph '{glyph}'")]
-    BadCategory { glyph: SmolStr, category: SmolStr },
 }

--- a/glyphs-reader/src/propagate_anchors.rs
+++ b/glyphs-reader/src/propagate_anchors.rs
@@ -110,7 +110,7 @@ fn anchors_traversing_components<'a>(
         return origin_adjusted_anchors(&layer.anchors).collect();
     }
 
-    let is_ligature = glyph.sub_category == Some(Subcategory::Ligature);
+    let is_ligature = glyph.sub_category == Subcategory::Ligature;
     let mut has_underscore = layer
         .anchors
         .iter()
@@ -459,7 +459,7 @@ mod tests {
                 name: name.into(),
                 export: true,
                 category: info.as_ref().map(|i| i.category),
-                sub_category: info.as_ref().map(|i| i.subcategory),
+                sub_category: info.as_ref().map(|i| i.subcategory).unwrap_or_default(),
 
                 unicode: info.and_then(|i| i.unicode).into_iter().collect(),
                 ..Default::default()
@@ -492,7 +492,7 @@ mod tests {
         }
 
         fn set_subcategory(&mut self, sub_category: Subcategory) -> &mut Self {
-            self.0.sub_category = Some(sub_category);
+            self.0.sub_category = sub_category;
             self
         }
 

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -457,7 +457,7 @@ fn category_for_glyph(glyph: &glyphs_reader::Glyph) -> Option<GlyphClassDef> {
                 .map(|a| a.is_attaching())
                 .unwrap_or(false)
         });
-    match (glyph.category, glyph.sub_category.unwrap_or_default()) {
+    match (glyph.category, glyph.sub_category) {
         (_, Subcategory::Ligature) if has_attaching_anchor => Some(GlyphClassDef::Ligature),
         (Some(Category::Mark), Subcategory::Nonspacing | Subcategory::SpacingCombining) => {
             Some(GlyphClassDef::Mark)


### PR DESCRIPTION
A number of our crater fails are the result of glyphs that have categories or subcategories that do not exist in the current version of glyphs.

With this patch, instead of erroring when we encounter these categories we will just ignore them, and fall through as we would when no explicit category was set (in which case we infer it based on unicodes and/or glyph name.)

This also changes the sub_category field on Glyph to be non-optional, since `Subcategory` has its own `None` variant, and it feels like asking for trouble if we have two different ways of indicating none-ness.