### PR TITLE
Crater rework targets

### DIFF
--- a/fontc_crater/src/ci.rs
+++ b/fontc_crater/src/ci.rs
@@ -125,7 +125,7 @@ fn run_crater_and_save_results(args: &CiArgs) -> Result<(), Error> {
     let began = Utc::now();
     let results = super::run_all(targets, &context, super::ttx_diff_runner::run_ttx_diff)?
         .into_iter()
-        .map(|(target, result)| (target.id(), result))
+        .map(|(target, result)| (target, result))
         .collect();
     let finished = Utc::now();
 
@@ -215,16 +215,18 @@ fn targets_for_source(
     config_path: &Path,
     config: &Config,
 ) -> impl Iterator<Item = Target> {
-    let default = Some(Target {
-        config: config_path.to_owned(),
-        source: src_path.to_owned(),
-        build: BuildType::Default,
-    });
+    let default = Some(Target::new(
+        src_path.to_owned(),
+        config_path.to_owned(),
+        BuildType::Default,
+    ));
 
-    let gftools = should_build_in_gftools_mode(src_path, config).then(|| Target {
-        config: config_path.to_owned(),
-        source: src_path.to_owned(),
-        build: BuildType::GfTools,
+    let gftools = should_build_in_gftools_mode(src_path, config).then(|| {
+        Target::new(
+            src_path.to_owned(),
+            config_path.to_owned(),
+            BuildType::GfTools,
+        )
     });
     [default, gftools].into_iter().flatten()
 }

--- a/fontc_crater/src/ci/html.rs
+++ b/fontc_crater/src/ci/html.rs
@@ -251,7 +251,7 @@ fn make_delta_decoration<T: PartialOrd + Copy + Sub<Output = T> + Display + Defa
 
 fn make_repro_cmd(repo_url: &str, repo_path: &Target) -> String {
     // the first component of the path is the repo, drop that
-    let mut repo_path = repo_path.source.components();
+    let mut repo_path = repo_path.src_dir_path().components();
     repo_path.next();
     let repo_path = repo_path.as_path();
 
@@ -296,7 +296,12 @@ fn make_diff_report(
             .collect()
     }
 
-    let get_repo_url = |id: &Target| sources.get(&id.source).map(String::as_str).unwrap_or("#");
+    let get_repo_url = |id: &Target| {
+        sources
+            .get(id.src_dir_path())
+            .map(String::as_str)
+            .unwrap_or("#")
+    };
 
     let current_diff = get_total_diff_ratios(current);
     let prev_diff = get_total_diff_ratios(prev);
@@ -602,7 +607,12 @@ fn make_error_report_group_items<'a>(
     details: impl Fn(&Target) -> Markup,
     sources: &BTreeMap<PathBuf, String>,
 ) -> Markup {
-    let get_repo_url = |id: &Target| sources.get(&id.source).map(String::as_str).unwrap_or("#");
+    let get_repo_url = |id: &Target| {
+        sources
+            .get(id.src_dir_path())
+            .map(String::as_str)
+            .unwrap_or("#")
+    };
     html! {
             @for (path, is_new) in paths_and_if_is_new_error {
                 details.report_group_item {

--- a/fontc_crater/src/main.rs
+++ b/fontc_crater/src/main.rs
@@ -21,7 +21,7 @@ use serde::{de::DeserializeOwned, Serialize};
 
 use args::{Args, Commands};
 use error::Error;
-use target::{BuildType, Target, TargetId};
+use target::{BuildType, Target};
 
 fn main() {
     env_logger::init();
@@ -40,8 +40,8 @@ fn run(args: &Args) -> Result<(), Error> {
 /// Results of all runs
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 struct Results<T, E> {
-    pub(crate) success: BTreeMap<TargetId, T>,
-    pub(crate) failure: BTreeMap<TargetId, E>,
+    pub(crate) success: BTreeMap<Target, T>,
+    pub(crate) failure: BTreeMap<Target, E>,
 }
 
 /// The output of trying to run on one font.
@@ -129,8 +129,8 @@ fn pip_freeze_sha() -> String {
         .to_owned()
 }
 
-impl<T, E> FromIterator<(TargetId, RunResult<T, E>)> for Results<T, E> {
-    fn from_iter<I: IntoIterator<Item = (TargetId, RunResult<T, E>)>>(iter: I) -> Self {
+impl<T, E> FromIterator<(Target, RunResult<T, E>)> for Results<T, E> {
+    fn from_iter<I: IntoIterator<Item = (Target, RunResult<T, E>)>>(iter: I) -> Self {
         let mut out = Results::default();
         for (path, reason) in iter.into_iter() {
             match reason {

--- a/fontc_crater/src/ttx_diff_runner.rs
+++ b/fontc_crater/src/ttx_diff_runner.rs
@@ -27,7 +27,9 @@ pub(super) fn run_ttx_diff(ctx: &TtxContext, target: &Target) -> RunResult<DiffO
         .arg("--normalizer_path")
         .arg(&ctx.normalizer_path);
     if target.build == BuildType::GfTools {
-        cmd.arg("--config").arg(&target.config);
+        if let Some(config) = target.config.as_ref() {
+            cmd.arg("--config").arg(config);
+        }
     }
     cmd.arg(source_path);
     let output = match cmd.output() {

--- a/fontc_crater/src/ttx_diff_runner.rs
+++ b/fontc_crater/src/ttx_diff_runner.rs
@@ -17,7 +17,7 @@ pub(super) struct TtxContext {
 pub(super) fn run_ttx_diff(ctx: &TtxContext, target: &Target) -> RunResult<DiffOutput, DiffError> {
     let tempdir = tempfile::tempdir().expect("couldn't create tempdir");
     let outdir = tempdir.path();
-    let source_path = ctx.cache_dir.join(&target.source);
+    let source_path = target.source_path(&ctx.cache_dir);
     let compare = target.build.name();
     let mut cmd = Command::new("python");
     cmd.args([SCRIPT_PATH, "--json", "--compare", compare, "--outdir"])
@@ -27,7 +27,7 @@ pub(super) fn run_ttx_diff(ctx: &TtxContext, target: &Target) -> RunResult<DiffO
         .arg("--normalizer_path")
         .arg(&ctx.normalizer_path);
     if target.build == BuildType::GfTools {
-        if let Some(config) = target.config.as_ref() {
+        if let Some(config) = target.config_path(&ctx.cache_dir) {
             cmd.arg("--config").arg(config);
         }
     }


### PR DESCRIPTION
Okay this... was annoying, but how we were handling targets had some dumb issues:

- we weren't including the config file in serialization, which means that we didn't have enough info to generate the repro command for gftools
- (and also it was possible to end up with distinct targets serializing identically, in the case where a repo contained multiple configs which pointed to overlapping sources; not sure if this existed but was possible)
- but I also want to be efficient in what we serialize, and the config and source paths generally share a stem
- because we serialize to json and use targets as the keys, we need to ensure they serialize as strings
- so the logic got complicated fairly quickly.

I have the repro command fix working on top of this, and will PR that separately.