### PR TITLE
[fea-rs] Add CompilerError::display_verbose

### DIFF
--- a/fea-rs/src/bin/compile.rs
+++ b/fea-rs/src/bin/compile.rs
@@ -6,7 +6,7 @@ use clap::Parser;
 use fea_rs::{
     compile::{
         self,
-        error::{FontGlyphOrderError, GlyphOrderError, UfoGlyphOrderError},
+        error::{CompilerError, FontGlyphOrderError, GlyphOrderError, UfoGlyphOrderError},
         Compiler, MockVariationInfo, NopFeatureProvider, Opts,
     },
     GlyphMap,
@@ -80,8 +80,8 @@ enum Error {
     MissingGlyphOrder,
     #[error("Error parsing axis info: L{line}, '{message}'")]
     BadAxisInfo { line: usize, message: String },
-    #[error("{0}")]
-    CompileFail(#[from] compile::error::CompilerError),
+    #[error("{}", .0.display_verbose())]
+    CompileFail(#[from] CompilerError),
 }
 
 /// Compile FEA files


### PR DESCRIPTION
fea-rs collects extensive diagnostic information during parsing and compilation, and is able to report errors associated to specific locations in the input FEA. This wasn't very fine-grained, though, and was causing problems with crater (because sometimes the stderr text for a given error would be extremely long, and include a bunch of ANSI escape codes) and so I turned off this finer-grained reporting.

It would be nice to have it available as an option, though, especially now that I'm trying to add support for new syntax, and would like to see what the actual errors are.

This adds a new method to the CompilerError that will print the error in the old verbose style, and makes it so that when you call the fea-rs binary directly (which is really not useful for debugging) it uses this method when printing the returned error.