### PR TITLE
[fea-rs] Better handling of featureNames & cvParam

### DIFF
--- a/fea-rs/src/compile/tables/name.rs
+++ b/fea-rs/src/compile/tables/name.rs
@@ -70,6 +70,12 @@ impl NameSpec {
         Encoding::new(self.platform_id, self.encoding_id) != Encoding::Unknown
     }
 
+    // used to ensure we only choose one name for a given platform/encoding
+    // when multiple are provided
+    pub(crate) fn key(&self) -> (u16, u16, u16) {
+        (self.platform_id, self.encoding_id, self.language_id)
+    }
+
     pub fn build(&self, name_id: NameId) -> write_fonts::tables::name::NameRecord {
         let string = parse_string(self.platform_id, self.string.trim_matches('"'));
         write_fonts::tables::name::NameRecord::new(

--- a/fea-rs/src/token_tree/typed.rs
+++ b/fea-rs/src/token_tree/typed.rs
@@ -671,14 +671,6 @@ impl Feature {
         self.iter().find_map(Tag::cast).unwrap()
     }
 
-    pub(crate) fn stylistic_set_feature_names(&self) -> Option<FeatureNames> {
-        self.statements().next().and_then(FeatureNames::cast)
-    }
-
-    pub(crate) fn character_variant_params(&self) -> Option<CvParameters> {
-        self.statements().next().and_then(CvParameters::cast)
-    }
-
     pub(crate) fn statements(&self) -> impl Iterator<Item = &NodeOrToken> {
         self.iter()
             .skip_while(|t| t.kind() != Kind::LBrace)

--- a/fea-rs/test-data/compile-tests/mini-latin/bad/cv_params.ERR
+++ b/fea-rs/test-data/compile-tests/mini-latin/bad/cv_params.ERR
@@ -4,7 +4,7 @@ in ./test-data/compile-tests/mini-latin/bad/cv_params.fea at 3:4
 3 |     cvParameters {
   |     ^^^^^^^^^^^^
 
-error: cvParameters must be first statement in feature block
+error: cvParameters must precede any rules
 in ./test-data/compile-tests/mini-latin/bad/cv_params.fea at 9:4
   | 
 9 |     cvParameters {

--- a/fea-rs/test-data/compile-tests/mini-latin/bad/stylistic_set_names.ERR
+++ b/fea-rs/test-data/compile-tests/mini-latin/bad/stylistic_set_names.ERR
@@ -4,7 +4,7 @@ in ./test-data/compile-tests/mini-latin/bad/stylistic_set_names.fea at 3:4
 3 |     featureNames {
   |     ^^^^^^^^^^^^
 
-error: featureNames must be first statement in feature block
+error: featureNames must precede any rules
 in ./test-data/compile-tests/mini-latin/bad/stylistic_set_names.fea at 10:4
    | 
 10 |     featureNames {

--- a/fea-rs/test-data/compile-tests/mini-latin/good/duplicate_feature_names.fea
+++ b/fea-rs/test-data/compile-tests/mini-latin/good/duplicate_feature_names.fea
@@ -1,0 +1,9 @@
+# https://github.com/googlefonts/fontc/issues/1019
+feature ss01 {
+    featureNames {
+        name "ss17";
+    };
+    featureNames {
+        name "Bulgarian letters";
+    };
+} ss01;

--- a/fea-rs/test-data/compile-tests/mini-latin/good/duplicate_feature_names.ttx
+++ b/fea-rs/test-data/compile-tests/mini-latin/good/duplicate_feature_names.ttx
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont>
+
+  <name>
+    <namerecord nameID="256" platformID="3" platEncID="1" langID="0x409">
+      Bulgarian letters
+    </namerecord>
+  </name>
+
+</ttFont>


### PR DESCRIPTION
Previously we would error if there were more than one of these blocks, but the spec merely says that they must occur before any rules.

This now supports multiple featureNames blocks, and matches the behaviour of fonttools (last writer wins).

For CvParameters, we will only look at the first such block, and skip the rest; no source in our collection has multiple such blocks defined within a given feature, and updating the logic is more complicated so I would like to defer it for now.

- fixes #1019 