### PR TITLE
[fea-rs] Fix issue with scope of 'script' statements

### DIFF
--- a/fea-rs/src/compile/compile_ctx.rs
+++ b/fea-rs/src/compile/compile_ctx.rs
@@ -387,6 +387,7 @@ impl<'a, F: FeatureProvider, V: VariationInfo> CompilationCtx<'a, F, V> {
 
         self.vertical_feature.end_feature();
         self.lookup_flags.clear();
+        self.script = None;
     }
 
     fn start_lookup_block(&mut self, name: &Token) {

--- a/fea-rs/test-data/compile-tests/mini-latin/good/script_stmt_scope.fea
+++ b/fea-rs/test-data/compile-tests/mini-latin/good/script_stmt_scope.fea
@@ -1,0 +1,15 @@
+languagesystem DFLT dflt;
+languagesystem latn dflt;
+
+feature test {
+script latn;
+    sub A by B;
+} test;
+
+feature mess {
+    # this feature should also only exist for latn;
+    # we had a bug where we were ignoring this script stmt because we
+    # hadn't cleared the script after the end of the previous feature block.
+    script latn;
+    sub D by E;
+} mess;

--- a/fea-rs/test-data/compile-tests/mini-latin/good/script_stmt_scope.ttx
+++ b/fea-rs/test-data/compile-tests/mini-latin/good/script_stmt_scope.ttx
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont>
+
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="latn"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=2 -->
+            <FeatureIndex index="0" value="0"/>
+            <FeatureIndex index="1" value="1"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=2 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="mess"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="1"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="1">
+        <FeatureTag value="test"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=2 -->
+      <Lookup index="0">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0">
+          <Substitution in="A" out="B"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="1">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0">
+          <Substitution in="D" out="E"/>
+        </SingleSubst>
+      </Lookup>
+    </LookupList>
+  </GSUB>
+
+</ttFont>


### PR DESCRIPTION
We were not clearing our internal state of the active script when finishing a feature block, which caused us to not handle an identical 'script' statement occurring at the start of the subsequent feature block.