### PR TITLE
[crater] Make ttx_diff write to a tempdir

### DIFF
--- a/fontc_crater/src/ttx_diff_runner.rs
+++ b/fontc_crater/src/ttx_diff_runner.rs
@@ -5,10 +5,14 @@ use crate::RunResult;
 static SCRIPT_PATH: &str = "./resources/scripts/ttx_diff.py";
 
 pub(super) fn run_ttx_diff(source: &Path) -> RunResult<DiffOutput, DiffError> {
+    let tempdir = tempfile::tempdir().expect("couldn't create tempdir");
+    let outdir = tempdir.path();
     let output = match Command::new("python")
         .arg(SCRIPT_PATH)
         .args(["--compare", "default"])
         .arg("--json")
+        .arg("--outdir")
+        .arg(outdir)
         .arg(source)
         .output()
     {


### PR DESCRIPTION
This fixes an issue where multiple instances of ttx_diff, running in parallel, would be overwriting each other's output.