### PR TITLE
[ttx_diff] set SOURCE_DATE_EPOCH to ensure head.modified and created are the same

### DIFF
--- a/resources/scripts/ttx_diff.py
+++ b/resources/scripts/ttx_diff.py
@@ -65,6 +65,10 @@ MARK_KERN_NAME = "(mark/kern)"
 # too much bloat when run in CI
 MAX_ERR_LEN = 1000
 
+# fontc and fontmake's builds may be off by a second or two in the
+# head.created/modified; setting this makes them the same
+if "SOURCE_DATE_EPOCH" not in os.environ:
+   os.environ["SOURCE_DATE_EPOCH"] = str(int(time.time()))
 
 # print to stderr
 def eprint(*objects):
@@ -333,11 +337,6 @@ def drop_weird_names(ttx):
         drop.getparent().remove(drop)
 
 
-def erase_modified(ttx):
-    el = select_one(ttx, "//head/modified")
-    del el.attrib["value"]
-
-
 def erase_checksum(ttx):
     el = select_one(ttx, "//head/checkSumAdjustment")
     del el.attrib["value"]
@@ -462,9 +461,6 @@ def reduce_diff_noise(fontc: etree.ElementTree, fontmake: etree.ElementTree):
 
         # deal with https://github.com/googlefonts/fontmake/issues/1003
         drop_weird_names(ttx)
-
-        # it's not at all helpful to see modified off by a second or two in a diff
-        erase_modified(ttx)
 
         # for matching purposes checksum is just noise
         erase_checksum(ttx)


### PR DESCRIPTION
In ttx_diff.py we already erased the head.modified, but we don't also erease the head.created. The latter is also set to the current time when the source does not contain an explicit openTypeHeadCreated (most do not). I have seen random ttx-diffs caused by the fact that sometimes fontc and fontmake builds differs by one or two seconds in the head.created.

For example this one in a recent run of fontc_crater:
<img width="1270" alt="Screenshot 2024-10-29 at 12 41 34" src="https://github.com/user-attachments/assets/4152b40b-5bf7-4867-ac36-979bff724880">


Since both compilers support the standard [`SOURCE_DATE_EPOCH`](https://reproducible-builds.org/docs/source-date-epoch/) variable for reproducible builds we may well make use of it here.
