### PR TITLE
[normalizer] Standardize location ordering

### DIFF
--- a/otl-normalizer/src/variations.rs
+++ b/otl-normalizer/src/variations.rs
@@ -44,6 +44,7 @@ impl<'a> DeltaComputer<'a> {
                     .collect(),
             );
         }
+        locations.sort();
         Ok(DeltaComputer { ivs, locations })
     }
 


### PR DESCRIPTION
The order of variation regions within the region list is left up to the compiler, and in some instances fontc and fontmake were choosing different orderings. This ensures that regardless of the ordering in the region list, deltas are presented in a consistent ordering in the output.