### PR TITLE
Fix bug where fontc didn't have Glyphs-specific underline defaults

### DIFF
--- a/resources/testdata/glyphs3/WghtVar1290upem.glyphs
+++ b/resources/testdata/glyphs3/WghtVar1290upem.glyphs
@@ -1,0 +1,26 @@
+{
+.formatVersion = 3;
+familyName = WghtVar;
+fontMaster = (
+{
+id = m01;
+name = Regular;
+}
+);
+glyphs = (
+{
+glyphname = space;
+layers = (
+{
+layerId = m01;
+width = 200;
+}
+);
+unicode = 32;
+}
+);
+
+unitsPerEm = 1290;
+versionMajor = 42;
+versionMinor = 42;
+}


### PR DESCRIPTION
`fontc` and `fontmake` disagree about `yStrikeoutSize` for [soft-type-jacquard/sources/Jacquard24Charted.glyphs](https://github.com/scfried/soft-type-jacquard).

In outlineCompiler.py in ufo2ft `yStrikeoutSize` is set to `openTypeOS2StrikeoutSize` if present, otherwise `postscriptUnderlineThickness`. Turns out 
 https://github.com/googlefonts/glyphsLib/blob/9d5828d874110c42dfc5f542db8eb84f88641eb5/Lib/glyphsLib/builder/custom_params.py#L1136-L1156 captures parameters that differ from the ufo2ft defaults, notably underline thickness and position.

After this fix `OS/2` and `post` match for Jacquard 24 Charted. Presumably impacts others too.