### PR TITLE
generate master names when upgrading glyphs2 to 3 

### DIFF
--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -2586,6 +2586,11 @@ mod tests {
         assert_load_v2_matches_load_v3("WghtVar_NoExport", LoadCompare::Glyphs);
     }
 
+    #[test]
+    fn read_master_names_2_and_3() {
+        assert_load_v2_matches_load_v3("MasterNames", LoadCompare::Glyphs);
+    }
+
     fn only_shape_in_only_layer<'a>(font: &'a Font, glyph_name: &str) -> &'a Shape {
         let glyph = font.glyphs.get(glyph_name).unwrap();
         assert_eq!(1, glyph.layers.len());

--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -885,6 +885,8 @@ struct RawFontMaster {
     name: Option<String>,
 
     weight: Option<String>,
+    width: Option<String>,
+    custom: Option<String>,
 
     weight_value: Option<OrderedFloat<f64>>,
     interpolation_weight: Option<OrderedFloat<f64>>,
@@ -1346,19 +1348,48 @@ impl RawFont {
         Ok(())
     }
 
-    fn v2_to_v3_weight(&mut self) -> Result<(), Error> {
+    fn v2_to_v3_master_names(&mut self) -> Result<(), Error> {
+        // in Glyphs 2, masters don't have a single 'name' attribute, but rather
+        // a concatenation of three other optional attributes weirdly called
+        // 'width', 'weight' and 'custom' (in exactly this order).
+        // The first two can only contain few predefined values, the last one is
+        // residual and free-form. They default to 'Regular' when omitted in
+        // the source. See:
+        // https://github.com/schriftgestalt/GlyphsSDK/blob/Glyphs3/GlyphsFileFormat/GlyphsFileFormatv2.md
+        // https://github.com/googlefonts/glyphsLib/blob/9d5828d/Lib/glyphsLib/classes.py#L1700-L1711
         for master in self.font_master.iter_mut() {
-            // Don't remove weightValue, we need it to understand axes
-            if master.weight_value.is_none() {
+            // Even though glyphs2 masters don't officially have a 'name' attribute,
+            // some glyphs2 sources produced by more recent versions of Glyphs
+            // sometimes have it (unclear exactly when or from which version on).
+            // We keep the 'name' attribute as is, instead of generating a one.
+            if master.name.is_some() {
                 continue;
             }
-            // Missing = default = Regular per @anthrotype
-            master.name = Some(
-                master
-                    .weight
-                    .take()
-                    .unwrap_or_else(|| String::from("Regular")),
-            );
+            let width_name = master.width.take();
+            let weight_name = master.weight.take();
+            let custom_name = master.custom.take();
+            // Remove Nones, empty strings and redundant occurrences of 'Regular'
+            let mut names: Vec<_> = vec![width_name, weight_name, custom_name]
+                .into_iter()
+                .flatten()
+                .filter(|x| !x.is_empty() && x != "Regular")
+                .collect();
+            // append "Italic" if italic angle != 0
+            if let Some(italic_angle) = master.italic_angle {
+                if italic_angle != 0.0
+                    && (names.is_empty()
+                        || (!names.contains(&"Italic".into())
+                            && !names.contains(&"Oblique".into())))
+                {
+                    names.push("Italic".into());
+                }
+            }
+            // if all are empty, default to "Regular"
+            master.name = if names.is_empty() {
+                Some("Regular".into())
+            } else {
+                Some(names.join(" "))
+            };
         }
         Ok(())
     }
@@ -1439,7 +1470,7 @@ impl RawFont {
 
     /// `<See https://github.com/schriftgestalt/GlyphsSDK/blob/Glyphs3/GlyphsFileFormat/GlyphsFileFormatv3.md#differences-between-version-2>`
     fn v2_to_v3(&mut self) -> Result<(), Error> {
-        self.v2_to_v3_weight()?;
+        self.v2_to_v3_master_names()?;
         self.v2_to_v3_axes()?;
         self.v2_to_v3_metrics()?;
         self.v2_to_v3_names()?;

--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -2591,6 +2591,11 @@ mod tests {
         assert_load_v2_matches_load_v3("MasterNames", LoadCompare::Glyphs);
     }
 
+    #[test]
+    fn read_master_names_with_italic_2_and_3() {
+        assert_load_v2_matches_load_v3("MasterNames-Italic", LoadCompare::Glyphs);
+    }
+
     fn only_shape_in_only_layer<'a>(font: &'a Font, glyph_name: &str) -> &'a Shape {
         let glyph = font.glyphs.get(glyph_name).unwrap();
         assert_eq!(1, glyph.layers.len());

--- a/resources/testdata/glyphs2/MasterNames-Italic.glyphs
+++ b/resources/testdata/glyphs2/MasterNames-Italic.glyphs
@@ -1,0 +1,65 @@
+{
+.appVersion = "3323";
+customParameters = (
+{
+name = "Disable Last Change";
+value = 1;
+},
+{
+name = "Write DisplayStrings";
+value = 0;
+},
+{
+name = Axes;
+value = (
+{
+Name = Weight;
+Tag = wght;
+}
+);
+}
+);
+date = "2024-10-08 16:36:05 +0000";
+familyName = "Master Names";
+fontMaster = (
+{
+custom = Thin;
+id = m01;
+italicAngle = 10;
+},
+{
+id = "6A2F1D49-B971-4E48-8DE2-E69486298540";
+italicAngle = 10;
+weightValue = 400;
+},
+{
+custom = Black;
+id = "369A7D90-43AB-4213-A84C-0A5C875E6474";
+italicAngle = 10;
+weightValue = 900;
+}
+);
+glyphs = (
+{
+glyphname = space;
+layers = (
+{
+layerId = m01;
+width = 200;
+},
+{
+layerId = "6A2F1D49-B971-4E48-8DE2-E69486298540";
+width = 600;
+},
+{
+layerId = "369A7D90-43AB-4213-A84C-0A5C875E6474";
+width = 600;
+}
+);
+unicode = 0020;
+}
+);
+unitsPerEm = 1000;
+versionMajor = 1;
+versionMinor = 0;
+}

--- a/resources/testdata/glyphs2/MasterNames.glyphs
+++ b/resources/testdata/glyphs2/MasterNames.glyphs
@@ -1,0 +1,134 @@
+{
+.appVersion = "3323";
+customParameters = (
+{
+name = "Disable Last Change";
+value = 1;
+},
+{
+name = "Write DisplayStrings";
+value = 0;
+},
+{
+name = Axes;
+value = (
+{
+Name = Weight;
+Tag = wght;
+},
+{
+Name = Width;
+Tag = wdth;
+},
+{
+Name = Slant;
+Tag = slnt;
+}
+);
+}
+);
+date = "2024-10-08 14:26:05 +0000";
+familyName = "Master Names";
+fontMaster = (
+{
+id = "DDF631D8-5AEE-4386-B5BF-03993C77B0AA";
+weightValue = 400;
+},
+{
+id = "D2EB1C31-8ED9-420F-9687-7D982D9A46E5";
+weight = Bold;
+weightValue = 700;
+},
+{
+custom = Oblique;
+customValue = -12;
+id = "40424968-1876-4FBA-AB58-8534574F0AE7";
+italicAngle = 12;
+weightValue = 400;
+},
+{
+custom = Oblique;
+customValue = -12;
+iconName = Bold;
+id = "A1ED4D18-7256-4F1D-9E3C-19F01B8B10F5";
+italicAngle = 12;
+weight = Bold;
+weightValue = 700;
+},
+{
+id = m01;
+weightValue = 400;
+width = Condensed;
+widthValue = 75;
+},
+{
+id = "DFE82E08-3484-4D87-BEAF-2D0CD3BBF55B";
+weight = Bold;
+weightValue = 700;
+width = Condensed;
+widthValue = 75;
+},
+{
+custom = Oblique;
+customValue = -12;
+id = "CDEADDDA-C88F-4ADE-A383-D2638CEACD31";
+italicAngle = 12;
+weightValue = 400;
+width = Condensed;
+widthValue = 75;
+},
+{
+custom = Oblique;
+customValue = -12;
+id = "E133C05F-65B2-430F-ABEB-52DE7F7E7147";
+italicAngle = 12;
+weight = Bold;
+weightValue = 700;
+width = Condensed;
+widthValue = 75;
+}
+);
+glyphs = (
+{
+glyphname = space;
+layers = (
+{
+layerId = m01;
+width = 200;
+},
+{
+layerId = "DDF631D8-5AEE-4386-B5BF-03993C77B0AA";
+width = 600;
+},
+{
+layerId = "D2EB1C31-8ED9-420F-9687-7D982D9A46E5";
+width = 600;
+},
+{
+layerId = "40424968-1876-4FBA-AB58-8534574F0AE7";
+width = 600;
+},
+{
+layerId = "A1ED4D18-7256-4F1D-9E3C-19F01B8B10F5";
+width = 600;
+},
+{
+layerId = "DFE82E08-3484-4D87-BEAF-2D0CD3BBF55B";
+width = 600;
+},
+{
+layerId = "CDEADDDA-C88F-4ADE-A383-D2638CEACD31";
+width = 600;
+},
+{
+layerId = "E133C05F-65B2-430F-ABEB-52DE7F7E7147";
+width = 600;
+}
+);
+unicode = 0020;
+}
+);
+unitsPerEm = 1000;
+versionMajor = 1;
+versionMinor = 0;
+}

--- a/resources/testdata/glyphs3/MasterNames-Italic.glyphs
+++ b/resources/testdata/glyphs3/MasterNames-Italic.glyphs
@@ -1,0 +1,88 @@
+{
+.appVersion = "3323";
+.formatVersion = 3;
+axes = (
+{
+name = Weight;
+tag = wght;
+}
+);
+customParameters = (
+{
+name = "Write lastChange";
+value = 0;
+},
+{
+name = "Write DisplayStrings";
+value = 0;
+}
+);
+date = "2024-10-08 16:36:05 +0000";
+familyName = "Master Names";
+fontMaster = (
+{
+axesValues = (
+100
+);
+id = m01;
+metricValues = (
+{
+pos = 10;
+}
+);
+name = "Thin Italic";
+},
+{
+axesValues = (
+400
+);
+id = "6A2F1D49-B971-4E48-8DE2-E69486298540";
+metricValues = (
+{
+pos = 10;
+}
+);
+name = Italic;
+},
+{
+axesValues = (
+900
+);
+id = "369A7D90-43AB-4213-A84C-0A5C875E6474";
+metricValues = (
+{
+pos = 10;
+}
+);
+name = "Black Italic";
+}
+);
+glyphs = (
+{
+glyphname = space;
+layers = (
+{
+layerId = m01;
+width = 200;
+},
+{
+layerId = "6A2F1D49-B971-4E48-8DE2-E69486298540";
+width = 600;
+},
+{
+layerId = "369A7D90-43AB-4213-A84C-0A5C875E6474";
+width = 600;
+}
+);
+unicode = 32;
+}
+);
+metrics = (
+{
+type = "italic angle";
+}
+);
+unitsPerEm = 1000;
+versionMajor = 1;
+versionMinor = 0;
+}

--- a/resources/testdata/glyphs3/MasterNames.glyphs
+++ b/resources/testdata/glyphs3/MasterNames.glyphs
@@ -1,0 +1,188 @@
+{
+.appVersion = "3323";
+.formatVersion = 3;
+axes = (
+{
+name = Weight;
+tag = wght;
+},
+{
+name = Width;
+tag = wdth;
+},
+{
+name = Slant;
+tag = slnt;
+}
+);
+customParameters = (
+{
+name = "Write lastChange";
+value = 0;
+},
+{
+name = "Write DisplayStrings";
+value = 0;
+}
+);
+date = "2024-10-08 14:26:05 +0000";
+familyName = "Master Names";
+fontMaster = (
+{
+axesValues = (
+400,
+100,
+0
+);
+id = "DDF631D8-5AEE-4386-B5BF-03993C77B0AA";
+metricValues = (
+{
+}
+);
+name = Regular;
+},
+{
+axesValues = (
+700,
+100,
+0
+);
+id = "D2EB1C31-8ED9-420F-9687-7D982D9A46E5";
+metricValues = (
+{
+}
+);
+name = Bold;
+},
+{
+axesValues = (
+400,
+100,
+-12
+);
+id = "40424968-1876-4FBA-AB58-8534574F0AE7";
+metricValues = (
+{
+pos = 12;
+}
+);
+name = Oblique;
+},
+{
+axesValues = (
+700,
+100,
+-12
+);
+id = "A1ED4D18-7256-4F1D-9E3C-19F01B8B10F5";
+metricValues = (
+{
+pos = 12;
+}
+);
+name = "Bold Oblique";
+},
+{
+axesValues = (
+400,
+75,
+0
+);
+id = m01;
+metricValues = (
+{
+}
+);
+name = Condensed;
+},
+{
+axesValues = (
+700,
+75,
+0
+);
+id = "DFE82E08-3484-4D87-BEAF-2D0CD3BBF55B";
+metricValues = (
+{
+}
+);
+name = "Condensed Bold";
+},
+{
+axesValues = (
+400,
+75,
+-12
+);
+id = "CDEADDDA-C88F-4ADE-A383-D2638CEACD31";
+metricValues = (
+{
+pos = 12;
+}
+);
+name = "Condensed Oblique";
+},
+{
+axesValues = (
+700,
+75,
+-12
+);
+id = "E133C05F-65B2-430F-ABEB-52DE7F7E7147";
+metricValues = (
+{
+pos = 12;
+}
+);
+name = "Condensed Bold Oblique";
+}
+);
+glyphs = (
+{
+glyphname = space;
+layers = (
+{
+layerId = m01;
+width = 200;
+},
+{
+layerId = "DDF631D8-5AEE-4386-B5BF-03993C77B0AA";
+width = 600;
+},
+{
+layerId = "D2EB1C31-8ED9-420F-9687-7D982D9A46E5";
+width = 600;
+},
+{
+layerId = "40424968-1876-4FBA-AB58-8534574F0AE7";
+width = 600;
+},
+{
+layerId = "A1ED4D18-7256-4F1D-9E3C-19F01B8B10F5";
+width = 600;
+},
+{
+layerId = "DFE82E08-3484-4D87-BEAF-2D0CD3BBF55B";
+width = 600;
+},
+{
+layerId = "CDEADDDA-C88F-4ADE-A383-D2638CEACD31";
+width = 600;
+},
+{
+layerId = "E133C05F-65B2-430F-ABEB-52DE7F7E7147";
+width = 600;
+}
+);
+unicode = 32;
+}
+);
+metrics = (
+{
+type = "italic angle";
+}
+);
+unitsPerEm = 1000;
+versionMajor = 1;
+versionMinor = 0;
+}


### PR DESCRIPTION
Fixes #264 for glyphs2 as well.

the test currently fails because we aren't generating glyphs2 master names properly (they are all set to 'Regular' which doesn't help)