### PR TITLE
Prove we don't match fontmake for Glyphs italic and fix it

### DIFF
--- a/resources/testdata/glyphs3/An-Italic.glyphs
+++ b/resources/testdata/glyphs3/An-Italic.glyphs
@@ -1,0 +1,51 @@
+{
+customParameters = (
+{
+name = Axes;
+value = (
+{
+Name = Weight;
+Tag = wght;
+}
+);
+}
+);
+
+familyName = An;
+
+fontMaster = (
+{
+custom = Italic;
+id = "light";
+italicAngle = 8;
+weight = Light;
+weightValue = 58;
+},
+
+{
+custom = "Extra Italic";
+id = "bold";
+italicAngle = 8;
+name = "ExtraBold Italic";
+weight = Bold;
+weightValue = 147;
+}
+);
+
+glyphs = (
+{
+glyphname = .notdef;
+layers = (
+{
+layerId = "light";
+},
+{
+layerId = "bold";
+}
+);
+}
+);
+
+unitsPerEm = 1000;
+versionMajor = 1;
+}


### PR DESCRIPTION
```shell
# main
$ python resources/scripts/ttx_diff.py 'https://github.com/Omnibus-Type/Faustina#sources/Faustina-Italic.glyphs' | grep DIFF
  DIFF 'OS_2', build/default/fontmake.OS_2.ttx (98.1%)
  DIFF 'STAT', build/default/fontmake.STAT.ttx (93.8%)
  DIFF 'fvar', build/default/fontmake.fvar.ttx (97.7%)
  DIFF 'glyf', build/default/fontmake.glyf.ttx (100.0%)
  DIFF 'head', build/default/fontmake.head.ttx (95.5%)
  DIFF 'hmtx', build/default/fontmake.hmtx.ttx (99.9%)
  DIFF 'name', build/default/fontmake.name.ttx (96.4%)

# this branch
$ python resources/scripts/ttx_diff.py 'https://github.com/Omnibus-Type/Faustina#sources/Faustina-Italic.glyphs' | grep DIFF
  DIFF 'glyf', build/default/fontmake.glyf.ttx (100.0%)
  DIFF 'hmtx', build/default/fontmake.hmtx.ttx (99.9%)
```

JMM if happy