### PR TITLE
[glyphs] Parse kerning as floats

### DIFF
--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -804,7 +804,7 @@ impl Work<Context, WorkId, Error> for KerningInstanceWork {
                 Some(((side1, side2), pos_adjust))
             })
             .for_each(|(participants, (_, value))| {
-                *kerning.kerns.entry(participants).or_default() = (value as f32).into();
+                *kerning.kerns.entry(participants).or_default() = (value.0 as f32).into();
             });
 
         context.kerning_at.set(kerning);

--- a/resources/testdata/glyphs3/KernFloats.glyphs
+++ b/resources/testdata/glyphs3/KernFloats.glyphs
@@ -1,0 +1,28 @@
+{
+.formatVersion = 3;
+familyName = KernFloats;
+fontMaster = (
+{
+id = m01;
+}
+);
+glyphs = (
+{
+glyphname = space;
+layers = (
+{
+layerId = m01;
+width = 200;
+}
+);
+}
+);
+unitsPerEm = 1000;
+kerning = {
+    "m01" = {
+        space = {
+        space = 4.2001;
+        };
+    };
+};
+}


### PR DESCRIPTION
Glyphs kern values can be floats, but we were parsing them as integers.

This also uncovered something else fishy: our integer parsing logic in glyps-reader/ascii-plist-derive will happy parse something like "1.321" as an integer, by parsing to a float and casting.

I think this is incorrect? I think it is reasonable to go the other way (to accept an integer value as a float) and it _might_ be reasonable to accept an integer value with no fractional component as a float, but I definitely don't think we should parse a float with a fractional value as an integer; it hides bugs like this.