### PR TITLE
crater html display tweaks

### DIFF
--- a/fontc_crater/resources/style.css
+++ b/fontc_crater/resources/style.css
@@ -64,13 +64,21 @@ td.rev {
   font-family: monospace;
 }
 
-.font_path .diff_result {
+.diff_result {
+  width: 10em;
   display: inline-block;
 }
 
 .font_path {
   width: 50%;
   display: inline-block;
+}
+
+.changed_tag_list {
+  /*display: inline-block;*/
+  font-family: monospace;
+  font-size: 0.8em;
+  color: #888;
 }
 
 .diff_info {

--- a/fontc_crater/src/ci/html.rs
+++ b/fontc_crater/src/ci/html.rs
@@ -318,6 +318,7 @@ fn make_diff_report(
             make_repro_cmd(repo_url, path)
         );
         let decoration = make_delta_decoration(*ratio, prev_ratio, More::IsBetter);
+        let changed_tag_list = list_different_tables(diff_details).unwrap_or_default();
         let details = format_diff_report_details(diff_details, prev_details, onclick);
         // avoid .9995 printing as 100%
         let ratio_fmt = format!("{:.3}%", (ratio * 1000.0).floor() / 1000.0);
@@ -329,6 +330,7 @@ fn make_diff_report(
                         a href = (repo_url) { (path) }
                     }
                     span.diff_result { (ratio_fmt) " " (decoration) }
+                    span.changed_tag_list { (changed_tag_list) }
                 }
                 (details)
             }
@@ -478,6 +480,18 @@ fn format_compiler_error(err: &CompilerFailure) -> Markup {
 
         }
     }
+}
+
+fn list_different_tables(current: &DiffOutput) -> Option<String> {
+    let changed = current
+        .iter_tables()
+        .filter(|x| *x != "total")
+        .collect::<Vec<_>>()
+        .join(", ");
+    if changed.is_empty() {
+        return None;
+    }
+    Some(format!("({changed})"))
 }
 
 /// for a given diff, the detailed information on per-table changes


### PR DESCRIPTION
- add a list of tables that differ inline
- move the reproduction link into the details view (we were running out of space)

<img width="1188" alt="Screenshot 2024-10-28 at 5 37 38 PM" src="https://github.com/user-attachments/assets/cf60567e-a814-40c7-8605-9a3b701b7bf3">
