### PR TITLE
[crater] Add detail view for particular fonts

### DIFF
--- a/fontc_crater/resources/style.css
+++ b/fontc_crater/resources/style.css
@@ -3,7 +3,7 @@ body {
   font-family: sans-serif;
 }
 
-table {
+#results {
   table-layout: fixed;
   width: 100%;
   border-collapse: collapse;
@@ -14,7 +14,7 @@ tbody td, th {
   text-align: left;
 }
 
-th {
+#results_head .th {
   padding: 5px 5px;
   border-bottom: 1px solid #bbb;
 }
@@ -37,19 +37,19 @@ td.rev {
   font-family: monospace;
 }
 
-thead th:nth-child(1) {
+#results_head th:nth-child(1) {
   width: 17%
 }
 
-thead th:nth-child(4) {
+#results_head th:nth-child(4) {
   width: 8%
 }
 
-thead th:nth-child(5) {
+#results_head th:nth-child(5) {
   width: 9%
 }
 
-thead th:nth-child(7) {
+#results_head th:nth-child(7) {
   width: 9%
 }
 
@@ -58,7 +58,21 @@ thead th:nth-child(7) {
   color: #888;
 }
 
-.diff_group_item .font_path {
-  float: left;
+.backtrace {
+  padding: 10px 20px;
+  border: 1px dashed #ccc;
+  font-family: monospace;
+}
+
+.font_path .diff_result {
+  display: inline-block;
+}
+
+.font_path {
   width: 50%;
+  display: inline-block;
+}
+
+.diff_info {
+  padding: 10px 20px;
 }

--- a/fontc_crater/src/ttx_diff_runner.rs
+++ b/fontc_crater/src/ttx_diff_runner.rs
@@ -311,8 +311,8 @@ pub(crate) struct CompileFailed {
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
 pub(crate) struct CompilerFailure {
-    command: String,
-    stderr: String,
+    pub(crate) command: String,
+    pub(crate) stderr: String,
 }
 
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
@@ -327,6 +327,18 @@ impl DiffValue {
         match self {
             DiffValue::Ratio(r) => Some(*r),
             DiffValue::Only(_) => None,
+        }
+    }
+}
+
+impl std::fmt::Display for DiffValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            DiffValue::Ratio(ratio) => {
+                let perc = ratio * 100.;
+                write!(f, "{perc:.3}%")
+            }
+            DiffValue::Only(compiler) => write!(f, "{compiler} only"),
         }
     }
 }


### PR DESCRIPTION
This will show what tables are producing a diff, or the text of an error for an error.

you can see how this looks at https://googlefonts.github.io/fontc_crater/ (it's not pretty! but it at least presents the relevant info)