### PR TITLE
[ttx_diff] ensure only the GPOS lookups get xpath'ed for pruning

### DIFF
--- a/resources/scripts/ttx_diff.py
+++ b/resources/scripts/ttx_diff.py
@@ -412,7 +412,10 @@ def remove_mark_and_kern_lookups(ttx):
     gpos = ttx.find("GPOS")
     if gpos is None:
         return
-    for lookup in gpos.xpath("//Lookup"):
+    # './/Lookup' xpath selects all the 'Lookup' elements that are descendants of
+    # the current 'GPOS' node - no matter where they are under it.
+    # Most importantly, this _excludes_ GSUB lookups, which shouldn't be pruned.
+    for lookup in gpos.xpath(".//Lookup"):
         lookup_type_el = lookup.find("LookupType")
         lookup_type = int(lookup_type_el.attrib["value"])
         is_extension = lookup_type == 9


### PR DESCRIPTION
right now the `gpos.xpath("//Lookup")` ends up selecting and removing GSUB lookups of type 2, 4, 5 and 6 as well, even though we only intended to prune the GPOS ones.

That's the way `//` works, it will select all matching elements following the current node anywhere they appear, not only their descendants. GSUB follows GPOS since ttx sorts table alphabetically.
Putting a dot in front `.//` ensures only the descendants of the current node are selected.

see https://www.w3schools.com/xml/xpath_syntax.asp