### PR TITLE
[glyphs] Clean up custom params

### DIFF
--- a/glyphs-reader/src/lib.rs
+++ b/glyphs-reader/src/lib.rs
@@ -9,7 +9,7 @@ mod plist;
 mod propagate_anchors;
 
 pub use font::{
-    Axis, Component, FeatureSnippet, Font, FontMaster, Glyph, InstanceType, Layer, Node, NodeType,
-    Path, Shape,
+    Axis, Component, FeatureSnippet, Font, FontCustomParameters, FontMaster, Glyph, InstanceType,
+    Layer, Node, NodeType, Path, Shape,
 };
 pub use plist::Plist;


### PR DESCRIPTION
We're going to need to support a bunch of of these, and it was becoming hard to keep track of what was being handled and what wasn't. This moves all the custom params (at the font level) into a new CustomFontParameters struct.

It also reduces boilerplate when these are used in glyphs2fontir.

The ultimate goal here is to do smarter parsing of these custom paramaters in such a way as to be able to warn if there are any we aren't handling.