### PR TITLE
[ttx_diff] Go back to using 'quick_ratio'

### DIFF
--- a/resources/scripts/ttx_diff.py
+++ b/resources/scripts/ttx_diff.py
@@ -521,7 +521,7 @@ def diff_ratio(text1: str, text2: str) -> float:
     lines1 = text1.splitlines()
     lines2 = text2.splitlines()
     m = SequenceMatcher(None, lines1, lines2)
-    return m.ratio()
+    return m.quick_ratio()
 
 
 def path_for_output_item(tag_or_normalizer_name: str, compiler: str) -> str:


### PR DESCRIPTION
This is less precise than the 'ratio' method we're currently using, but we don't _really_ care about precision here, and quick_ratio is much much much faster.

computing all the ratios for `NotoSans` currently takes several hours; with this patch it takes several minutes.

This should hugely speedup our CI runs; on my laptop we now finish in ~20 minutes.