### PR TITLE
Expose and fix name processing discrepency

### DIFF
--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -2133,7 +2133,8 @@ impl TryFrom<RawFont> for Font {
 
         let mut names = BTreeMap::new();
         for name in from.properties {
-            // TODO: we only support dflt, .glyphs l10n names are ignored
+            // We don't support full l10n of names, just the limited capability of glyphsLib
+            // See <https://github.com/googlefonts/fontc/issues/1011>
             name.value
                 .or_else(|| {
                     name.values
@@ -2141,6 +2142,7 @@ impl TryFrom<RawFont> for Font {
                         .find(|v| v.language == "dflt")
                         .map(|v| v.value.clone())
                 })
+                .or_else(|| name.values.first().map(|v| v.value.clone()))
                 .and_then(|value| names.insert(name.key, value));
         }
         names.insert("familyNames".into(), from.family_name);

--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -2133,17 +2133,35 @@ impl TryFrom<RawFont> for Font {
 
         let mut names = BTreeMap::new();
         for name in from.properties {
-            // We don't support full l10n of names, just the limited capability of glyphsLib
-            // See <https://github.com/googlefonts/fontc/issues/1011>
-            name.value
-                .or_else(|| {
-                    name.values
-                        .iter()
-                        .find(|v| v.language == "dflt")
-                        .map(|v| v.value.clone())
-                })
-                .or_else(|| name.values.first().map(|v| v.value.clone()))
-                .and_then(|value| names.insert(name.key, value));
+            if name.value.is_some() {
+                name.value
+            } else {
+                // We don't support full l10n of names, just the limited capability of glyphsLib
+                // See <https://github.com/googlefonts/fontc/issues/1011>
+                // In order of preference: dflt, default, ENG, whatever is first
+                // <https://github.com/googlefonts/glyphsLib/blob/1cb4fc5ae2cf385df95d2b7768e7ab4eb60a5ac3/Lib/glyphsLib/classes.py#L3155-L3161>
+                name.values
+                    .iter()
+                    .enumerate()
+                    // (score [lower better], index)
+                    .map(|(i, n)| match n.language.as_str() {
+                        "dflt" => (-3, i),
+                        "default" => (-2, i),
+                        "ENG" => (-1, i),
+                        _ => (i as i32, i),
+                    })
+                    .reduce(
+                        |(best_score, best_index), (candidate_score, candidate_index)| {
+                            if best_score < candidate_score {
+                                (best_score, best_index)
+                            } else {
+                                (candidate_score, candidate_index)
+                            }
+                        },
+                    )
+                    .map(|(_, i)| name.values[i].value.clone())
+            }
+            .and_then(|value| names.insert(name.key, value));
         }
         names.insert("familyNames".into(), from.family_name);
         if let Some(version) = names.remove("versionString") {

--- a/resources/testdata/glyphs3/TheBestNames.glyphs
+++ b/resources/testdata/glyphs3/TheBestNames.glyphs
@@ -260,6 +260,10 @@ value = "The greatest weight var";
 key = copyrights;
 values = (
 {
+language = default;
+value = "Wrong answer";
+},
+{
 language = dflt;
 value = "Copy!";
 }
@@ -337,7 +341,15 @@ value = "Licensed to thrill";
 key = sampleTexts;
 values = (
 {
-language = dflt;
+language = MEH;
+value = "Don't pull this text";
+},
+{
+language = ENG;
+value = "Also bad";
+},
+{
+language = default;
 value = "Sam pull text";
 }
 );
@@ -346,7 +358,11 @@ value = "Sam pull text";
 key = compatibleFullNames;
 values = (
 {
-language = dflt;
+language = WRONG;
+value = "For the BeOS only";
+},
+{
+language = ENG;
 value = "For the Mac's only";
 }
 );

--- a/resources/testdata/glyphs3/TheBestNames.glyphs
+++ b/resources/testdata/glyphs3/TheBestNames.glyphs
@@ -294,6 +294,10 @@ value = "A trade in marks";
 key = manufacturers;
 values = (
 {
+language = ENG;
+value = "Wrong answer :(";
+},
+{
 language = dflt;
 value = "Who made you?!";
 }
@@ -307,8 +311,12 @@ value = "https://example.com/manufacturer";
 key = designers;
 values = (
 {
-language = dflt;
+language = IT_CAN_BE_ANYTHING;
 value = "Designed by me!";
+},
+{
+language = NOT_THIS_ONE;
+value = "Designed by ... you?!";
 }
 );
 },


### PR DESCRIPTION
Fixes #1011.

Combined with #1009 at least two families (listed in #1011) will have a matching `name` table