### PR TITLE
[fontbe] Create GDEF for GlyphClassDef if needed

### DIFF
--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -3049,4 +3049,17 @@ mod tests {
             // read-fonts would return an error when a glyph's variations are empty
             .is_err()));
     }
+
+    // if a font has custom gdef categories defined, create the gdef table and
+    // with the appropriate GlyphClassDef subtable, even if there's no GPOS/GSUB
+    // or no other stuff in GDEF (... to match fontmake, see
+    // <https://github.com/googlefonts/fontmake/issues/1120>)
+    #[test]
+    fn gdef_glyph_categories_without_any_layout() {
+        let compile = TestCompile::compile_source("glyphs3/gdef_categories_no_layout.glyphs");
+        let font = compile.font();
+        let gdef = font.gdef().unwrap();
+        let classdef = gdef.glyph_class_def().unwrap().unwrap();
+        assert_eq!(classdef.iter().count(), 1)
+    }
 }

--- a/resources/testdata/glyphs3/gdef_categories_no_layout.glyphs
+++ b/resources/testdata/glyphs3/gdef_categories_no_layout.glyphs
@@ -1,0 +1,49 @@
+{
+.appVersion = "3260";
+.formatVersion = 3;
+DisplayStrings = (
+"/space",
+"/mycustommark"
+);
+date = "2023-05-05 15:11:55 +0000";
+familyName = Dated;
+fontMaster = (
+{
+id = m01;
+name = Regular;
+}
+);
+glyphs = (
+{
+glyphname = space;
+lastChange = "2024-09-05 19:35:17 +0000";
+layers = (
+{
+layerId = m01;
+width = 200;
+}
+);
+},
+{
+category = Mark;
+glyphname = mycustommark;
+lastChange = "2024-09-05 19:36:39 +0000";
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (187,388);
+}
+);
+layerId = m01;
+width = 600;
+}
+);
+subCategory = Nonspacing;
+}
+);
+unitsPerEm = 1000;
+versionMajor = 1;
+versionMinor = 1;
+}


### PR DESCRIPTION
Previously we would only add a GlyphClassDef table to an existing GDEF table, but would not create a GDEF table if one had not been produced by feature compilation.

This patch matches the behaviour of fontmake.

This does raise the question of whether or not either compiler should bother generating a GlyphClassDef subtable in the absense of GPOS/GSUB, but that's something we can address separately.