### PR TITLE
OS/2 strikeout size defaults to underline thickness

### DIFF
--- a/fontbe/src/os2.rs
+++ b/fontbe/src/os2.rs
@@ -587,11 +587,12 @@ mod tests {
     #[test]
     fn build_basic_os2() {
         let default_location = NormalizedLocation::new();
-        let mut global_metrics =
-            GlobalMetrics::new(default_location.clone(), 1000, None, None, None, 0.0);
+        let mut global_metrics = GlobalMetrics::new();
 
         global_metrics.set(GlobalMetric::CapHeight, default_location.clone(), 37.5);
         global_metrics.set(GlobalMetric::XHeight, default_location.clone(), 112.2);
+
+        global_metrics.populate_defaults(&default_location, 1000, None, None, None, Some(0.0));
 
         let mut os2 = Os2 {
             ach_vend_id: Tag::new(b"DUCK"),

--- a/fontc/Cargo.toml
+++ b/fontc/Cargo.toml
@@ -49,6 +49,7 @@ pretty_assertions.workspace = true
 skrifa.workspace = true
 kurbo.workspace = true
 chrono.workspace = true
+ordered-float.workspace = true
 
 [build-dependencies]
 vergen = { version = "8.2.6", features = ["build", "cargo", "git", "gitcl", "rustc"] }

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -555,6 +555,8 @@ mod tests {
         time::Instant,
     };
 
+    use ordered_float::OrderedFloat;
+
     use chrono::{Duration, TimeZone, Utc};
     use fontbe::orchestration::{
         AnyWorkId, Context as BeContext, Glyph, LocaFormatWrapper, WorkId as BeWorkIdentifier,
@@ -565,7 +567,7 @@ mod tests {
         types::{GlyphName, WidthClass},
     };
     use fontir::{
-        ir::{self, GlyphOrder, KernGroup, KernPair, KernSide},
+        ir::{self, GlobalMetric, GlyphOrder, KernGroup, KernPair, KernSide},
         orchestration::{Context as FeContext, Persistable, WorkId as FeWorkIdentifier},
     };
     use indexmap::IndexSet;
@@ -3038,6 +3040,31 @@ mod tests {
     fn mvar_from_glyphs3() {
         let compile = TestCompile::compile_source("glyphs3/MVAR.glyphs");
         assert_mvar_from_glyphs(compile.font().mvar().unwrap());
+    }
+
+    #[test]
+    fn strikeout_size_fallback() {
+        let compile =
+            TestCompile::compile_source("glyphs3/GlobalMetrics_font_customParameters.glyphs");
+        let strikeout_sizes = compile
+            .fe_context
+            .global_metrics
+            .get()
+            .iter()
+            .filter_map(|(metric, values)| {
+                if *metric == GlobalMetric::StrikeoutSize {
+                    Some(values)
+                } else {
+                    None
+                }
+            })
+            .flat_map(|v| v.values().copied())
+            .collect::<HashSet<_>>();
+        // Light has an explicit 40, everything else uses 42
+        assert_eq!(
+            HashSet::from([OrderedFloat(40.0), OrderedFloat(42.0)]),
+            strikeout_sizes
+        );
     }
 
     #[test]

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -2916,7 +2916,6 @@ mod tests {
         expected_value_records: Vec<(Tag, u16)>,
         expected_delta_sets: Vec<Vec<i32>>,
     ) {
-        assert_eq!(mvar.value_records().len(), expected_value_records.len());
         let actual_records = mvar
             .value_records()
             .iter()

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -507,25 +507,9 @@ fn adjust_offset(offset: f64, angle: f64) -> f64 {
 pub type GlobalMetricValues = HashMap<NormalizedLocation, OrderedFloat<f32>>;
 
 impl GlobalMetrics {
-    /// Creates a new [GlobalMetrics] with default values at the default location.
-    pub fn new(
-        default_location: NormalizedLocation,
-        units_per_em: u16,
-        x_height: Option<f64>,
-        ascender: Option<f64>,
-        descender: Option<f64>,
-        italic_angle: f64,
-    ) -> GlobalMetrics {
-        let mut metrics = GlobalMetrics(HashMap::new());
-        metrics.populate_defaults(
-            &default_location,
-            units_per_em,
-            x_height,
-            ascender,
-            descender,
-            Some(italic_angle),
-        );
-        metrics
+    /// Creates a new, empty, [GlobalMetrics]
+    pub fn new() -> Self {
+        Self(HashMap::new())
     }
 
     /// Populate default values for all metrics at the given location.
@@ -546,13 +530,14 @@ impl GlobalMetrics {
     ) {
         let units_per_em = units_per_em as f64;
 
-        let mut set = |metric, value| self.set(metric, location.clone(), value as f32);
+        let mut set_if_absent =
+            |metric, value| self.set_if_absent(metric, location.clone(), value as f32);
 
         // https://github.com/googlefonts/ufo2ft/blob/fca66fe3ea1ea88ffb36f8264b21ce042d3afd05/Lib/ufo2ft/fontInfoData.py#L38-L45
         let ascender = ascender.unwrap_or(0.8 * units_per_em);
         let descender = descender.unwrap_or(-0.2 * units_per_em);
-        set(GlobalMetric::Ascender, ascender);
-        set(GlobalMetric::Descender, descender);
+        set_if_absent(GlobalMetric::Ascender, ascender);
+        set_if_absent(GlobalMetric::Descender, descender);
 
         // https://github.com/googlefonts/ufo2ft/blob/0d2688cd847d003b41104534d16973f72ef26c40/Lib/ufo2ft/fontInfoData.py#L229-L238
         let typo_line_gap = units_per_em * 1.2 + descender - ascender;
@@ -561,71 +546,72 @@ impl GlobalMetrics {
         } else {
             0.0
         };
-        set(GlobalMetric::Os2TypoLineGap, typo_line_gap);
+        set_if_absent(GlobalMetric::Os2TypoLineGap, typo_line_gap);
 
         // https://github.com/googlefonts/ufo2ft/blob/0d2688cd847d003b41104534d16973f72ef26c40/Lib/ufo2ft/fontInfoData.py#L215-L226
-        set(GlobalMetric::Os2TypoAscender, ascender);
-        set(GlobalMetric::Os2TypoDescender, descender);
+        set_if_absent(GlobalMetric::Os2TypoAscender, ascender);
+        set_if_absent(GlobalMetric::Os2TypoDescender, descender);
 
         // https://github.com/googlefonts/ufo2ft/blob/0d2688cd847d003b41104534d16973f72ef26c40/Lib/ufo2ft/fontInfoData.py#L126-L130
-        set(GlobalMetric::HheaAscender, ascender + typo_line_gap);
-        set(GlobalMetric::HheaDescender, descender);
+        set_if_absent(GlobalMetric::HheaAscender, ascender + typo_line_gap);
+        set_if_absent(GlobalMetric::HheaDescender, descender);
         // https://github.com/googlefonts/ufo2ft/blob/0d2688cd847d003b41104534d16973f72ef26c40/Lib/ufo2ft/fontInfoData.py#L366
-        set(GlobalMetric::HheaLineGap, 0.0);
+        set_if_absent(GlobalMetric::HheaLineGap, 0.0);
 
         // https://github.com/googlefonts/ufo2ft/blob/0d2688cd847d003b41104534d16973f72ef26c40/Lib/ufo2ft/fontInfoData.py#L241-L254
-        set(GlobalMetric::Os2WinAscent, ascender + typo_line_gap);
-        set(GlobalMetric::Os2WinDescent, descender.abs());
+        set_if_absent(GlobalMetric::Os2WinAscent, ascender + typo_line_gap);
+        set_if_absent(GlobalMetric::Os2WinDescent, descender.abs());
 
         // https://github.com/googlefonts/ufo2ft/blob/fca66fe3ea1ea88ffb36f8264b21ce042d3afd05/Lib/ufo2ft/fontInfoData.py#L48-L55
-        set(GlobalMetric::CapHeight, 0.7 * units_per_em);
+        set_if_absent(GlobalMetric::CapHeight, 0.7 * units_per_em);
         let x_height = x_height.unwrap_or(0.5 * units_per_em);
-        set(GlobalMetric::XHeight, x_height);
+        set_if_absent(GlobalMetric::XHeight, x_height);
 
         // https://github.com/googlefonts/ufo2ft/blob/150c2d6a00da9d5854173c8457a553ce03b89cf7/Lib/ufo2ft/fontInfoData.py#L133-L148
         // https://github.com/googlefonts/ufo2ft/blob/150c2d6a00da9d5854173c8457a553ce03b89cf7/Lib/ufo2ft/fontInfoData.py#L151-L161
         let italic_angle = italic_angle.unwrap_or(0.0);
-        set(GlobalMetric::CaretSlopeRise, units_per_em);
-        set(
+        set_if_absent(GlobalMetric::CaretSlopeRise, units_per_em);
+        set_if_absent(
             GlobalMetric::CaretSlopeRun,
             adjust_offset(units_per_em, italic_angle),
         );
 
         // https://github.com/googlefonts/ufo2ft/blob/0d2688cd847d003b41104534d16973f72ef26c40/Lib/ufo2ft/fontInfoData.py#L367
-        set(GlobalMetric::CaretOffset, 0.0);
+        set_if_absent(GlobalMetric::CaretOffset, 0.0);
 
         // https://github.com/googlefonts/ufo2ft/blob/0d2688cd847d003b41104534d16973f72ef26c40/Lib/ufo2ft/outlineCompiler.py#L575-L616
         let subscript_x_size = units_per_em * 0.65;
         let subscript_y_size = units_per_em * 0.60;
         let subscript_y_offset = units_per_em * 0.075;
         let superscript_y_offset = units_per_em * 0.35;
-        set(GlobalMetric::SubscriptXSize, subscript_x_size);
-        set(GlobalMetric::SubscriptYSize, subscript_y_size);
-        set(
+
+        set_if_absent(GlobalMetric::SubscriptXSize, subscript_x_size);
+        set_if_absent(GlobalMetric::SubscriptYSize, subscript_y_size);
+        set_if_absent(
             GlobalMetric::SubscriptXOffset,
             adjust_offset(-subscript_y_offset, italic_angle),
         );
-        set(GlobalMetric::SubscriptYOffset, subscript_y_offset);
+        set_if_absent(GlobalMetric::SubscriptYOffset, subscript_y_offset);
 
-        set(GlobalMetric::SuperscriptXSize, subscript_x_size);
-        set(GlobalMetric::SuperscriptYSize, subscript_y_size);
-        set(
+        set_if_absent(GlobalMetric::SuperscriptXSize, subscript_x_size);
+        set_if_absent(GlobalMetric::SuperscriptYSize, subscript_y_size);
+        set_if_absent(
             GlobalMetric::SuperscriptXOffset,
             adjust_offset(superscript_y_offset, italic_angle),
         );
-        set(GlobalMetric::SuperscriptYOffset, superscript_y_offset);
+        set_if_absent(GlobalMetric::SuperscriptYOffset, superscript_y_offset);
 
         // // https://github.com/googlefonts/ufo2ft/blob/0d2688cd847d003b41104534d16973f72ef26c40/Lib/ufo2ft/fontInfoData.py#L313-L316
-        set(GlobalMetric::StrikeoutSize, 0.05 * units_per_em);
-        set(GlobalMetric::StrikeoutPosition, x_height * 0.6);
+        set_if_absent(GlobalMetric::StrikeoutSize, 0.05 * units_per_em);
+        set_if_absent(GlobalMetric::StrikeoutPosition, x_height * 0.6);
 
         // ufo2ft and Glyphs.app have different defaults for the post.underlinePosition:
         // the former uses 0.075*UPEM whereas the latter 0.1*UPEM (both use the same
         // underlineThickness 0.05*UPEM). We prefer to match Glyphs.app as more widely used.
         // https://github.com/googlefonts/ufo2ft/blob/main/Lib/ufo2ft/fontInfoData.py#L313-L322
         // https://github.com/googlefonts/glyphsLib/blob/main/Lib/glyphsLib/builder/custom_params.py#L1116-L1125
-        set(GlobalMetric::UnderlineThickness, 0.05 * units_per_em);
-        set(GlobalMetric::UnderlinePosition, -0.1 * units_per_em);
+        set_if_absent(GlobalMetric::UnderlineThickness, 0.05 * units_per_em);
+        set_if_absent(GlobalMetric::UnderlinePosition, -0.1 * units_per_em);
     }
 
     fn values(&self, metric: GlobalMetric) -> &GlobalMetricValues {
@@ -653,8 +639,17 @@ impl GlobalMetrics {
         self.values_mut(metric).insert(pos, value.into());
     }
 
+    pub fn set_if_absent(
+        &mut self,
+        metric: GlobalMetric,
+        pos: NormalizedLocation,
+        value: impl Into<OrderedFloat<f32>>,
+    ) {
+        self.values_mut(metric).entry(pos).or_insert(value.into());
+    }
+
     pub fn set_if_some(
-        self: &mut GlobalMetrics,
+        &mut self,
         metric: GlobalMetric,
         pos: NormalizedLocation,
         maybe_value: Option<impl Into<OrderedFloat<f64>>>,

--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -3246,7 +3246,7 @@ mod tests {
         assert_eq!(Some(0), font.hhea_line_gap);
         assert_eq!(Some(1185), font.win_ascent);
         assert_eq!(Some(420), font.win_descent);
-        assert_eq!(Some(OrderedFloat(50_f64)), font.underline_thickness);
+        assert_eq!(Some(OrderedFloat(42_f64)), font.underline_thickness);
         assert_eq!(Some(OrderedFloat(-300_f64)), font.underline_position);
     }
 }

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -559,29 +559,10 @@ impl Work<Context, WorkId, Error> for GlobalMetricWork {
         );
 
         let static_metadata = context.static_metadata.get();
-        let default_master = font.default_master();
-        let mut metrics = GlobalMetrics::new(
-            static_metadata.default_location().clone(),
-            static_metadata.units_per_em,
-            default_master.x_height(),
-            default_master.ascender(),
-            default_master.descender(),
-            static_metadata.italic_angle.into_inner(),
-        );
+        let mut metrics = GlobalMetrics::new();
 
         for master in font.masters.iter() {
             let pos = font_info.locations.get(&master.axes_values).unwrap();
-            if !pos.is_default() {
-                metrics.populate_defaults(
-                    pos,
-                    static_metadata.units_per_em,
-                    master.x_height(),
-                    master.ascender(),
-                    master.descender(),
-                    // turn clockwise angle counter-clockwise
-                    master.italic_angle().map(|v| -v),
-                );
-            }
 
             metrics.set_if_some(GlobalMetric::CapHeight, pos.clone(), master.cap_height());
             metrics.set_if_some(GlobalMetric::XHeight, pos.clone(), master.x_height());
@@ -732,7 +713,17 @@ impl Work<Context, WorkId, Error> for GlobalMetricWork {
                 GlobalMetric::UnderlinePosition,
                 pos.clone(),
                 master.underline_position.or(font.underline_position),
-            )
+            );
+
+            metrics.populate_defaults(
+                pos,
+                static_metadata.units_per_em,
+                master.x_height(),
+                master.ascender(),
+                master.descender(),
+                // turn clockwise angle counter-clockwise
+                master.italic_angle().map(|v| -v),
+            );
         }
 
         context.global_metrics.set(metrics);

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -1801,66 +1801,37 @@ mod tests {
             .get()
             .at(static_metadata.default_location());
         assert_eq!(
-            GlobalMetricsInstance {
-                pos: static_metadata.default_location().clone(),
-                ascender: 800.0.into(),
-                descender: (-200.0).into(),
-                caret_slope_rise: 1000.0.into(),
-                cap_height: 660.0.into(),
-                x_height: 478.0.into(),
-                subscript_x_size: 650.0.into(),
-                subscript_y_size: 600.0.into(),
-                subscript_y_offset: 75.0.into(),
-                superscript_x_size: 650.0.into(),
-                superscript_y_size: 600.0.into(),
-                superscript_y_offset: 350.0.into(),
-                strikeout_position: 286.8.into(),
-                strikeout_size: 50.0.into(),
-                os2_typo_ascender: 950.0.into(),
-                os2_typo_descender: (-350.0).into(),
-                os2_typo_line_gap: 0.0.into(),
-                os2_win_ascent: 1185.0.into(),
-                os2_win_descent: 420.0.into(),
-                hhea_ascender: 950.0.into(),
-                hhea_descender: (-350.0).into(),
-                hhea_line_gap: 0.0.into(),
-                underline_thickness: 50.0.into(),
-                underline_position: (-300.0).into(),
-                ..Default::default()
-            },
-            default_metrics
-        );
-        let light = NormalizedLocation::for_pos(&[("wght", 0.0)]);
-        let light_metrics = context.global_metrics.get().at(&light);
-        assert_eq!(
-            GlobalMetricsInstance {
-                pos: light.clone(),
-                ascender: 800.0.into(),
-                descender: (-200.0).into(),
-                caret_slope_rise: 1000.0.into(),
-                cap_height: 660.0.into(),
-                x_height: 478.0.into(),
-                subscript_x_size: 650.0.into(),
-                subscript_y_size: 600.0.into(),
-                subscript_y_offset: 75.0.into(),
-                superscript_x_size: 650.0.into(),
-                superscript_y_size: 600.0.into(),
-                superscript_y_offset: 350.0.into(),
-                strikeout_position: 286.8.into(),
-                strikeout_size: 50.0.into(),
-                os2_typo_ascender: 950.0.into(),
-                os2_typo_descender: (-350.0).into(),
-                os2_typo_line_gap: 0.0.into(),
-                os2_win_ascent: 1185.0.into(),
-                os2_win_descent: 420.0.into(),
-                hhea_ascender: 950.0.into(),
-                hhea_descender: (-350.0).into(),
-                hhea_line_gap: 0.0.into(),
-                underline_thickness: 50.0.into(),
-                underline_position: (-300.0).into(),
-                ..Default::default()
-            },
-            light_metrics
+            (
+                NormalizedLocation::for_pos(&[("wght", 0.0)]),
+                GlobalMetricsInstance {
+                    pos: static_metadata.default_location().clone(),
+                    ascender: 800.0.into(),
+                    descender: (-200.0).into(),
+                    caret_slope_rise: 1000.0.into(),
+                    cap_height: 660.0.into(),
+                    x_height: 478.0.into(),
+                    subscript_x_size: 650.0.into(),
+                    subscript_y_size: 600.0.into(),
+                    subscript_y_offset: 75.0.into(),
+                    superscript_x_size: 650.0.into(),
+                    superscript_y_size: 600.0.into(),
+                    superscript_y_offset: 350.0.into(),
+                    strikeout_position: 286.8.into(),
+                    strikeout_size: 40.0.into(), // fallback to underline thickness
+                    os2_typo_ascender: 950.0.into(),
+                    os2_typo_descender: (-350.0).into(),
+                    os2_typo_line_gap: 0.0.into(),
+                    os2_win_ascent: 1185.0.into(),
+                    os2_win_descent: 420.0.into(),
+                    hhea_ascender: 950.0.into(),
+                    hhea_descender: (-350.0).into(),
+                    hhea_line_gap: 0.0.into(),
+                    underline_thickness: 40.0.into(), // overridden from global value
+                    underline_position: (-300.0).into(),
+                    ..Default::default()
+                }
+            ),
+            (static_metadata.default_location().clone(), default_metrics)
         );
         let black = NormalizedLocation::for_pos(&[("wght", 1.0)]);
         let black_metrics = context.global_metrics.get().at(&black);
@@ -1879,7 +1850,7 @@ mod tests {
                 superscript_y_size: 600.0.into(),
                 superscript_y_offset: 350.0.into(),
                 strikeout_position: 300.0.into(),
-                strikeout_size: 50.0.into(),
+                strikeout_size: 42.0.into(), // fallback to underline thickness
                 os2_typo_ascender: 1000.0.into(),
                 os2_typo_descender: (-400.0).into(),
                 os2_typo_line_gap: 0.0.into(),
@@ -1888,7 +1859,7 @@ mod tests {
                 hhea_ascender: 1000.0.into(),
                 hhea_descender: (-400.0).into(),
                 hhea_line_gap: 0.0.into(),
-                underline_thickness: 50.0.into(),
+                underline_thickness: 42.0.into(), // global value
                 underline_position: (-300.0).into(),
                 ..Default::default()
             },

--- a/resources/testdata/glyphs3/GlobalMetrics_font_customParameters.glyphs
+++ b/resources/testdata/glyphs3/GlobalMetrics_font_customParameters.glyphs
@@ -55,7 +55,7 @@ value = 420;
 },
 {
 name = underlineThickness;
-value = 50;
+value = 42;
 },
 {
 name = underlinePosition;
@@ -90,6 +90,12 @@ pos = -200;
 }
 );
 name = ExtraLight;
+customParameters = (
+{
+name = underlineThickness;
+value = 40;
+},
+);
 },
 {
 axesValues = (


### PR DESCRIPTION
The only actual change is using underline thickness as the default for strikeout size. The rest is just shuffling things so we can conveniently know that a value is missing to decide to assign it a fallback. 

Helps with #973, [hanken-grotesk/sources/HankenGrotesk.glyphs](https://github.com/marcologous/hanken-grotesk) now matches OS/2. Surprisingly [soft-type-jersey/sources/Jersey25Charted.glyphs](https://github.com/scfried/soft-type-jersey) still produces an OS/2 that differs only on yStrikeoutSize. Baby steps :)