### PR TITLE
Take abs of win descent when reading .glyphs files

### DIFF
--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -595,10 +595,14 @@ impl Work<Context, WorkId, Error> for GlobalMetricWork {
                 pos.clone(),
                 master.win_ascent.or(font.win_ascent).map(|v| v as f64),
             );
+            // Some .glyphs files have a negative win descent so abs()
             metrics.set_if_some(
                 GlobalMetric::Os2WinDescent,
                 pos.clone(),
-                master.win_descent.or(font.win_descent).map(|v| v as f64),
+                master
+                    .win_descent
+                    .or(font.win_descent)
+                    .map(|v| v.abs() as f64),
             );
             metrics.set_if_some(
                 GlobalMetric::StrikeoutPosition,
@@ -1687,6 +1691,17 @@ mod tests {
             },
             default_metrics.round2()
         );
+    }
+
+    #[test]
+    fn captures_abs_of_win_descent() {
+        let (_, context) = build_global_metrics(glyphs3_dir().join("MVAR.glyphs"));
+        let static_metadata = &context.static_metadata.get();
+        let default_metrics = context
+            .global_metrics
+            .get()
+            .at(static_metadata.default_location());
+        assert_eq!(200.0, default_metrics.os2_win_descent.0);
     }
 
     #[test]

--- a/resources/testdata/glyphs3/MVAR.glyphs
+++ b/resources/testdata/glyphs3/MVAR.glyphs
@@ -39,7 +39,7 @@ value = 1195;
 },
 {
 name = winDescent;
-value = 195;
+value = -195;
 },
 {
 name = subscriptXSize;
@@ -145,7 +145,7 @@ value = 1200;
 },
 {
 name = winDescent;
-value = 200;
+value = -200;
 },
 {
 name = subscriptXSize;
@@ -250,7 +250,7 @@ value = 1205;
 },
 {
 name = winDescent;
-value = 205;
+value = -205;
 },
 {
 name = subscriptXSize;


### PR DESCRIPTION
OS/2 for Ga Maamli, Alumni Sans Pinstripe, and likely more should match after. Alumni Sans Pinstripe now reports identical in default mode locally.