### PR TITLE
Two small fixes for two small crater crashes

### DIFF
--- a/fontc_crater/src/target.rs
+++ b/fontc_crater/src/target.rs
@@ -152,7 +152,7 @@ impl Target {
         let just_source_dir = self.source_dir.file_name().unwrap();
         let rel_source_path = Path::new(just_source_dir).join(&self.source);
         let mut cmd = format!(
-            "python resources/scripts/ttx_diff.py {repo_url}#{}",
+            "python resources/scripts/ttx_diff.py '{repo_url}#{}'",
             rel_source_path.display()
         );
         if self.build == BuildType::GfTools {

--- a/resources/scripts/ttx_diff.py
+++ b/resources/scripts/ttx_diff.py
@@ -624,7 +624,7 @@ def resolve_source(source: str) -> Path:
         repo_name = source_url.path.split("/")[-1]
         local_repo = (Path.home() / ".fontc_crater_cache" / org_name / repo_name).resolve()
         if not local_repo.parent.is_dir():
-            local_repo.parent.mkdir()
+            local_repo.parent.mkdir(parents=True)
         if not local_repo.is_dir():
             cmd = ("git", "clone", source_url._replace(fragment="").geturl())
             print("Running", " ".join(cmd), "in", local_repo.parent)


### PR DESCRIPTION
Hello! This is just a small one with QoL fixes for two crater-related crashes:

- [Quote URL in reproduction command, to help parse sources with spaces in their name](https://github.com/googlefonts/fontc/commit/b3faa37e41e3b6d63f61e2ea7d5c7b8dbacf2638)
- [Create cache directory (~/.fontc_crater_cache) if it does not exist yet](https://github.com/googlefonts/fontc/commit/0af851f8659abda5240e191f3240379a1add9706)

---

Both can be reproduced and tested by copying the reproduction command for 'Konkhmer Sleokchher.glyphs' from [the hosted fontc_crater results](https://googlefonts.github.io/fontc_crater/) and running it without a `~/.fontc_crater_cache` directory present :boom: 

<sub>Note: this is a personal contribution independent of my employer, and so I've submitted from a fork under my personal profile and email to make this distinction</sub>
