### PR TITLE
Avoid assigning names for unreachable instances

### DIFF
--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -3128,4 +3128,30 @@ mod tests {
         let classdef = gdef.glyph_class_def().unwrap().unwrap();
         assert_eq!(classdef.iter().count(), 1)
     }
+
+    // <https://github.com/googlefonts/fontc/issues/1008>
+    #[test]
+    fn no_names_for_instances_in_a_static_font() {
+        let compile = TestCompile::compile_source("glyphs3/StaticWithInstance.glyphs");
+        let font = compile.font();
+
+        // <https://learn.microsoft.com/en-us/typography/opentype/spec/name#name-ids>
+        let name = font.name().unwrap();
+        let font_specific_names = name
+            .name_record()
+            .iter()
+            .filter_map(|nr| {
+                if nr.name_id().to_u16() > 255 {
+                    Some((nr.name_id(), nr.string(name.string_data()).unwrap()))
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+
+        assert!(
+            font_specific_names.is_empty(),
+            "Should have no font specific names, got {font_specific_names:?}"
+        );
+    }
 }

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -355,10 +355,18 @@ impl StaticMetadata {
         // Point axes are less exciting than ranged ones
         let variable_axes: Vec<_> = axes.iter().filter(|a| !a.is_point()).cloned().collect();
 
+        // Named instances of static fonts are unhelpful <https://github.com/googlefonts/fontc/issues/1008>
+        let named_instances = if !variable_axes.is_empty() {
+            named_instances
+        } else {
+            Default::default()
+        };
+
         // Claim names for axes and named instances
         let mut name_id_gen = 255;
         let mut key_to_name = names;
         let mut visited = HashSet::new();
+
         variable_axes
             .iter()
             .map(|axis| &axis.name)

--- a/resources/testdata/glyphs3/StaticWithInstance.glyphs
+++ b/resources/testdata/glyphs3/StaticWithInstance.glyphs
@@ -1,0 +1,37 @@
+{
+.appVersion = "3151";
+.formatVersion = 3;
+familyName = WghtVar;
+fontMaster = (
+{
+id = m01;
+name = "Regular";
+}
+);
+glyphs = (
+{
+glyphname = space;
+lastChange = "2022-12-01 04:58:12 +0000";
+layers = (
+{
+layerId = m01;
+width = 200;
+}
+);
+unicode = 32;
+}
+);
+
+instances = (
+{
+instanceInterpolations = {
+m01 = 1;
+};
+name = Regular;
+}
+);
+
+unitsPerEm = 1000;
+versionMajor = 42;
+versionMinor = 42;
+}


### PR DESCRIPTION
Fixes #1008. Makes `name` identical for [soft-type-jacquard/sources/Jacquard24Charted.glyphs](https://github.com/scfried/soft-type-jacquard)