### PR TITLE
Update python dependencies

### DIFF
--- a/resources/scripts/requirements.in
+++ b/resources/scripts/requirements.in
@@ -9,4 +9,4 @@ lxml
 cdifflib
 glyphsLib
 # our custom branch of gftools
-git+https://github.com/googlefonts/gftools.git@fontc-flag-sketch
+git+https://github.com/googlefonts/gftools.git@27b013a

--- a/resources/scripts/requirements.txt
+++ b/resources/scripts/requirements.txt
@@ -130,7 +130,7 @@ gflanguages==0.7.0
     #   glyphsets
 gfsubsets==2024.9.25
     # via gftools
-gftools @ git+https://github.com/googlefonts/gftools.git@fontc-flag-sketch
+gftools @ git+https://github.com/googlefonts/gftools.git@27b013a
     # via -r resources/scripts/requirements.in
 gitdb==4.0.11
     # via gitpython
@@ -138,7 +138,7 @@ gitpython==3.1.43
     # via font-v
 glyphsets==1.0.0
     # via gftools
-glyphslib==6.9.2
+glyphslib==6.9.3
     # via
     #   -r resources/scripts/requirements.in
     #   babelfont
@@ -185,7 +185,7 @@ openstep-plist==0.4.0
     #   glyphslib
 opentype-sanitizer==9.1.0
     # via gftools
-orjson==3.10.10
+orjson==3.10.11
     # via
     #   babelfont
     #   ufolib2
@@ -235,7 +235,7 @@ requests==2.32.3
     #   pygithub
 resvg-cli==0.44.0
     # via nanoemoji
-rich==13.9.3
+rich==13.9.4
     # via gftools
 ruamel-yaml==0.18.6
     # via gftools


### PR DESCRIPTION
Brings in the newest glyphsLib, as well as updates our gftools to include a commit that stops us from running ttxautohint.

JMM