### PR TITLE
[fea-rs] Support 'pos a 20 b' pairpos syntax

### DIFF
--- a/fea-rs/src/parse/grammar/gpos.rs
+++ b/fea-rs/src/parse/grammar/gpos.rs
@@ -60,7 +60,10 @@ pub(crate) fn gpos_rule(parser: &mut Parser, recovery: TokenSet) {
             // now either a single or pair (type A)
             if metrics::eat_value_record(parser, recovery) {
                 if glyph::eat_glyph_or_glyph_class(parser, recovery) {
-                    metrics::expect_value_record(parser, recovery);
+                    // second value record is expected per the spec, but
+                    // skipping it is supported in afdko & feaLib:
+                    // https://github.com/adobe-type-tools/afdko/issues/1757
+                    metrics::eat_value_record(parser, recovery);
                     parser.expect_semi();
                     return AstKind::GposType2;
                 }

--- a/fea-rs/test-data/compile-tests/mini-latin/good/pair_pos_funny_syntax.fea
+++ b/fea-rs/test-data/compile-tests/mini-latin/good/pair_pos_funny_syntax.fea
@@ -1,0 +1,8 @@
+feature derp {
+    # this is not documented syntax but is treated equivalently to
+    # 'pos a b 30' and is handled by both feaLib and afdko
+    # ( see https://github.com/adobe-type-tools/afdko/issues/1757 )
+    pos a 30 b;
+    # so basically the same as,
+    pos a c 30;
+} derp;

--- a/fea-rs/test-data/compile-tests/mini-latin/good/pair_pos_funny_syntax.ttx
+++ b/fea-rs/test-data/compile-tests/mini-latin/good/pair_pos_funny_syntax.ttx
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont>
+
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=1 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="derp"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=1 -->
+      <Lookup index="0">
+        <LookupType value="2"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <PairPos index="0" Format="1">
+          <Coverage>
+            <Glyph value="a"/>
+          </Coverage>
+          <ValueFormat1 value="4"/>
+          <ValueFormat2 value="0"/>
+          <!-- PairSetCount=1 -->
+          <PairSet index="0">
+            <!-- PairValueCount=2 -->
+            <PairValueRecord index="0">
+              <SecondGlyph value="b"/>
+              <Value1 XAdvance="30"/>
+            </PairValueRecord>
+            <PairValueRecord index="1">
+              <SecondGlyph value="c"/>
+              <Value1 XAdvance="30"/>
+            </PairValueRecord>
+          </PairSet>
+        </PairPos>
+      </Lookup>
+    </LookupList>
+  </GPOS>
+
+</ttFont>


### PR DESCRIPTION
This syntax is not documented, but it is treated as equivalent to 'pos a b 20' by both afdko and feaLib, and exists in at least one noto font.

Opened https://github.com/adobe-type-tools/afdko/issues/1757 to see if this is intended or just works by accident; in either case I think supporting it is expedient.