### PR TITLE
DONT MERGE: add failing test to repro #1043

### DIFF
--- a/fontbe/src/features/marks.rs
+++ b/fontbe/src/features/marks.rs
@@ -1337,4 +1337,36 @@ mod tests {
 
         assert_eq!(values, [239, 271, 305]);
     }
+
+    #[test]
+    fn mark_anchors_rounding() {
+        // These values are taken from Teachers-Italic.glyphs. The composite glyph
+        // 'ordfeminine' inherits a 'top' base anchor from a scaled 'a' component, so the
+        // propagated anchor ends up with float coordinates; these are expected to be
+        // rounded before deltas get computed in order to match the output of fontmake:
+        // https://github.com/googlefonts/fontc/issues/1043#issuecomment-2444388789
+        let out = MarksInput::new([&[0.0], &[0.75], &[1.0]])
+            .add_glyph("a", None, |anchors| {
+                anchors.add("top", [(377.0, 451.0), (386.0, 450.0), (389.0, 450.0)]);
+            })
+            .add_glyph("ordfeminine", None, |anchors| {
+                anchors.add("top", [(282.75, 691.25), (289.5, 689.5), (291.75, 689.5)]);
+            })
+            .add_glyph("acutecomb", None, |anchors| {
+                anchors.add("_top", [(218.0, 704.0), (265.0, 707.0), (282.0, 708.0)]);
+            })
+            .get_normalized_output();
+
+        assert_eq_ignoring_ws!(
+            out,
+            r#"
+                # mark: DFLT/dflt ## 2 MarkToBase rules
+                # lookupflag LookupFlag(0)
+                a @(x: 377 {386,389}, y: 451 {450,450})
+                @(x: 218 {265,282}, y: 704 {707,708}) acutecomb
+                ordfeminine @(x: 283 {290,292}, y: 691 {690,690})
+                @(x: 218 {265,282}, y: 704 {707,708}) acutecomb
+            "#
+        );
+    }
 }


### PR DESCRIPTION
the deltas for Teachers-Italic.glyphs' ordfeminine 'top' anchor are off-by-one because the anchor's master values are un-rounded floats.

https://github.com/googlefonts/fontc/pull/1082 will fix this and similar others.

Related issue: https://github.com/googlefonts/fontc/issues/1043