### PR TITLE
[propagate_anchors] do not sort anchors by name in test

### DIFF
--- a/glyphs-reader/src/propagate_anchors.rs
+++ b/glyphs-reader/src/propagate_anchors.rs
@@ -919,11 +919,8 @@ mod tests {
         for (g1, g2) in expected.glyphs.values().zip(font.glyphs.values()) {
             assert_eq!(g1.layers.len(), g2.layers.len());
             for (l1, l2) in g1.layers.iter().zip(g2.layers.iter()) {
-                // our anchors end up in a slightly different order, which shouldn't matter?
-                let mut a1 = l1.anchors.clone();
-                let mut a2 = l2.anchors.clone();
-                a1.sort_by_key(|a| a.name.clone());
-                a2.sort_by_key(|a| a.name.clone());
+                let a1 = l1.anchors.clone();
+                let a2 = l2.anchors.clone();
                 assert_eq!(a1, a2, "{}", g1.name);
             }
         }

--- a/resources/testdata/glyphs3/PropagateAnchorsTest-propagated.glyphs
+++ b/resources/testdata/glyphs3/PropagateAnchorsTest-propagated.glyphs
@@ -1337,6 +1337,14 @@ name = bottom_1;
 pos = (262,7);
 },
 {
+name = ogonek_1;
+pos = (422,9);
+},
+{
+name = top_1;
+pos = (266,548);
+},
+{
 name = bottom_2;
 pos = (718,8);
 },
@@ -1345,20 +1353,12 @@ name = bottom_3;
 pos = (1242,7);
 },
 {
-name = ogonek_1;
-pos = (422,9);
-},
-{
 name = ogonek_2;
 pos = (898,9);
 },
 {
 name = ogonek_3;
 pos = (1402,9);
-},
-{
-name = top_1;
-pos = (266,548);
 },
 {
 name = top_2;
@@ -1388,6 +1388,14 @@ name = bottom_1;
 pos = (294,5);
 },
 {
+name = ogonek_1;
+pos = (463,13);
+},
+{
+name = top_1;
+pos = (287,559);
+},
+{
 name = bottom_2;
 pos = (831,0);
 },
@@ -1396,20 +1404,12 @@ name = bottom_3;
 pos = (1384,5);
 },
 {
-name = ogonek_1;
-pos = (463,13);
-},
-{
 name = ogonek_2;
 pos = (1019,13);
 },
 {
 name = ogonek_3;
 pos = (1553,13);
-},
-{
-name = top_1;
-pos = (287,559);
 },
 {
 name = top_2;
@@ -1630,20 +1630,20 @@ name = bottom_1;
 pos = (262,7);
 },
 {
-name = bottom_2;
-pos = (767,-247);
-},
-{
 name = ogonek_1;
 pos = (422,9);
 },
 {
-name = ogonek_2;
-pos = (922,9);
-},
-{
 name = top_1;
 pos = (286,760);
+},
+{
+name = bottom_2;
+pos = (767,-247);
+},
+{
+name = ogonek_2;
+pos = (922,9);
 },
 {
 name = top_2;
@@ -1669,20 +1669,20 @@ name = bottom_1;
 pos = (294,5);
 },
 {
-name = bottom_2;
-pos = (849,-253);
-},
-{
 name = ogonek_1;
 pos = (463,13);
 },
 {
-name = ogonek_2;
-pos = (1013,13);
-},
-{
 name = top_1;
 pos = (290,771);
+},
+{
+name = bottom_2;
+pos = (849,-253);
+},
+{
+name = ogonek_2;
+pos = (1013,13);
 },
 {
 name = top_2;
@@ -2492,11 +2492,11 @@ name = _top;
 pos = (323,554);
 },
 {
-name = exit;
-},
-{
 name = top;
 pos = (323,554);
+},
+{
+name = exit;
 }
 );
 layerId = m01;
@@ -2518,11 +2518,11 @@ name = _top;
 pos = (323,554);
 },
 {
-name = exit;
-},
-{
 name = top;
 pos = (323,554);
+},
+{
+name = exit;
 }
 );
 layerId = "D3EE0982-E416-4D68-847E-1544F56AC980";


### PR DESCRIPTION
this is unnecessary, the order we generate is not random, we use IndexMap and we append in the order in which components appear in the composite glyph, therefore it's better to keep the resulting ordering of propagated anchors (and adjust the test file accordingly) instead of artificially sorting the anchors by name in the test code only, just to make the test pass. In Python glyphsLib we use (ordered) dicts that remember insertion order so we will generate identical propagated anchors as well. The order of anchors is not semantically meaningful anyway, so this is a minor cosmetic change only.