### PR TITLE
Generate LigCaretList table

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,8 @@ rayon = "1.6"
 icu_properties = "1.4"
 
 # fontations etc
-write-fonts = { version = "0.28.1", features = ["serde", "read"] }
-skrifa = "0.20.0"
+write-fonts = { version = "0.29.0", features = ["serde", "read"] }
+skrifa = "0.21.0"
 norad = "0.12"
 
 # dev dependencies

--- a/fea-rs/src/compile.rs
+++ b/fea-rs/src/compile.rs
@@ -19,7 +19,7 @@ pub use lookups::{
     Builder, CursivePosBuilder, FeatureKey, LookupId, MarkToBaseBuilder, MarkToLigBuilder,
     MarkToMarkBuilder, PairPosBuilder, PreviouslyAssignedClass,
 };
-pub use metrics::{Anchor, ValueRecord};
+pub use metrics::{Anchor, CaretValue, ValueRecord};
 pub use opts::Opts;
 pub use output::Compilation;
 pub use variations::{AxisLocation, NopVariationInfo, VariationInfo};

--- a/fea-rs/src/compile/feature_writer.rs
+++ b/fea-rs/src/compile/feature_writer.rs
@@ -2,7 +2,10 @@
 
 use std::collections::{BTreeMap, HashMap};
 
-use write_fonts::{tables::layout::LookupFlag, types::Tag};
+use write_fonts::{
+    tables::layout::LookupFlag,
+    types::{GlyphId16, Tag},
+};
 
 use crate::GlyphSet;
 
@@ -11,6 +14,7 @@ use super::{
     language_system::{DefaultLanguageSystems, LanguageSystem},
     lookups::{FeatureKey, FilterSetId, LookupBuilder, LookupId, PositionLookup},
     tables::{GdefBuilder, Tables},
+    CaretValue,
 };
 
 /// A trait that can be implemented by the client to do custom feature writing.
@@ -32,6 +36,7 @@ pub struct FeatureBuilder<'a> {
     pub(crate) tables: &'a mut Tables,
     pub(crate) lookups: Vec<(LookupId, PositionLookup)>,
     pub(crate) features: BTreeMap<FeatureKey, FeatureLookups>,
+    pub(crate) lig_carets: BTreeMap<GlyphId16, Vec<CaretValue>>,
     mark_filter_sets: &'a mut HashMap<GlyphSet, FilterSetId>,
 }
 
@@ -95,6 +100,7 @@ impl<'a> FeatureBuilder<'a> {
             lookups: Default::default(),
             features: Default::default(),
             mark_filter_sets,
+            lig_carets: Default::default(),
         }
     }
 
@@ -106,6 +112,11 @@ impl<'a> FeatureBuilder<'a> {
     /// If the FEA text contained an explicit GDEF table block, return its contents
     pub fn gdef(&self) -> Option<&GdefBuilder> {
         self.tables.gdef.as_ref()
+    }
+
+    /// Add caret positions for the GDEF `LigCaretList` table
+    pub fn add_lig_carets(&mut self, lig_carets: BTreeMap<GlyphId16, Vec<CaretValue>>) {
+        self.lig_carets = lig_carets;
     }
 
     /// Add a lookup to the lookup list.

--- a/fea-rs/src/compile/tables/gdef.rs
+++ b/fea-rs/src/compile/tables/gdef.rs
@@ -18,6 +18,7 @@ use write_fonts::tables::{
         LigGlyph, MarkGlyphSets,
     },
     layout::{ClassDef, ClassDefBuilder, CoverageTableBuilder},
+    variations::ivs_builder::RemapVariationIndices,
 };
 
 use super::{VariationIndexRemapping, VariationStoreBuilder};
