### PR TITLE
[glyphs] Move loading logic into RawFont

### DIFF
--- a/glyphs-reader/src/propagate_anchors.rs
+++ b/glyphs-reader/src/propagate_anchors.rs
@@ -963,7 +963,7 @@ mod tests {
     #[test]
     fn real_files() {
         let expected =
-            Font::load_impl("../resources/testdata/glyphs3/PropagateAnchorsTest-propagated.glyphs")
+            Font::load_raw("../resources/testdata/glyphs3/PropagateAnchorsTest-propagated.glyphs")
                 .unwrap();
         let font = Font::load(std::path::Path::new(
             "../resources/testdata/glyphs3/PropagateAnchorsTest.glyphs",


### PR DESCRIPTION
The loading logic mostly involves the RawFont type, and if we ever move that to its own module it will make sense to keep this together.

(no functional change)