### PR TITLE
Remove `set_unconditionally` & `BeValue`

### DIFF
--- a/fontbe/src/avar.rs
+++ b/fontbe/src/avar.rs
@@ -107,7 +107,7 @@ impl Work<Context, AnyWorkId, Error> for AvarWork {
             .iter()
             .any(|segmap| !segmap.is_identity())
             .then(|| Avar::new(axis_segment_maps));
-        context.avar.set_unconditionally(avar.into());
+        context.avar.set(avar.into());
         Ok(())
     }
 }

--- a/fontbe/src/cmap.rs
+++ b/fontbe/src/cmap.rs
@@ -52,7 +52,7 @@ impl Work<Context, AnyWorkId, Error> for CmapWork {
             });
 
         let cmap = Cmap::from_mappings(mappings)?;
-        context.cmap.set_unconditionally(cmap.into());
+        context.cmap.set(cmap);
         Ok(())
     }
 }

--- a/fontbe/src/features.rs
+++ b/fontbe/src/features.rs
@@ -584,13 +584,13 @@ impl Work<Context, AnyWorkId, Error> for FeatureCompilationWork {
             result.gdef.is_some(),
         );
         if let Some(gpos) = result.gpos {
-            context.gpos.set_unconditionally(gpos.into());
+            context.gpos.set(gpos);
         }
         if let Some(gsub) = result.gsub {
-            context.gsub.set_unconditionally(gsub.into());
+            context.gsub.set(gsub);
         }
         if let Some(gdef) = result.gdef {
-            context.gdef.set_unconditionally(gdef.into());
+            context.gdef.set(gdef);
         }
 
         // Enables the assumption that if the file exists features were compiled

--- a/fontbe/src/font.rs
+++ b/fontbe/src/font.rs
@@ -163,7 +163,7 @@ impl Work<Context, AnyWorkId, Error> for FontWork {
         debug!("Building font");
         let font = builder.build();
         debug!("Assembled {} byte font", font.len());
-        context.font.set_unconditionally(font.into());
+        context.font.set(font.into());
         Ok(())
     }
 }

--- a/fontbe/src/font.rs
+++ b/fontbe/src/font.rs
@@ -81,7 +81,7 @@ fn has(context: &Context, id: WorkId) -> bool {
 fn bytes_for(context: &Context, id: WorkId) -> Result<Option<Vec<u8>>, Error> {
     // TODO: to_vec copies :(
     let bytes = match id {
-        WorkId::Avar => to_bytes(context.avar.get().as_ref()),
+        WorkId::Avar => context.avar.get().as_ref().as_ref().and_then(to_bytes),
         WorkId::Cmap => to_bytes(context.cmap.get().as_ref()),
         WorkId::Fvar => to_bytes(context.fvar.get().as_ref()),
         WorkId::Head => to_bytes(context.head.get().as_ref()),

--- a/fontbe/src/fvar.rs
+++ b/fontbe/src/fvar.rs
@@ -93,7 +93,7 @@ impl Work<Context, AnyWorkId, Error> for FvarWork {
     /// Generate [fvar](https://learn.microsoft.com/en-us/typography/opentype/spec/fvar)
     fn exec(&self, context: &Context) -> Result<(), Error> {
         if let Some(fvar) = generate_fvar(&context.ir.static_metadata.get()) {
-            context.fvar.set_unconditionally(fvar.into());
+            context.fvar.set(fvar);
         }
         Ok(())
     }

--- a/fontbe/src/gvar.rs
+++ b/fontbe/src/gvar.rs
@@ -76,7 +76,7 @@ impl Work<Context, AnyWorkId, Error> for GvarWork {
                 context: "gvar".into(),
             })?
             .into();
-        context.gvar.set_unconditionally(raw_gvar);
+        context.gvar.set(raw_gvar);
 
         Ok(())
     }

--- a/fontbe/src/head.rs
+++ b/fontbe/src/head.rs
@@ -132,7 +132,7 @@ impl Work<Context, AnyWorkId, Error> for HeadWork {
         );
         apply_created_modified(&mut head, static_metadata.misc.created);
         apply_macstyle(&mut head, static_metadata.misc.selection_flags);
-        context.head.set_unconditionally(head.into());
+        context.head.set(head);
 
         // Defer x/y Min/Max to metrics and limits job
 

--- a/fontbe/src/hvar.rs
+++ b/fontbe/src/hvar.rs
@@ -228,7 +228,7 @@ impl Work<Context, AnyWorkId, Error> for HvarWork {
         }
 
         let hvar = Hvar::new(MajorMinor::VERSION_1_0, varstore, varidx_map, None, None);
-        context.hvar.set_unconditionally(hvar.into());
+        context.hvar.set(hvar);
 
         Ok(())
     }

--- a/fontbe/src/metrics_and_limits.rs
+++ b/fontbe/src/metrics_and_limits.rs
@@ -310,7 +310,7 @@ impl Work<Context, AnyWorkId, Error> for MetricAndLimitWork {
                 }
             })?,
         };
