### PR TITLE
Merge names from FEA into final table

### DIFF
--- a/fontbe/src/name.rs
+++ b/fontbe/src/name.rs
@@ -1,9 +1,12 @@
 //! Generates a [name](https://learn.microsoft.com/en-us/typography/opentype/spec/name) table.
 
-use fontdrasil::orchestration::{Access, Work};
+use std::collections::BTreeMap;
+
+use fontdrasil::orchestration::{Access, AccessBuilder, Work};
 use fontir::orchestration::WorkId as FeWorkId;
 use write_fonts::{
     tables::name::{Name, NameRecord},
+    types::NameId,
     OffsetMarker,
 };
 
@@ -25,12 +28,16 @@ impl Work<Context, AnyWorkId, Error> for NameWork {
     }
 
     fn read_access(&self) -> Access<AnyWorkId> {
-        Access::Variant(AnyWorkId::Fe(FeWorkId::StaticMetadata))
+        AccessBuilder::new()
+            .variant(AnyWorkId::Fe(FeWorkId::StaticMetadata))
+            .variant(AnyWorkId::Be(WorkId::ExtraFeaTables))
+            .build()
     }
 
     /// Generate [name](https://learn.microsoft.com/en-us/typography/opentype/spec/name)
     fn exec(&self, context: &Context) -> Result<(), Error> {
         let static_metadata = context.ir.static_metadata.get();
+        let extra_tables = context.extra_fea_tables.try_get();
 
         let mut name_records = static_metadata
             .names
@@ -43,9 +50,49 @@ impl Work<Context, AnyWorkId, Error> for NameWork {
                 string: OffsetMarker::new(value.clone()),
             })
             .collect::<Vec<_>>();
-        name_records.sort();
+
+        if let Some(name) = extra_tables
+            .as_ref()
+            .and_then(|tables| tables.name.as_ref())
+        {
+            log::info!("merging name records from FEA");
+            name_records = merge_name_records(name_records, name);
+        } else {
+            name_records.sort();
+        }
 
         context.name.set(Name::new(name_records));
         Ok(())
     }
+}
+
+// records from fea overwrite records derived elsewhere:
+// https://github.com/fonttools/fonttools/blob/b90ac3c29f6030ec/Lib/fontTools/feaLib/builder.py#L452
+fn merge_name_records(records: Vec<NameRecord>, fea_names: &Name) -> Vec<NameRecord> {
+    fn split_key_and_string(name_record: NameRecord) -> ((u16, u16, u16, NameId), String) {
+        let NameRecord {
+            platform_id,
+            encoding_id,
+            language_id,
+            name_id,
+            string,
+        } = name_record;
+        (
+            (platform_id, encoding_id, language_id, name_id),
+            string.into_inner(),
+        )
+    }
+
+    let sorted_and_deduped = records
+        .into_iter()
+        .chain(fea_names.name_record.iter().cloned())
+        .map(split_key_and_string)
+        .collect::<BTreeMap<_, _>>();
+
+    sorted_and_deduped
+        .into_iter()
+        .map(|((platform, encoding, language, name), string)| {
+            NameRecord::new(platform, encoding, language, name, string.into())
+        })
+        .collect()
 }

--- a/fontbe/src/paths.rs
+++ b/fontbe/src/paths.rs
@@ -94,6 +94,7 @@ impl Paths {
             WorkId::Os2 => self.build_dir.join("os2.table"),
             WorkId::Post => self.build_dir.join("post.table"),
             WorkId::Stat => self.build_dir.join("stat.table"),
+            WorkId::ExtraFeaTables => self.build_dir.join("extra_tables.bin"),
             WorkId::Font => self
                 .output_file
                 .as_ref()

--- a/fontc/src/timing.rs
+++ b/fontc/src/timing.rs
@@ -161,6 +161,7 @@ fn short_name(id: &AnyWorkId) -> &'static str {
         AnyWorkId::Be(BeWorkIdentifier::Os2) => "OS/2",
         AnyWorkId::Be(BeWorkIdentifier::Post) => "post",
         AnyWorkId::Be(BeWorkIdentifier::Stat) => "STAT",
+        AnyWorkId::Be(BeWorkIdentifier::ExtraFeaTables) => "ExtraFeaTables",
         AnyWorkId::InternalTiming(name) => name,
     }
 }

