### PR TITLE
Glyphs custom params parsing rework

### DIFF
--- a/glyphs-reader/src/lib.rs
+++ b/glyphs-reader/src/lib.rs
@@ -9,7 +9,7 @@ mod plist;
 mod propagate_anchors;
 
 pub use font::{
-    Axis, Component, FeatureSnippet, Font, FontCustomParameters, FontMaster, Glyph, InstanceType,
+    Axis, Component, CustomParameters, FeatureSnippet, Font, FontMaster, Glyph, InstanceType,
     Layer, Node, NodeType, Path, Shape,
 };
 pub use plist::Plist;

--- a/glyphs-reader/src/plist.rs
+++ b/glyphs-reader/src/plist.rs
@@ -393,6 +393,13 @@ impl FromPlist for Plist {
     }
 }
 
+impl Default for Plist {
+    fn default() -> Self {
+        // kind of arbitrary but seems okay
+        Plist::Array(Vec::new())
+    }
+}
+
 fn hex_digits_for_byte(byte: u8) -> [char; 2] {
     fn to_hex_digit(val: u8) -> char {
         match val {
@@ -808,11 +815,6 @@ impl VecDelimiters {
         start: b'{',
         end: b'}',
         sep: b',',
-    };
-    pub(crate) const SEMICOLON_SV_IN_BRACES: VecDelimiters = VecDelimiters {
-        start: b'{',
-        end: b'}',
-        sep: b';',
     };
 }
 

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -27,7 +27,7 @@ use fontir::{
 };
 use glyphs_reader::{
     glyphdata::{Category, Subcategory},
-    Font, FontCustomParameters, InstanceType,
+    CustomParameters, Font, InstanceType,
 };
 use ordered_float::OrderedFloat;
 use smol_str::SmolStr;
@@ -124,7 +124,7 @@ impl GlyphsIrSource {
             version_minor: Default::default(),
             date: None,
             kerning_ltr: font.kerning_ltr.clone(),
-            custom_parameters: FontCustomParameters {
+            custom_parameters: CustomParameters {
                 unicode_range_bits: None,
                 codepage_range_bits: None,
                 panose: None,
@@ -556,6 +556,7 @@ impl Work<Context, WorkId, Error> for GlobalMetricWork {
                 GlobalMetric::Os2WinDescent,
                 pos.clone(),
                 master
+                    .custom_parameters
                     .win_descent
                     .or(font.custom_parameters.win_descent)
                     .map(|v| v.abs() as f64),
@@ -567,6 +568,7 @@ impl Work<Context, WorkId, Error> for GlobalMetricWork {
                     set_metric!(
                         $variant,
                         master
+                            .custom_parameters
                             .$field_name
                             .or(font.custom_parameters.$field_name)
                             .map(|v| v as f64)
@@ -577,6 +579,7 @@ impl Work<Context, WorkId, Error> for GlobalMetricWork {
                     set_metric!(
                         $variant,
                         master
+                            .custom_parameters
                             .$field_name
                             .or(font.custom_parameters.$field_name)
                             .or(Some($fallback.into()))


### PR DESCRIPTION
This is a rollup of three commits that rework how we parse custom parameter values from glyphs sources.

- This now parses all custom param values to the `Plist` type, which represents any plist data
- This means we do not need to know the expected type for a given key in order to parse it; we will parse anything that is in the source.
- *exhaustive handling*: Instead of querying into the custom parameters with the keys that we know, we now iterate through all the parameters in sequence, which forces us to handle them all (or report where we don't).
- This reuses the same parsing logic and `CustomParameters` type for the top-level `Font` as well as each individual master, which lets us delete a bunch of code


This PR doesn't change any observable behaviour, but there is a followup that will add handling for some additional params.