@@ -58,9 +59,10 @@ impl GdefBuilder {
 
         table.mark_glyph_sets_def = self.build_mark_glyph_sets().into();
         // only use the var_store if we had one set at the start of this fn
-        let var_store = Some(var_store).filter(|_| self.var_store.is_some());
-        if let Some((var_store, key_map)) = var_store.map(VariationStoreBuilder::build) {
+        if self.var_store.is_some() {
+            let (var_store, key_map) = var_store.build();
             table.item_var_store.set(var_store);
+            table.remap_variation_indices(&key_map);
             (table, Some(key_map))
         } else {
             (table, None)

--- a/fea-rs/src/compile/tables/gdef.rs
+++ b/fea-rs/src/compile/tables/gdef.rs
@@ -14,13 +14,15 @@ use write_fonts::types::GlyphId16;
 use write_fonts::tables::{
     self,
     gdef::{
-        AttachList, AttachPoint, CaretValue, GlyphClassDef, LigCaretList, LigGlyph, MarkGlyphSets,
+        AttachList, AttachPoint, CaretValue as RawCaretValue, GlyphClassDef, LigCaretList,
+        LigGlyph, MarkGlyphSets,
     },
     layout::{ClassDef, ClassDefBuilder, CoverageTableBuilder},
 };
 
 use super::{VariationIndexRemapping, VariationStoreBuilder};
 use crate::common::{GlyphClass, GlyphSet};
+use crate::compile::metrics::CaretValue;
 
 /// Data collected from a GDEF block.
 #[derive(Clone, Debug, Default)]
@@ -40,16 +42,24 @@ pub struct GdefBuilder {
 
 impl GdefBuilder {
     pub fn build(&self) -> (tables::gdef::Gdef, Option<VariationIndexRemapping>) {
+        let mut var_store = self
+            .var_store
+            .clone()
+            // we need to always have a varstore builder in order to build the lig_caret
+            // table, but if we did not have one by now we aren't a variable font, so
+            // we will throw it away after.
+            .unwrap_or_else(|| VariationStoreBuilder::new(0));
         let mut table = tables::gdef::Gdef::new(
             self.build_class_def(),
             self.build_attach_list(),
-            self.build_lig_caret_list(),
+            self.build_lig_caret_list(&mut var_store),
             self.build_mark_attach_class_def(),
         );
 
         table.mark_glyph_sets_def = self.build_mark_glyph_sets().into();
-        if let Some((var_store, key_map)) = self.var_store.clone().map(VariationStoreBuilder::build)
-        {
+        // only use the var_store if we had one set at the start of this fn
+        let var_store = Some(var_store).filter(|_| self.var_store.is_some());
+        if let Some((var_store, key_map)) = var_store.map(VariationStoreBuilder::build) {
             table.item_var_store.set(var_store);
             (table, Some(key_map))
         } else {
@@ -77,12 +87,25 @@ impl GdefBuilder {
         (!attach_points.is_empty()).then(|| AttachList::new(coverage.build(), attach_points))
     }
 
-    fn build_lig_caret_list(&self) -> Option<LigCaretList> {
+    fn build_lig_caret_list(&self, var_store: &mut VariationStoreBuilder) -> Option<LigCaretList> {
         let mut coverage = CoverageTableBuilder::default();
         let mut lig_glyphs = Vec::new();
         for (glyph, carets) in &self.ligature_pos {
             coverage.add(*glyph);
-            lig_glyphs.push(LigGlyph::new(carets.clone()));
+            let mut carets = carets
+                .iter()
+                .map(|caret| caret.clone().build(var_store))
+                .collect::<Vec<_>>();
+            // TODO: I feel like we shouldn't be sorting these values if they are
+            // point indices? Opened https://github.com/fonttools/fonttools/issues/3608 for
+            // discussion
+            carets.sort_by_key(|c| match c {
+                RawCaretValue::Format1(table) => table.coordinate as i32,
+                RawCaretValue::Format2(table) => table.caret_value_point_index as i32,
+                RawCaretValue::Format3(table) => table.coordinate as i32,
+            });
+
+            lig_glyphs.push(LigGlyph::new(carets));
         }
         (!lig_glyphs.is_empty()).then(|| LigCaretList::new(coverage.build(), lig_glyphs))
     }

--- a/fontbe/src/orchestration.rs
+++ b/fontbe/src/orchestration.rs
@@ -11,8 +11,8 @@ use std::{
 
 use fea_rs::{
     compile::{
-        CursivePosBuilder, FeatureKey, MarkToBaseBuilder, MarkToLigBuilder, MarkToMarkBuilder,
-        PairPosBuilder, PendingLookup, ValueRecord as ValueRecordBuilder,
+        CaretValue, CursivePosBuilder, FeatureKey, MarkToBaseBuilder, MarkToLigBuilder,
+        MarkToMarkBuilder, PairPosBuilder, PendingLookup, ValueRecord as ValueRecordBuilder,
     },
     GlyphMap, GlyphSet, ParseTree,
 };
@@ -334,6 +334,7 @@ pub struct FeaRsMarks {
     pub(crate) mark_mark: Vec<PendingLookup<MarkToMarkBuilder>>,
     pub(crate) mark_lig: Vec<PendingLookup<MarkToLigBuilder>>,
     pub(crate) curs: Vec<PendingLookup<CursivePosBuilder>>,
+    pub(crate) lig_carets: BTreeMap<GlyphId16, Vec<CaretValue>>,
 }
 
 impl Persistable for FeaRsMarks {


### PR DESCRIPTION
~*This is currently patching fontations to bring in https://github.com/googlefonts/fontations/pull/1090, I'll do a release when that gets merged*~

This patch generates a `LigCaretList` entry for any glyphs which include an anchor name beginning with `caret_` or `vcaret_`.

- currently this happens during mark generation, which is convenient since we have access to all the anchors there.
- this matches the `LigCaretList` produced by `fontmake` for oswald.
- closes #809