### PR TITLE
[crater] Add basic 'detail view' for previous run

### DIFF
--- a/fontc_crater/resources/style.css
+++ b/fontc_crater/resources/style.css
@@ -57,3 +57,8 @@ thead th:nth-child(7) {
   padding-bottom: 10px;
   color: #888;
 }
+
+.diff_group_item .font_path {
+  float: left;
+  width: 50%;
+}

--- a/fontc_crater/src/main.rs
+++ b/fontc_crater/src/main.rs
@@ -157,10 +157,10 @@ fn prune_sources<T: Clone>(sources: &[T], n_items: usize) -> Vec<T> {
 /// Results of all runs
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 struct Results<T, E> {
-    success: BTreeMap<PathBuf, T>,
-    failure: BTreeMap<PathBuf, E>,
-    panic: BTreeSet<PathBuf>,
-    skipped: BTreeMap<PathBuf, SkipReason>,
+    pub(crate) success: BTreeMap<PathBuf, T>,
+    pub(crate) failure: BTreeMap<PathBuf, E>,
+    pub(crate) panic: BTreeSet<PathBuf>,
+    pub(crate) skipped: BTreeMap<PathBuf, SkipReason>,
 }
 
 /// The output of trying to run on one font.
@@ -205,6 +205,10 @@ fn run_all<T: Send, E: Send>(
             let i = counter.fetch_add(1, Ordering::Relaxed);
             eprintln!("running {} ({i}/{total_targets})", target.display());
             let r = runner(&target);
+            let target = target
+                .strip_prefix(cache_dir)
+                .unwrap_or(target.as_path())
+                .to_path_buf();
             (target, r)
         })
         .collect::<Vec<_>>();

--- a/fontc_crater/src/ttx_diff_runner.rs
+++ b/fontc_crater/src/ttx_diff_runner.rs
@@ -302,9 +302,9 @@ pub(crate) enum DiffError {
 #[serde(rename_all = "snake_case")]
 pub(crate) struct CompileFailed {
     #[serde(skip_serializing_if = "Option::is_none")]
-    fontc: Option<CompilerFailure>,
+    pub(crate) fontc: Option<CompilerFailure>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    fontmake: Option<CompilerFailure>,
+    pub(crate) fontmake: Option<CompilerFailure>,
 }
 
 /// Info regarding the failure of a single compiler
@@ -320,6 +320,15 @@ pub(crate) struct CompilerFailure {
 pub(super) enum DiffValue {
     Ratio(f32),
     Only(String),
+}
+
+impl DiffValue {
+    pub(crate) fn ratio(&self) -> Option<f32> {
+        match self {
+            DiffValue::Ratio(r) => Some(*r),
+            DiffValue::Only(_) => None,
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This now renders a very basic summary of changes and results for the last run after the overall summary table.

In the future I would like to make it so this is hidden by default and can be displayed as desired for the last N runs, but this first pass is a useful start.

In addition I would like to add another level of detail for individual runs (showing the command that failed and the backtrace) but that can be followup.

you can preview the new look at https://googlefonts.github.io/fontc_crater/