### PR TITLE
[ttx_diff] replace difflib with cdifflib

### DIFF
--- a/resources/scripts/requirements.txt
+++ b/resources/scripts/requirements.txt
@@ -6,3 +6,4 @@ fontmake[repacker]==3.8.1
 # our scripts import it directly, so we list it among the top-level requirements.
 fonttools
 lxml
+cdifflib

--- a/resources/scripts/ttx_diff.py
+++ b/resources/scripts/ttx_diff.py
@@ -42,7 +42,7 @@ import json
 import shutil
 import subprocess
 import sys
-from difflib import SequenceMatcher
+from cdifflib import CSequenceMatcher as SequenceMatcher
 from typing import MutableSequence
 
 


### PR DESCRIPTION
difflib is not very efficient, and this has a significant impact on runtime; for `NotoSansMono` I go from 18m of wall time to 13m16s.