### PR TITLE
Deterministic resolving of mixed component/contour glyphs

### DIFF
--- a/fontbe/src/glyphs.rs
+++ b/fontbe/src/glyphs.rs
@@ -615,12 +615,7 @@ impl CheckedGlyph {
         let path_els: HashSet<String> = glyph
             .sources()
             .values()
-            .map(|s| {
-                s.contours
-                    .iter()
-                    .map(|c| c.elements().iter().map(path_el_type).collect::<String>())
-                    .collect()
-            })
+            .map(|g| g.path_elements())
             .collect();
         if path_els.len() > 1 {
             warn!(
@@ -716,16 +711,6 @@ impl CheckedGlyph {
                 *contour = contour.reverse_subpaths();
             }
         }
-    }
-}
-
-fn path_el_type(el: &PathEl) -> &'static str {
-    match el {
-        PathEl::MoveTo(..) => "M",
-        PathEl::LineTo(..) => "L",
-        PathEl::QuadTo(..) => "Q",
-        PathEl::CurveTo(..) => "C",
-        PathEl::ClosePath => "Z",
     }
 }
 

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -1792,6 +1792,28 @@ pub struct GlyphInstance {
     pub components: Vec<Component>,
 }
 
+impl GlyphInstance {
+    /// Returns the concatenation of the element types for each outline.
+    ///
+    /// These are 'M' for moveto, 'L' for lineto, 'Q' for quadto, 'C' for
+    /// curveto and 'Z' for closepath.
+    pub fn path_elements(&self) -> String {
+        fn path_el_type(el: &PathEl) -> &'static str {
+            match el {
+                PathEl::MoveTo(..) => "M",
+                PathEl::LineTo(..) => "L",
+                PathEl::QuadTo(..) => "Q",
+                PathEl::CurveTo(..) => "C",
+                PathEl::ClosePath => "Z",
+            }
+        }
+        self.contours
+            .iter()
+            .flat_map(|c| c.elements().iter().map(path_el_type))
+            .collect()
+    }
+}
+
 /// A single glyph component, reference to another glyph.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Component {

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -1548,6 +1548,16 @@ impl Glyph {
         self.sources.get_mut(loc)
     }
 
+    /// Iterate over the names of all components in all instances.
+    ///
+    /// This will return duplicates if multiple instances have identical
+    /// components (which is normal)
+    pub(crate) fn component_names(&self) -> impl Iterator<Item = &GlyphName> {
+        self.sources
+            .values()
+            .flat_map(|inst| inst.components.iter().map(|comp| &comp.base))
+    }
+
     /// Does the Glyph use the same components, (name, 2x2 transform), for all instances?
     ///
     /// The (glyphname, 2x2 transform) pair is considered for uniqueness. Note that


### PR DESCRIPTION
If a glyph has mixed components & contours, we need to convert it to use all of one or the other.

If such a glyph has a component that _also_ has mixed components & contours, we need to make sure we handle the child component first.

We handles this by first collecting the set of such glyphs, and then determining an appropriate ordering.


I tried to keep this as simple as possible; in particular I'm defensive against cycles but am not reporting those errors here, since I assume we catch them elsewhere.

- fixes #1146 