### PR TITLE
We want more (f64)

### DIFF
--- a/fea-rs/src/compile/compile_ctx.rs
+++ b/fea-rs/src/compile/compile_ctx.rs
@@ -1985,10 +1985,10 @@ impl<'a, F: FeatureProvider, V: VariationInfo> CompilationCtx<'a, F, V> {
                 ConditionFormat1 {
                     axis_index: axis_index as u16,
                     filter_range_min_value: F2Dot14::from_f32(
-                        min.to_normalized(&axis.converter).to_f32(),
+                        min.to_normalized(&axis.converter).to_f64() as _,
                     ),
                     filter_range_max_value: F2Dot14::from_f32(
-                        max.to_normalized(&axis.converter).to_f32(),
+                        max.to_normalized(&axis.converter).to_f64() as _,
                     ),
                 }
                 .into()

--- a/fea-rs/src/compile/validate.rs
+++ b/fea-rs/src/compile/validate.rs
@@ -249,7 +249,7 @@ impl<'a, V: VariationInfo> ValidationCtx<'a, V> {
             self.error(condition.tag().range(), "unknown axis");
             return;
         };
-        if (condition.min_value().parse_signed() as f64) < axis.min.into_inner().0 as f64 {
+        if (condition.min_value().parse_signed() as f64) < axis.min.into_inner().0 {
             self.error(
                 condition.min_value().range(),
                 format!(
@@ -258,7 +258,7 @@ impl<'a, V: VariationInfo> ValidationCtx<'a, V> {
                 ),
             );
         }
-        if (condition.max_value().parse_signed() as f64) > axis.max.into_inner().0 as f64 {
+        if (condition.max_value().parse_signed() as f64) > axis.max.into_inner().0 {
             self.error(
                 condition.max_value().range(),
                 format!(

--- a/fea-rs/src/compile/variations.rs
+++ b/fea-rs/src/compile/variations.rs
@@ -98,11 +98,11 @@ pub struct MockVariationInfo {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum AxisLocation {
     /// A position in the user coordinate space
-    User(OrderedFloat<f32>),
+    User(OrderedFloat<f64>),
     /// A position in the design coordinate space
-    Design(OrderedFloat<f32>),
+    Design(OrderedFloat<f64>),
     /// A normalized position
-    Normalized(OrderedFloat<f32>),
+    Normalized(OrderedFloat<f64>),
 }
 
 /// Create an axis where user coords == design coords

--- a/fea-rs/src/token_tree/typed.rs
+++ b/fea-rs/src/token_tree/typed.rs
@@ -644,19 +644,19 @@ impl Number {
 }
 
 impl Float {
-    pub(crate) fn parse(&self) -> f32 {
+    pub(crate) fn parse(&self) -> f64 {
         self.text().parse().unwrap()
     }
 
     pub(crate) fn parse_fixed(&self) -> Fixed {
-        Fixed::from_f64(self.parse() as _)
+        Fixed::from_f64(self.parse())
     }
 }
 
 impl FloatLike {
-    pub(crate) fn parse(&self) -> f32 {
+    pub(crate) fn parse(&self) -> f64 {
         match self {
-            FloatLike::Number(n) => n.parse_signed() as f32,
+            FloatLike::Number(n) => n.parse_signed() as _,
             FloatLike::Float(n) => n.parse(),
         }
     }
@@ -1336,10 +1336,10 @@ impl AxisLocation {
         }
     }
 
-    fn value(&self) -> f32 {
+    fn value(&self) -> f64 {
         let raw = self.iter().next().unwrap();
         Number::cast(raw)
-            .map(|num| num.parse_signed() as f32)
+            .map(|num| num.parse_signed() as f64)
             .or_else(|| Float::cast(raw).map(|num| num.parse()))
             .unwrap()
     }

--- a/fontbe/src/features.rs
+++ b/fontbe/src/features.rs
@@ -156,7 +156,7 @@ impl<'a> FeaVariationInfo<'a> {
 //except they have slightly different inputs?
 pub(crate) fn resolve_variable_metric<'a>(
     static_metadata: &StaticMetadata,
-    values: impl Iterator<Item = (&'a NormalizedLocation, &'a OrderedFloat<f32>)>,
+    values: impl Iterator<Item = (&'a NormalizedLocation, &'a OrderedFloat<f64>)>,
 ) -> Result<(i16, Vec<(VariationRegion, i16)>), DeltaError> {
     let point_seqs: HashMap<_, _> = values
         .into_iter()
@@ -166,8 +166,8 @@ pub(crate) fn resolve_variable_metric<'a>(
             // a VF at the masters' location is expected to be equivalent to building
             // individual masters as static fonts. fontmake does the same, see
             // https://github.com/googlefonts/fontc/issues/1043
-            let value: f32 = value.into_inner().ot_round();
-            (pos.to_owned(), vec![value as f64])
+            let value: f64 = value.into_inner().ot_round();
+            (pos.to_owned(), vec![value])
         })
         .collect();
     let locations: HashSet<_> = point_seqs.keys().collect();
@@ -202,10 +202,10 @@ pub(crate) fn resolve_variable_metric<'a>(
             let scaler = region.scalar_at(&var_model.default).into_inner();
             match scaler {
                 scaler if scaler == 0.0 => None,
-                scaler => Some(scaler * *value as f32),
+                scaler => Some(scaler * { *value }),
             }
         })
-        .sum::<f32>()
+        .sum::<f64>()
         .ot_round();
 
     let mut deltas = Vec::with_capacity(raw_deltas.len());
@@ -340,10 +340,10 @@ impl VariationInfo for FeaVariationInfo<'_> {
                 let scaler = region.scalar_at(&var_model.default).into_inner();
                 match scaler {
                     scaler if scaler == 0.0 => None,
-                    scaler => Some(scaler * *value as f32),
+                    scaler => Some(scaler * { *value }),
                 }
             })
-            .sum::<f32>()
+            .sum::<f64>()
             .ot_round();
 
         // Produce the desired delta type
@@ -659,7 +659,7 @@ mod tests {
 
     use super::*;
 
-    fn weight_variable_static_metadata(min: f32, def: f32, max: f32) -> StaticMetadata {
+    fn weight_variable_static_metadata(min: f64, def: f64, max: f64) -> StaticMetadata {
         let min_wght_user = UserCoord::new(min);
         let def_wght_user = UserCoord::new(def);
         let max_wght_user = UserCoord::new(max);

--- a/fontbe/src/features/kern.rs
+++ b/fontbe/src/features/kern.rs
@@ -252,7 +252,7 @@ fn align_kerning(
 
 fn align_instance(
     all_pairs: &HashSet<ir::KernPair>,
-    instance: &mut BTreeMap<ir::KernPair, OrderedFloat<f32>>,
+    instance: &mut BTreeMap<ir::KernPair, OrderedFloat<f64>>,
     side1_glyphs: &HashMap<&GlyphName, &KernGroup>,
     side2_glyphs: &HashMap<&GlyphName, &KernGroup>,
 ) {
@@ -274,10 +274,10 @@ fn align_instance(
 // <https://github.com/fonttools/fonttools/blob/a3b9eddcafca/Lib/fontTools/ufoLib/kerning.py#L1>
 fn lookup_kerning_value(
     pair: &ir::KernPair,
-    kerning: &BTreeMap<ir::KernPair, OrderedFloat<f32>>,
+    kerning: &BTreeMap<ir::KernPair, OrderedFloat<f64>>,
     side1_glyphs: &HashMap<&GlyphName, &KernGroup>,
     side2_glyphs: &HashMap<&GlyphName, &KernGroup>,
-) -> OrderedFloat<f32> {
+) -> OrderedFloat<f64> {
     // if already a group, return it, else look for group for glyph
     fn get_group_if_glyph(
         side: &ir::KernSide,
@@ -1328,7 +1328,7 @@ mod tests {
         // run a few times because triggering depended on hashmap iteration order
         for _ in 0..20 {
             align_instance(&all_pairs, &mut kerns, &side1_glyphs, &side2_glyphs);
-            assert_eq!(kerns.get(&glyph_glyph).map(|x| x.0), Some(10.0f32));
+            assert_eq!(kerns.get(&glyph_glyph).map(|x| x.0), Some(10.0f64));
         }
     }
 

--- a/fontbe/src/features/marks.rs
+++ b/fontbe/src/features/marks.rs
@@ -600,8 +600,8 @@ fn resolve_anchor_once(
         .iter()
         .map(|(loc, pt)| {
             (
-                (loc.clone(), OrderedFloat::from(pt.x as f32)),
-                (loc.clone(), OrderedFloat::from(pt.y as f32)),
+                (loc.clone(), OrderedFloat::from(pt.x)),
+                (loc.clone(), OrderedFloat::from(pt.y)),
             )
         })
         .unzip();
@@ -676,7 +676,7 @@ fn make_caret_value(
         .iter()
         .map(|(loc, pt)| {
             let pos = if is_vertical { pt.y } else { pt.x };
-            (loc.clone(), OrderedFloat::from(pos as f32))
+            (loc.clone(), OrderedFloat::from(pos))
         })
         .collect::<Vec<_>>();
 
@@ -824,7 +824,7 @@ mod tests {
 
     impl<const N: usize> MarksInput<N> {
         /// Create test input with `N` locations
-        fn new(locations: [&[f32]; N]) -> Self {
+        fn new(locations: [&[f64]; N]) -> Self {
             const TAG_NAMES: [Tag; 3] = [Tag::new(b"axs1"), Tag::new(b"axs2"), Tag::new(b"axs3")];
             let locations = locations
                 .iter()

--- a/fontbe/src/fvar.rs
+++ b/fontbe/src/fvar.rs
@@ -70,7 +70,7 @@ fn generate_fvar(static_metadata: &StaticMetadata) -> Option<Fvar> {
                             .get(axis.tag)
                             .unwrap_or(axis.default)
                             .into_inner();
-                        Fixed::from_f64(loc.into_inner() as f64)
+                        Fixed::from_f64(loc.into_inner())
                     })
                     .collect(),
                 ..Default::default()

--- a/fontbe/src/mvar.rs
+++ b/fontbe/src/mvar.rs
@@ -179,7 +179,7 @@ mod tests {
 
     use super::*;
 
-    fn axis(tag: &str, min: f32, default: f32, max: f32) -> Axis {
+    fn axis(tag: &str, min: f64, default: f64, max: f64) -> Axis {
         let min = UserCoord::new(min);
         let default = UserCoord::new(default);
         let max = UserCoord::new(max);
@@ -203,11 +203,11 @@ mod tests {
     fn add_sources(
         builder: &mut MvarBuilder,
         mvar_tag: &str,
-        sources: &[(&NormalizedLocation, f32)],
+        sources: &[(&NormalizedLocation, f64)],
     ) {
         let sources = sources
             .iter()
-            .map(|(loc, value)| ((*loc).clone(), (*value as f64).into()))
+            .map(|(loc, value)| ((*loc).clone(), { *value }.into()))
             .collect::<HashMap<_, _>>();
         builder
             .add_sources(Tag::from_str(mvar_tag).unwrap(), &sources)
@@ -283,11 +283,11 @@ mod tests {
             Self { mvar }
         }
 
-        fn metric_delta(&self, mvar_tag: &str, coords: &[f32]) -> f64 {
+        fn metric_delta(&self, mvar_tag: &str, coords: &[f64]) -> f64 {
             let mvar_tag = Tag::from_str(mvar_tag).unwrap();
             let coords: Vec<F2Dot14> = coords
                 .iter()
-                .map(|coord| F2Dot14::from_f32(*coord))
+                .map(|coord| F2Dot14::from_f32(*coord as _))
                 .collect();
             self.mvar.metric_delta(mvar_tag, &coords).unwrap().to_f64()
         }

--- a/fontbe/src/orchestration.rs
+++ b/fontbe/src/orchestration.rs
@@ -418,9 +418,11 @@ impl TupleBuilder {
         for tag in axis_order {
             let tent = region.get(tag).unwrap();
             builder.axes.push(*tag);
-            builder.min.push(F2Dot14::from_f32(tent.min.to_f32()));
-            builder.peak.push(F2Dot14::from_f32(tent.peak.to_f32()));
-            builder.max.push(F2Dot14::from_f32(tent.max.to_f32()));
+            builder.min.push(F2Dot14::from_f32(tent.min.to_f64() as _));
+            builder
+                .peak
+                .push(F2Dot14::from_f32(tent.peak.to_f64() as _));
+            builder.max.push(F2Dot14::from_f32(tent.max.to_f64() as _));
         }
         trace!("{builder:?}");
         builder
@@ -510,7 +512,7 @@ impl Persistable for FeaAst {
 }
 
 /// Kerning adjustments at various locations
-pub type KernAdjustments = BTreeMap<NormalizedLocation, OrderedFloat<f32>>;
+pub type KernAdjustments = BTreeMap<NormalizedLocation, OrderedFloat<f64>>;
 
 /// Every kerning pair we have, taking from IR.
 ///

--- a/fontbe/src/test_util.rs
+++ b/fontbe/src/test_util.rs
@@ -9,7 +9,7 @@ use fontdrasil::{
 use write_fonts::types::Tag;
 
 #[cfg(test)]
-pub(crate) fn axis(min: f32, default: f32, max: f32) -> Axis {
+pub(crate) fn axis(min: f64, default: f64, max: f64) -> Axis {
     let mut mappings = Vec::new();
     if min < default {
         mappings.push((UserCoord::new(min), DesignCoord::new(min / 10.0)));

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -1773,7 +1773,7 @@ mod tests {
         )
     }
 
-    fn assert_named_instances(source: &str, expected: Vec<(String, Vec<(&str, f32)>)>) {
+    fn assert_named_instances(source: &str, expected: Vec<(String, Vec<(&str, f64)>)>) {
         let result = TestCompile::compile_source(source);
         let font = result.font();
 
@@ -1798,7 +1798,7 @@ mod tests {
                     inst.coordinates
                         .iter()
                         .enumerate()
-                        .map(|(i, coord)| { (axis_names[i].as_str(), coord.get().to_f64() as f32) })
+                        .map(|(i, coord)| { (axis_names[i].as_str(), coord.get().to_f64()) })
                         .collect(),
                 ))
                 .collect::<Vec<_>>()
@@ -2035,7 +2035,7 @@ mod tests {
         groups.sort();
 
         let wght = Tag::new(b"wght");
-        let mut kerns: HashMap<KernPair, Vec<(String, f32)>> = HashMap::new();
+        let mut kerns: HashMap<KernPair, Vec<(String, f64)>> = HashMap::new();
         for kern_loc in kerning_groups.locations.iter() {
             assert_eq!(
                 vec![wght],
@@ -2050,7 +2050,7 @@ mod tests {
                 kerns.entry(pair.clone()).or_default().push((
                     format!(
                         "wght {}",
-                        kern_loc.iter().map(|(_, v)| *v).next().unwrap().to_f32()
+                        kern_loc.iter().map(|(_, v)| *v).next().unwrap().to_f64()
                     ),
                     adjustment.0,
                 ));
@@ -2505,7 +2505,7 @@ mod tests {
             let gid = self.glyph_order.glyph_id(&name).unwrap();
             let coords: Vec<F2Dot14> = coords
                 .iter()
-                .map(|coord| F2Dot14::from_f32(coord.into_inner().into()))
+                .map(|coord| F2Dot14::from_f32(coord.to_f64() as _))
                 .collect();
             self.hvar
                 .advance_width_delta(gid.into(), &coords)

--- a/fontdrasil/src/coords.rs
+++ b/fontdrasil/src/coords.rs
@@ -58,7 +58,7 @@ pub struct NormalizedSpace;
 /// A coordinate in some coordinate space.
 #[derive(Serialize, Deserialize, Default, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Coord<Space> {
-    coord: OrderedFloat<f32>,
+    coord: OrderedFloat<f64>,
     // we want to be covariant but also Send + Sync. See
     // <https://doc.rust-lang.org/1.74.0/nomicon/phantom-data.html#table-of-phantomdata-patterns>
     space: PhantomData<fn() -> Space>,
@@ -75,18 +75,18 @@ impl<Space> Coord<Space> {
     /// Create a new coordinate.
     ///
     /// Note that we do *not* impl From because we want conversion to be explicit.
-    pub fn new(value: impl Into<OrderedFloat<f32>>) -> Self {
+    pub fn new(value: impl Into<OrderedFloat<f64>>) -> Self {
         Coord {
             coord: value.into(),
             space: PhantomData,
         }
     }
 
-    pub fn into_inner(self) -> OrderedFloat<f32> {
+    pub fn into_inner(self) -> OrderedFloat<f64> {
         self.coord
     }
 
-    pub fn to_f32(&self) -> f32 {
+    pub fn to_f64(&self) -> f64 {
         self.coord.into_inner()
     }
 
@@ -247,13 +247,13 @@ impl CoordConverter {
 
 impl From<UserCoord> for Fixed {
     fn from(value: UserCoord) -> Self {
-        Fixed::from_f64(value.to_f32() as f64)
+        Fixed::from_f64(value.to_f64())
     }
 }
 
 impl From<NormalizedCoord> for F2Dot14 {
     fn from(value: NormalizedCoord) -> Self {
-        F2Dot14::from_f32(value.to_f32())
+        F2Dot14::from_f32(value.to_f64() as _)
     }
 }
 
@@ -261,7 +261,7 @@ impl<Space> Sub<Coord<Space>> for Coord<Space> {
     type Output = Coord<Space>;
 
     fn sub(self, rhs: Coord<Space>) -> Self::Output {
-        Coord::new(self.to_f32() - rhs.to_f32())
+        Coord::new(self.to_f64() - rhs.to_f64())
     }
 }
 
@@ -284,7 +284,7 @@ impl<Space> Location<Space> {
 
     /// For testing only, make a location from raw tags + values
     #[doc(hidden)]
-    pub fn for_pos(positions: &[(&str, f32)]) -> Self {
+    pub fn for_pos(positions: &[(&str, f64)]) -> Self {
         positions
             .iter()
             .map(|(tag, value)| {
@@ -337,11 +337,11 @@ impl<Space> Location<Space> {
 // methods we only want available on NormalizedSpace
 impl Location<NormalizedSpace> {
     pub fn has_non_zero(&self, tag: Tag) -> bool {
-        self.get(tag).unwrap_or_default().to_f32() != 0.0
+        self.get(tag).unwrap_or_default().to_f64() != 0.0
     }
 
     pub fn has_any_non_zero(&self) -> bool {
-        self.0.values().any(|v| v.to_f32() != 0.0)
+        self.0.values().any(|v| v.to_f64() != 0.0)
     }
 
     /// Returns true if all normalized coordinates are zero
@@ -398,13 +398,13 @@ impl<T> Clone for Coord<T> {
 
 impl<T> Copy for Coord<T> {}
 
-impl<Space> PartialEq<f32> for Coord<Space> {
-    fn eq(&self, other: &f32) -> bool {
+impl<Space> PartialEq<f64> for Coord<Space> {
+    fn eq(&self, other: &f64) -> bool {
         self.coord.as_ref() == other
     }
 }
 
-impl<Space> PartialEq<Coord<Space>> for f32 {
+impl<Space> PartialEq<Coord<Space>> for f64 {
     fn eq(&self, other: &Coord<Space>) -> bool {
         other == self
     }
@@ -417,7 +417,7 @@ impl<Space> Serialize for Location<Space> {
     {
         let mut seq = serializer.serialize_seq(Some(self.0.len()))?;
         for (key, value) in &self.0 {
-            seq.serialize_element(&(key, value.to_f32()))?;
+            seq.serialize_element(&(key, value.to_f64()))?;
         }
         seq.end()
     }
@@ -428,7 +428,7 @@ impl<'de, Space> Deserialize<'de> for Location<Space> {
     where
         D: Deserializer<'de>,
     {
-        Vec::<(Tag, OrderedFloat<f32>)>::deserialize(deserializer).map(|vals| {
+        Vec::<(Tag, OrderedFloat<f64>)>::deserialize(deserializer).map(|vals| {
             Location(
                 vals.into_iter()
                     .map(|(tag, val)| (tag, Coord::new(val)))
@@ -441,7 +441,7 @@ impl<'de, Space> Deserialize<'de> for Location<Space> {
 fn format_location<'a, 'b>(
     name: &str,
     f: &mut std::fmt::Formatter<'a>,
-    items: impl Iterator<Item = (&'b Tag, OrderedFloat<f32>)>,
+    items: impl Iterator<Item = (&'b Tag, OrderedFloat<f64>)>,
 ) -> std::fmt::Result {
     f.write_str(name)?;
     f.write_str(" {")?;

--- a/fontdrasil/src/coords.rs
+++ b/fontdrasil/src/coords.rs
@@ -557,7 +557,11 @@ mod tests {
         assert_eq!(5.5, UserCoord::new(300.0).to_design(&converter));
         assert_eq!(10.0, UserCoord::new(400.0).to_design(&converter));
 
-        assert_eq!(-0.45, UserCoord::new(300.0).to_normalized(&converter));
+        // this used to look like the others but was failing after switch to f64
+        assert!(
+            (-0.45 - UserCoord::new(300.0).to_normalized(&converter).to_f64()).abs()
+                <= f64::EPSILON
+        );
         assert_eq!(0.0, UserCoord::new(400.0).to_normalized(&converter));
     }
 

--- a/fontdrasil/src/piecewise_linear_map.rs
+++ b/fontdrasil/src/piecewise_linear_map.rs
@@ -14,24 +14,11 @@ pub struct PiecewiseLinearMap {
     to: Vec<OrderedFloat<f64>>,   // sorted, ||'s from
 }
 
-#[inline]
-fn as_of64(value: OrderedFloat<f32>) -> OrderedFloat<f64> {
-    (value.into_inner() as f64).into()
-}
-
-#[inline]
-fn as_of32(value: OrderedFloat<f64>) -> OrderedFloat<f32> {
-    (value.into_inner() as f32).into()
-}
-
 impl PiecewiseLinearMap {
     /// Create a new map from a series of (from, to) values.
-    pub fn new(mut mappings: Vec<(OrderedFloat<f32>, OrderedFloat<f32>)>) -> PiecewiseLinearMap {
+    pub fn new(mut mappings: Vec<(OrderedFloat<f64>, OrderedFloat<f64>)>) -> PiecewiseLinearMap {
         mappings.sort();
-        let (from, to): (Vec<_>, Vec<_>) = mappings
-            .into_iter()
-            .map(|(k, v)| (as_of64(k), as_of64(v)))
-            .unzip();
+        let (from, to): (Vec<_>, Vec<_>) = mappings.into_iter().unzip();
         PiecewiseLinearMap { from, to }
     }
 
@@ -43,29 +30,22 @@ impl PiecewiseLinearMap {
         let mappings = self
             .to
             .iter()
-            .zip(self.from.iter())
-            .map(|(k, v)| (as_of32(*k), as_of32(*v)))
+            .copied()
+            .zip(self.from.iter().copied())
             .collect();
         PiecewiseLinearMap::new(mappings)
     }
 
     /// An iterator over (from, to) values.
-    pub(crate) fn iter(&self) -> impl Iterator<Item = (f32, f32)> + '_ {
+    pub(crate) fn iter(&self) -> impl Iterator<Item = (f64, f64)> + '_ {
         self.from
             .iter()
             .zip(self.to.iter())
-            .map(|(from, to)| (from.into_inner() as f32, to.into_inner() as f32))
+            .map(|(from, to)| (from.0, to.0))
     }
 
     /// Based on <https://github.com/fonttools/fonttools/blob/5a0dc4bc8dfaa0c7da146cf902395f748b3cebe5/Lib/fontTools/varLib/models.py#L502>
-    pub fn map(&self, value: OrderedFloat<f32>) -> OrderedFloat<f32> {
-        // perform internal computations in f64 to increase precision but keep
-        // the current interface in f32; avoids issues like this:
-        // https://github.com/googlefonts/fontc/issues/1117
-        as_of32(self.map_impl(as_of64(value)))
-    }
-
-    fn map_impl(&self, value: OrderedFloat<f64>) -> OrderedFloat<f64> {
+    pub fn map(&self, value: OrderedFloat<f64>) -> OrderedFloat<f64> {
         match self.from.binary_search(&value) {
             Ok(idx) => self.to[idx], // This value is just right
             Err(idx) => {
@@ -115,50 +95,50 @@ mod tests {
     fn single_segment_map() {
         // User likes to use 0..10 in their sources to mean wght 0..1000 in userspace
         let from_to = vec![
-            (OrderedFloat(0_f32), OrderedFloat(0_f32)),
-            (OrderedFloat(10_f32), OrderedFloat(1000_f32)),
+            (OrderedFloat(0_f64), OrderedFloat(0_f64)),
+            (OrderedFloat(10_f64), OrderedFloat(1000_f64)),
         ];
         let plm = PiecewiseLinearMap::new(from_to);
 
-        assert_eq!(plm.map(OrderedFloat(0_f32)), OrderedFloat(0_f32));
-        assert_eq!(plm.map(OrderedFloat(5_f32)), OrderedFloat(500_f32));
-        assert_eq!(plm.map(OrderedFloat(10_f32)), OrderedFloat(1000_f32));
+        assert_eq!(plm.map(OrderedFloat(0_f64)), OrderedFloat(0_f64));
+        assert_eq!(plm.map(OrderedFloat(5_f64)), OrderedFloat(500_f64));
+        assert_eq!(plm.map(OrderedFloat(10_f64)), OrderedFloat(1000_f64));
 
         // walk off the end, why not
-        assert_eq!(plm.map(OrderedFloat(-1_f32)), OrderedFloat(-1_f32));
-        assert_eq!(plm.map(OrderedFloat(20_f32)), OrderedFloat(1010_f32));
+        assert_eq!(plm.map(OrderedFloat(-1_f64)), OrderedFloat(-1_f64));
+        assert_eq!(plm.map(OrderedFloat(20_f64)), OrderedFloat(1010_f64));
     }
 
     #[test]
     fn multi_segment_map() {
         // We obviously want to map -1..0 to 100.400 and 0..10 to 400..700.
         let from_to = vec![
-            (OrderedFloat(-1_f32), OrderedFloat(100_f32)),
-            (OrderedFloat(0_f32), OrderedFloat(400_f32)),
-            (OrderedFloat(10_f32), OrderedFloat(700_f32)),
+            (OrderedFloat(-1_f64), OrderedFloat(100_f64)),
+            (OrderedFloat(0_f64), OrderedFloat(400_f64)),
+            (OrderedFloat(10_f64), OrderedFloat(700_f64)),
         ];
         let plm = PiecewiseLinearMap::new(from_to);
 
-        assert_eq!(plm.map(OrderedFloat(-1_f32)), OrderedFloat(100_f32));
-        assert_eq!(plm.map(OrderedFloat(0_f32)), OrderedFloat(400_f32));
-        assert_eq!(plm.map(OrderedFloat(5_f32)), OrderedFloat(550_f32));
-        assert_eq!(plm.map(OrderedFloat(10_f32)), OrderedFloat(700_f32));
+        assert_eq!(plm.map(OrderedFloat(-1_f64)), OrderedFloat(100_f64));
+        assert_eq!(plm.map(OrderedFloat(0_f64)), OrderedFloat(400_f64));
+        assert_eq!(plm.map(OrderedFloat(5_f64)), OrderedFloat(550_f64));
+        assert_eq!(plm.map(OrderedFloat(10_f64)), OrderedFloat(700_f64));
     }
 
     #[test]
     fn float_precision() {
         // https://github.com/googlefonts/fontc/issues/1117
         let from_to = vec![
-            (OrderedFloat(100_f32), OrderedFloat(-1_f32)),
-            (OrderedFloat(400_f32), OrderedFloat(0_f32)),
-            (OrderedFloat(900_f32), OrderedFloat(1_f32)),
+            (OrderedFloat(100_f64), OrderedFloat(-1_f64)),
+            (OrderedFloat(400_f64), OrderedFloat(0_f64)),
+            (OrderedFloat(900_f64), OrderedFloat(1_f64)),
         ];
         let plm = PiecewiseLinearMap::new(from_to);
 
-        assert_eq!(plm.map(OrderedFloat(200_f32)), OrderedFloat(-0.6666667_f32));
+        assert_eq!(plm.map(OrderedFloat(200_f64)), OrderedFloat(-0.6666667_f64));
         assert_eq!(
-            plm.reverse().map(OrderedFloat(-0.6666667_f32)),
-            OrderedFloat(200_f32)
+            plm.reverse().map(OrderedFloat(-0.6666667_f64)),
+            OrderedFloat(200_f64)
         );
     }
 }

--- a/fontdrasil/src/piecewise_linear_map.rs
+++ b/fontdrasil/src/piecewise_linear_map.rs
@@ -88,6 +88,7 @@ fn lerp(a: f64, b: f64, t: f64) -> f64 {
 #[cfg(test)]
 mod tests {
     use ordered_float::OrderedFloat;
+    use write_fonts::types::Fixed;
 
     use super::PiecewiseLinearMap;
 
@@ -135,10 +136,10 @@ mod tests {
         ];
         let plm = PiecewiseLinearMap::new(from_to);
 
-        assert_eq!(plm.map(OrderedFloat(200_f64)), OrderedFloat(-0.6666667_f64));
-        assert_eq!(
-            plm.reverse().map(OrderedFloat(-0.6666667_f64)),
-            OrderedFloat(200_f64)
-        );
+        let map_to = plm.map(OrderedFloat(200_f64));
+        assert_eq!(Fixed::from_f64(map_to.0), Fixed::from_f64(-2f64 / 3f64));
+
+        let map_from = plm.reverse().map(map_to);
+        assert_eq!(Fixed::from_f64(map_from.0), Fixed::from_f64(200.0));
     }
 }

--- a/fontdrasil/src/types.rs
+++ b/fontdrasil/src/types.rs
@@ -165,7 +165,7 @@ impl TryFrom<u16> for WidthClass {
 
 impl WidthClass {
     // Lookup percent using the assigned value of the WidthClass
-    const _PERCENT_LUT: [f32; 10] = [
+    const _PERCENT_LUT: [f64; 10] = [
         0.0, // no width class has value 0, never used
         50.0, 62.5, 75.0, 87.5, 100.0, 112.5, 125.0, 150.0, 200.0,
     ];
@@ -184,12 +184,12 @@ impl WidthClass {
         ]
     }
 
-    pub fn to_percent(&self) -> f32 {
+    pub fn to_percent(&self) -> f64 {
         Self::_PERCENT_LUT[*self as usize]
     }
 
     /// Returns the WidthClass with the nearest percent width
-    pub fn nearest(percent: f32) -> Self {
+    pub fn nearest(percent: f64) -> Self {
         Self::all_values()
             .iter()
             .map(|v| (*v, (v.to_percent() - percent).abs()))

--- a/fontir/src/glyph.rs
+++ b/fontir/src/glyph.rs
@@ -424,8 +424,8 @@ fn ensure_notdef_exists_and_is_gid_0(
             let builder = GlyphBuilder::new_notdef(
                 static_metadata.default_location().clone(),
                 static_metadata.units_per_em,
-                metrics.ascender.0 as f32,
-                metrics.descender.0 as f32,
+                metrics.ascender.0,
+                metrics.descender.0,
             );
             context.glyphs.set(builder.build()?);
         }

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -305,7 +305,7 @@ pub struct KerningInstance {
     ///
     /// Used for both LTR and RTL. The BE application differs but the concept
     /// is the same.
-    pub kerns: BTreeMap<KernPair, OrderedFloat<f32>>,
+    pub kerns: BTreeMap<KernPair, OrderedFloat<f64>>,
 }
 
 /// A named set of glyphs with common kerning behaviour
@@ -1718,10 +1718,10 @@ impl GlyphBuilder {
     pub fn new_notdef(
         default_location: NormalizedLocation,
         upem: u16,
-        ascender: f32,
-        descender: f32,
+        ascender: f64,
+        descender: f64,
     ) -> Self {
-        let upem = upem as f32;
+        let upem = upem as f64;
         let width: u16 = (upem * 0.5).ot_round();
         let width = width as f64;
         let stroke: u16 = (upem * 0.05).ot_round();
@@ -1732,8 +1732,8 @@ impl GlyphBuilder {
         // outer box
         let x_min = stroke;
         let x_max = width - stroke;
-        let y_max = ascender as f64;
-        let y_min = descender as f64;
+        let y_max = ascender;
+        let y_min = descender;
         path.move_to((x_min, y_min));
         path.line_to((x_max, y_min));
         path.line_to((x_max, y_max));

--- a/fontir/src/paths.rs
+++ b/fontir/src/paths.rs
@@ -56,7 +56,7 @@ impl Paths {
         let filename = "kern_".to_string()
             + &location
                 .iter()
-                .map(|(tag, pos)| format!("{tag}_{:.2}", pos.to_f32()))
+                .map(|(tag, pos)| format!("{tag}_{:.2}", pos.to_f64()))
                 .collect::<Vec<_>>()
                 .join("_")
             + ".yml";

--- a/fontir/src/variations.rs
+++ b/fontir/src/variations.rs
@@ -1201,17 +1201,17 @@ mod tests {
                 ],
                 vec![
                     (0_usize, OrderedFloat(1.0)),
-                    (3_usize, OrderedFloat(0.7555555)),
-                    (4_usize, OrderedFloat(0.24444449)),
+                    (3_usize, OrderedFloat(0.7555555555555555)),
+                    (4_usize, OrderedFloat(0.24444444444444444)),
                     (5_usize, OrderedFloat(1.0)),
                     (6_usize, OrderedFloat(0.66))
                 ],
                 vec![
                     (0_usize, OrderedFloat(1.0)),
-                    (3_usize, OrderedFloat(0.7555555)),
-                    (4_usize, OrderedFloat(0.24444449)),
+                    (3_usize, OrderedFloat(0.7555555555555555)),
+                    (4_usize, OrderedFloat(0.24444444444444444)),
                     (5_usize, OrderedFloat(0.66)),
-                    (6_usize, OrderedFloat(0.43560004)),
+                    (6_usize, OrderedFloat(0.43560000000000004)),
                     (7_usize, OrderedFloat(0.66))
                 ],
             ],
@@ -1304,17 +1304,17 @@ mod tests {
                 vec![(0_usize, OrderedFloat(1.0))],
                 vec![
                     (0_usize, OrderedFloat(1.0)),
-                    (1_usize, OrderedFloat(0.33333334))
+                    (1_usize, OrderedFloat(1.0 / 3.0))
                 ],
                 vec![(0_usize, OrderedFloat(1.0))],
                 vec![(0_usize, OrderedFloat(1.0))],
                 vec![
                     (0_usize, OrderedFloat(1.0)),
-                    (4_usize, OrderedFloat(0.6666667))
+                    (4_usize, OrderedFloat(2.0 / 3.0))
                 ],
                 vec![
                     (0_usize, OrderedFloat(1.0)),
-                    (4_usize, OrderedFloat(0.33333334)),
+                    (4_usize, OrderedFloat(1.0 / 3.0)),
                     (5_usize, OrderedFloat(0.5))
                 ],
                 vec![(0_usize, OrderedFloat(1.0))],

--- a/fontra2fontir/src/toir.rs
+++ b/fontra2fontir/src/toir.rs
@@ -28,9 +28,9 @@ pub(crate) fn to_ir_static_metadata(font_data: &FontraFontData) -> Result<Static
         })
         .map(|a| {
             let a = a?;
-            let min = UserCoord::new(a.min_value as f32);
-            let default = UserCoord::new(a.default_value as f32);
-            let max = UserCoord::new(a.max_value as f32);
+            let min = UserCoord::new(a.min_value);
+            let default = UserCoord::new(a.default_value);
+            let max = UserCoord::new(a.max_value);
 
             if min > default || max < default {
                 return Err(Error::InconsistentAxisDefinitions(format!("{a:?}")));
@@ -41,10 +41,7 @@ pub(crate) fn to_ir_static_metadata(font_data: &FontraFontData) -> Result<Static
                     .mapping
                     .iter()
                     .map(|[raw_user, raw_design]| {
-                        (
-                            UserCoord::new(*raw_user as f32),
-                            DesignCoord::new(*raw_design as f32),
-                        )
+                        (UserCoord::new(*raw_user), DesignCoord::new(*raw_design))
                     })
                     .collect();
                 let has_min_max = examples.iter().any(|(u, _)| *u == min)
@@ -121,7 +118,7 @@ fn to_ir_glyph(
             .map(|(name, tag)| {
                 (
                     *tag,
-                    NormalizedCoord::new(location.get(name).copied().unwrap_or_default() as f32),
+                    NormalizedCoord::new(location.get(name).copied().unwrap_or_default()),
                 )
             })
             .collect();
@@ -240,9 +237,9 @@ mod tests {
                 (
                     a.name.as_str(),
                     a.tag,
-                    a.min.to_f32() as f64,
-                    a.default.to_f32() as f64,
-                    a.max.to_f32() as f64,
+                    a.min.to_f64(),
+                    a.default.to_f64(),
+                    a.max.to_f64(),
                 )
             })
             .collect::<Vec<_>>()

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -863,7 +863,7 @@ impl Work<Context, WorkId, Error> for KerningInstanceWork {
                 Some(((side1, side2), pos_adjust))
             })
             .for_each(|(participants, (_, value))| {
-                *kerning.kerns.entry(participants).or_default() = (value.0 as f32).into();
+                *kerning.kerns.entry(participants).or_default() = value;
             });
 
         context.kerning_at.set(kerning);

--- a/glyphs2fontir/src/toir.rs
+++ b/glyphs2fontir/src/toir.rs
@@ -135,7 +135,7 @@ pub(crate) fn design_location(
 ) -> DesignLocation {
     axes.iter()
         .zip(axes_values.iter())
-        .map(|(axis, pos)| (axis.tag, DesignCoord::new(pos.into_inner() as f32)))
+        .map(|(axis, pos)| (axis.tag, DesignCoord::new(*pos)))
         .collect()
 }
 
@@ -165,22 +165,14 @@ fn to_ir_axis(
     default_idx: usize,
     axis: &glyphs_reader::Axis,
 ) -> Result<fontdrasil::types::Axis, Error> {
-    let min = axis_values
-        .iter()
-        .map(|v| OrderedFloat::<f32>(v.into_inner() as f32))
-        .min()
-        .unwrap();
-    let max = axis_values
-        .iter()
-        .map(|v| OrderedFloat::<f32>(v.into_inner() as f32))
-        .max()
-        .unwrap();
-    let default = OrderedFloat(axis_values[default_idx].into_inner() as f32);
+    let min = axis_values.iter().min().unwrap();
+    let max = axis_values.iter().max().unwrap();
+    let default = axis_values[default_idx];
 
     // Given in design coords based on a sample file
     let default = DesignCoord::new(default);
-    let min = DesignCoord::new(min);
-    let max = DesignCoord::new(max);
+    let min = DesignCoord::new(*min);
+    let max = DesignCoord::new(*max);
 
     let converter = if font.axis_mappings.contains(&axis.name)
         && !font.axis_mappings.get(&axis.name).unwrap().is_identity()

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -538,7 +538,7 @@ fn default_master(designspace: &DesignSpaceDocument) -> Option<(usize, &designsp
         .map(|a| {
             let tag = Tag::from_str(&a.tag).unwrap();
             let converter = &axes.get(&tag).unwrap().converter;
-            (tag, UserCoord::new(a.default).to_design(converter))
+            (tag, UserCoord::new(a.default as f64).to_design(converter))
         })
         .collect();
     designspace
@@ -1525,7 +1525,7 @@ impl Work<Context, WorkId, Error> for KerningInstanceWork {
                 continue;
             };
 
-            *kerns.kerns.entry((side1, side2)).or_default() = (adjustment as f32).into();
+            *kerns.kerns.entry((side1, side2)).or_default() = adjustment.into();
         }
 
         debug!("{:?} has {} kern entries", self.location, kerns.kerns.len());
@@ -1782,7 +1782,7 @@ mod tests {
         add_to: &mut HashMap<PathBuf, Vec<DesignLocation>>,
         glif_file: &str,
         tag: Tag,
-        pos: f32,
+        pos: f64,
     ) {
         let mut loc = DesignLocation::new();
         loc.insert(tag, DesignCoord::new(pos));

--- a/ufo2fontir/src/toir.rs
+++ b/ufo2fontir/src/toir.rs
@@ -22,7 +22,7 @@ pub(crate) fn to_design_location(
         .map(|d| {
             (
                 *tags_by_name.get(d.name.as_str()).unwrap(),
-                DesignCoord::new(d.xvalue.unwrap()),
+                DesignCoord::new(d.xvalue.unwrap() as f64),
             )
         })
         .collect()
@@ -120,15 +120,20 @@ pub fn to_ir_axis(axis: &designspace::Axis) -> Result<fontdrasil::types::Axis, E
     })?;
 
     // <https://fonttools.readthedocs.io/en/latest/designspaceLib/xml.html#axis-element>
-    let min = UserCoord::new(axis.minimum.unwrap());
-    let default = UserCoord::new(axis.default);
-    let max = UserCoord::new(axis.maximum.unwrap());
+    let min = UserCoord::new(axis.minimum.unwrap() as f64);
+    let default = UserCoord::new(axis.default as f64);
+    let max = UserCoord::new(axis.maximum.unwrap() as f64);
 
     // <https://fonttools.readthedocs.io/en/latest/designspaceLib/xml.html#map-element>
     let converter = if let Some(mappings) = &axis.map {
         let examples: Vec<_> = mappings
             .iter()
-            .map(|map| (UserCoord::new(map.input), DesignCoord::new(map.output)))
+            .map(|map| {
+                (
+                    UserCoord::new(map.input as f64),
+                    DesignCoord::new(map.output as f64),
+                )
+            })
             .collect();
 
         // make sure we have min/max/default mappings:


### PR DESCRIPTION
This replaces a bunch of use of f32 (in parsing and in coordinate types) with f64.

There are two tests that are failing which I don't want to touch, because I don't really understand what's best.

This doesn't have a dramatic impact on crater, but it does show improvements for fvar & HVAR for a number of fonts.

closes #1152 

(The main place where we still use f32 is when we are close to `F2Dot14` types, because f32 fully captures the precision these can represent)