### PR TITLE
[fea-rs] Allow unescaped 'NULL' keyword as glyph name

### DIFF
--- a/fea-rs/src/parse/grammar/glyph.rs
+++ b/fea-rs/src/parse/grammar/glyph.rs
@@ -134,6 +134,12 @@ pub(crate) fn eat_glyph_name_like(parser: &mut Parser) -> bool {
     if parser.matches(0, TokenSet::IDENT_LIKE) {
         eat_and_validate_glyph_name(parser);
         true
+    } else if parser.matches(0, Kind::NullKw) {
+        // this is not technically allowed but is common in noto fonts
+        // and accepted by feaLib so we will accept it as well
+        parser.warn(" when used as glyph name 'NULL' should be escaped ('\\NULL')");
+        parser.eat_remap(Kind::NullKw, AstKind::GlyphName);
+        true
     } else {
         parser.eat(Kind::Cid)
     }

--- a/fea-rs/test-data/parse-tests/good/null_as_glyphname.PARSE_TREE
+++ b/fea-rs/test-data/parse-tests/good/null_as_glyphname.PARSE_TREE
@@ -1,0 +1,18 @@
+FILE@[0; 91)
+  #@0 "# per the spec NULL should be \'\\NULL\' but we\'ve decided to accept this"
+  WS@70 "\n"
+    GlyphClassDefNode@[71; 90)
+      @GlyphClass@71 "@name"
+      WS@76 " "
+      =@77 "="
+      WS@78 " "
+        GlyphClass@[79; 89)
+          [@79 "["
+          GlyphName@80 "A"
+          WS@81 " "
+          GlyphName@82 "b"
+          WS@83 " "
+          GlyphName@84 "NULL"
+          ]@88 "]"
+      ;@89 ";"
+  WS@90 "\n"

--- a/fea-rs/test-data/parse-tests/good/null_as_glyphname.fea
+++ b/fea-rs/test-data/parse-tests/good/null_as_glyphname.fea
@@ -1,0 +1,2 @@
+# per the spec NULL should be '\NULL' but we've decided to accept this
+@name = [A b NULL];


### PR DESCRIPTION
The spec is explicit that if a keyword is used as a glyphname than it needs to be escaped with '\', but feaLib does not enforce this and a bunch of noto fonts use 'NULL' (unescaped) as a glyph name.

Making this work is pretty trivial, and this gets us compiling a bunch of (12) additional sources, so I'm happy to compromise principles for expediency.