### PR TITLE
use gftools==0.9.74, update glyphsLib==6.9.4

### DIFF
--- a/resources/scripts/requirements.in
+++ b/resources/scripts/requirements.in
@@ -8,5 +8,6 @@ fonttools
 lxml
 cdifflib
 glyphsLib
-# our custom branch of gftools
-git+https://github.com/googlefonts/gftools.git@27b013a
+# keep gftools pinned as well to ensure ttx_diff.py output is stable.
+# 0.9.74 is when experimental support for fontc was added to gftools.
+gftools==0.9.74

--- a/resources/scripts/requirements.txt
+++ b/resources/scripts/requirements.txt
@@ -10,7 +10,7 @@ absl-py==2.1.0
     #   gftools
     #   nanoemoji
     #   picosvg
-afdko==4.0.1
+afdko==4.0.2
     # via gftools
 appdirs==1.4.4
     # via fs
@@ -130,7 +130,7 @@ gflanguages==0.7.0
     #   glyphsets
 gfsubsets==2024.9.25
     # via gftools
-gftools @ git+https://github.com/googlefonts/gftools.git@27b013a
+gftools==0.9.74
     # via -r resources/scripts/requirements.in
 gitdb==4.0.11
     # via gitpython
@@ -138,7 +138,7 @@ gitpython==3.1.43
     # via font-v
 glyphsets==1.0.0
     # via gftools
-glyphslib==6.9.3
+glyphslib==6.9.4
     # via
     #   -r resources/scripts/requirements.in
     #   babelfont
@@ -183,7 +183,7 @@ openstep-plist==0.4.0
     #   babelfont
     #   bumpfontversion
     #   glyphslib
-opentype-sanitizer==9.1.0
+opentype-sanitizer==9.2.0
     # via gftools
 orjson==3.10.11
     # via
@@ -210,7 +210,7 @@ pycparser==2.22
     # via cffi
 pygit2==1.14.1
     # via gftools
-pygithub==2.4.0
+pygithub==2.5.0
     # via gftools
 pygments==2.18.0
     # via rich
@@ -226,7 +226,7 @@ pyyaml==6.0.2
     # via
     #   gftools
     #   glyphsets
-regex==2024.9.11
+regex==2024.11.6
     # via nanoemoji
 requests==2.32.3
     # via
@@ -261,7 +261,7 @@ tabulate==0.9.0
     # via gftools
 toml==0.10.2
     # via nanoemoji
-tqdm==4.66.6
+tqdm==4.67.0
     # via afdko
 ttfautohint-py==0.5.1
     # via gftools
@@ -291,7 +291,7 @@ ufonormalizer==0.6.2
     #   vfblib
 ufoprocessor==1.13.1
     # via afdko
-uharfbuzz==0.41.1
+uharfbuzz==0.42.0
     # via
     #   fonttools
     #   vharfbuzz


### PR DESCRIPTION
we no longer need to install gftools from github, as our patches were released upstream.

also, glyphsLib [6.9.4 reverted a change in 6.9.3](https://github.com/googlefonts/glyphsLib/pull/1044) that caused lots of unnecessary diffs in GlyphOrder

JMM