### PR TITLE
Make ttx_diff use the same repo dir as crater

### DIFF
--- a/resources/scripts/ttx_diff.py
+++ b/resources/scripts/ttx_diff.py
@@ -595,7 +595,7 @@ def resolve_source(source: str) -> Path:
         source_url = urlparse(source)
         repo_path = source_url.fragment
         last_path_segment = source_url.path.split("/")[-1]
-        local_repo = (Path(__file__).parent / ".." / ".." / "font_repos" / last_path_segment).resolve()
+        local_repo = (Path.home() / ".fontc_crater_cache" / last_path_segment).resolve()
         if not local_repo.parent.is_dir():
             local_repo.parent.mkdir()
         if not local_repo.is_dir():


### PR DESCRIPTION
The flow here may change in future but for now it's handy if both tools agree

JMM