### PR TITLE
Update to norad 0.14.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ icu_properties = "1.4"
 # fontations etc
 write-fonts = { version = "0.29.0", features = ["serde", "read"] }
 skrifa = "0.21.0"
-norad = "0.12"
+norad = "0.14.2"
 
 # dev dependencies
 diff = "0.1.12"

--- a/glyphs-reader/Cargo.toml
+++ b/glyphs-reader/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 [dependencies]
 ascii_plist_derive = { version = "0.0.1", path = "ascii_plist_derive" }
 fontdrasil = { version = "0.0.1", path = "../fontdrasil" }
-quick-xml = "0.31"
+quick-xml = "0.36"
 ordered-float.workspace = true
 kurbo.workspace = true
 indexmap.workspace = true
@@ -36,7 +36,7 @@ bincode.workspace = true
 pretty_assertions.workspace = true
 
 [build-dependencies]
-quick-xml = "0.31"
+quick-xml = "0.36"
 smol_str.workspace = true
 serde.workspace = true
 thiserror.workspace = true

--- a/glyphs-reader/src/glyphdata/glyphdata_impl.rs
+++ b/glyphs-reader/src/glyphdata/glyphdata_impl.rs
@@ -96,7 +96,7 @@ pub fn parse_entries(xml: &[u8]) -> Result<Vec<GlyphInfo>, GlyphDataError> {
     }
 
     let mut reader = Reader::from_reader(xml);
-    reader.trim_text(true);
+    reader.config_mut().trim_text(true);
 
     check_and_advance_past_preamble(&mut reader)?;
     iter_rows(&mut reader)


### PR DESCRIPTION
This includes a fix for a .glif parsing bug.


This _would_ get us compiling Noto Sans Mongolian but now I'm running into the thing I noticed for the first time yesterday, and which I was confident I would never see in the wild: #996