### PR TITLE
Support long parameter name for PANOSE, to match glyphsLib

### DIFF
--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -437,10 +437,10 @@ impl CustomParameters {
     }
 
     fn panose(&self) -> Option<&Vec<i64>> {
-        let Some(CustomParameterValue::Panose(values)) = self.get("panose") else {
-            return None;
-        };
-        Some(values)
+        match self.get("panose").or_else(|| self.get("openTypeOS2Panose")) {
+            Some(CustomParameterValue::Panose(values)) => Some(values),
+            _ => None,
+        }
     }
 }
 
@@ -569,7 +569,9 @@ impl FromPlist for CustomParameters {
                                 value =
                                     Some(CustomParameterValue::CodepageRange(tokenizer.parse()?));
                             }
-                            _ if name == Some(String::from("panose")) => {
+                            _ if name == Some(String::from("panose"))
+                                || name == Some(String::from("openTypeOS2Panose")) =>
+                            {
                                 let Token::OpenParen = peek else {
                                     return Err(Error::UnexpectedChar('('));
                                 };

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -1966,8 +1966,18 @@ mod tests {
 
     #[test]
     fn captures_panose() {
+        let expected: Option<Panose> = Some([2, 0, 5, 3, 6, 0, 0, 2, 0, 3].into());
+
+        // short parameter name
         let (_, context) = build_static_metadata(glyphs3_dir().join("WghtVarPanose.glyphs"));
-        let expected: Panose = [2, 0, 5, 3, 6, 0, 0, 2, 0, 3].into();
-        assert_eq!(Some(expected), context.static_metadata.get().misc.panose);
+        assert_eq!(expected, context.static_metadata.get().misc.panose);
+
+        // long parameter name
+        let (_, context) = build_static_metadata(glyphs3_dir().join("WghtVarPanoseLong.glyphs"));
+        assert_eq!(expected, context.static_metadata.get().misc.panose);
+
+        // both parameters; value under short name should be preferred
+        let (_, context) = build_static_metadata(glyphs3_dir().join("WghtVarPanoseBoth.glyphs"));
+        assert_eq!(expected, context.static_metadata.get().misc.panose);
     }
 }

--- a/resources/testdata/glyphs3/WghtVarPanoseBoth.glyphs
+++ b/resources/testdata/glyphs3/WghtVarPanoseBoth.glyphs
@@ -1,0 +1,58 @@
+{
+.formatVersion = 3;
+customParameters = (
+{
+name = panose;
+value = (
+2,
+0,
+5,
+3,
+6,
+0,
+0,
+2,
+0,
+3
+);
+},
+{
+name = openTypeOS2Panose;
+value = (
+0,
+1,
+2,
+3,
+4,
+5,
+6,
+7,
+8,
+9
+);
+}
+);
+familyName = WghtVar;
+fontMaster = (
+{
+id = m01;
+name = Regular;
+}
+);
+glyphs = (
+{
+glyphname = space;
+layers = (
+{
+layerId = m01;
+width = 200;
+}
+);
+unicode = 32;
+}
+);
+
+unitsPerEm = 1234;
+versionMajor = 42;
+versionMinor = 42;
+}

--- a/resources/testdata/glyphs3/WghtVarPanoseLong.glyphs
+++ b/resources/testdata/glyphs3/WghtVarPanoseLong.glyphs
@@ -1,0 +1,43 @@
+{
+.formatVersion = 3;
+customParameters = (
+{
+name = openTypeOS2Panose;
+value = (
+2,
+0,
+5,
+3,
+6,
+0,
+0,
+2,
+0,
+3
+);
+}
+);
+familyName = WghtVar;
+fontMaster = (
+{
+id = m01;
+name = Regular;
+}
+);
+glyphs = (
+{
+glyphname = space;
+layers = (
+{
+layerId = m01;
+width = 200;
+}
+);
+unicode = 32;
+}
+);
+
+unitsPerEm = 1234;
+versionMajor = 42;
+versionMinor = 42;
+}


### PR DESCRIPTION
glyphsLib supports longer alternative names for some of its parameters, [including PANOSE](https://github.com/googlefonts/glyphsLib/blob/050ef62c52906bc8ca820e7cfc6963138253f41f/Lib/glyphsLib/builder/custom_params.py#L322-L323) (albeit with [the short name taking precedence](https://github.com/googlefonts/glyphsLib/blob/050ef62c52906bc8ca820e7cfc6963138253f41f/Lib/glyphsLib/builder/custom_params.py#L258-L269)). This PR adds support for the longer name, and tests that it is parsed and has its precedence weighed correctly.

With this change, most of the OS/2 diff for Noto Sundanese is resolved; an unrelated diff in `xAvgCharWidth` remains.

```bash
$ python resources/scripts/ttx_diff.py https://github.com/notofonts/sundanese#sources/NotoSansSundanese.glyphs
```

Before:
```
...
DIFF 'OS_2', [...]/build/default/fontc.OS_2.ttx [...]/build/default/fontmake.OS_2.ttx (79.6%)
...
```

After:
```
...
DIFF 'hmtx', [...]/build/default/fontc.hmtx.ttx [...]/build/default/fontmake.hmtx.ttx (98.9%)
...
```

<sub>Note: this is a personal contribution independent of my employer, and so I've submitted from a fork under my personal profile and email to make this distinction</sub>