### PR TITLE
[crater] Make git sha a link to github diff

### DIFF
--- a/fontc_crater/src/ci/html.rs
+++ b/fontc_crater/src/ci/html.rs
@@ -143,10 +143,18 @@ fn make_table_body(runs: &[RunSummary]) -> Markup {
             true,
         );
         let diff_fmt = format!("{:.3}", run.stats.diff_perc_including_failures);
+        let diff_url = format!(
+            "https://github.com/googlefonts/fontc/compare/{}...{}/",
+            prev.as_ref()
+                .map(|p| p.fontc_rev.as_str())
+                .unwrap_or(run.fontc_rev.as_str()),
+            run.fontc_rev,
+        );
+        let short_rev = run.fontc_rev.get(..16).unwrap_or(run.fontc_rev.as_str());
         html! {
             tr.run {
                 td.date { (run.began.format("%Y-%m-%d %H:%M:%S")) }
-                td.rev { ( run.fontc_rev.get(..16).unwrap_or(run.fontc_rev.as_str()) ) }
+                td.rev { a href=(diff_url) { (short_rev) } }
                 td.total {  ( run.stats.total_targets) " " (total_diff) }
                 td.identical {  (run.stats.identical) " " (identical_diff)  }
                 td.fontc_err {  (run.stats.fontc_failed) " " (fontc_err_diff)  }


### PR DESCRIPTION
This makes it easy to see what changes have been made in fontc between two runs, which should help us figure out what is causing a given change.

For example, given the run that is current as of the time of this PR, we create the link [`1c75077e`](https://github.com/googlefonts/fontc/compare/b8d421ca...1c75077e/).