### PR TITLE
[crater] Report number of identical families

### DIFF
--- a/fontc_crater/resources/style.css
+++ b/fontc_crater/resources/style.css
@@ -69,6 +69,12 @@ td.rev {
   font-family: monospace;
 }
 
+.matching_families {
+  font-style: italic;
+  padding-bottom: 10px;
+
+}
+
 .diff_result {
   width: 10em;
   display: inline-block;


### PR DESCRIPTION
This is shown as a single line in the results section, not in the main table.


looks like this:

<img width="991" alt="Screenshot 2024-11-05 at 4 02 25 PM" src="https://github.com/user-attachments/assets/1c707052-fc89-44a3-b4f7-dad5735f8473">
