### PR TITLE
Revert "[ttx_diff] Only report size issues if fontc > fontmake"

### DIFF
--- a/resources/scripts/ttx_diff.py
+++ b/resources/scripts/ttx_diff.py
@@ -531,7 +531,7 @@ def check_sizes(fontmake_ttf: Path, fontc_ttf: Path):
     for key in shared_keys:
         fontmake_len = fontmake[key]
         fontc_len = fontc[key]
-        len_ratio = fontc_len / fontmake_len
+        len_ratio = min(fontc_len, fontmake_len) / max(fontc_len, fontmake_len)
         if (1 - len_ratio) > THRESHOLD:
             rel_len = fontc_len - fontmake_len
             eprint(f"{key} {fontmake_len} {fontc_len} {len_ratio:.3} {rel_len}")


### PR DESCRIPTION
This reverts commit ffcfadfc3ce0ee35166baa3e2f8d6df2fee7f3a4.

I edited this PR after review and the change I made was not correct.