### PR TITLE
[glyphs] Ignore extra axes in axis mapping

### DIFF
--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -1486,7 +1486,11 @@ fn user_to_design_from_axis_mapping(
     let mut axis_mappings: BTreeMap<String, RawAxisUserToDesignMap> = BTreeMap::new();
     for mapping in mappings {
         let Some(axis_index) = axis_index(from, |a| a.tag == mapping.tag) else {
-            panic!("No such axes: {:?}", mapping.tag);
+            log::warn!(
+                "axis mapping includes tag {:?} not included in font",
+                mapping.tag
+            );
+            continue;
         };
         let axis_name = &from.axes.get(axis_index).unwrap().name;
         for (user, design) in mapping.user_to_design.iter() {


### PR DESCRIPTION
This exists in one of our test fonts, and doesn't seem like it should be fatal (fontmake does the iteration in the other direction and doesn't hit this)

