### PR TITLE
We no longer have to avoid reusing non-font-specific names

### DIFF
--- a/fontbe/src/fvar.rs
+++ b/fontbe/src/fvar.rs
@@ -34,9 +34,6 @@ fn generate_fvar(static_metadata: &StaticMetadata) -> Option<Fvar> {
     let reverse_names: HashMap<_, _> = static_metadata
         .names
         .iter()
-        // To match fontmake we should use the font-specific name range and not reuse
-        // a well-known name, even if the name matches.
-        .filter(|(key, _)| key.name_id.to_u16() > 255)
         .map(|(key, name)| (name.as_str(), key.name_id))
         .collect();
 

--- a/fontbe/src/stat.rs
+++ b/fontbe/src/stat.rs
@@ -48,9 +48,6 @@ impl Work<Context, AnyWorkId, Error> for StatWork {
         let reverse_names: HashMap<_, _> = static_metadata
             .names
             .iter()
-            // To match fontmake we should use the font-specific name range and not reuse
-            // a well-known name, even if the name matches.
-            .filter(|(key, _)| key.name_id.to_u16() > 255)
             .map(|(key, name)| (name.as_str(), key.name_id))
             .collect();
 

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -3306,4 +3306,20 @@ mod tests {
 
         assert_eq!(vec![expected_rot30_bbox, expected_rot60more_bbox], boxes);
     }
+
+    #[test]
+    fn unique_names() {
+        // Axis name matches subfamily; they should share
+        let compile = TestCompile::compile_source("glyphs3/DuplicateNames.glyphs");
+        let axis_name_ids = compile
+            .font()
+            .fvar()
+            .unwrap()
+            .axes()
+            .unwrap()
+            .iter()
+            .map(|a| a.axis_name_id())
+            .collect::<Vec<_>>();
+        assert_eq!(vec![NameId::SUBFAMILY_NAME], axis_name_ids);
+    }
 }

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -424,14 +424,14 @@ impl StaticMetadata {
         // Claim names for axes and named instances
         let mut name_id_gen = 255;
         let mut key_to_name = names;
-        let mut visited = HashSet::new();
+        let mut visited = key_to_name.values().cloned().collect::<HashSet<_>>();
 
         variable_axes
             .iter()
             .map(|axis| axis.ui_label_name())
             .chain(named_instances.iter().map(|ni| ni.name.as_ref()))
             .for_each(|name| {
-                if !visited.insert(name) {
+                if !visited.insert(name.to_string()) {
                     return;
                 }
                 name_id_gen += 1;

--- a/resources/testdata/glyphs3/DuplicateNames.glyphs
+++ b/resources/testdata/glyphs3/DuplicateNames.glyphs
@@ -1,0 +1,45 @@
+{
+.formatVersion = 3;
+axes = (
+{
+name = Regular;
+tag = wght;
+}
+);
+familyName = DuplicateNames;
+fontMaster = (
+{
+axesValues = (
+400
+);
+id = m01;
+name = Regular;
+},
+{
+axesValues = (
+700
+);
+iconName = Bold;
+id = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+name = Bold;
+}
+);
+glyphs = (
+{
+glyphname = space;
+lastChange = "2022-12-01 04:58:12 +0000";
+layers = (
+{
+layerId = m01;
+width = 200;
+},
+{
+layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+width = 600;
+}
+);
+unicode = 32;
+},
+);
+unitsPerEm = 1000;
+}


### PR DESCRIPTION
Fix for #1105 on the python side made it possible to reuse non-font-specific names, make fontc consistent.

Makes `python resources/scripts/ttx_diff.py 'https://github.com/googlefonts/Exo-2.0#sources/Glyphs/Exo2-Italic.glyphs'` and `python resources/scripts/ttx_diff.py 'https://github.com/googlefonts/atkinson-hyperlegible#sources/AtkinsonHyperlegible.glyphs'` and hopefully others identical instead of different on `(name, fvar)`. 

JMM if happy.