### PR TITLE
[fea-rs] Fix validation of ss01-ss20 & cv01-cv99

### DIFF
--- a/fea-rs/src/parse/grammar/feature.rs
+++ b/fea-rs/src/parse/grammar/feature.rs
@@ -206,12 +206,18 @@ fn cv_parameters(parser: &mut Parser, recovery: TokenSet) {
                 parser.expect_recover(Kind::RBrace, recovery);
                 parser.expect_semi();
             });
+        } else {
+            parser.err_and_bump("token not valid in cvParameters block");
+            parser.eat_until(recovery);
+            parser.eat(Kind::Semi);
         }
     }
 
-    let entry_recovery = recovery
-        .union(PARAM_KEYWORDS)
-        .union(TokenSet::new(&[LexemeKind::RBrace, LexemeKind::Semi]));
+    let entry_recovery = recovery.union(PARAM_KEYWORDS).union(TokenSet::new(&[
+        LexemeKind::RBrace,
+        LexemeKind::CharacterKw,
+        LexemeKind::Semi,
+    ]));
 
     parser.in_node(Kind::CvParametersKw, |parser| {
         assert!(parser.eat(Kind::CvParametersKw));

--- a/fea-rs/src/token_tree/typed.rs
+++ b/fea-rs/src/token_tree/typed.rs
@@ -1403,6 +1403,11 @@ impl Os2FamilyClass {
 }
 
 impl FeatureNames {
+    pub(crate) fn keyword(&self) -> &Token {
+        debug_assert_eq!(self.iter().next().unwrap().kind(), Kind::FeatureNamesKw);
+        self.iter().next().and_then(|t| t.as_token()).unwrap()
+    }
+
     pub(crate) fn statements(&self) -> impl Iterator<Item = NameSpec> + '_ {
         self.iter().filter_map(NameSpec::cast)
     }

--- a/fea-rs/test-data/compile-tests/mini-latin/bad/cv_params.ERR
+++ b/fea-rs/test-data/compile-tests/mini-latin/bad/cv_params.ERR
@@ -1,0 +1,11 @@
+error: cvParameters block only valid in cv01-cv99 features
+in ./test-data/compile-tests/mini-latin/bad/cv_params.fea at 3:4
+  | 
+3 |     cvParameters {
+  |     ^^^^^^^^^^^^
+
+error: cvParameters must be first statement in feature block
+in ./test-data/compile-tests/mini-latin/bad/cv_params.fea at 9:4
+  | 
+9 |     cvParameters {
+  |     ^^^^^^^^^^^^

--- a/fea-rs/test-data/compile-tests/mini-latin/bad/cv_params.fea
+++ b/fea-rs/test-data/compile-tests/mini-latin/bad/cv_params.fea
@@ -1,0 +1,12 @@
+feature cvNO {
+    # not valid in this feature
+    cvParameters {
+    };
+} cvNO;
+
+feature cv01 {
+    sub a by b;
+    cvParameters {
+    };
+} cv01;
+

--- a/fea-rs/test-data/compile-tests/mini-latin/bad/stylistic_set_names.ERR
+++ b/fea-rs/test-data/compile-tests/mini-latin/bad/stylistic_set_names.ERR
@@ -1,0 +1,11 @@
+error: featureNames block only valid in ss01-ss20 features
+in ./test-data/compile-tests/mini-latin/bad/stylistic_set_names.fea at 3:4
+  | 
+3 |     featureNames {
+  |     ^^^^^^^^^^^^
+
+error: featureNames must be first statement in feature block
+in ./test-data/compile-tests/mini-latin/bad/stylistic_set_names.fea at 10:4
+   | 
+10 |     featureNames {
+   |     ^^^^^^^^^^^^

--- a/fea-rs/test-data/compile-tests/mini-latin/bad/stylistic_set_names.fea
+++ b/fea-rs/test-data/compile-tests/mini-latin/bad/stylistic_set_names.fea
@@ -1,0 +1,14 @@
+feature ssNO {
+    # not valid in this feature
+    featureNames {
+        name "my cool name";
+    };
+} ssNO;
+
+feature ss01 {
+    sub a by b;
+    featureNames {
+        name "if present, block must be first item in feature";
+    };
+} ss01;
+


### PR DESCRIPTION
Our validation code was broken in a subtle way, where we were skipping the first statement in the block if it wasn't one of the special statements.

This fixes that, and also fixes a possible deadlock in the parsing of the cvParameters block.


This gets at least one more font compiling.