### PR TITLE
propagate_anchors: test no log warnings when there are no cycles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ more-asserts = "0.3.1"
 pretty_assertions = "1.3.0"
 temp-env = "0.3.3"
 rstest = "0.18.2"
+testing_logger = "0.1.1"
 
 [workspace]
 resolver = "2"

--- a/glyphs-reader/Cargo.toml
+++ b/glyphs-reader/Cargo.toml
@@ -34,6 +34,7 @@ bincode.workspace = true
 
 [dev-dependencies]
 pretty_assertions.workspace = true
+testing_logger.workspace = true
 
 [build-dependencies]
 quick-xml = "0.31"


### PR DESCRIPTION
the 'no_cycles_hence_no_warnings' test below is currently failing because the glyph 'B' is wrongly reported as having a cycle, which is not the case.

I think the logic in #907 isn't making sure that all the children are processed before their parents. 
It initially populates the queue by iterating over the glyphs; this is a BTreeMap so it's sorted alphabetically by glyph name.
In my failing test case below I used names like "A", "B", "C", etc. to control the order in which glyphs gets processed.
The test fails because it incorrectly issues a warning "glyph 'B' has cyclical components", but that's not true. Glyph "B" has no cyles, it just happens to be encountered before some of its components ("D" comes later) so it's pushed to waiting_for_components set; then "D" is also pushed at the back of the queue as it's waiting on "E"; then "E" is eventually processed, but then "B" is now the first in the queue, but it's still waiting on "D"... so a cycle is wrongly detected.

In https://github.com/googlefonts/glyphsLib/pull/1023, I do a depth-first traversal of each component tree and calculate the depth only while backtracking.

I think that's more correct.