### PR TITLE
[glyphs] Remove Error::SomethingWentWrong

### DIFF
--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -505,7 +505,11 @@ impl FromPlist for CustomParameters {
                         tokenizer.eat(b';')?;
                         break;
                     }
-                    _ => return Err(Error::SomethingWentWrong),
+                    other => {
+                        return Err(Error::Parse(format!(
+                            "unexpected key '{other}' in CustomParams"
+                        )))
+                    }
                 }
             }
 
@@ -1056,8 +1060,8 @@ fn parse_node_from_tokenizer(tokenizer: &mut Tokenizer<'_>) -> Result<Node, crat
     let y: f64 = tokenizer.parse()?;
     tokenizer.eat(b',')?;
     let node_type: String = tokenizer.parse()?;
-    let node_type =
-        NodeType::from_str(&node_type).map_err(|_| crate::plist::Error::SomethingWentWrong)?;
+    let node_type = NodeType::from_str(&node_type)
+        .map_err(|_| crate::plist::Error::Parse(format!("unknown node type '{node_type}'")))?;
 
     // Sometimes there is userData; ignore it
     if tokenizer.eat(b',').is_ok() {

--- a/glyphs-reader/src/plist.rs
+++ b/glyphs-reader/src/plist.rs
@@ -58,9 +58,10 @@ pub enum Error {
         expected: &'static str,
         found: &'static str,
     },
-
-    #[error("Oops, this parser is just broken")]
-    SomethingWentWrong,
+    #[error("Unexpected token '{name}'")]
+    UnexpectedToken { name: &'static str },
+    #[error("parsing failed: '{0}'")]
+    Parse(String),
 }
 
 #[derive(Debug)]
@@ -295,7 +296,7 @@ impl Plist {
                     }
                 }
             }
-            _ => Err(Error::SomethingWentWrong),
+            _ => Err(Error::UnexpectedToken { name: tok.name() }),
         }
     }
 
@@ -637,7 +638,7 @@ impl<'a> Tokenizer<'a> {
                     self.eat(b',')?;
                 }
             }
-            _ => Err(Error::SomethingWentWrong),
+            other => Err(Error::UnexpectedToken { name: other.name() }),
         }
     }
 
@@ -773,7 +774,7 @@ impl FromPlist for Point {
         };
         let coords: Vec<f64> = tokenizer.parse_delimited_vec(delims)?;
         if coords.len() != 2 {
-            return Err(Error::SomethingWentWrong);
+            return Err(Error::Parse("wrong number of coords in point".to_string()));
         }
         Ok((coords[0], coords[1]).into())
     }


### PR DESCRIPTION
And replace it with two new variants which try to capture more context. This will hopefully make it easier to debug glyphs parsing failures.