### PR TITLE
[crater] Skip writing if results unchanged

### DIFF
--- a/fontc_crater/src/ci.rs
+++ b/fontc_crater/src/ci.rs
@@ -108,8 +108,11 @@ fn run_crater_and_save_results(args: &CiArgs) -> Result<(), Error> {
         .collect();
     let finished = Utc::now();
 
-    super::try_write_json(&results, &out_path)?;
     let summary = super::ttx_diff_runner::Summary::new(&results);
+    if Some(&summary) == prev_runs.last().map(|run| &run.stats) {
+        log::info!("output identical to last run, skipping");
+        return Ok(());
+    }
     let input_file = args
         .to_run
         .file_name()
@@ -127,6 +130,7 @@ fn run_crater_and_save_results(args: &CiArgs) -> Result<(), Error> {
 
     prev_runs.push(summary);
 
+    super::try_write_json(&results, &out_path)?;
     super::try_write_json(&prev_runs, &summary_file)?;
 
     // we write the map of target -> source repo to a separate file because

--- a/fontc_crater/src/ttx_diff_runner.rs
+++ b/fontc_crater/src/ttx_diff_runner.rs
@@ -71,7 +71,7 @@ pub(super) enum DiffOutput {
 }
 
 /// Summary of one ttx_diff run
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 pub(crate) struct Summary {
     pub(crate) total_targets: u32,
     pub(crate) identical: u32,


### PR DESCRIPTION
There are lots of commits to this repo that would trigger a CI run but which won't produce any difference to the behaviour of fontc; this patch lets us avoid spamming the crater report with identical entries.