### PR TITLE
[crater] Show runtime in html

### DIFF
--- a/fontc_crater/resources/style.css
+++ b/fontc_crater/resources/style.css
@@ -33,6 +33,11 @@ td {
   font-size: 0.8em;
 }
 
+.elapsed {
+  color: #888;
+  font-size: 0.8em;
+}
+
 td.rev {
   font-family: monospace;
 }
@@ -75,7 +80,6 @@ td.rev {
 }
 
 .changed_tag_list {
-  /*display: inline-block;*/
   font-family: monospace;
   font-size: 0.8em;
   color: #888;

--- a/fontc_crater/src/ci.rs
+++ b/fontc_crater/src/ci.rs
@@ -7,10 +7,11 @@
 
 use std::{
     collections::BTreeMap,
+    fmt::Write,
     path::{Path, PathBuf},
 };
 
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, TimeZone, Utc};
 use google_fonts_sources::{Config, RepoInfo};
 use serde::de::DeserializeOwned;
 
@@ -99,12 +100,16 @@ fn run_crater_and_save_results(args: &CiArgs) -> Result<(), Error> {
     log::info!("using cache dir {}", cache_dir.display());
 
     let (targets, source_repos) = make_targets(&cache_dir, &inputs);
+    let n_targets = targets.len();
     let began = Utc::now();
     let results = super::run_all(targets, &cache_dir, super::ttx_diff_runner::run_ttx_diff)?
         .into_iter()
         .map(|(target, result)| (target.id(), result))
         .collect();
     let finished = Utc::now();
+
+    let elapsed = format_elapsed_time(&began, &finished);
+    log::info!("completed {n_targets} targets in {elapsed}");
 
     let summary = super::ttx_diff_runner::Summary::new(&results);
     if Some(&summary) == prev_runs.last().map(|run| &run.stats) {
@@ -220,4 +225,19 @@ fn should_build_in_gftools_mode(src_path: &Path, config: &Config) -> bool {
         .as_ref()
         .filter(|provider| *provider != "googlefonts")
         .is_none()
+}
+
+fn format_elapsed_time<Tmz: TimeZone>(start: &DateTime<Tmz>, end: &DateTime<Tmz>) -> String {
+    let delta = end.clone().signed_duration_since(start);
+    let mut out = String::new();
+    let hours = delta.num_hours();
+    let mins = delta.num_minutes() - hours * 60;
+    let secs = delta.num_seconds() - (hours * 60 + mins) * 60;
+    assert!(!hours.is_negative() | mins.is_negative() | secs.is_negative());
+    if delta.num_hours() > 0 {
+        write!(&mut out, "{hours}h").unwrap();
+    }
+    write!(&mut out, "{mins}m").unwrap();
+    write!(&mut out, "{secs}s").unwrap();
+    out
 }

--- a/fontc_crater/src/ci/html.rs
+++ b/fontc_crater/src/ci/html.rs
@@ -188,9 +188,10 @@ fn make_table_body(runs: &[RunSummary]) -> Markup {
             td.other_err {  (run.stats.other_failure) " " (other_err_diff)  }
             }
         };
+        let elapsed = super::format_elapsed_time(&run.began, &run.finished);
         html! {
             tr.run {
-                td.date { (run.began.format("%Y-%m-%d %H:%M:%S")) }
+                td.date { (run.began.format("%Y-%m-%d %H%M")) span.elapsed { " (" (elapsed) ")"} }
                 td.rev { a href=(diff_url) { (short_rev) } }
                 td.total {  ( run.stats.total_targets) " " (total_diff) }
                 td.identical {  (run.stats.identical) " " (identical_diff)  }


### PR DESCRIPTION
This is useful information, and will be even more useful if we want to know if caching is useful.

This is also potentially useful diagnostic info; if runtimes spike after some particular change, we probably broke something.

looks like:
<img width="1226" alt="Screenshot 2024-10-29 at 2 27 20 PM" src="https://github.com/user-attachments/assets/5fd23c88-9542-4b08-b919-f518fd8edce0">
