### PR TITLE
Use our logging framework for logging

### DIFF
--- a/fea-rs/src/compile/error.rs
+++ b/fea-rs/src/compile/error.rs
@@ -67,16 +67,23 @@ impl CompilerError {
         impl std::fmt::Display for Verbose<'_> {
             fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
                 write!(f, "{}", self.0)?;
-                let diagnostic = match self.0 {
-                    CompilerError::ParseFail(x)
-                    | CompilerError::ValidationFail(x)
-                    | CompilerError::CompilationFail(x) => x,
-                    _ => return Ok(()),
-                };
-                write!(f, "\n{}", diagnostic.display())
+                if let Some(diagnostics) = self.0.diagnostics() {
+                    write!(f, "\n{}", diagnostics.display())?;
+                }
+                Ok(())
             }
         }
         Verbose(self)
+    }
+
+    /// Return the `DiagnosticSet` associated, if any
+    pub fn diagnostics(&self) -> Option<&DiagnosticSet> {
+        match self {
+            CompilerError::ParseFail(x)
+            | CompilerError::ValidationFail(x)
+            | CompilerError::CompilationFail(x) => Some(x),
+            _ => None,
+        }
     }
 }
 

--- a/fontc/src/args.rs
+++ b/fontc/src/args.rs
@@ -89,6 +89,12 @@ pub struct Args {
     // cargo profile, and cargo optimization level.
     #[arg(long = "vv", default_value = "false")]
     pub verbose_version: bool,
+
+    /// Set the log level, either globally or per module.
+    ///
+    /// See <https://docs.rs/env_logger/latest/env_logger/#enabling-logging> for format.
+    #[arg(long)]
+    pub log: Option<String>,
 }
 
 /// A wrapper around a validated regex string
@@ -136,6 +142,7 @@ impl Args {
             keep_direction: false,
             no_production_names: false,
             verbose_version: false,
+            log: None,
         }
     }
 

--- a/fontc/src/args.rs
+++ b/fontc/src/args.rs
@@ -89,10 +89,6 @@ pub struct Args {
     // cargo profile, and cargo optimization level.
     #[arg(long = "vv", default_value = "false")]
     pub verbose_version: bool,
-
-    /// Print additional information about errors, if possible.
-    #[arg(long, short)]
-    pub verbose: bool,
 }
 
 /// A wrapper around a validated regex string
@@ -140,7 +136,6 @@ impl Args {
             keep_direction: false,
             no_production_names: false,
             verbose_version: false,
-            verbose: false,
         }
     }
 

--- a/fontc/src/main.rs
+++ b/fontc/src/main.rs
@@ -10,16 +10,19 @@ fn main() {
     let args = Args::parse();
 
     // catch and print errors manually, to avoid just seeing the Debug impls
+    // The default log level is error so the user will see it unless they specifically turned off logging
     if let Err(e) = run(args) {
         let mut error_displayed = false;
         let mut additional = "";
         if let Error::Backend(fontbe::error::Error::FeaCompileError(e)) = &e {
             if log::log_enabled!(log::Level::Warn) {
-                warn!("{}", e.display_verbose());
+                error!("{e}");
+                if let Some(diagnostic) = e.diagnostics() {
+                    warn!("{}", diagnostic.display());
+                }
                 error_displayed = true;
             } else {
-                additional =
-                    ", set log level to warn or higher (export RUST_LOG=warn) for additional detail"
+                additional = ", set log level to warn or higher (--log warn) for additional detail"
             }
         }
         if !error_displayed {
@@ -39,20 +42,23 @@ fn run(args: Args) -> Result<(), Error> {
     let time = create_timer(AnyWorkId::InternalTiming("Init logger"), 0)
         .queued()
         .run();
-    env_logger::builder()
-        .format(|buf, record| {
-            let ts = buf.timestamp_micros();
-            let style = buf.default_level_style(record.level());
-            writeln!(
-                buf,
-                "[{ts} {:?} {} {style}{}{style:#}] {}",
-                std::thread::current().id(),
-                record.target(),
-                record.level(),
-                record.args()
-            )
-        })
-        .init();
+    let mut log_cfg = env_logger::builder();
+    log_cfg.format(|buf, record| {
+        let ts = buf.timestamp_micros();
+        let style = buf.default_level_style(record.level());
+        writeln!(
+            buf,
+            "[{ts} {:?} {} {style}{}{style:#}] {}",
+            std::thread::current().id(),
+            record.target(),
+            record.level(),
+            record.args()
+        )
+    });
+    if let Some(log_filters) = &args.log {
+        log_cfg.parse_filters(log_filters);
+    }
+    log_cfg.init();
     timer.add(time.complete());
 
     fontc::run(args, timer)


### PR DESCRIPTION
It's quite confusing that you can set `RUST_LOG` to adjust how much you see except for one specific thing that relies on a flag.

Delete the flag, use the same logging as everything else, and tell the user how to see the error if we aren't showing them.

JMM