### PR TITLE
[crater] Report size differences

### DIFF
--- a/fontc_crater/src/ci/html.rs
+++ b/fontc_crater/src/ci/html.rs
@@ -564,14 +564,16 @@ fn format_diff_report_detail_table(current: &DiffOutput, prev: Option<&DiffOutpu
         };
 
         // size reporting is sort of hacked on, and doesn't really follow the same pattern
-        // as table diffs; the diff % we show in this case
+        // as table diffs; the diff % we show in this case is the ratio between the two
+        // sizes. For instance a value of +60% means fontmake is 40% the size of fontc.
+        // negative numbers mean fontc is smaller than fontmake.
         if table.starts_with("sizeof") {
             if let (DiffValue::Ratio(r), Some(DiffValue::Ratio(prev))) =
                 (&value, prev_value.as_ref())
             {
                 return make_delta_decoration(
-                    r.abs() * 100.,
-                    Some(prev.abs() * 100.),
+                    r.abs() as i32,
+                    Some(prev.abs() as i32),
                     More::IsWorse,
                 );
             }
@@ -633,7 +635,14 @@ fn format_diff_report_detail_table(current: &DiffOutput, prev: Option<&DiffOutpu
                 @for (table, value) in all_items {
                     tr.table_diff_row {
                         td.table_diff_name { (table) }
-                        td.table_diff_value { (value) " " ( {value_decoration(table, value) }) }
+                        @if table.starts_with("sizeof") {
+
+                            td.table_diff_value {
+                                (value.as_n_of_bytes()) "B " ( {value_decoration(table, value) })
+                            }
+                        } @else {
+                            td.table_diff_value { (value) " " ( {value_decoration(table, value) }) }
+                        }
                     }
                 }
             }

--- a/fontc_crater/src/ttx_diff_runner.rs
+++ b/fontc_crater/src/ttx_diff_runner.rs
@@ -278,6 +278,14 @@ impl DiffValue {
             DiffValue::Only(_) => None,
         }
     }
+
+    pub(crate) fn as_n_of_bytes(&self) -> i32 {
+        match self {
+            DiffValue::Ratio(r) => *r as _,
+            // this branch shouldn't be hit but let's notice if it is??
+            DiffValue::Only(_) => 123456789,
+        }
+    }
 }
 
 impl DiffOutput {

--- a/resources/scripts/ttx_diff.py
+++ b/resources/scripts/ttx_diff.py
@@ -514,12 +514,10 @@ def check_sizes(fontmake_ttf: Path, fontc_ttf: Path):
         fontmake_len = fontmake[key]
         fontc_len = fontc[key]
         len_ratio = min(fontc_len, fontmake_len) / max(fontc_len, fontmake_len)
-        sign = -1 if fontc_len < fontmake_len else 1
-        # invert to make this represent difference rather than similarity
-        len_ratio = (1 - len_ratio) * sign
-        if abs(len_ratio) > THRESHOLD:
-            eprint(f"{key} {fontmake_len} {fontc_len} {len_ratio}")
-            output[key] = len_ratio
+        if (1 - len_ratio) > THRESHOLD:
+            rel_len = fontc_len - fontmake_len
+            eprint(f"{key} {fontmake_len} {fontc_len} {len_ratio:.3} {rel_len}")
+            output[key] = rel_len
     return output
 
 
@@ -576,8 +574,7 @@ def print_output(build_dir: Path, output: dict[str, dict[str, Any]]):
     if output.get("sizes"):
         print("SIZE DIFFERENCES")
     for tag, diff in output.get("sizes", {}).items():
-        diffperc = diff * 100.0
-        print(f"SIZE DIFFERENCE: '{tag}': {diffperc:.1%}")
+        print(f"SIZE DIFFERENCE: '{tag}': {diff}B")
 
 
 def jsonify_output(output: dict[str, dict[str, Any]]):


### PR DESCRIPTION
This is a bit hacky, because comparing size doesn't really work like difference, but I've squeezed it into a shape where it seems to work okay?

It basically works like this:
- for each table produced by both compilers, we find the ratio of their sizes
- if the ratio exceeds a threshold (currently 1/10) then we add it to the the report
- in the actual report, we just display these size differences as a delta, in bytes. Negative numbers mean that fontc is smaller than fontmake, and positive numbers mean the inverse.