-        context.hhea.set_unconditionally(hhea.into());
+        context.hhea.set(hhea);
 
         // Send hmtx out into the world
         let hmtx = Hmtx::new(long_metrics, lsbs);
@@ -320,7 +320,7 @@ impl Work<Context, AnyWorkId, Error> for MetricAndLimitWork {
                 context: "hmtx".into(),
             })?
             .into();
-        context.hmtx.set_unconditionally(raw_hmtx);
+        context.hmtx.set(raw_hmtx);
 
         // Might as well do maxp while we're here
         let composite_limits = glyph_limits.update_composite_limits();
@@ -342,7 +342,7 @@ impl Work<Context, AnyWorkId, Error> for MetricAndLimitWork {
             max_component_elements: Some(glyph_limits.max_component_elements),
             max_component_depth: Some(composite_limits.max_depth),
         };
-        context.maxp.set_unconditionally(maxp.into());
+        context.maxp.set(maxp);
 
         // Set x/y min/max in head
         let mut head = Arc::unwrap_or_clone(context.head.get());
@@ -351,7 +351,7 @@ impl Work<Context, AnyWorkId, Error> for MetricAndLimitWork {
         head.y_min = bbox.y_min;
         head.x_max = bbox.x_max;
         head.y_max = bbox.y_max;
-        context.head.set_unconditionally(head);
+        context.head.set(head);
 
         Ok(())
     }

--- a/fontbe/src/metrics_and_limits.rs
+++ b/fontbe/src/metrics_and_limits.rs
@@ -5,6 +5,7 @@
 use std::{
     cmp::{max, min},
     collections::HashMap,
+    sync::Arc,
 };
 
 use fontdrasil::orchestration::{Access, AccessBuilder, Work};
@@ -344,13 +345,13 @@ impl Work<Context, AnyWorkId, Error> for MetricAndLimitWork {
         context.maxp.set_unconditionally(maxp.into());
 
         // Set x/y min/max in head
-        let mut head = context.head.get().0.clone().unwrap();
+        let mut head = Arc::unwrap_or_clone(context.head.get());
         let bbox = glyph_limits.bbox.unwrap_or_default();
         head.x_min = bbox.x_min;
         head.y_min = bbox.y_min;
         head.x_max = bbox.x_max;
         head.y_max = bbox.y_max;
-        context.head.set_unconditionally(head.into());
+        context.head.set_unconditionally(head);
 
         Ok(())
     }

--- a/fontbe/src/mvar.rs
+++ b/fontbe/src/mvar.rs
@@ -153,7 +153,7 @@ impl Work<Context, AnyWorkId, Error> for MvarWork {
             }
         }
         if let Some(mvar) = mvar_builder.build() {
-            context.mvar.set_unconditionally(mvar);
+            context.mvar.set(mvar);
         }
 
         Ok(())

--- a/fontbe/src/mvar.rs
+++ b/fontbe/src/mvar.rs
@@ -152,9 +152,9 @@ impl Work<Context, AnyWorkId, Error> for MvarWork {
                 mvar_builder.add_sources(mvar_tag, values)?;
             }
         }
-        let mvar = mvar_builder.build();
-
-        context.mvar.set_unconditionally(mvar.into());
+        if let Some(mvar) = mvar_builder.build() {
+            context.mvar.set_unconditionally(mvar);
+        }
 
         Ok(())
     }

--- a/fontbe/src/name.rs
+++ b/fontbe/src/name.rs
@@ -46,7 +46,7 @@ impl Work<Context, AnyWorkId, Error> for NameWork {
 
         context
             .name
-            .set_unconditionally(Name::new(name_records.into_iter().collect()).into());
+            .set(Name::new(name_records.into_iter().collect()));
         Ok(())
     }
 }

