### PR TITLE
[fea-rs] Match fontmake for class-based pairpos

### DIFF
--- a/fea-rs/test-data/compile-tests/mini-latin/good/pairpos_format_choice.fea
+++ b/fea-rs/test-data/compile-tests/mini-latin/good/pairpos_format_choice.fea
@@ -1,0 +1,9 @@
+feature test {
+    @kern1.a = [a];
+    @kern1.c = [c];
+    @kern2.f = [f];
+
+    pos @kern1.a @kern2.f -20;
+    # this should force the earlier rule to use this value format
+    pos @kern1.c @kern2.f <-11 0 5 0>;
+} test;

--- a/fea-rs/test-data/compile-tests/mini-latin/good/pairpos_format_choice.ttx
+++ b/fea-rs/test-data/compile-tests/mini-latin/good/pairpos_format_choice.ttx
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont>
+
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=1 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="test"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=1 -->
+      <Lookup index="0">
+        <LookupType value="2"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <PairPos index="0" Format="2">
+          <Coverage>
+            <Glyph value="a"/>
+            <Glyph value="c"/>
+          </Coverage>
+          <ValueFormat1 value="5"/>
+          <ValueFormat2 value="0"/>
+          <ClassDef1>
+            <ClassDef glyph="c" class="1"/>
+          </ClassDef1>
+          <ClassDef2>
+            <ClassDef glyph="f" class="1"/>
+          </ClassDef2>
+          <!-- Class1Count=2 -->
+          <!-- Class2Count=2 -->
+          <Class1Record index="0">
+            <Class2Record index="0">
+              <Value1 XPlacement="0" XAdvance="0"/>
+            </Class2Record>
+            <Class2Record index="1">
+              <Value1 XPlacement="0" XAdvance="-20"/>
+            </Class2Record>
+          </Class1Record>
+          <Class1Record index="1">
+            <Class2Record index="0">
+              <Value1 XPlacement="0" XAdvance="0"/>
+            </Class2Record>
+            <Class2Record index="1">
+              <Value1 XPlacement="-11" XAdvance="5"/>
+            </Class2Record>
+          </Class1Record>
+        </PairPos>
+      </Lookup>
+    </LookupList>
+  </GPOS>
+
+</ttFont>


### PR DESCRIPTION
In particular this means that we will not try to be smart about grouping rules into subtables based on their actual value formats; we will instead minimize the number of subtables by choosing the union of the value formats for each rule.