### PR TITLE
[glyphs] Handle additional custom params

### DIFF
--- a/resources/testdata/glyphs3/UnusualCustomParams.glyphs
+++ b/resources/testdata/glyphs3/UnusualCustomParams.glyphs
@@ -1,0 +1,36 @@
+{
+.appVersion = "3260";
+.formatVersion = 3;
+customParameters = (
+{
+name = openTypeHeadFlags;
+value = (
+0
+);
+},
+{
+name = openTypeHeadLowestRecPPEM;
+value = 7;
+},
+{
+name = openTypeHheaCaretOffset;
+value = 2;
+},
+{
+name = openTypeHheaCaretSlopeRise;
+value = 1;
+},
+{
+name = openTypeHheaCaretSlopeRun;
+value = 5;
+},
+);
+familyName = UnusualParams;
+fontMaster = (
+{
+id = master01;
+name = Regular;
+}
+);
+unitsPerEm = 1000;
+}


### PR DESCRIPTION
_This is based on #1143_

This handles additional custom parameters, specifically `openTypeHeadLowestRecPPEM`, and the various hhea & vhea caret properties (vhea isn't handled yet, but we can at least parse it now in preparation).


 These params are kind of funny because you don't seem to be able to add them via the glyphs.app UI? But they exist in some fonts, and were causing crater failures.


- closes #1128

