### PR TITLE
[ttx_diff] If truncating stderr, truncate head

### DIFF
--- a/resources/scripts/ttx_diff.py
+++ b/resources/scripts/ttx_diff.py
@@ -606,12 +606,12 @@ def main(argv):
             build_fontc(source.resolve(), fontc_manifest_path, build_dir, compare)
         except BuildFail as e:
             failures["fontc"] = {"command": " ".join(
-                e.command), "stderr": e.stderr[:MAX_ERR_LEN]}
+                e.command), "stderr": e.stderr[-MAX_ERR_LEN:]}
         try:
             build_fontmake(source.resolve(), build_dir, compare)
         except BuildFail as e:
             failures["fontmake"] = {"command": " ".join(
-                e.command), "stderr": e.stderr[:MAX_ERR_LEN]}
+                e.command), "stderr": e.stderr[-MAX_ERR_LEN:]}
 
         report_errors_and_exit_if_there_were_any(failures)
 


### PR DESCRIPTION
Because the most relevant information (in the case of an error) is going to be what gets printed at the end of the stream, not the start of it.

JMM