### PR TITLE
Obey UFO fs type specifications

### DIFF
--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -2824,7 +2824,7 @@ mod tests {
 
     #[test]
     fn default_fs_type_designspace() {
-        assert_fs_type("designspace_from_glyphs/WghtVar.designspace", 1 << 2);
+        assert_fs_type("wght_var.designspace", 1 << 2);
     }
 
     #[test]


### PR DESCRIPTION
Fixes #976. 

`$ resources/scripts/ttx_diff.py --compare default ../font_repos/cherokee/sources/NotoSansCherokee.designspace` now reports identical OS/2 instead of differing on fsType.

The file used for the `default_fs_type_designspace` test amusingly actually specified an fsType so I changed to one that doesn't.

JMM.