--- a/resources/scripts/ttx_diff.py
+++ b/resources/scripts/ttx_diff.py
@@ -444,9 +444,9 @@ def sort_fontmake_feature_lookups(ttx):
 
     for feature in features:
         # the first item is 'Feature', the second always a comment
-        has_value = [el for el in feature.iter() if "value" in el.attrib]
-        values = sorted(int(v.attrib["value"]) for v in has_value)
-        for i, lookup_index in enumerate(has_value):
+        lookup_indices = [el for el in feature.iter() if el.tag == "LookupListIndex"]
+        values = sorted(int(v.attrib["value"]) for v in lookup_indices)
+        for i, lookup_index in enumerate(lookup_indices):
             lookup_index.attrib["value"] = str(values[i])
 
 

--- a/resources/testdata/CustomNameTableInFea.ufo/features.fea
+++ b/resources/testdata/CustomNameTableInFea.ufo/features.fea
@@ -1,0 +1,6 @@
+languagesystem DFLT dflt;
+
+table name {
+    nameid 9 "Joachim Müller-Lancé"; # DESIGNER
+    nameid 4 "set from FEA name table"; # FULL_NAME
+} name;

--- a/resources/testdata/CustomNameTableInFea.ufo/fontinfo.plist
+++ b/resources/testdata/CustomNameTableInFea.ufo/fontinfo.plist
@@ -1,0 +1,27 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>unitsPerEm</key>
+    <integer>1000</integer>
+    <key>ascender</key>
+    <real>799</real>
+    <key>familyName</key>
+    <string>Wght Var</string>
+    <key>openTypeHeadCreated</key>
+    <string>2023/05/05 15:11:55</string>
+    <key>openTypeOS2Panose</key>
+    <array>
+      <integer>2</integer>
+      <integer>11</integer>
+      <integer>5</integer>
+      <integer>2</integer>
+      <integer>4</integer>
+      <integer>5</integer>
+      <integer>4</integer>
+      <integer>2</integer>
+      <integer>2</integer>
+      <integer>4</integer>
+    </array>
+  </dict>
+</plist>

--- a/resources/testdata/CustomNameTableInFea.ufo/glyphs.{600}/bar.glif
+++ b/resources/testdata/CustomNameTableInFea.ufo/glyphs.{600}/bar.glif
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="bar" format="2">
+  <advance width="540"/>
+  <unicode hex="007C"/>
+  <outline>
+    <contour>
+      <point x="222" y="-232" type="line"/>
+      <point x="318" y="-232" type="line"/>
+      <point x="318" y="758" type="line"/>
+      <point x="222" y="758" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/resources/testdata/CustomNameTableInFea.ufo/glyphs.{600}/contents.plist
+++ b/resources/testdata/CustomNameTableInFea.ufo/glyphs.{600}/contents.plist
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>bar</key>
+    <string>bar.glif</string>
+  </dict>
+</plist>

--- a/resources/testdata/CustomNameTableInFea.ufo/glyphs/bar.glif
+++ b/resources/testdata/CustomNameTableInFea.ufo/glyphs/bar.glif
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="bar" format="2">
+  <advance width="517"/>
+  <unicode hex="007C"/>
+  <outline>
+    <contour>
+      <point x="222" y="-241" type="line"/>
+      <point x="295" y="-241" type="line"/>
+      <point x="295" y="760" type="line"/>
+      <point x="222" y="760" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/resources/testdata/CustomNameTableInFea.ufo/glyphs/contents.plist
+++ b/resources/testdata/CustomNameTableInFea.ufo/glyphs/contents.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>bar</key>
+    <string>bar.glif</string>
+    <key>plus</key>
+    <string>plus.glif</string>
+  </dict>
+</plist>

--- a/resources/testdata/CustomNameTableInFea.ufo/glyphs/plus.glif
+++ b/resources/testdata/CustomNameTableInFea.ufo/glyphs/plus.glif
@@ -1,0 +1,21 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="plus" format="2">
+  <advance width="557"/>
+  <unicode hex="002B"/>
+  <outline>
+    <contour>
+      <point x="242" y="111" type="line"/>
+      <point x="314" y="111" type="line"/>
+      <point x="314" y="317" type="line"/>
+      <point x="513" y="317" type="line"/>
+      <point x="513" y="388" type="line"/>
+      <point x="314" y="388" type="line"/>
+      <point x="314" y="595" type="line"/>
+      <point x="242" y="595" type="line"/>
+      <point x="242" y="388" type="line"/>
+      <point x="43" y="388" type="line"/>
+      <point x="43" y="317" type="line"/>
+      <point x="242" y="317" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/resources/testdata/CustomNameTableInFea.ufo/groups.plist
+++ b/resources/testdata/CustomNameTableInFea.ufo/groups.plist
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>public.kern1.correct_name</key>
+    <array>
+      <string>bar</string>
+      <string>plus</string>
+    </array>
+  </dict>
+</plist>

