### PR TITLE
Expose and fix broken processing of bbox for components whose transform is more than scale and transform

### DIFF
--- a/resources/testdata/glyphs2/MatrixComponent.glyphs
+++ b/resources/testdata/glyphs2/MatrixComponent.glyphs
@@ -8,24 +8,40 @@ id = m01;
 );
 glyphs = (
 {
-glyphname = infinity;
+glyphname = rot60more;
 layers = (
 {
 components = (
 {
-name = eight;
-transform = "{0.9, -0.1, -0.1, 0.9, 500, 300}";
+name = rot30;
+transform = "{0.5, 0.866, -0.866, 0.5, 179.9, -11.6}";
 }
 );
 layerId = "m01";
 width = 705;
 }
 );
-note = infinity;
+unicode = 221D;
+},
+{
+glyphname = rot30;
+layers = (
+{
+components = (
+{
+name = triangle;
+
+transform = "{0.866, 0.5, -0.5, 0.866, 88.4, -29.9}";
+}
+);
+layerId = "m01";
+width = 705;
+}
+);
 unicode = 221E;
 },
 {
-glyphname = eight;
+glyphname = triangle;
 layers = (
 {
 layerId = "m01";
@@ -33,19 +49,15 @@ paths = (
 {
 closed = 1;
 nodes = (
-"250 -20 OFFCURVE",
-"300 0 OFFCURVE",
-"350 50 CURVE SMOOTH",
-"400 50 OFFCURVE",
-"421 127 OFFCURVE",
-"421 192 CURVE SMOOTH",
+"100 100 LINE",
+"400 150 LINE",
+"100 200 LINE",
 );
 }
 );
 width = 474;
 }
 );
-note = eight;
 unicode = 0038;
 }
 );

--- a/resources/testdata/glyphs2/MatrixComponent.glyphs
+++ b/resources/testdata/glyphs2/MatrixComponent.glyphs
@@ -1,0 +1,56 @@
+{
+.appVersion = "3219";
+familyName = MatrixComponent;
+fontMaster = (
+{
+id = m01;
+}
+);
+glyphs = (
+{
+glyphname = infinity;
+layers = (
+{
+components = (
+{
+name = eight;
+transform = "{0.9, -0.1, -0.1, 0.9, 500, 300}";
+}
+);
+layerId = "m01";
+width = 705;
+}
+);
+note = infinity;
+unicode = 221E;
+},
+{
+glyphname = eight;
+layers = (
+{
+layerId = "m01";
+paths = (
+{
+closed = 1;
+nodes = (
+"250 -20 OFFCURVE",
+"300 0 OFFCURVE",
+"350 50 CURVE SMOOTH",
+"400 50 OFFCURVE",
+"421 127 OFFCURVE",
+"421 192 CURVE SMOOTH",
+);
+}
+);
+width = 474;
+}
+);
+note = eight;
+unicode = 0038;
+}
+);
+
+unitsPerEm = 1000;
+versionMajor = 42;
+versionMinor = 42;
+}


### PR DESCRIPTION
Simplified reproduction of problem impacting Luxurious Roman (`python resources/scripts/ttx_diff.py https://github.com/googlefonts/luxurious-roman#sources/Luxurious-Roman.glyphs`)

```shell
$ python resources/scripts/ttx_diff.py resources/testdata/glyphs2/MatrixComponent.glyphs
...glyf, head, hhea, hmtx diff...

$ diff ~/oss/fontc/build/default/fontc.glyf.ttx ~/oss/fontc/build/default/fontmake.glyf.ttx
38c38
<     <TTGlyph name="infinity" xMin="750" yMin="272" xMax="877" yMax="443">
---
>     <TTGlyph name="infinity" xMin="767" yMin="284" xMax="863" yMax="431">
```

This appears to be due to fontc assuming it can simply apply the component transform to the control box when in fact it needs to transform the points and compute the control box of the new points. https://codepen.io/rs42/pen/wvVqVPL?editors=1000 sketches the impact of transformation for the new test font.

Reproduced in simplified test that now passes. Luxurious Roman is now identical when ttx_diff'd locally. 