### PR TITLE
Better reporting of InvalidTag errors

### DIFF
--- a/fontir/src/error.rs
+++ b/fontir/src/error.rs
@@ -71,8 +71,8 @@ pub enum Error {
         mappings: Vec<(UserCoord, DesignCoord)>,
         value: DesignCoord,
     },
-    #[error("Invalid tag")]
-    InvalidTag(#[from] InvalidTag),
+    #[error("Invalid tag '{raw_tag}': {cause}")]
+    InvalidTag { raw_tag: String, cause: InvalidTag },
     #[error("Source file contained a construct we don't yet support: {0}")]
     UnsupportedConstruct(String),
 }

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -401,7 +401,11 @@ impl Work<Context, WorkId, Error> for StaticMetadataWork {
         .map_err(Error::VariationModelError)?;
         static_metadata.misc.selection_flags = selection_flags;
         if let Some(vendor_id) = font.vendor_id() {
-            static_metadata.misc.vendor_id = Tag::from_str(vendor_id).map_err(Error::InvalidTag)?;
+            static_metadata.misc.vendor_id =
+                Tag::from_str(vendor_id).map_err(|cause| Error::InvalidTag {
+                    raw_tag: vendor_id.to_owned(),
+                    cause,
+                })?;
         }
 
         // Default per <https://github.com/googlefonts/glyphsLib/blob/cb8a4a914b0a33431f0a77f474bf57eec2f19bcc/Lib/glyphsLib/builder/custom_params.py#L1117-L1119>

--- a/glyphs2fontir/src/toir.rs
+++ b/glyphs2fontir/src/toir.rs
@@ -207,7 +207,10 @@ fn to_ir_axis(
 
     Ok(fontdrasil::types::Axis {
         name: axis.name.clone(),
-        tag: Tag::from_str(&axis.tag).map_err(Error::InvalidTag)?,
+        tag: Tag::from_str(&axis.tag).map_err(|cause| Error::InvalidTag {
+            raw_tag: axis.tag.clone(),
+            cause,
+        })?,
         hidden: axis.hidden.unwrap_or(false),
         min: min.to_user(&converter),
         default: default.to_user(&converter),

--- a/ufo2fontir/src/toir.rs
+++ b/ufo2fontir/src/toir.rs
@@ -114,7 +114,10 @@ pub fn to_ir_axes(axes: &[designspace::Axis]) -> Result<Vec<fontdrasil::types::A
 }
 
 pub fn to_ir_axis(axis: &designspace::Axis) -> Result<fontdrasil::types::Axis, Error> {
-    let tag = Tag::from_str(&axis.tag).map_err(Error::InvalidTag)?;
+    let tag = Tag::from_str(&axis.tag).map_err(|cause| Error::InvalidTag {
+        raw_tag: axis.tag.clone(),
+        cause,
+    })?;
 
     // <https://fonttools.readthedocs.io/en/latest/designspaceLib/xml.html#axis-element>
     let min = UserCoord::new(axis.minimum.unwrap());


### PR DESCRIPTION
In particular, we will now actually include the invalid string.

There are a number of failures on crater that report this error, so it would be nice to see what's going on.