### PR TITLE
[fontc] Add verbose flag, print FEA errors if set

### DIFF
--- a/fontc/src/args.rs
+++ b/fontc/src/args.rs
@@ -89,6 +89,10 @@ pub struct Args {
     // cargo profile, and cargo optimization level.
     #[arg(long = "vv", default_value = "false")]
     pub verbose_version: bool,
+
+    /// Print additional information about errors, if possible.
+    #[arg(long, short)]
+    pub verbose: bool,
 }
 
 /// A wrapper around a validated regex string
@@ -136,6 +140,7 @@ impl Args {
             keep_direction: false,
             no_production_names: false,
             verbose_version: false,
+            verbose: false,
         }
     }
 


### PR DESCRIPTION
Previously we were always printing the full error info for FEA errors but that's very verbose and was annoying for the crater stuff, so I had turned it off for a bit. This gives control back to the user, who can pass `-v` at the command line to see the old-style error report.

- fixes #900 

