### PR TITLE
fix parsing widthClass from glyphs2 instances

### DIFF
--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -2842,7 +2842,24 @@ mod tests {
     }
 
     #[test]
-    fn os2_width_class_matches_default_wdth() {
+    fn os2_width_class_matches_default_wdth_glyphs2() {
+        let compile = TestCompile::compile_source("glyphs2/WdthVar.glyphs");
+        let font = compile.font();
+
+        // the default value for 'wdth' is 50 (UltraCondensed) in this test font
+        assert_eq!(
+            vec![(Tag::from_str("wdth").unwrap(), 50.0, 50.0, 200.0)],
+            axes(&font),
+        );
+        // ... which is reflected in the OS/2 table usWidthClass (UltraCondensed = 1)
+        assert_eq!(
+            WidthClass::UltraCondensed as u16,
+            font.os2().unwrap().us_width_class()
+        );
+    }
+
+    #[test]
+    fn os2_width_class_matches_default_wdth_glyphs3() {
         let compile = TestCompile::compile_source("glyphs3/WdthVar.glyphs");
         let font = compile.font();
 

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -550,7 +550,6 @@ mod tests {
         fs::{self, File},
         io::Read,
         path::{Path, PathBuf},
-        str::FromStr,
         sync::Arc,
         time::Instant,
     };
@@ -1650,10 +1649,7 @@ mod tests {
         let result = TestCompile::compile_source("glyphs2/WghtVar.glyphs");
         let font = result.font();
 
-        assert_eq!(
-            vec![(Tag::from_str("wght").unwrap(), 400.0, 400.0, 700.0)],
-            axes(&font),
-        );
+        assert_eq!(vec![(Tag::new(b"wght"), 400.0, 400.0, 700.0)], axes(&font),);
 
         assert_eq!(
             vec![
@@ -1674,10 +1670,7 @@ mod tests {
         let result = TestCompile::compile_source("glyphs2/WghtVar_Avar.glyphs");
         let font = result.font();
         // Default 400 is important, it means we found the index of Regular
-        assert_eq!(
-            vec![(Tag::from_str("wght").unwrap(), 300.0, 400.0, 700.0)],
-            axes(&font),
-        );
+        assert_eq!(vec![(Tag::new(b"wght"), 300.0, 400.0, 700.0)], axes(&font),);
 
         let axis_maps: Vec<_> = font
             .avar()
@@ -1967,7 +1960,7 @@ mod tests {
         let name = font.name().unwrap();
         let stat = font.stat().unwrap();
         assert_eq!(
-            ("Regular", vec![Tag::from_str("wght").unwrap(),]),
+            ("Regular", vec![Tag::new(b"wght"),]),
             (
                 resolve_name(&name, stat.elided_fallback_name_id().unwrap())
                     .unwrap()
@@ -2833,10 +2826,7 @@ mod tests {
         let font = compile.font();
 
         // the default value for 'wght' is 700 (Bold) in this test font
-        assert_eq!(
-            vec![(Tag::from_str("wght").unwrap(), 200.0, 700.0, 700.0)],
-            axes(&font),
-        );
+        assert_eq!(vec![(Tag::new(b"wght"), 200.0, 700.0, 700.0)], axes(&font),);
         // ... which is reflected in the OS/2 table usWeightClass
         assert_eq!(700, font.os2().unwrap().us_weight_class());
     }
@@ -2847,10 +2837,7 @@ mod tests {
         let font = compile.font();
 
         // the default value for 'wdth' is 50 (UltraCondensed) in this test font
-        assert_eq!(
-            vec![(Tag::from_str("wdth").unwrap(), 50.0, 50.0, 200.0)],
-            axes(&font),
-        );
+        assert_eq!(vec![(Tag::new(b"wdth"), 50.0, 50.0, 200.0)], axes(&font),);
         // ... which is reflected in the OS/2 table usWidthClass (UltraCondensed = 1)
         assert_eq!(
             WidthClass::UltraCondensed as u16,
@@ -2864,10 +2851,7 @@ mod tests {
         let font = compile.font();
 
         // the default value for 'wdth' is 50 (UltraCondensed) in this test font
-        assert_eq!(
-            vec![(Tag::from_str("wdth").unwrap(), 50.0, 50.0, 200.0)],
-            axes(&font),
-        );
+        assert_eq!(vec![(Tag::new(b"wdth"), 50.0, 50.0, 200.0)], axes(&font),);
         // ... which is reflected in the OS/2 table usWidthClass (UltraCondensed = 1)
         assert_eq!(
             WidthClass::UltraCondensed as u16,

--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -1422,7 +1422,7 @@ impl RawFont {
                 let Some(value) = lookup_class_value(tag, value) else {
                     return Err(Error::UnknownValueName(value.clone()));
                 };
-                let _ = opt.insert(format!("{}", value));
+                let _ = opt.insert(value.to_string());
             }
         }
 
@@ -1954,26 +1954,19 @@ fn lookup_class_value(axis_tag: &str, user_class: &str) -> Option<u16> {
     };
     match (axis_tag, user_class.as_str()) {
         ("wght", "thin") => Some(100),
-        ("wght", "extralight") => Some(200),
-        ("wght", "ultralight") => Some(200),
+        ("wght", "extralight" | "ultralight") => Some(200),
         ("wght", "light") => Some(300),
-        ("wght", "") => Some(400),
-        ("wght", "normal") => Some(400),
-        ("wght", "regular") => Some(400),
+        ("wght", "" | "normal" | "regular") => Some(400),
         ("wght", "medium") => Some(500),
-        ("wght", "demibold") => Some(600),
-        ("wght", "semibold") => Some(600),
+        ("wght", "demibold" | "semibold") => Some(600),
         ("wght", "bold") => Some(700),
-        ("wght", "ultrabold") => Some(800),
-        ("wght", "extrabold") => Some(800),
-        ("wght", "black") => Some(900),
-        ("wght", "heavy") => Some(900),
+        ("wght", "ultrabold" | "extrabold") => Some(800),
+        ("wght", "black" | "heavy") => Some(900),
         ("wdth", "ultracondensed") => Some(1),
         ("wdth", "extracondensed") => Some(2),
         ("wdth", "condensed") => Some(3),
         ("wdth", "semicondensed") => Some(4),
-        ("wdth", "") => Some(5),
-        ("wdth", "Medium (normal)") => Some(5),
+        ("wdth", "" | "Medium (normal)") => Some(5),
         ("wdth", "semiexpanded") => Some(6),
         ("wdth", "expanded") => Some(7),
         ("wdth", "extraexpanded") => Some(8),

--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -1422,7 +1422,7 @@ impl RawFont {
                 let Some(value) = lookup_class_value(tag, value) else {
                     return Err(Error::UnknownValueName(value.clone()));
                 };
-                let _ = opt.insert(format!("{}", value as i64));
+                let _ = opt.insert(format!("{}", value));
             }
         }
 
@@ -1943,7 +1943,7 @@ fn raw_feature_to_feature(feature: RawFeature) -> Result<FeatureSnippet, Error> 
 }
 
 /// <https://github.com/googlefonts/glyphsLib/blob/6f243c1f732ea1092717918d0328f3b5303ffe56/Lib/glyphsLib/classes.py#L220-L249>
-fn lookup_class_value(axis_tag: &str, user_class: &str) -> Option<f32> {
+fn lookup_class_value(axis_tag: &str, user_class: &str) -> Option<u16> {
     let user_class = match user_class {
         value if !value.is_empty() => {
             let mut value = value.to_ascii_lowercase();
@@ -1953,31 +1953,31 @@ fn lookup_class_value(axis_tag: &str, user_class: &str) -> Option<f32> {
         _ => String::from(""),
     };
     match (axis_tag, user_class.as_str()) {
-        ("wght", "thin") => Some(100.0),
-        ("wght", "extralight") => Some(200.0),
-        ("wght", "ultralight") => Some(200.0),
-        ("wght", "light") => Some(300.0),
-        ("wght", "") => Some(400.0),
-        ("wght", "normal") => Some(400.0),
-        ("wght", "regular") => Some(400.0),
-        ("wght", "medium") => Some(500.0),
-        ("wght", "demibold") => Some(600.0),
-        ("wght", "semibold") => Some(600.0),
-        ("wght", "bold") => Some(700.0),
-        ("wght", "ultrabold") => Some(800.0),
-        ("wght", "extrabold") => Some(800.0),
-        ("wght", "black") => Some(900.0),
-        ("wght", "heavy") => Some(900.0),
-        ("wdth", "ultracondensed") => Some(50.0),
-        ("wdth", "extracondensed") => Some(62.5),
-        ("wdth", "condensed") => Some(75.0),
-        ("wdth", "semicondensed") => Some(87.5),
-        ("wdth", "") => Some(100.0),
-        ("wdth", "Medium (normal)") => Some(100.0),
-        ("wdth", "semiexpanded") => Some(112.5),
-        ("wdth", "expanded") => Some(125.0),
-        ("wdth", "extraexpanded") => Some(150.0),
-        ("wdth", "ultraexpanded") => Some(200.0),
+        ("wght", "thin") => Some(100),
+        ("wght", "extralight") => Some(200),
+        ("wght", "ultralight") => Some(200),
+        ("wght", "light") => Some(300),
+        ("wght", "") => Some(400),
+        ("wght", "normal") => Some(400),
+        ("wght", "regular") => Some(400),
+        ("wght", "medium") => Some(500),
+        ("wght", "demibold") => Some(600),
+        ("wght", "semibold") => Some(600),
+        ("wght", "bold") => Some(700),
+        ("wght", "ultrabold") => Some(800),
+        ("wght", "extrabold") => Some(800),
+        ("wght", "black") => Some(900),
+        ("wght", "heavy") => Some(900),
+        ("wdth", "ultracondensed") => Some(1),
+        ("wdth", "extracondensed") => Some(2),
+        ("wdth", "condensed") => Some(3),
+        ("wdth", "semicondensed") => Some(4),
+        ("wdth", "") => Some(5),
+        ("wdth", "Medium (normal)") => Some(5),
+        ("wdth", "semiexpanded") => Some(6),
+        ("wdth", "expanded") => Some(7),
+        ("wdth", "extraexpanded") => Some(8),
+        ("wdth", "ultraexpanded") => Some(9),
         _ => {
             warn!("Unrecognized ('{axis_tag}', '{user_class}')");
             None

--- a/resources/testdata/glyphs2/WdthVar.glyphs
+++ b/resources/testdata/glyphs2/WdthVar.glyphs
@@ -1,0 +1,155 @@
+{
+.appVersion = "3323";
+copyright = "Copy!";
+customParameters = (
+{
+name = description;
+value = "The greatest width var";
+},
+{
+name = familyName;
+value = WdthVar;
+},
+{
+name = licenseURL;
+value = "https://example.com/my/font/license";
+},
+{
+name = versionString;
+value = "New Value";
+},
+{
+name = Axes;
+value = (
+{
+Name = Width;
+Tag = wdth;
+}
+);
+}
+);
+date = "2022-12-01 04:52:20 +0000";
+familyName = WdthVar;
+fontMaster = (
+{
+alignmentZones = (
+"{737, 16}",
+"{0, -16}",
+"{-42, -16}"
+);
+ascender = 737;
+capHeight = 702;
+descender = -42;
+iconName = Light_Condensed;
+id = m01;
+weightValue = 22;
+width = Condensed;
+xHeight = 501;
+},
+{
+ascender = 800;
+capHeight = 700;
+custom = Expanded;
+descender = -200;
+iconName = Light_Extended;
+id = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+weightValue = 62;
+xHeight = 500;
+}
+);
+glyphs = (
+{
+glyphname = space;
+lastChange = "2022-12-01 04:58:12 +0000";
+layers = (
+{
+layerId = m01;
+width = 200;
+},
+{
+layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+width = 600;
+}
+);
+unicode = 0020;
+},
+{
+glyphname = hyphen;
+lastChange = "2024-08-28 11:45:55 +0000";
+layers = (
+{
+layerId = m01;
+paths = (
+{
+closed = 1;
+nodes = (
+"151 250 LINE {name = hr00;}",
+"451 250 LINE",
+"451 330 LINE",
+"151 330 LINE"
+);
+}
+);
+width = 600;
+},
+{
+layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+paths = (
+{
+closed = 1;
+nodes = (
+"75 224 LINE",
+"525 224 LINE",
+"525 356 LINE",
+"75 356 LINE"
+);
+}
+);
+width = 600;
+}
+);
+unicode = 002D;
+}
+);
+instances = (
+{
+interpolationWeight = 22;
+instanceInterpolations = {
+m01 = 1;
+};
+name = "Ultra Condensed";
+widthClass = "Ultra Condensed";
+},
+{
+interpolationWeight = 41;
+instanceInterpolations = {
+"E09E0C54-128D-4FEA-B209-1B70BEFE300B" = 0.475;
+m01 = 0.525;
+};
+name = Regular;
+},
+{
+interpolationWeight = 62;
+instanceInterpolations = {
+"E09E0C54-128D-4FEA-B209-1B70BEFE300B" = 1;
+};
+name = "Ultra Expanded";
+widthClass = "Ultra Expanded";
+}
+);
+kerning = {
+m01 = {
+hyphen = {
+hyphen = -150;
+};
+};
+"E09E0C54-128D-4FEA-B209-1B70BEFE300B" = {
+hyphen = {
+hyphen = -50;
+};
+};
+};
+unitsPerEm = 1000;
+versionMajor = 42;
+versionMinor = 42;
+}


### PR DESCRIPTION
we were only testing parsing instance widthClass for glyphs3 sources, where this property already holds a number 1..9
for glyphs2 this is an enumerated string that maps to numbers from 1 to 9.

`lookup_class_value` is incorrectly mapping the widthClass to numbers from 50 to 200 (i.e. using the corresponding percentages instead of the enumerated integer values)

https://github.com/googlefonts/fontc/blob/4a4019c66902e9ce68c7b98403a734b94a88eaf2/glyphs-reader/src/font.rs#L1971-L1980

... but then the WidthClass::try_from fails because only numbers 1 to 9 are supported:

https://github.com/googlefonts/fontc/blob/4a4019c66902e9ce68c7b98403a734b94a88eaf2/fontdrasil/src/types.rs#L110-L134

I first push a failing test case (simply duplicating an existing test for glyphs3/WdthVar.glyphs, coverted to glyphs2 using the Glyphs.app), then will follow up with the actual fix.