### PR TITLE
Prevent navigation on copy repro click

### DIFF
--- a/fontc_crater/README.md
+++ b/fontc_crater/README.md
@@ -57,7 +57,7 @@ To run in CI mode locally to play with the html output:
 # clone git@github.com:googlefonts/fontc_crater.git somewhere, we'll assume at ../fontc_crater
 # CI currently has it's own format for the repo list, use the file from ^
 
-$ cargo run --release -p=fontc_crater -- ci ../fontc_crater/gf-repos-2024-08-12.json -o ../fontc_crater/results/ --html_only
+$ cargo run --release -p=fontc_crater -- ci ../fontc_crater/gf-repos-2024-08-12.json -o ../fontc_crater/results/ --html-only
 
 # Review ../fontc_crater/results/index.html (NOT ../fontc_crater/index.html)
 ```

--- a/fontc_crater/src/ci/html.rs
+++ b/fontc_crater/src/ci/html.rs
@@ -312,7 +312,10 @@ fn make_diff_report(
         }
 
         let repo_url = get_repo_url(path);
-        let repro_cmd = make_repro_cmd(repo_url, path);
+        let onclick = format!(
+            "event.preventDefault(); {};",
+            make_repro_cmd(repo_url, path)
+        );
         let decoration = make_delta_decoration(*ratio, prev_ratio, More::IsBetter);
         let details = format_diff_report_details(diff_details, prev_details);
         // avoid .9995 printing as 100%
@@ -324,7 +327,7 @@ fn make_diff_report(
                     span.font_path {
                         a href = (repo_url) { (path.display()) }
                         " ("
-                        a href = "#" onclick = (repro_cmd) { "copy repro" }
+                        a href = "" onclick = (onclick) { "copy repro" }
                         ")"
                     }
                     span.diff_result { (ratio_fmt) " " (decoration) }


### PR DESCRIPTION
Right now if you click copy repro on https://googlefonts.github.io/fontc_crater/ it navigates, effectively scrolling to top of page.

JMM