### PR TITLE
[glyphs] Improve g2 -> g3 metric conversion

### DIFF
--- a/resources/testdata/glyphs2/alignment_zones_v2.glyphs
+++ b/resources/testdata/glyphs2/alignment_zones_v2.glyphs
@@ -1,0 +1,48 @@
+{
+.appVersion = "1365";
+date = "2024-07-18 16:00:55 +0000";
+familyName = "New Font";
+fontMaster = (
+{
+alignmentZones = (
+"{1000, 20}",
+"{800, 17}",
+"{700, 16}",
+"{500, 15}",
+"{0, -16}",
+"{-100, -15}",
+"{-200, -17}"
+);
+ascender = 800;
+capHeight = 700;
+descender = -200;
+id = "CEAF8881-3B30-4737-AC29-09BAEF72AFFD";
+xHeight = 500;
+}
+);
+glyphs = (
+{
+glyphname = A;
+layers = (
+{
+layerId = "CEAF8881-3B30-4737-AC29-09BAEF72AFFD";
+width = 600;
+}
+);
+unicode = 0041;
+},
+{
+glyphname = a;
+layers = (
+{
+layerId = "CEAF8881-3B30-4737-AC29-09BAEF72AFFD";
+width = 600;
+}
+);
+unicode = 0061;
+}
+);
+unitsPerEm = 1000;
+versionMajor = 1;
+versionMinor = 0;
+}


### PR DESCRIPTION
In particular we are now more careful about associating alignment zones with the appropriate metrics.

This mostly resolves #873, with the exception that we do not correctly add additional metrics for any defined alignment zones which do not correspond to standard metrics.

This issue (in particular the removed assert) was causing us to panic on eight inputs.