--- a/resources/testdata/CustomNameTableInFea.ufo/kerning.plist
+++ b/resources/testdata/CustomNameTableInFea.ufo/kerning.plist
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>bar</key>
+    <dict>
+      <key>bar</key>
+      <integer>-300</integer>
+    </dict>
+  </dict>
+</plist>

--- a/resources/testdata/CustomNameTableInFea.ufo/layercontents.plist
+++ b/resources/testdata/CustomNameTableInFea.ufo/layercontents.plist
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <array>
+    <array>
+      <string>public.default</string>
+      <string>glyphs</string>
+    </array>
+    <array>
+      <string>{600}</string>
+      <string>glyphs.{600}</string>
+    </array>
+  </array>
+</plist>

--- a/resources/testdata/CustomNameTableInFea.ufo/lib.plist
+++ b/resources/testdata/CustomNameTableInFea.ufo/lib.plist
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>public.glyphOrder</key>
+    <array>
+      <string>plus</string>
+      <!-- bar is deliberately omitted -->
+    </array>
+  </dict>
+</plist>

--- a/resources/testdata/CustomNameTableInFea.ufo/metainfo.plist
+++ b/resources/testdata/CustomNameTableInFea.ufo/metainfo.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>creator</key>
+    <string>com.github.fonttools.ufoLib</string>
+    <key>formatVersion</key>
+    <integer>3</integer>
+  </dict>
+</plist>

