### PR TITLE
[glyphs2fontir] Fallback to setting GlobalMetrics from font

### DIFF
--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -664,20 +664,6 @@ impl GlobalMetrics {
         }
     }
 
-    pub fn set_if_some_or_fallback(
-        self: &mut GlobalMetrics,
-        metric: GlobalMetric,
-        pos: NormalizedLocation,
-        maybe_value: Option<impl Into<OrderedFloat<f64>>>,
-        maybe_fallback: Option<impl Into<OrderedFloat<f64>>>,
-    ) {
-        if let Some(value) = maybe_value {
-            self.set(metric, pos, value.into().into_inner() as f32);
-        } else if let Some(fallback) = maybe_fallback {
-            self.set(metric, pos, fallback.into().into_inner() as f32);
-        }
-    }
-
     pub fn at(&self, pos: &NormalizedLocation) -> GlobalMetricsInstance {
         GlobalMetricsInstance {
             pos: pos.clone(),

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -664,6 +664,20 @@ impl GlobalMetrics {
         }
     }
 
+    pub fn set_if_some_or_fallback(
+        self: &mut GlobalMetrics,
+        metric: GlobalMetric,
+        pos: NormalizedLocation,
+        maybe_value: Option<impl Into<OrderedFloat<f64>>>,
+        maybe_fallback: Option<impl Into<OrderedFloat<f64>>>,
+    ) {
+        if let Some(value) = maybe_value {
+            self.set(metric, pos, value.into().into_inner() as f32);
+        } else if let Some(fallback) = maybe_fallback {
+            self.set(metric, pos, fallback.into().into_inner() as f32);
+        }
+    }
+
     pub fn at(&self, pos: &NormalizedLocation) -> GlobalMetricsInstance {
         GlobalMetricsInstance {
             pos: pos.clone(),

--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -64,6 +64,27 @@ pub struct Font {
 
     // master id => { (name or class, name or class) => adjustment }
     pub kerning_ltr: Kerning,
+
+    pub typo_ascender: Option<i64>,
+    pub typo_descender: Option<i64>,
+    pub typo_line_gap: Option<i64>,
+    pub win_ascent: Option<i64>,
+    pub win_descent: Option<i64>,
+    pub hhea_ascender: Option<i64>,
+    pub hhea_descender: Option<i64>,
+    pub hhea_line_gap: Option<i64>,
+    pub underline_thickness: Option<OrderedFloat<f64>>,
+    pub underline_position: Option<OrderedFloat<f64>>,
+    pub strikeout_position: Option<i64>,
+    pub strikeout_size: Option<i64>,
+    pub subscript_x_offset: Option<i64>,
+    pub subscript_x_size: Option<i64>,
+    pub subscript_y_offset: Option<i64>,
+    pub subscript_y_size: Option<i64>,
+    pub superscript_x_offset: Option<i64>,
+    pub superscript_x_size: Option<i64>,
+    pub superscript_y_offset: Option<i64>,
+    pub superscript_y_size: Option<i64>,
 }
 
 /// master id => { (name or class, name or class) => adjustment }
@@ -2010,6 +2031,26 @@ impl TryFrom<RawFont> for Font {
 
         let use_typo_metrics = from.custom_parameters.bool("Use Typo Metrics");
         let has_wws_names = from.custom_parameters.bool("Has WWS Names");
+        let typo_ascender = from.custom_parameters.int("typoAscender");
+        let typo_descender = from.custom_parameters.int("typoDescender");
+        let typo_line_gap = from.custom_parameters.int("typoLineGap");
+        let win_ascent = from.custom_parameters.int("winAscent");
+        let win_descent = from.custom_parameters.int("winDescent");
+        let hhea_ascender = from.custom_parameters.int("hheaAscender");
+        let hhea_descender = from.custom_parameters.int("hheaDescender");
+        let hhea_line_gap = from.custom_parameters.int("hheaLineGap");
+        let underline_thickness = from.custom_parameters.float("underlineThickness");
+        let underline_position = from.custom_parameters.float("underlinePosition");
+        let strikeout_position = from.custom_parameters.int("strikeoutPosition");
+        let strikeout_size = from.custom_parameters.int("strikeoutSize");
+        let subscript_x_offset = from.custom_parameters.int("subscriptXOffset");
+        let subscript_x_size = from.custom_parameters.int("subscriptXSize");
+        let subscript_y_offset = from.custom_parameters.int("subscriptYOffset");
+        let subscript_y_size = from.custom_parameters.int("subscriptYSize");
+        let superscript_x_offset = from.custom_parameters.int("superscriptXOffset");
+        let superscript_x_size = from.custom_parameters.int("superscriptXSize");
+        let superscript_y_offset = from.custom_parameters.int("superscriptYOffset");
+        let superscript_y_size = from.custom_parameters.int("superscriptYSize");
 
         let axes = from.axes.clone();
         let instances: Vec<_> = from
@@ -2150,6 +2191,26 @@ impl TryFrom<RawFont> for Font {
             version_minor: from.versionMinor.unwrap_or_default() as u32,
             date: from.date,
             kerning_ltr: from.kerning_LTR,
+            typo_ascender,
+            typo_descender,
+            typo_line_gap,
+            win_ascent,
+            win_descent,
+            hhea_ascender,
+            hhea_descender,
+            hhea_line_gap,
+            underline_thickness,
+            underline_position,
+            strikeout_position,
+            strikeout_size,
+            subscript_x_offset,
+            subscript_x_size,
+            subscript_y_offset,
+            subscript_y_size,
+            superscript_x_offset,
+            superscript_x_size,
+            superscript_y_offset,
+            superscript_y_size,
         })
     }
 }
@@ -3171,5 +3232,21 @@ mod tests {
             font.masters[1].number_values.get("foo"),
             Some(&OrderedFloat(0f64))
         );
+    }
+
+    #[test]
+    fn read_font_metrics() {
+        let font =
+            Font::load(&glyphs3_dir().join("GlobalMetrics_font_customParameters.glyphs")).unwrap();
+        assert_eq!(Some(950), font.typo_ascender);
+        assert_eq!(Some(-350), font.typo_descender);
+        assert_eq!(Some(0), font.typo_line_gap);
+        assert_eq!(Some(950), font.hhea_ascender);
+        assert_eq!(Some(-350), font.hhea_descender);
+        assert_eq!(Some(0), font.hhea_line_gap);
+        assert_eq!(Some(1185), font.win_ascent);
+        assert_eq!(Some(420), font.win_descent);
+        assert_eq!(Some(OrderedFloat(50_f64)), font.underline_thickness);
+        assert_eq!(Some(OrderedFloat(-300_f64)), font.underline_position);
     }
 }

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -585,125 +585,153 @@ impl Work<Context, WorkId, Error> for GlobalMetricWork {
 
             metrics.set_if_some(GlobalMetric::CapHeight, pos.clone(), master.cap_height());
             metrics.set_if_some(GlobalMetric::XHeight, pos.clone(), master.x_height());
-            metrics.set_if_some_or_fallback(
+            metrics.set_if_some(
                 GlobalMetric::Os2TypoAscender,
                 pos.clone(),
-                master.typo_ascender.map(|v| v as f64),
-                font.typo_ascender.map(|v| v as f64),
+                master
+                    .typo_ascender
+                    .or(font.typo_ascender)
+                    .map(|v| v as f64),
             );
-            metrics.set_if_some_or_fallback(
+            metrics.set_if_some(
                 GlobalMetric::Os2TypoDescender,
                 pos.clone(),
-                master.typo_descender.map(|v| v as f64),
-                font.typo_descender.map(|v| v as f64),
+                master
+                    .typo_descender
+                    .or(font.typo_descender)
+                    .map(|v| v as f64),
             );
-            metrics.set_if_some_or_fallback(
+            metrics.set_if_some(
                 GlobalMetric::Os2TypoLineGap,
                 pos.clone(),
-                master.typo_line_gap.map(|v| v as f64),
-                font.typo_line_gap.map(|v| v as f64),
+                master
+                    .typo_line_gap
+                    .or(font.typo_line_gap)
+                    .map(|v| v as f64),
             );
-            metrics.set_if_some_or_fallback(
+            metrics.set_if_some(
                 GlobalMetric::Os2WinAscent,
                 pos.clone(),
-                master.win_ascent.map(|v| v as f64),
-                font.win_ascent.map(|v| v as f64),
+                master.win_ascent.or(font.win_ascent).map(|v| v as f64),
             );
-            metrics.set_if_some_or_fallback(
+            metrics.set_if_some(
                 GlobalMetric::Os2WinDescent,
                 pos.clone(),
-                master.win_descent.map(|v| v as f64),
-                font.win_descent.map(|v| v as f64),
+                master.win_descent.or(font.win_descent).map(|v| v as f64),
             );
-            metrics.set_if_some_or_fallback(
+            metrics.set_if_some(
                 GlobalMetric::StrikeoutPosition,
                 pos.clone(),
-                master.strikeout_position.map(|v| v as f64),
-                font.strikeout_position.map(|v| v as f64),
+                master
+                    .strikeout_position
+                    .or(font.strikeout_position)
+                    .map(|v| v as f64),
             );
-            metrics.set_if_some_or_fallback(
+            metrics.set_if_some(
                 GlobalMetric::StrikeoutSize,
                 pos.clone(),
-                master.strikeout_size.map(|v| v as f64),
-                font.strikeout_size.map(|v| v as f64),
+                master
+                    .strikeout_size
+                    .or(font.strikeout_size)
+                    .map(|v| v as f64),
             );
-            metrics.set_if_some_or_fallback(
+            metrics.set_if_some(
                 GlobalMetric::SubscriptXOffset,
                 pos.clone(),
-                master.subscript_x_offset.map(|v| v as f64),
-                font.subscript_x_offset.map(|v| v as f64),
+                master
+                    .subscript_x_offset
+                    .or(font.subscript_x_offset)
+                    .map(|v| v as f64),
             );
-            metrics.set_if_some_or_fallback(
+            metrics.set_if_some(
                 GlobalMetric::SubscriptXSize,
                 pos.clone(),
-                master.subscript_x_size.map(|v| v as f64),
-                font.subscript_x_size.map(|v| v as f64),
+                master
+                    .subscript_x_size
+                    .or(font.subscript_x_size)
+                    .map(|v| v as f64),
             );
-            metrics.set_if_some_or_fallback(
+            metrics.set_if_some(
                 GlobalMetric::SubscriptYOffset,
                 pos.clone(),
-                master.subscript_y_offset.map(|v| v as f64),
-                font.subscript_y_offset.map(|v| v as f64),
+                master
+                    .subscript_y_offset
+                    .or(font.subscript_y_offset)
+                    .map(|v| v as f64),
             );
-            metrics.set_if_some_or_fallback(
+            metrics.set_if_some(
                 GlobalMetric::SubscriptYSize,
                 pos.clone(),
-                master.subscript_y_size.map(|v| v as f64),
-                font.subscript_y_size.map(|v| v as f64),
+                master
+                    .subscript_y_size
+                    .or(font.subscript_y_size)
+                    .map(|v| v as f64),
             );
-            metrics.set_if_some_or_fallback(
+            metrics.set_if_some(
                 GlobalMetric::SuperscriptXOffset,
                 pos.clone(),
-                master.superscript_x_offset.map(|v| v as f64),
-                font.superscript_x_offset.map(|v| v as f64),
+                master
+                    .superscript_x_offset
+                    .or(font.superscript_x_offset)
+                    .map(|v| v as f64),
             );
-            metrics.set_if_some_or_fallback(
+            metrics.set_if_some(
                 GlobalMetric::SuperscriptXSize,
                 pos.clone(),
-                master.superscript_x_size.map(|v| v as f64),
-                font.superscript_x_size.map(|v| v as f64),
+                master
+                    .superscript_x_size
+                    .or(font.superscript_x_size)
+                    .map(|v| v as f64),
             );
-            metrics.set_if_some_or_fallback(
+            metrics.set_if_some(
                 GlobalMetric::SuperscriptYOffset,
                 pos.clone(),
-                master.superscript_y_offset.map(|v| v as f64),
-                font.superscript_y_offset.map(|v| v as f64),
+                master
+                    .superscript_y_offset
+                    .or(font.superscript_y_offset)
+                    .map(|v| v as f64),
             );
-            metrics.set_if_some_or_fallback(
+            metrics.set_if_some(
                 GlobalMetric::SuperscriptYSize,
                 pos.clone(),
-                master.superscript_y_size.map(|v| v as f64),
-                font.superscript_y_size.map(|v| v as f64),
+                master
+                    .superscript_y_size
+                    .or(font.superscript_y_size)
+                    .map(|v| v as f64),
             );
-            metrics.set_if_some_or_fallback(
+            metrics.set_if_some(
                 GlobalMetric::HheaAscender,
                 pos.clone(),
-                master.hhea_ascender.map(|v| v as f64),
-                font.hhea_ascender.map(|v| v as f64),
+                master
+                    .hhea_ascender
+                    .or(font.hhea_ascender)
+                    .map(|v| v as f64),
             );
-            metrics.set_if_some_or_fallback(
+            metrics.set_if_some(
                 GlobalMetric::HheaDescender,
                 pos.clone(),
-                master.hhea_descender.map(|v| v as f64),
-                font.hhea_descender.map(|v| v as f64),
+                master
+                    .hhea_descender
+                    .or(font.hhea_descender)
+                    .map(|v| v as f64),
             );
-            metrics.set_if_some_or_fallback(
+            metrics.set_if_some(
                 GlobalMetric::HheaLineGap,
                 pos.clone(),
-                master.hhea_line_gap.map(|v| v as f64),
-                font.hhea_line_gap.map(|v| v as f64),
+                master
+                    .hhea_line_gap
+                    .or(font.hhea_line_gap)
+                    .map(|v| v as f64),
             );
-            metrics.set_if_some_or_fallback(
+            metrics.set_if_some(
                 GlobalMetric::UnderlineThickness,
                 pos.clone(),
-                master.underline_thickness,
-                font.underline_thickness,
+                master.underline_thickness.or(font.underline_thickness),
             );
-            metrics.set_if_some_or_fallback(
+            metrics.set_if_some(
                 GlobalMetric::UnderlinePosition,
                 pos.clone(),
-                master.underline_position,
-                font.underline_position,
+                master.underline_position.or(font.underline_position),
             )
         }
 

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -107,6 +107,26 @@ impl GlyphsIrSource {
             version_minor: Default::default(),
             date: None,
             kerning_ltr: Default::default(),
+            typo_ascender: font.typo_ascender,
+            typo_descender: font.typo_descender,
+            typo_line_gap: font.typo_line_gap,
+            win_ascent: font.win_ascent,
+            win_descent: font.win_descent,
+            hhea_ascender: font.hhea_ascender,
+            hhea_descender: font.hhea_descender,
+            hhea_line_gap: font.hhea_line_gap,
+            underline_thickness: font.underline_thickness,
+            underline_position: font.underline_position,
+            strikeout_position: font.strikeout_position,
+            strikeout_size: font.strikeout_size,
+            subscript_x_offset: font.subscript_x_offset,
+            subscript_x_size: font.subscript_x_size,
+            subscript_y_offset: font.subscript_y_offset,
+            subscript_y_size: font.subscript_y_size,
+            superscript_x_offset: font.superscript_x_offset,
+            superscript_x_size: font.superscript_x_size,
+            superscript_y_offset: font.superscript_y_offset,
+            superscript_y_size: font.superscript_y_size,
         };
         state.track_memory("/font_master".to_string(), &font)?;
         Ok(state)
@@ -136,6 +156,26 @@ impl GlyphsIrSource {
             version_minor: Default::default(),
             date: None,
             kerning_ltr: font.kerning_ltr.clone(),
+            typo_ascender: font.typo_ascender,
+            typo_descender: font.typo_descender,
+            typo_line_gap: font.typo_line_gap,
+            win_ascent: font.win_ascent,
+            win_descent: font.win_descent,
+            hhea_ascender: font.hhea_ascender,
+            hhea_descender: font.hhea_descender,
+            hhea_line_gap: font.hhea_line_gap,
+            underline_thickness: font.underline_thickness,
+            underline_position: font.underline_position,
+            strikeout_position: font.strikeout_position,
+            strikeout_size: font.strikeout_size,
+            subscript_x_offset: font.subscript_x_offset,
+            subscript_x_size: font.subscript_x_size,
+            subscript_y_offset: font.subscript_y_offset,
+            subscript_y_size: font.subscript_y_size,
+            superscript_x_offset: font.superscript_x_offset,
+            superscript_x_size: font.superscript_x_size,
+            superscript_y_offset: font.superscript_y_offset,
+            superscript_y_size: font.superscript_y_size,
         };
         state.track_memory("/font_master".to_string(), &font)?;
         Ok(state)
@@ -545,105 +585,125 @@ impl Work<Context, WorkId, Error> for GlobalMetricWork {
 
             metrics.set_if_some(GlobalMetric::CapHeight, pos.clone(), master.cap_height());
             metrics.set_if_some(GlobalMetric::XHeight, pos.clone(), master.x_height());
-            metrics.set_if_some(
+            metrics.set_if_some_or_fallback(
                 GlobalMetric::Os2TypoAscender,
                 pos.clone(),
                 master.typo_ascender.map(|v| v as f64),
+                font.typo_ascender.map(|v| v as f64),
             );
-            metrics.set_if_some(
+            metrics.set_if_some_or_fallback(
                 GlobalMetric::Os2TypoDescender,
                 pos.clone(),
                 master.typo_descender.map(|v| v as f64),
+                font.typo_descender.map(|v| v as f64),
             );
-            metrics.set_if_some(
+            metrics.set_if_some_or_fallback(
                 GlobalMetric::Os2TypoLineGap,
                 pos.clone(),
                 master.typo_line_gap.map(|v| v as f64),
+                font.typo_line_gap.map(|v| v as f64),
             );
-            metrics.set_if_some(
+            metrics.set_if_some_or_fallback(
                 GlobalMetric::Os2WinAscent,
                 pos.clone(),
                 master.win_ascent.map(|v| v as f64),
+                font.win_ascent.map(|v| v as f64),
             );
-            metrics.set_if_some(
+            metrics.set_if_some_or_fallback(
                 GlobalMetric::Os2WinDescent,
                 pos.clone(),
                 master.win_descent.map(|v| v as f64),
+                font.win_descent.map(|v| v as f64),
             );
-            metrics.set_if_some(
+            metrics.set_if_some_or_fallback(
                 GlobalMetric::StrikeoutPosition,
                 pos.clone(),
                 master.strikeout_position.map(|v| v as f64),
+                font.strikeout_position.map(|v| v as f64),
             );
-            metrics.set_if_some(
+            metrics.set_if_some_or_fallback(
                 GlobalMetric::StrikeoutSize,
                 pos.clone(),
                 master.strikeout_size.map(|v| v as f64),
+                font.strikeout_size.map(|v| v as f64),
             );
-            metrics.set_if_some(
+            metrics.set_if_some_or_fallback(
                 GlobalMetric::SubscriptXOffset,
                 pos.clone(),
                 master.subscript_x_offset.map(|v| v as f64),
+                font.subscript_x_offset.map(|v| v as f64),
             );
-            metrics.set_if_some(
+            metrics.set_if_some_or_fallback(
                 GlobalMetric::SubscriptXSize,
                 pos.clone(),
                 master.subscript_x_size.map(|v| v as f64),
+                font.subscript_x_size.map(|v| v as f64),
             );
-            metrics.set_if_some(
+            metrics.set_if_some_or_fallback(
                 GlobalMetric::SubscriptYOffset,
                 pos.clone(),
                 master.subscript_y_offset.map(|v| v as f64),
+                font.subscript_y_offset.map(|v| v as f64),
             );
-            metrics.set_if_some(
+            metrics.set_if_some_or_fallback(
                 GlobalMetric::SubscriptYSize,
                 pos.clone(),
                 master.subscript_y_size.map(|v| v as f64),
+                font.subscript_y_size.map(|v| v as f64),
             );
-            metrics.set_if_some(
+            metrics.set_if_some_or_fallback(
                 GlobalMetric::SuperscriptXOffset,
                 pos.clone(),
                 master.superscript_x_offset.map(|v| v as f64),
+                font.superscript_x_offset.map(|v| v as f64),
             );
-            metrics.set_if_some(
+            metrics.set_if_some_or_fallback(
                 GlobalMetric::SuperscriptXSize,
                 pos.clone(),
                 master.superscript_x_size.map(|v| v as f64),
+                font.superscript_x_size.map(|v| v as f64),
             );
-            metrics.set_if_some(
+            metrics.set_if_some_or_fallback(
                 GlobalMetric::SuperscriptYOffset,
                 pos.clone(),
                 master.superscript_y_offset.map(|v| v as f64),
+                font.superscript_y_offset.map(|v| v as f64),
             );
-            metrics.set_if_some(
+            metrics.set_if_some_or_fallback(
                 GlobalMetric::SuperscriptYSize,
                 pos.clone(),
                 master.superscript_y_size.map(|v| v as f64),
+                font.superscript_y_size.map(|v| v as f64),
             );
-            metrics.set_if_some(
+            metrics.set_if_some_or_fallback(
                 GlobalMetric::HheaAscender,
                 pos.clone(),
                 master.hhea_ascender.map(|v| v as f64),
+                font.hhea_ascender.map(|v| v as f64),
             );
-            metrics.set_if_some(
+            metrics.set_if_some_or_fallback(
                 GlobalMetric::HheaDescender,
                 pos.clone(),
                 master.hhea_descender.map(|v| v as f64),
+                font.hhea_descender.map(|v| v as f64),
             );
-            metrics.set_if_some(
+            metrics.set_if_some_or_fallback(
                 GlobalMetric::HheaLineGap,
                 pos.clone(),
                 master.hhea_line_gap.map(|v| v as f64),
+                font.hhea_line_gap.map(|v| v as f64),
             );
-            metrics.set_if_some(
+            metrics.set_if_some_or_fallback(
                 GlobalMetric::UnderlineThickness,
                 pos.clone(),
                 master.underline_thickness,
+                font.underline_thickness,
             );
-            metrics.set_if_some(
+            metrics.set_if_some_or_fallback(
                 GlobalMetric::UnderlinePosition,
                 pos.clone(),
                 master.underline_position,
+                font.underline_position,
             )
         }
 
@@ -1710,5 +1770,110 @@ mod tests {
     fn reads_fs_type_0x0104() {
         let (_, context) = build_static_metadata(glyphs3_dir().join("fstype_0x0104.glyphs"));
         assert_eq!(Some(0x104), context.static_metadata.get().misc.fs_type);
+    }
+
+    #[test]
+    fn captures_global_metrics_from_font() {
+        let (_, context) =
+            build_global_metrics(glyphs3_dir().join("GlobalMetrics_font_customParameters.glyphs"));
+        let static_metadata = &context.static_metadata.get();
+        let default_metrics = context
+            .global_metrics
+            .get()
+            .at(static_metadata.default_location());
+        assert_eq!(
+            GlobalMetricsInstance {
+                pos: static_metadata.default_location().clone(),
+                ascender: 800.0.into(),
+                descender: (-200.0).into(),
+                caret_slope_rise: 1000.0.into(),
+                cap_height: 660.0.into(),
+                x_height: 478.0.into(),
+                subscript_x_size: 650.0.into(),
+                subscript_y_size: 600.0.into(),
+                subscript_y_offset: 75.0.into(),
+                superscript_x_size: 650.0.into(),
+                superscript_y_size: 600.0.into(),
+                superscript_y_offset: 350.0.into(),
+                strikeout_position: 286.8.into(),
+                strikeout_size: 50.0.into(),
+                os2_typo_ascender: 950.0.into(),
+                os2_typo_descender: (-350.0).into(),
+                os2_typo_line_gap: 0.0.into(),
+                os2_win_ascent: 1185.0.into(),
+                os2_win_descent: 420.0.into(),
+                hhea_ascender: 950.0.into(),
+                hhea_descender: (-350.0).into(),
+                hhea_line_gap: 0.0.into(),
+                underline_thickness: 50.0.into(),
+                underline_position: (-300.0).into(),
+                ..Default::default()
+            },
+            default_metrics
+        );
+        let light = NormalizedLocation::for_pos(&[("wght", 0.0)]);
+        let light_metrics = context.global_metrics.get().at(&light);
+        assert_eq!(
+            GlobalMetricsInstance {
+                pos: light.clone(),
+                ascender: 800.0.into(),
+                descender: (-200.0).into(),
+                caret_slope_rise: 1000.0.into(),
+                cap_height: 660.0.into(),
+                x_height: 478.0.into(),
+                subscript_x_size: 650.0.into(),
+                subscript_y_size: 600.0.into(),
+                subscript_y_offset: 75.0.into(),
+                superscript_x_size: 650.0.into(),
+                superscript_y_size: 600.0.into(),
+                superscript_y_offset: 350.0.into(),
+                strikeout_position: 286.8.into(),
+                strikeout_size: 50.0.into(),
+                os2_typo_ascender: 950.0.into(),
+                os2_typo_descender: (-350.0).into(),
+                os2_typo_line_gap: 0.0.into(),
+                os2_win_ascent: 1185.0.into(),
+                os2_win_descent: 420.0.into(),
+                hhea_ascender: 950.0.into(),
+                hhea_descender: (-350.0).into(),
+                hhea_line_gap: 0.0.into(),
+                underline_thickness: 50.0.into(),
+                underline_position: (-300.0).into(),
+                ..Default::default()
+            },
+            light_metrics
+        );
+        let black = NormalizedLocation::for_pos(&[("wght", 1.0)]);
+        let black_metrics = context.global_metrics.get().at(&black);
+        assert_eq!(
+            GlobalMetricsInstance {
+                pos: black.clone(),
+                ascender: 800.0.into(),
+                descender: (-200.0).into(),
+                caret_slope_rise: 1000.0.into(),
+                cap_height: 650.0.into(),
+                x_height: 500.0.into(),
+                subscript_x_size: 650.0.into(),
+                subscript_y_size: 600.0.into(),
+                subscript_y_offset: 75.0.into(),
+                superscript_x_size: 650.0.into(),
+                superscript_y_size: 600.0.into(),
+                superscript_y_offset: 350.0.into(),
+                strikeout_position: 300.0.into(),
+                strikeout_size: 50.0.into(),
+                os2_typo_ascender: 1000.0.into(),
+                os2_typo_descender: (-400.0).into(),
+                os2_typo_line_gap: 0.0.into(),
+                os2_win_ascent: 1185.0.into(),
+                os2_win_descent: 420.0.into(),
+                hhea_ascender: 1000.0.into(),
+                hhea_descender: (-400.0).into(),
+                hhea_line_gap: 0.0.into(),
+                underline_thickness: 50.0.into(),
+                underline_position: (-300.0).into(),
+                ..Default::default()
+            },
+            black_metrics
+        );
     }
 }

--- a/resources/testdata/glyphs3/GlobalMetrics_font_customParameters.glyphs
+++ b/resources/testdata/glyphs3/GlobalMetrics_font_customParameters.glyphs
@@ -1,0 +1,202 @@
+{
+.appVersion = "3316";
+.formatVersion = 3;
+DisplayStrings = (
+"",
+" "
+);
+axes = (
+{
+name = Weight;
+tag = wght;
+}
+);
+customParameters = (
+{
+name = fsType;
+value = (
+);
+},
+{
+name = "Use Typo Metrics";
+value = 1;
+},
+{
+name = typoAscender;
+value = 950;
+},
+{
+name = typoDescender;
+value = -350;
+},
+{
+name = typoLineGap;
+value = 0;
+},
+{
+name = hheaAscender;
+value = 950;
+},
+{
+name = hheaDescender;
+value = -350;
+},
+{
+name = hheaLineGap;
+value = 0;
+},
+{
+name = winAscent;
+value = 1185;
+},
+{
+name = winDescent;
+value = 420;
+},
+{
+name = underlineThickness;
+value = 50;
+},
+{
+name = underlinePosition;
+value = -300;
+}
+);
+date = "2024-09-11 20:25:35 +0000";
+familyName = "GlobalMetrics Font Test";
+fontMaster = (
+{
+axesValues = (
+0
+);
+iconName = Light;
+id = "0CAB57D4-4FC4-49C3-B456-FB7666EAA712";
+metricValues = (
+{
+pos = 800;
+},
+{
+pos = 660;
+},
+{
+pos = 478;
+},
+{
+},
+{
+pos = -200;
+},
+{
+}
+);
+name = ExtraLight;
+},
+{
+axesValues = (
+1000
+);
+customParameters = (
+{
+name = typoAscender;
+value = 1000;
+},
+{
+name = typoDescender;
+value = -400;
+},
+{
+name = hheaAscender;
+value = 1000;
+},
+{
+name = hheaDescender;
+value = -400;
+}
+);
+iconName = Bold;
+id = "42B3044F-4D5A-45CA-9EB7-C1889731596B";
+metricValues = (
+{
+pos = 800;
+},
+{
+pos = 650;
+},
+{
+pos = 500;
+},
+{
+},
+{
+pos = -200;
+},
+{
+}
+);
+name = Black;
+}
+);
+glyphs = (
+{
+glyphname = space;
+lastChange = "2024-09-11 21:06:25 +0000";
+layers = (
+{
+layerId = "0CAB57D4-4FC4-49C3-B456-FB7666EAA712";
+width = 200;
+},
+{
+layerId = "42B3044F-4D5A-45CA-9EB7-C1889731596B";
+width = 200;
+}
+);
+unicode = 32;
+}
+);
+instances = (
+{
+axesValues = (
+368
+);
+customParameters = (
+{
+name = "Axis Location";
+value = (
+{
+Axis = Weight;
+Location = 400;
+}
+);
+}
+);
+instanceInterpolations = {
+"0CAB57D4-4FC4-49C3-B456-FB7666EAA712" = 0.632;
+"42B3044F-4D5A-45CA-9EB7-C1889731596B" = 0.368;
+};
+name = Regular;
+}
+);
+metrics = (
+{
+type = ascender;
+},
+{
+type = "cap height";
+},
+{
+type = "x-height";
+},
+{
+type = baseline;
+},
+{
+type = descender;
+},
+{
+type = "italic angle";
+}
+);
+unitsPerEm = 1000;
+versionMajor = 1;
+versionMinor = 0;
+}


### PR DESCRIPTION
If the corresponding custom parameter is missing from the master, try it from the parent font.

- Fixes https://github.com/googlefonts/fontc/issues/949