### PR TITLE
[crater] Cache output of fontmake between runs

### DIFF
--- a/fontc_crater/src/ci/results_cache.rs
+++ b/fontc_crater/src/ci/results_cache.rs
@@ -1,0 +1,84 @@
+//! Caching fontmake's output between runs
+
+use std::path::{Path, PathBuf};
+
+use crate::Target;
+
+static CACHE_DIR_NAME: &str = "crater_cached_results";
+
+// the files that we cache for each target
+static FONT_FILE: &str = "fontmake.ttf";
+static TTX_FILE: &str = "fontmake.ttx";
+static MARKKERN_FILE: &str = "fontmake.markkern.txt";
+
+/// Manages a cache of files on disk
+pub(crate) struct ResultsCache {
+    base_results_cache_dir: PathBuf,
+}
+
+impl ResultsCache {
+    /// argument is the directory that will contain the cache dir.
+    ///
+    /// By convention this is the same directory where we checkout git repos.
+    pub fn in_dir(path: &Path) -> Self {
+        Self {
+            base_results_cache_dir: path.join(CACHE_DIR_NAME),
+        }
+    }
+
+    /// Delete any cache contents
+    pub fn delete_all(&self) {
+        if self.base_results_cache_dir.exists() {
+            std::fs::remove_dir_all(&self.base_results_cache_dir).expect("failed to remove cache")
+        }
+    }
+
+    /// if we have cached files for this target, copy them into the build directory.
+    pub fn copy_cached_files_to_build_dir(&self, target: &Target, build_dir: &Path) {
+        let target_cache_dir = target.cache_dir(&self.base_results_cache_dir);
+        if !target_cache_dir.exists() {
+            log::info!("{} does not exist, skipping", target_cache_dir.display());
+            return;
+        }
+
+        if copy_cache_files(&target_cache_dir, build_dir).unwrap() {
+            log::info!("reused cached files for {target}",);
+        }
+    }
+
+    /// Copy files generated from a previous run into the permanent cache.
+    pub fn save_built_files_to_cache(&self, target: &Target, build_dir: &Path) {
+        let target_cache_dir = target.cache_dir(&self.base_results_cache_dir);
+        if !target_cache_dir.exists() {
+            std::fs::create_dir_all(&target_cache_dir).unwrap();
+        }
+        // no need to overwrite existing cache
+        if [FONT_FILE, TTX_FILE, MARKKERN_FILE]
+            .into_iter()
+            .all(|p| target_cache_dir.join(p).exists())
+        {
+            return;
+        }
+        if copy_cache_files(build_dir, &target_cache_dir).unwrap() {
+            log::debug!("cached files to {}", target_cache_dir.display());
+        }
+    }
+}
+
+fn copy_cache_files(from_dir: &Path, to_dir: &Path) -> std::io::Result<bool> {
+    let font = from_dir.join(FONT_FILE);
+    let ttx = from_dir.join(TTX_FILE);
+    let markkern = from_dir.join(MARKKERN_FILE);
+
+    if [&font, &ttx, &markkern].into_iter().all(|p| p.exists()) {
+        if !to_dir.exists() {
+            std::fs::create_dir_all(to_dir)?;
+        }
+        std::fs::copy(font, to_dir.join(FONT_FILE)).map(|_| ())?;
+        std::fs::copy(ttx, to_dir.join(TTX_FILE)).map(|_| ())?;
+        std::fs::copy(markkern, to_dir.join(MARKKERN_FILE)).map(|_| ())?;
+        Ok(true)
+    } else {
+        Ok(false)
+    }
+}

--- a/fontc_crater/src/target.rs
+++ b/fontc_crater/src/target.rs
@@ -1,6 +1,7 @@
 //! targets of a compilation
 
 use std::{
+    ffi::OsStr,
     fmt::{Display, Write},
     path::{Path, PathBuf},
     str::FromStr,
@@ -123,6 +124,27 @@ impl Target {
         let mut out = git_cache.join(&self.source_dir);
         out.push(config);
         Some(out)
+    }
+
+    /// Return the path where we should cache the results of running this target.
+    ///
+    /// This is unique for each target, and is in the form,
+    ///
+    /// {BASE}{source_dir}/{config_stem}/{file_stem}/{build}
+    ///
+    /// where {source_dir} is the path to the sources/Sources directory of this
+    /// target, relative to the root git cache.
+    pub(crate) fn cache_dir(&self, in_dir: &Path) -> PathBuf {
+        let config = self
+            .config
+            .as_ref()
+            .and_then(|p| p.file_stem())
+            .unwrap_or(OsStr::new("config"));
+        let mut result = in_dir.join(&self.source_dir);
+        result.push(config);
+        result.push(self.source.file_stem().unwrap());
+        result.push(self.build.name());
+        result
     }
 
     pub(crate) fn repro_command(&self, repo_url: &str) -> String {

--- a/resources/scripts/ttx_diff.py
+++ b/resources/scripts/ttx_diff.py
@@ -255,6 +255,8 @@ def run_gftools(
     filename = tool + ".ttf"
     out_file = build_dir / filename
     out_dir = build_dir / "gftools_temp_dir"
+    if out_dir.exists():
+        shutil.rmtree(out_dir)
     cmd = [
         "gftools",
         "builder",


### PR DESCRIPTION
This clears the cache if the pip freeze output is different.

It's possible that this isn't worth the complexity, but it should offer meaningful runtime speed improvements, so let's give it a try?