### PR TITLE
[crater] Tidy ci report html

### DIFF
--- a/fontc_crater/Cargo.toml
+++ b/fontc_crater/Cargo.toml
@@ -12,6 +12,7 @@ fontc = { version = "0.0.1", path = "../fontc" }
 
 google-fonts-sources = "0.3.1"
 maud = "0.26.0"
+tidier = "0.5.3"
 
 chrono.workspace = true
 rayon.workspace = true

--- a/fontc_crater/src/error.rs
+++ b/fontc_crater/src/error.rs
@@ -34,4 +34,7 @@ pub(super) enum Error {
         #[source]
         error: std::io::Error,
     },
+
+    #[error("Failed to tidy html: '{0}")]
+    TidyHtml(#[from] tidier::Error),
 }


### PR DESCRIPTION
Previously we would just write a big contatenated string of html, which was unreadable and also impossible to diff.

With this patch we clean up the html (newlines & indentation) using tidy.

This is particularly important because it means git can efficiently compute deltas on the index, instead of each new commit involving adding a new ~1MB blob to the repo.

JMM