### PR TITLE
[crater] Remove 'fonts_repo' cli arg

### DIFF
--- a/fontc_crater/src/args.rs
+++ b/fontc_crater/src/args.rs
@@ -27,9 +27,6 @@ pub(super) struct RunArgs {
     ///
     /// This directory is also used to write cached results during repo discovery.
     pub(super) font_cache: PathBuf,
-    /// Path to local checkout of google/fonts repository
-    #[arg(short, long)]
-    pub(super) fonts_repo: Option<PathBuf>,
     /// Optional path to write out results (as json)
     #[arg(short = 'o', long = "out")]
     pub(super) out_path: Option<PathBuf>,

--- a/fontc_crater/src/main.rs
+++ b/fontc_crater/src/main.rs
@@ -44,7 +44,7 @@ fn run(args: &Args) -> Result<(), Error> {
     if !run_args.font_cache.exists() {
         try_create_dir(&run_args.font_cache)?;
     }
-    let sources = RepoList::get_or_create(&run_args.font_cache, run_args.fonts_repo.as_deref())?;
+    let sources = RepoList::get_or_create(&run_args.font_cache)?;
 
     let pruned = run_args.n_fonts.map(|n| prune_sources(&sources.sources, n));
     let inputs = pruned.as_ref().unwrap_or(&sources.sources);

--- a/fontc_crater/src/sources.rs
+++ b/fontc_crater/src/sources.rs
@@ -19,10 +19,7 @@ pub(crate) struct RepoList {
 }
 
 impl RepoList {
-    pub(crate) fn get_or_create(
-        cache_dir: &Path,
-        fonts_repo: Option<&Path>,
-    ) -> Result<Self, Error> {
+    pub(crate) fn get_or_create(cache_dir: &Path) -> Result<Self, Error> {
         let cache_file_path = cache_dir.join(CACHED_REPO_INFO_FILE);
         if let Some(cached_list) = Self::load(&cache_file_path)? {
             let stale = cached_list
@@ -35,8 +32,7 @@ impl RepoList {
             }
         }
 
-        let mut sources =
-            google_fonts_sources::discover_sources(fonts_repo, Some(cache_dir), false);
+        let mut sources = google_fonts_sources::discover_sources(None, Some(cache_dir), false);
 
         // only keep sources for which we have a repo + config
         sources.retain(|s| !s.config_files.is_empty());


### PR DESCRIPTION
This has nothing to do with CI, and is only used by the old-style runners.

Ultimately we should just unify these different interfaces; by default we could keep a list of inputs in the cache dir as a json file, and with no provided args we would create or run that.