### PR TITLE
Fix crater quality-of-life fix

### DIFF
--- a/fontc_crater/src/ci/html.rs
+++ b/fontc_crater/src/ci/html.rs
@@ -362,7 +362,7 @@ fn make_diff_report(
 
         let repo_url = get_repo_url(target);
         let ttx_command = target.repro_command(repo_url);
-        let onclick = format!("event.preventDefault(); copyText('{ttx_command}');",);
+        let onclick = format!("event.preventDefault(); copyText(\"{ttx_command}\");",);
         let decoration = make_delta_decoration(*ratio, prev_ratio, More::IsBetter);
         let changed_tag_list = list_different_tables(diff_details).unwrap_or_default();
         let diff_table = format_diff_report_detail_table(diff_details, prev_details);
@@ -683,7 +683,7 @@ fn make_error_report_group_items<'a>(
     let make_repro_command = |target: &Target| {
         let url = get_repo_url(target);
         let ttx_command = target.repro_command(url);
-        format!("event.preventDefault(); copyText('{ttx_command}');",)
+        format!("event.preventDefault(); copyText(\"{ttx_command}\");",)
     };
     html! {
         @for (path, is_new) in paths_and_if_is_new_error {


### PR DESCRIPTION
Unfortunately my fix for reproduction commands in #1103 – introducing bash quotes – interfered with the outer JavaScript quotes, breaking the 'copy reproduction command' entirely...

This PR remedies this by alternating the quotes style. For this and all future changes, I have now got a local fontc_crater setup, and have verified the fix. The documentation for doing so was excellent, and I wish I'd checked for it the first time; sorry for the trouble!

<sub>Note: this is a personal contribution independent of my employer, and so I've submitted from a fork under my personal profile and email to make this distinction</sub>