### PR TITLE
[fontbe] Match fonttools behaviour for LigCaret rounding

### DIFF
--- a/fea-rs/src/compile/tables/gdef.rs
+++ b/fea-rs/src/compile/tables/gdef.rs
@@ -58,8 +58,7 @@ impl GdefBuilder {
         );
 
         table.mark_glyph_sets_def = self.build_mark_glyph_sets().into();
-        // only use the var_store if we had one set at the start of this fn
-        if self.var_store.is_some() {
+        if !var_store.is_empty() {
             let (var_store, key_map) = var_store.build();
             table.item_var_store.set(var_store);
             table.remap_variation_indices(&key_map);


### PR DESCRIPTION
When generating variable FEA the various Feature Writers use otround, since variable FEA syntax does not support floats.

This is not an issue with kerning, since glyphsapp does not allow for non-integer kerning values, but it is an issue for LigatureCarets and potentially for other variable mark positions (this needs more investigation)

- closes #810