### PR TITLE
Tweaks to make reproducing builds from crater easier

### DIFF
--- a/fontc_crater/README.md
+++ b/fontc_crater/README.md
@@ -7,13 +7,16 @@ fonts.
 
 
 ```sh
-$ cargo run --release -p=fontc_crater -- compile FONT_CACHE --fonts-repo GOOGLE/FONTS  -o results.json
-```
+# By default font repositories and results will be written to ~/.fontc_crater_cache
 
-or, to run ttx_diff (comparing with fontmake)
+# Just see if we can compile with fontc
+$ cargo run --release -p=fontc_crater -- compile
 
-```sh
-$ cargo run --release -p=fontc_crater -- diff FONT_CACHE --fonts-repo GOOGLE/FONTS  -o results.json
+# To take it for a test-spin do a limited # of fonts
+$ cargo run --release -p=fontc_crater -- compile --limit 8
+
+# Build with fontmake and fontc and compare the results with ttx_diff
+$ cargo run --release -p=fontc_crater -- diff
 ```
 
 This is a binary for executing font compilation (and possibly other tasks) in
@@ -39,7 +42,7 @@ You can generate a report from the saved json by passing it back to
 `fontc_crater`:
 
 ```sh
-$ cargo run -p fontc_crater -- report results.json
+$ cargo run -p fontc_crater -- report
 ```
 
 ## CI
@@ -47,6 +50,17 @@ $ cargo run -p fontc_crater -- report results.json
 This binary is also run in CI. In that case, the execution is managed by a
 script in the [`fontc_crater` repo][crater-repo] and results are posted to
 [github pages][crater-results].
+
+To run in CI mode locally to play with the html output:
+
+```shell
+# clone git@github.com:googlefonts/fontc_crater.git somewhere, we'll assume at ../fontc_crater
+# CI currently has it's own format for the repo list, use the file from ^
+
+$ cargo run --release -p=fontc_crater -- ci ../fontc_crater/gf-repos-2024-08-12.json -o ../fontc_crater/results/ --html_only
+
+# Review ../fontc_crater/results/index.html (NOT ../fontc_crater/index.html)
+```
 
 [google-fonts-sources]: https://github.com/googlefonts/google-fonts-sources
 [google/fonts]: https://github.com/google/fonts

--- a/fontc_crater/src/args.rs
+++ b/fontc_crater/src/args.rs
@@ -21,18 +21,19 @@ pub(super) enum Commands {
 
 #[derive(Debug, PartialEq, clap::Args)]
 pub(super) struct RunArgs {
-    /// Directory to store font sources.
+    /// Directory to store font sources and the google/fonts repo.
     ///
     /// Reusing this directory saves us having to clone all the repos on each run.
     ///
     /// This directory is also used to write cached results during repo discovery.
-    pub(super) font_cache: PathBuf,
+    #[arg(short, long, default_value = "~/.fontc_crater_cache")]
+    pub(super) cache_dir: PathBuf,
     /// Optional path to write out results (as json)
     #[arg(short = 'o', long = "out")]
     pub(super) out_path: Option<PathBuf>,
     /// for debugging, execute only a given number of fonts
     #[arg(long)]
-    pub(super) n_fonts: Option<usize>,
+    pub(super) limit: Option<usize>,
 }
 
 #[derive(Debug, PartialEq, clap::Args)]

--- a/fontc_crater/src/ci.rs
+++ b/fontc_crater/src/ci.rs
@@ -94,6 +94,7 @@ fn run_crater_and_save_results(args: &CiArgs) -> Result<(), Error> {
     }
 
     let inputs: Vec<RepoInfo> = super::try_read_json(&args.to_run)?;
+
     let out_file = result_path_for_current_date();
     let out_path = args.out_dir.join(&out_file);
     // for now we are going to be cloning each repo freshly


### PR DESCRIPTION
* Set defaults on crater arguments and simplify example commands
* Use the same default for local font repos in ttx_diff
* Default ttx_diff to compare default because gftools doesn't actually do what it says at time of writing
* Add the ability to run ttx_diff against a specific source in a repository
   * `python resources/scripts/ttx_diff.py https://github.com/cyrealtype/Alice#sources/Alice.glyphs` will check for a local copy of the repo, clone it if there isn't one, and then build/compare the glyphs file specified in the fragment
* Document how to run ci locally to get an html report; very useful when trying to alter the html!
* Add a copy repro button to the results

![image](https://github.com/user-attachments/assets/ece2b9c2-9855-47d9-89ab-e48de8aa7505)

Copy repro gets you something like `python resources/scripts/ttx_diff.py https://github.com/googlefonts/are-you-serious#sources/AreYouSerious.glyphs` which ttx_diff now supports.