--- a/fontbe/src/orchestration.rs
+++ b/fontbe/src/orchestration.rs
@@ -25,7 +25,7 @@ use fontir::{
     ir::{self, GlyphOrder, KernGroup},
     orchestration::{
         Context as FeContext, ContextItem, ContextMap, Flags, IdAware, Persistable,
-        PersistableOption, PersistentStorage, WorkId as FeWorkIdentifier,
+        PersistentStorage, WorkId as FeWorkIdentifier,
     },
     variations::VariationRegion,
 };
@@ -38,7 +38,6 @@ use write_fonts::{
     dump_table,
     read::FontRead,
     tables::{
-        avar::Avar,
         cmap::Cmap,
         fvar::Fvar,
         gdef::Gdef,
@@ -63,7 +62,7 @@ use write_fonts::{
     FontWrite,
 };
 
-use crate::{error::Error, paths::Paths};
+use crate::{avar::PossiblyEmptyAvar, error::Error, paths::Paths};
 
 type KernBlock = usize;
 
@@ -689,7 +688,7 @@ pub struct Context {
     pub glyphs: BeContextMap<Glyph>,
 
     // Allow avar to be explicitly None to record a noop avar being generated
-    pub avar: BeContextItem<PersistableOption<Avar>>,
+    pub avar: BeContextItem<PossiblyEmptyAvar>,
     pub cmap: BeContextItem<Cmap>,
     pub fvar: BeContextItem<Fvar>,
     pub glyf: BeContextItem<Bytes>,

--- a/fontbe/src/orchestration.rs
+++ b/fontbe/src/orchestration.rs
@@ -25,7 +25,7 @@ use fontir::{
     ir::{self, GlyphOrder, KernGroup},
     orchestration::{
         Context as FeContext, ContextItem, ContextMap, Flags, IdAware, Persistable,
-        PersistentStorage, WorkId as FeWorkIdentifier,
+        PersistableOption, PersistentStorage, WorkId as FeWorkIdentifier,
     },
     variations::VariationRegion,
 };
@@ -36,7 +36,7 @@ use serde::{Deserialize, Serialize};
 
 use write_fonts::{
     dump_table,
-    read::{FontData, FontRead},
+    read::FontRead,
     tables::{
         avar::Avar,
         cmap::Cmap,
@@ -235,7 +235,7 @@ impl IdAware<AnyWorkId> for Glyph {
 impl Persistable for Glyph {
     fn read(from: &mut dyn Read) -> Self {
         let (name, bytes): (GlyphName, Vec<u8>) = bincode::deserialize_from(from).unwrap();
-        let glyph = RawGlyph::read(bytes.as_slice().into()).unwrap();
+        let glyph = FontRead::read(bytes.as_slice().into()).unwrap();
         Glyph { name, data: glyph }
     }
 
@@ -638,51 +638,6 @@ impl Persistable for LocaFormatWrapper {
 
 pub type BeWork = dyn Work<Context, AnyWorkId, Error> + Send;
 
-/// Allows us to implement [Persistable] w/o violating the orphan rules
-///
-/// Other than that just kind of gets in the way
-pub struct BeValue<T>(pub Option<T>);
-
-impl<T> Persistable for BeValue<T>
-where
-    for<'a> T: FontRead<'a> + FontWrite + Validate,
-{
-    fn read(from: &mut dyn Read) -> Self {
-        let mut buf = Vec::new();
-        from.read_to_end(&mut buf).unwrap();
-        (!buf.is_empty())
-            .then(|| T::read(FontData::new(&buf)).unwrap())
-            .into()
-    }
-
-    fn write(&self, to: &mut dyn io::Write) {
-        let bytes = self
-            .0
-            .as_ref()
-            .map(|t| dump_table(t).unwrap())
-            .unwrap_or_default();
-        to.write_all(&bytes).unwrap();
-    }
-}
-
-impl<T> From<T> for BeValue<T>
-where
-    T: FontWrite + Validate,
-{
-    fn from(value: T) -> Self {
-        BeValue(Some(value))
-    }
-}
-
-impl<T> From<Option<T>> for BeValue<T>
-where
-    T: FontWrite + Validate,
-{
-    fn from(value: Option<T>) -> Self {
-        BeValue(value)
-    }
-}
-
 pub struct BePersistentStorage {
     active: bool,
     pub(crate) paths: Paths,
@@ -734,31 +689,31 @@ pub struct Context {
     pub glyphs: BeContextMap<Glyph>,
 
     // Allow avar to be explicitly None to record a noop avar being generated
-    pub avar: BeContextItem<BeValue<Avar>>,
-    pub cmap: BeContextItem<BeValue<Cmap>>,
-    pub fvar: BeContextItem<BeValue<Fvar>>,
+    pub avar: BeContextItem<PersistableOption<Avar>>,
+    pub cmap: BeContextItem<Cmap>,
+    pub fvar: BeContextItem<Fvar>,
     pub glyf: BeContextItem<Bytes>,
-    pub gsub: BeContextItem<BeValue<Gsub>>,
-    pub gpos: BeContextItem<BeValue<Gpos>>,
-    pub gdef: BeContextItem<BeValue<Gdef>>,
+    pub gsub: BeContextItem<Gsub>,
+    pub gpos: BeContextItem<Gpos>,
+    pub gdef: BeContextItem<Gdef>,
     pub gvar: BeContextItem<Bytes>,
-    pub post: BeContextItem<BeValue<Post>>,
+    pub post: BeContextItem<Post>,
     pub loca: BeContextItem<Bytes>,
     pub loca_format: BeContextItem<LocaFormatWrapper>,
-    pub maxp: BeContextItem<BeValue<Maxp>>,
-    pub name: BeContextItem<BeValue<Name>>,
-    pub os2: BeContextItem<BeValue<Os2>>,
-    pub head: BeContextItem<BeValue<Head>>,
-    pub hhea: BeContextItem<BeValue<Hhea>>,
+    pub maxp: BeContextItem<Maxp>,
+    pub name: BeContextItem<Name>,
+    pub os2: BeContextItem<Os2>,
+    pub head: BeContextItem<Head>,
+    pub hhea: BeContextItem<Hhea>,
     pub hmtx: BeContextItem<Bytes>,
-    pub hvar: BeContextItem<BeValue<Hvar>>,
-    pub mvar: BeContextItem<BeValue<Mvar>>,
+    pub hvar: BeContextItem<Hvar>,
+    pub mvar: BeContextItem<Mvar>,
     pub all_kerning_pairs: BeContextItem<AllKerningPairs>,
     pub kern_fragments: BeContextMap<KernFragment>,
     pub fea_ast: BeContextItem<FeaAst>,
     pub fea_rs_kerns: BeContextItem<FeaRsKerns>,
     pub fea_rs_marks: BeContextItem<FeaRsMarks>,
-    pub stat: BeContextItem<BeValue<Stat>>,
+    pub stat: BeContextItem<Stat>,
     pub font: BeContextItem<Bytes>,
 }
 
@@ -912,11 +867,11 @@ impl Persistable for Bytes {
     }
 }
 
-pub(crate) fn to_bytes<T>(table: &BeValue<T>) -> Option<Vec<u8>>
+pub(crate) fn to_bytes<T>(table: &T) -> Option<Vec<u8>>
 where
     T: FontWrite + Validate,
 {
-    table.0.as_ref().map(|t| dump_table(t).unwrap())
+    write_fonts::dump_table(table).ok()
 }
 
 #[cfg(test)]

--- a/fontbe/src/os2.rs
+++ b/fontbe/src/os2.rs
@@ -215,10 +215,7 @@ pub fn create_os2_work() -> Box<BeWork> {
 /// <https://github.com/fonttools/fonttools/blob/115275cbf429d91b75ac5536f5f0b2d6fe9d823a/Lib/fontTools/ttLib/tables/O_S_2f_2.py#L336-L348>
 fn x_avg_char_width(context: &Context) -> Result<i16, Error> {
     let glyph_order = context.ir.glyph_order.get();
-    let arc_hhea = context.hhea.get();
-    let Some(hhea) = &arc_hhea.as_ref().0 else {
-        return Err(Error::MissingTable(Tag::new(b"hhea")));
-    };
+    let hhea = context.hhea.get();
     let raw_hmtx = context.hmtx.get();
     let num_glyphs = glyph_order.len() as u64;
     let hmtx = Hmtx::read(
@@ -497,9 +494,9 @@ fn apply_min_max_char_index(os2: &mut Os2, codepoints: &HashSet<u32>) {
 /// * <https://learn.microsoft.com/en-us/typography/opentype/spec/gpos#gpos-header>
 fn apply_max_context(os2: &mut Os2, context: &Context) {
     let gsub = context.gsub.try_get();
-    let gsub = gsub.as_deref().and_then(|x| x.0.as_ref());
+    let gsub = gsub.as_deref();
     let gpos = context.gpos.try_get();
-    let gpos = gpos.as_deref().and_then(|x| x.0.as_ref());
+    let gpos = gpos.as_deref();
 
     os2.us_max_context = Some(max_context::compute_max_context_value(gpos, gsub));
 }

--- a/fontbe/src/os2.rs
+++ b/fontbe/src/os2.rs
@@ -595,7 +595,7 @@ impl Work<Context, AnyWorkId, Error> for Os2Work {
 
         apply_max_context(&mut os2, context);
 
-        context.os2.set_unconditionally(os2.into());
+        context.os2.set(os2);
         Ok(())
     }
 }

--- a/fontbe/src/post.rs
+++ b/fontbe/src/post.rs
@@ -54,7 +54,7 @@ impl Work<Context, AnyWorkId, Error> for PostWork {
         post.italic_angle = Fixed::from_f64(static_metadata.italic_angle.into_inner());
         post.underline_position = FWord::new(metrics.underline_position.ot_round());
         post.underline_thickness = FWord::new(metrics.underline_thickness.ot_round());
-        context.post.set_unconditionally(post.into());
+        context.post.set(post);
         Ok(())
     }
 }

--- a/fontbe/src/stat.rs
+++ b/fontbe/src/stat.rs
@@ -51,7 +51,7 @@ impl Work<Context, AnyWorkId, Error> for StatWork {
             .map(|(key, name)| (name.as_str(), key.name_id))
             .collect();
 
-        context.stat.set_unconditionally(
+        context.stat.set(
             Stat {
                 design_axes: static_metadata
                     .axes

--- a/fontbe/src/stat.rs
+++ b/fontbe/src/stat.rs
@@ -51,24 +51,21 @@ impl Work<Context, AnyWorkId, Error> for StatWork {
             .map(|(key, name)| (name.as_str(), key.name_id))
             .collect();
 
-        context.stat.set(
-            Stat {
-                design_axes: static_metadata
-                    .axes
-                    .iter()
-                    .enumerate()
-                    .map(|(idx, a)| AxisRecord {
-                        axis_tag: a.tag,
-                        axis_name_id: *reverse_names.get(a.ui_label_name()).unwrap(),
-                        axis_ordering: idx as u16,
-                    })
-                    .collect::<Vec<_>>()
-                    .into(),
-                elided_fallback_name_id: Some(NameId::SUBFAMILY_NAME),
-                ..Default::default()
-            }
-            .into(),
-        );
+        context.stat.set(Stat {
+            design_axes: static_metadata
+                .axes
+                .iter()
+                .enumerate()
+                .map(|(idx, a)| AxisRecord {
+                    axis_tag: a.tag,
+                    axis_name_id: *reverse_names.get(a.ui_label_name()).unwrap(),
+                    axis_ordering: idx as u16,
+                })
+                .collect::<Vec<_>>()
+                .into(),
+            elided_fallback_name_id: Some(NameId::SUBFAMILY_NAME),
+            ..Default::default()
+        });
 
         Ok(())
     }

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -1355,7 +1355,7 @@ mod tests {
     fn writes_cmap() {
         let result = TestCompile::compile_source("glyphs2/Component.glyphs");
 
-        let raw_cmap = dump_table(&result.be_context.cmap.get().0).unwrap();
+        let raw_cmap = dump_table(result.be_context.cmap.get().as_ref()).unwrap();
         let font_data = FontData::new(&raw_cmap);
         let cmap = Cmap::read(font_data).unwrap();
 
@@ -1422,20 +1422,14 @@ mod tests {
     fn metrics_and_limits_of_mono() {
         let result = TestCompile::compile_source("glyphs2/Mono.glyphs");
 
-        let arc_hhea = result.be_context.hhea.get();
-        let Some(hhea) = &arc_hhea.0 else {
-            panic!("Missing hhea");
-        };
+        let hhea = result.be_context.hhea.get();
         assert_eq!(1, hhea.number_of_long_metrics);
         assert_eq!(175, hhea.min_left_side_bearing.to_i16());
         assert_eq!(50, hhea.min_right_side_bearing.to_i16());
         assert_eq!(375, hhea.x_max_extent.to_i16());
         assert_eq!(425, hhea.advance_width_max.to_u16());
 
-        let arc_maxp = result.be_context.maxp.get();
-        let Some(maxp) = &arc_maxp.0 else {
-            panic!("Missing maxp");
-        };
+        let maxp = result.be_context.maxp.get();
         assert_eq!(3, maxp.num_glyphs);
         assert_eq!(Some(4), maxp.max_points);
         assert_eq!(Some(1), maxp.max_contours);

--- a/fontir/src/orchestration.rs
+++ b/fontir/src/orchestration.rs
@@ -279,15 +279,6 @@ pub trait Persistable {
     fn write(&self, to: &mut dyn Write);
 }
 
-/// A persistable type that may be None.
-///
-/// We can't just use `Option` because it interferes with other blanket impls.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum PersistableOption<T> {
-    Some(T),
-    None,
-}
-
 /// Reads and writes to somewhere that lives longer than processes.
 ///
 /// This enables the compiler to restore state from prior executions which is
@@ -395,59 +386,6 @@ where
     fn write(&self, to: &mut dyn io::Write) {
         let bytes = write_fonts::dump_table(self).unwrap();
         to.write_all(&bytes).unwrap();
-    }
-}
-
-// To serialize option we will use a 1-byte prefix (0 or 1) to indicate
-// the presence of the value.
-//
-// We dont't just write nothing because when reading there's no simple
-// way to check the length of the io::Read object.
-impl<T: Persistable> Persistable for PersistableOption<T> {
-    fn read(from: &mut dyn Read) -> Self {
-        let mut buf = [255u8];
-        from.read_exact(&mut buf).unwrap();
-        if buf[0] == 0 {
-            return Self::None;
-        }
-        Self::Some(T::read(from))
-    }
-
-    fn write(&self, to: &mut dyn Write) {
-        match self {
-            PersistableOption::Some(obj) => {
-                to.write_all(&[1u8]).unwrap();
-                obj.write(to);
-            }
-            PersistableOption::None => to.write_all(&[0u8]).unwrap(),
-        }
-    }
-}
-
-impl<T> From<Option<T>> for PersistableOption<T> {
-    fn from(src: Option<T>) -> PersistableOption<T> {
-        match src {
-            Some(obj) => Self::Some(obj),
-            None => Self::None,
-        }
-    }
-}
-
-impl<T> From<PersistableOption<T>> for Option<T> {
-    fn from(src: PersistableOption<T>) -> Option<T> {
-        match src {
-            PersistableOption::Some(obj) => Some(obj),
-            PersistableOption::None => None,
-        }
-    }
-}
-
-impl<T> PersistableOption<T> {
-    pub fn as_ref(&self) -> Option<&T> {
-        match self {
-            PersistableOption::Some(obj) => Some(obj),
-            PersistableOption::None => None,
-        }
     }
 }
 


### PR DESCRIPTION
How this happened:

- I was looking into an issue with name records generated from FEA
- I got confused about why we were calling a method called `set_unconditionally`, instead of just `set`
- The docs for that method had a TODO saying it was (mostly?) only necessary because `write-fonts` types don't impl `PartialEq`
- ... except that they have, for over a year
- so I went and tried to impl that trait, except we don't impl it for them directly, we impl it for a wrapper type, `BeValue`
- ...and the docs for _that_ type said it was only necessary to get around the orphan rules
- ... which wouldn't be a problem if we just impl'd the `Persistable` trait for the write-fonts types in the same crate where the trait is defined (`fontir`)
- So I did _that_, and then ran into an issue where for `avar` we want to be able to store an explicit `Option<T>` (the only case like this) and we were repurposing the `BeValue` to also do that job
- ~so I added a `PersistableOption` type to explicitly handle this case (which I still do not fully understand)~
- so I just made this an explicit special case, with a `MaybeEmptyAvar` type.
- and now everything compiles again, and overall feels simpler.
- ... profit?


Bonus:

Why do we have this special case for avar? why do we need an explicit option? Why can't we just serialize an empty table in the case where we want to have an empty table in the final font? cc @rsheeter 
