### PR TITLE
[fea-rs] Fix bug in valuerecord access logic

### DIFF
--- a/fea-rs/src/parse/grammar/metrics.rs
+++ b/fea-rs/src/parse/grammar/metrics.rs
@@ -429,6 +429,8 @@ pub(crate) fn expect_name_record(parser: &mut Parser, recovery: TokenSet) {
 
 #[cfg(test)]
 mod tests {
+    use crate::typed::AstNode;
+
     use super::super::debug_parse_output;
     use super::*;
 
@@ -500,5 +502,18 @@ mod tests {
             expect_metric(parser, TokenSet::EMPTY);
         });
         assert!(errstr.contains("expected variation location"), "{errstr}");
+    }
+
+    // https://github.com/googlefonts/fontc/issues/948
+    #[test]
+    fn glyphs_value_syntax() {
+        let fea = "<0 $hi 0 0>";
+        let (token, _err, _) = debug_parse_output(fea, |parser| {
+            expect_value_record(parser, TokenSet::EMPTY);
+        });
+
+        let valrecord = crate::typed::ValueRecord::cast(&token).unwrap();
+        assert!(valrecord.advance().is_none());
+        assert!(valrecord.placement().is_some());
     }
 }

--- a/fea-rs/src/token_tree/typed.rs
+++ b/fea-rs/src/token_tree/typed.rs
@@ -1086,12 +1086,7 @@ impl ValueRecord {
     }
 
     pub(crate) fn placement(&self) -> Option<[Metric; 4]> {
-        if self
-            .iter()
-            .filter(|t| t.kind() == Kind::Number || t.kind() == Kind::VariableMetricNode)
-            .count()
-            == 4
-        {
+        if self.iter().filter_map(Metric::cast).count() == 4 {
             let mut iter = self.iter().filter_map(Metric::cast);
             return Some([
                 iter.next().unwrap(),


### PR DESCRIPTION
I'd failed to update one function in light of adding a new possible type of metric (for glyphs number value syntax)


- fixes #948 