### PR TITLE
[ttx_diff] Only report size differences if fontc bigger

### DIFF
--- a/resources/scripts/ttx_diff.py
+++ b/resources/scripts/ttx_diff.py
@@ -531,6 +531,8 @@ def check_sizes(fontmake_ttf: Path, fontc_ttf: Path):
     for key in shared_keys:
         fontmake_len = fontmake[key]
         fontc_len = fontc[key]
+        if fontc_len < fontmake_len:
+            continue
         len_ratio = min(fontc_len, fontmake_len) / max(fontc_len, fontmake_len)
         if (1 - len_ratio) > THRESHOLD:
             rel_len = fontc_len - fontmake_len


### PR DESCRIPTION
This is not a very elegant way of expressing this but it works and leaves the existing logic in place, in case at some point we decide we _do_ care if fontc produces something significantly smaller.