--- a/resources/testdata/glyphs3/WghtVarWithStylisticSet.glyphs
+++ b/resources/testdata/glyphs3/WghtVarWithStylisticSet.glyphs
@@ -1,0 +1,418 @@
+{
+.appVersion = "3260";
+.formatVersion = 3;
+DisplayStrings = (
+"![]!"
+);
+axes = (
+{
+name = Weight;
+tag = wght;
+}
+);
+customParameters = (
+{
+name = "Use Typo Metrics";
+value = 1;
+},
+{
+name = "Has WWS Names";
+value = 1;
+}
+);
+date = "2022-12-01 04:52:20 +0000";
+familyName = WghtVar;
+features = (
+{
+code = "sub exclam by hyphen;";
+labels = (
+{
+language = dflt;
+value = "my fun feature";
+}
+);
+tag = ss01;
+}
+);
+fontMaster = (
+{
+axesValues = (
+400
+);
+id = m01;
+metricValues = (
+{
+over = 16;
+pos = 737;
+},
+{
+over = -16;
+},
+{
+over = -16;
+pos = -42;
+},
+{
+pos = 702;
+},
+{
+pos = 501;
+}
+);
+name = Regular;
+},
+{
+axesValues = (
+700
+);
+iconName = Bold;
+id = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+metricValues = (
+{
+pos = 800;
+},
+{
+},
+{
+pos = -200;
+},
+{
+pos = 700;
+},
+{
+pos = 500;
+}
+);
+name = Bold;
+}
+);
+glyphs = (
+{
+glyphname = space;
+lastChange = "2022-12-01 04:58:12 +0000";
+layers = (
+{
+layerId = m01;
+width = 200;
+},
+{
+layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+width = 600;
+}
+);
+unicode = 32;
+},
+{
+glyphname = exclam;
+lastChange = "2023-06-07 22:35:08 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(354,183,l),
+(414,585,l),
+(178,585,l),
+(238,182,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(354,0,l),
+(354,107,l),
+(238,107,l),
+(238,0,l)
+);
+}
+);
+width = 600;
+},
+{
+layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(364,176,l),
+(434,605,l),
+(159,605,l),
+(228,174,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(364,-20,l),
+(364,94,l),
+(228,94,l),
+(228,-20,l)
+);
+}
+);
+width = 600;
+}
+);
+unicode = 33;
+},
+{
+glyphname = hyphen;
+lastChange = "2023-06-05 23:23:03 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(131,250,l,{
+name = hr00;
+}),
+(470,250,l),
+(470,330,l),
+(131,330,l)
+);
+}
+);
+width = 600;
+},
+{
+layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(92,224,l),
+(508,224,l),
+(508,356,l),
+(92,356,l)
+);
+}
+);
+width = 600;
+}
+);
+unicode = 45;
+},
+{
+glyphname = bracketleft;
+kernLeft = bracketleft_L;
+kernRight = bracketleft_R;
+lastChange = "2023-06-07 22:37:02 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(324,637,l),
+(324,51,l),
+(454,51,l),
+(454,-10,l),
+(259,-10,l),
+(259,696,l),
+(454,696,l),
+(454,637,l)
+);
+}
+);
+width = 600;
+},
+{
+layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(324,629,l),
+(324,58,l),
+(454,58,l),
+(454,-17,l),
+(243,-17,l),
+(243,704,l),
+(454,704,l),
+(454,629,l)
+);
+}
+);
+width = 600;
+}
+);
+unicode = 91;
+},
+{
+glyphname = bracketright;
+kernLeft = bracketright_L;
+kernRight = bracketright_R;
+lastChange = "2023-06-07 22:35:47 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(259,696,l),
+(454,696,l),
+(454,-10,l),
+(259,-10,l),
+(259,51,l),
+(389,51,l),
+(389,637,l),
+(259,637,l)
+);
+}
+);
+width = 600;
+},
+{
+layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(243,704,l),
+(454,704,l),
+(454,-17,l),
+(243,-17,l),
+(243,58,l),
+(373,58,l),
+(373,629,l),
+(243,629,l)
+);
+}
+);
+width = 600;
+}
+);
+unicode = 93;
+},
+{
+glyphname = "manual-component";
+lastChange = "2022-12-01 04:57:39 +0000";
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+pos = (0,100);
+ref = hyphen;
+},
+{
+ref = hyphen;
+}
+);
+width = 600;
+},
+{
+layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+shapes = (
+{
+pos = (10,100);
+ref = hyphen;
+scale = (1.15,1.25);
+},
+{
+ref = hyphen;
+}
+);
+width = 600;
+}
+);
+unicode = 61;
+}
+);
+kerningLTR = {
+m01 = {
+"@MMK_L_bracketleft_R" = {
+exclam = -165;
+};
+bracketleft = {
+bracketright = -300;
+};
+exclam = {
+"@MMK_R_bracketright_L" = -160;
+exclam = -360;
+hyphen = 20;
+};
+hyphen = {
+hyphen = -150;
+};
+};
+"E09E0C54-128D-4FEA-B209-1B70BEFE300B" = {
+bracketleft = {
+bracketright = -150;
+};
+exclam = {
+exclam = -100;
+};
+hyphen = {
+hyphen = -50;
+};
+};
+};
+metrics = (
+{
+type = ascender;
+},
+{
+type = baseline;
+},
+{
+type = descender;
+},
+{
+type = "cap height";
+},
+{
+type = "x-height";
+}
+);
+properties = (
+{
+key = copyrights;
+values = (
+{
+language = dflt;
+value = "Copy!";
+}
+);
+},
+{
+key = descriptions;
+values = (
+{
+language = dflt;
+value = "The greatest weight var";
+},
+{
+language = ESP;
+value = "El mayor peso variable";
+}
+);
+},
+{
+key = familyNames;
+values = (
+{
+language = ESP;
+value = SpanishWghtVar;
+}
+);
+},
+{
+key = licenseURL;
+value = "https://example.com/my/font/license";
+},
+{
+key = versionString;
+value = "Version 1.234";
+}
+);
+unitsPerEm = 1000;
+versionMajor = 42;
+versionMinor = 42;
+}


### PR DESCRIPTION
Previously we were just dropping them on the floor.

This is one of a number of cases where it is possible for FEA to generate a table that is also generated (or could be generated) through the main compilation process.

This introduces an overall strategy for handling this: when FEA generates these extra tables we now stash them in the main context, where we can reference them when building the final font.

This patch also uses this mechanism to merge name records generated from FEA into the main name table; this looks to get us at least a +7 on crater.

As a bonus this includes a commit that fixes a little bug in ttx_diff where we were accidentally sorting name ids as if they were lookup ids, and which very briefly had me doubting my sanity.

- fixes #1130 