### PR TITLE
ttx_diff.py: fix lmxl FutureWarning when doing `if not element:`

### DIFF
--- a/resources/scripts/ttx_diff.py
+++ b/resources/scripts/ttx_diff.py
@@ -351,7 +351,7 @@ def allow_some_off_by_ones(
 # fontc always has them in sorted order but fontmake doesn't, so sort them
 def sort_fontmake_feature_lookups(ttx):
     gpos = ttx.find("GPOS")
-    if not gpos:
+    if gpos is None:
         return
     features = gpos.xpath("//Feature")
 


### PR DESCRIPTION
lxml throws the following warning message when running ttx_diff script at line 354

```
    FutureWarning: The behavior of this method will change in future versions.
        Use specific 'len(elem)' or 'elem is not None' test instead.
```

So let's be explicit