### PR TITLE
[crater] Use timestamp to key crater results

### DIFF
--- a/fontc_crater/src/ci.rs
+++ b/fontc_crater/src/ci.rs
@@ -85,7 +85,7 @@ fn run_crater_and_save_results(args: &CiArgs) -> Result<(), Error> {
     let mut prev_runs: Vec<RunSummary> = load_json_if_exists_else_default(&summary_file)?;
     // todo: fontc_repo should be checked out by us, and have a known path
     let fontc_rev = super::get_git_rev(None).unwrap();
-    let pip_freeze_sha = super::pip_freeze_sha();
+    let pip_freeze_sha = dbg!(super::pip_freeze_sha());
     if let Some(last_run) = prev_runs.last() {
         if last_run.fontc_rev == fontc_rev
             && Some(last_run.input_file.as_os_str()) == args.to_run.file_name()


### PR DESCRIPTION
We were using the fontc rev as the key to a map of runs -> detailed results, which doesn't work because it's possible for multiple runs to share the same git rev (e.g. if the inputs or the installed python packages have changed)

JMM