### PR TITLE
Support v2 style names in v3 files

### DIFF
--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -2144,6 +2144,9 @@ impl TryFrom<RawFont> for Font {
     fn try_from(mut from: RawFont) -> Result<Self, Self::Error> {
         if from.is_v2() {
             from.v2_to_v3()?;
+        } else {
+            // <https://github.com/googlefonts/fontc/issues/1029>
+            from.v2_to_v3_names()?;
         }
 
         let radix = if from.is_v2() { 16 } else { 10 };
@@ -3179,6 +3182,14 @@ mod tests {
         let v2 = Font::load(&glyphs2_dir().join("TheBestNames.glyphs")).unwrap();
         let v3 = Font::load(&glyphs3_dir().join("TheBestNames.glyphs")).unwrap();
         assert_eq!(v3.names, v2.names);
+    }
+
+    #[test]
+    fn v2_style_names_in_a_v3_file() {
+        let v3_mixed_with_v2 =
+            Font::load(&glyphs3_dir().join("TheBestV2NamesInAV3File.glyphs")).unwrap();
+        let v3 = Font::load(&glyphs3_dir().join("TheBestNames.glyphs")).unwrap();
+        assert_eq!(v3.names, v3_mixed_with_v2.names);
     }
 
     fn assert_wghtvar_avar_master_and_axes(glyphs_file: &Path) {

--- a/resources/testdata/glyphs3/TheBestV2NamesInAV3File.glyphs
+++ b/resources/testdata/glyphs3/TheBestV2NamesInAV3File.glyphs
@@ -1,0 +1,127 @@
+{
+.appVersion = "3151";
+.formatVersion = 3;
+axes = (
+{
+name = Weight;
+tag = wght;
+}
+);
+copyright = "Copy!";
+customParameters = (
+{
+name = licenseURL;
+value = "https://example.com/my/font/license";
+},
+{
+name = vendorID;
+value = RODS;
+},
+{
+name = description;
+value = "The greatest weight var";
+},
+{
+name = versionString;
+value = "New Value";
+},
+{
+name = uniqueID;
+value = "We are all unique";
+},
+{
+name = postscriptFullName;
+value = "Full of names";
+},
+{
+name = postscriptFontName;
+value = "Postscript Name";
+},
+{
+name = trademark;
+value = "A trade in marks";
+},
+{
+name = license;
+value = "Licensed to thrill";
+},
+{
+name = sampleText;
+value = "Sam pull text";
+},
+{
+name = compatibleFullName;
+value = "For the Mac's only";
+},
+{
+name = WWSFamilyName;
+value = "We Will Slant you";
+},
+{
+name = Axes;
+value = (
+{
+Name = Weight;
+Tag = wght;
+}
+);
+}
+);
+designer = "Designed by me!";
+designerURL = "https://example.com/designer";
+familyName = FamilyName;
+fontMaster = (
+{
+axesValues = (
+400
+);
+id = m01;
+name = Regular;
+},
+{
+axesValues = (
+700
+);
+iconName = Bold;
+id = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+metricValues = (
+{
+pos = 800;
+},
+{
+},
+{
+pos = -200;
+},
+{
+pos = 700;
+},
+{
+pos = 500;
+}
+);
+name = Bold;
+}
+);
+glyphs = (
+{
+glyphname = space;
+layers = (
+{
+layerId = m01;
+width = 200;
+},
+{
+layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+width = 600;
+}
+);
+unicode = 32;
+}
+);
+manufacturer = "Who made you?!";
+manufacturerURL = "https://example.com/manufacturer";
+unitsPerEm = 1000;
+versionMajor = 42;
+versionMinor = 42;
+}


### PR DESCRIPTION
Fixes #1029. [sedan/sources/Sedan-Regular.glyphs](https://github.com/googlefonts/sedan), marked v3 but with a v2-style name in it, is now identical locally.