### PR TITLE
Allow identical (same glyph, same transform) components

### DIFF
--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -3322,4 +3322,10 @@ mod tests {
             .collect::<Vec<_>>();
         assert_eq!(vec![NameId::SUBFAMILY_NAME], axis_name_ids);
     }
+
+    #[test]
+    fn allow_duplicate_components() {
+        // This used to crash us, <https://github.com/googlefonts/fontc/issues/1115>
+        TestCompile::compile_source("DoubleComponentError/OuterInner.designspace");
+    }
 }


### PR DESCRIPTION
I think when I originally wrote this I assumed it to be nonsensical to repeat a component but for a VF it's OK if some locations do this.

Per #1115 this occurs in real fonts.