### PR TITLE
requirements.txt: bump fontmake==3.10.0

### DIFF
--- a/resources/scripts/requirements.txt
+++ b/resources/scripts/requirements.txt
@@ -1,7 +1,7 @@
 absl-py
 # keep fontmake version pinned to ensure output from ttx_diff.py is stable;
 # the 'repacker' option enables faster GSUB/GPOS serialization via uharfbuzz
-fontmake[repacker]==3.8.1
+fontmake[repacker]==3.10.0
 # technically fonttools is in turn a dependency of fontmake but a few of
 # our scripts import it directly, so we list it among the top-level requirements.
 fonttools


### PR DESCRIPTION
https://github.com/googlefonts/fontmake/releases/tag/v3.10.0

no code changes to fontmake itself, this is simply bumping the minimum required dependencies (e.g. fonttools, ufo2ft, glyphsLib) which in turn fixes a bunch of bugs

JMM