### PR TITLE
[crater] Show per-table deltas in diff detail view

### DIFF
--- a/fontc_crater/src/ttx_diff_runner.rs
+++ b/fontc_crater/src/ttx_diff_runner.rs
@@ -334,6 +334,19 @@ impl DiffValue {
     }
 }
 
+impl DiffOutput {
+    pub(crate) fn iter_tables(&self) -> impl Iterator<Item = &str> + '_ {
+        let opt_map = match self {
+            DiffOutput::Identical => None,
+            DiffOutput::Diffs(diffs) => Some(diffs),
+        };
+
+        opt_map
+            .into_iter()
+            .flat_map(|diffs| diffs.keys().map(String::as_str))
+    }
+}
+
 impl std::fmt::Display for DiffValue {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {


### PR DESCRIPTION
That is, in the detail view where it shows the per-table diff percentages for a given font, if there have been any changes from the previous run display the delta at the per-table level, so we can better understand what changed.

You can see how this looks at https://googlefonts.github.io/fontc_crater/