### PR TITLE
Obey `fontinfo.plist` `openTypeOS2Panose` value for the default ufo

### DIFF
--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -122,6 +122,59 @@ pub struct MiscMetadata {
     pub lowest_rec_ppm: u16,
 
     pub created: Option<DateTime<Utc>>,
+
+    pub panose: Option<Panose>,
+}
+
+/// PANOSE bytes
+///
+/// <https://learn.microsoft.com/en-us/typography/opentype/spec/os2#panose>
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct Panose {
+    pub family_type: u8,
+    pub serif_style: u8,
+    pub weight: u8,
+    pub proportion: u8,
+    pub contrast: u8,
+    pub stroke_variation: u8,
+    pub arm_style: u8,
+    pub letterform: u8,
+    pub midline: u8,
+    pub x_height: u8,
+}
+
+impl From<[u8; 10]> for Panose {
+    fn from(value: [u8; 10]) -> Self {
+        Self {
+            family_type: value[0],
+            serif_style: value[1],
+            weight: value[2],
+            proportion: value[3],
+            contrast: value[4],
+            stroke_variation: value[5],
+            arm_style: value[6],
+            letterform: value[7],
+            midline: value[8],
+            x_height: value[9],
+        }
+    }
+}
+
+impl Panose {
+    pub fn to_bytes(&self) -> [u8; 10] {
+        [
+            self.family_type,
+            self.serif_style,
+            self.weight,
+            self.proportion,
+            self.contrast,
+            self.stroke_variation,
+            self.arm_style,
+            self.letterform,
+            self.midline,
+            self.x_height,
+        ]
+    }
 }
 
 /// The name of every glyph, in the order it will be emitted
@@ -410,6 +463,7 @@ impl StaticMetadata {
                 // <https://github.com/googlefonts/ufo2ft/blob/0d2688cd847d003b41104534d16973f72ef26c40/Lib/ufo2ft/fontInfoData.py#L365>
                 head_flags: 3,
                 created: None,
+                panose: None,
             },
         })
     }
@@ -2069,6 +2123,7 @@ mod tests {
                 head_flags: 42,
                 lowest_rec_ppm: 42,
                 created: None,
+                panose: None,
             },
             number_values: Default::default(),
         }

--- a/resources/testdata/WghtVar-Bold.ufo/fontinfo.plist
+++ b/resources/testdata/WghtVar-Bold.ufo/fontinfo.plist
@@ -8,5 +8,19 @@
     <real>801</real>
     <key>familyName</key>
     <string>Wght Var</string>
+    <key>openTypeOS2Panose</key>
+    <!-- different values than regular -->
+    <array>
+      <integer>3</integer>
+      <integer>12</integer>
+      <integer>6</integer>
+      <integer>3</integer>
+      <integer>5</integer>
+      <integer>6</integer>
+      <integer>5</integer>
+      <integer>3</integer>
+      <integer>3</integer>
+      <integer>5</integer>
+    </array>
   </dict>
 </plist>

--- a/resources/testdata/WghtVar-Regular.ufo/fontinfo.plist
+++ b/resources/testdata/WghtVar-Regular.ufo/fontinfo.plist
@@ -10,5 +10,18 @@
     <string>Wght Var</string>
     <key>openTypeHeadCreated</key>
     <string>2023/05/05 15:11:55</string>
+    <key>openTypeOS2Panose</key>
+    <array>
+      <integer>2</integer>
+      <integer>11</integer>
+      <integer>5</integer>
+      <integer>2</integer>
+      <integer>4</integer>
+      <integer>5</integer>
+      <integer>4</integer>
+      <integer>2</integer>
+      <integer>2</integer>
+      <integer>4</integer>
+    </array>
   </dict>
 </plist>


### PR DESCRIPTION
Fixes #1026, [cuneiform/sources/NotoSansCuneiform.designspace](https://github.com/notofonts/cuneiform) is identical locally after.

Ty @cmyr for [pointing out](https://github.com/googlefonts/fontc/issues/1026#issuecomment-2409468203) that I misread the `.designspace` initially.

JMM if happy.