### PR TITLE
Fix the NameBuilder family/subfamily fallback logic 

### DIFF
--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -270,7 +270,7 @@ impl Source for GlyphsIrSource {
 fn try_name_id(name: &str) -> Option<NameId> {
     match name {
         "copyrights" => Some(NameId::COPYRIGHT_NOTICE),
-        "familyNames" => Some(NameId::FAMILY_NAME),
+        "familyNames" => Some(NameId::TYPOGRAPHIC_FAMILY_NAME),
         "uniqueID" => Some(NameId::UNIQUE_ID),
         "postscriptFullName" => Some(NameId::FULL_NAME),
         "version" => Some(NameId::VERSION_STRING),
@@ -301,6 +301,10 @@ fn names(font: &Font) -> HashMap<NameKey, String> {
             builder.add(name_id, value.clone());
         }
     }
+    builder.add(
+        NameId::TYPOGRAPHIC_SUBFAMILY_NAME,
+        font.default_master().name.clone(),
+    );
     let vendor = font
         .vendor_id()
         .map(|v| v.as_str())

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -1457,7 +1457,7 @@ mod tests {
                 ),
                 (
                     NameKey::new_bmp_only(NameId::SUBFAMILY_NAME),
-                    String::from("Regular")
+                    String::from("Bold")
                 ),
                 (
                     NameKey::new_bmp_only(NameId::UNIQUE_ID),

--- a/resources/testdata/glyphs3/TheBestNames.glyphs
+++ b/resources/testdata/glyphs3/TheBestNames.glyphs
@@ -11,6 +11,12 @@ name = Weight;
 tag = wght;
 }
 );
+customParameters = (
+{
+name = "Variable Font Origin";
+value = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+}
+);
 date = "2022-12-01 04:52:20 +0000";
 familyName = FamilyName;
 fontMaster = (

--- a/resources/testdata/glyphs3/VersionMajorMinor.glyphs
+++ b/resources/testdata/glyphs3/VersionMajorMinor.glyphs
@@ -4,10 +4,19 @@ familyName = "Meh";
 glyphs = (
 	{
 		glyphname = meh;
-		layers = ();
+		layers = (
+			{
+				layerId = m01;
+			}
+		);
 	}
 );
-fontMaster = ();
+fontMaster = (
+	{
+		id = m01;
+		name = Regular;
+	}
+);
 unitsPerEm = 1000;
 versionMajor = 42;
 versionMinor = 43;

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -734,14 +734,7 @@ fn names(font_info: &norad::FontInfo) -> HashMap<NameKey, String> {
 
     // Name's that get individual fields
     builder.add_if_present(NameId::COPYRIGHT_NOTICE, &font_info.copyright);
-    builder.add_if_present(
-        NameId::FAMILY_NAME,
-        &font_info
-            .style_map_family_name
-            .as_ref()
-            .or(font_info.family_name.as_ref())
-            .cloned(),
-    );
+    builder.add_if_present(NameId::FAMILY_NAME, &font_info.style_map_family_name);
     builder.add_if_present(
         NameId::SUBFAMILY_NAME,
         &font_info.style_map_style_name.as_ref().map(|s| {
@@ -756,10 +749,6 @@ fn names(font_info: &norad::FontInfo) -> HashMap<NameKey, String> {
     );
     builder.add_if_present(NameId::UNIQUE_ID, &font_info.open_type_name_unique_id);
     builder.add_if_present(NameId::VERSION_STRING, &font_info.open_type_name_version);
-    builder.add_if_present(
-        NameId::TYPOGRAPHIC_FAMILY_NAME,
-        &font_info.open_type_name_preferred_family_name,
-    );
     builder.add_if_present(NameId::POSTSCRIPT_NAME, &font_info.postscript_font_name);
     builder.add_if_present(NameId::TRADEMARK, &font_info.trademark);
     builder.add_if_present(NameId::MANUFACTURER, &font_info.open_type_name_manufacturer);
@@ -775,6 +764,22 @@ fn names(font_info: &norad::FontInfo) -> HashMap<NameKey, String> {
         &font_info.open_type_name_license,
     );
     builder.add_if_present(NameId::LICENSE_URL, &font_info.open_type_name_license_url);
+    builder.add_if_present(
+        NameId::TYPOGRAPHIC_FAMILY_NAME,
+        &font_info
+            .open_type_name_preferred_family_name
+            .as_ref()
+            .or(font_info.family_name.as_ref())
+            .cloned(),
+    );
+    builder.add_if_present(
+        NameId::TYPOGRAPHIC_SUBFAMILY_NAME,
+        &font_info
+            .open_type_name_preferred_subfamily_name
+            .as_ref()
+            .or(font_info.style_name.as_ref())
+            .cloned(),
+    );
     builder.add_if_present(
         NameId::COMPATIBLE_FULL_NAME,
         &font_info.open_type_name_compatible_full_name,


### PR DESCRIPTION
Fixes #906 

We should now match fontmake (ufo2ft) logic for determining the two sets of family and subfamily names depending on which one is present or not.