### PR TITLE
Don't overwrite Glyphs v3 values with v2 values

### DIFF
--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -687,6 +687,12 @@ struct RawName {
     values: Vec<RawNameValue>,
 }
 
+impl RawName {
+    fn is_empty(&self) -> bool {
+        self.value.is_none() && self.values.is_empty()
+    }
+}
+
 #[derive(Default, Clone, Debug, PartialEq, Eq, Hash, FromPlist)]
 struct RawNameValue {
     language: String,
@@ -1558,6 +1564,11 @@ impl RawFont {
         );
 
         let mut v2_to_v3_param = |v2_name: &str, v3_name: &str| {
+            if let Some(v3) = properties.iter().find(|n| n.key == v3_name) {
+                if !v3.is_empty() {
+                    return;
+                }
+            }
             if let Some(value) = self.custom_parameters.string(v2_name) {
                 v2_to_v3_name(&mut properties, Some(value), v3_name);
             }

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -1951,4 +1951,11 @@ mod tests {
             )
         );
     }
+
+    #[test]
+    fn prefer_vendorid_in_properties() {
+        let (_, context) = build_static_metadata(glyphs3_dir().join("MultipleVendorIDs.glyphs"));
+        let static_metadata = context.static_metadata.get();
+        assert_eq!(Tag::new(b"RGHT"), static_metadata.misc.vendor_id);
+    }
 }

--- a/resources/testdata/glyphs3/MultipleVendorIDs.glyphs
+++ b/resources/testdata/glyphs3/MultipleVendorIDs.glyphs
@@ -1,0 +1,56 @@
+{
+.formatVersion = 3;
+axes = (
+{
+name = Weight;
+tag = wght;
+}
+);
+customParameters = (
+{
+name = vendorID;
+value = WRNG;
+}
+);
+
+familyName = FamilyName;
+fontMaster = (
+{
+axesValues = (
+400
+);
+id = m01;
+name = Regular;
+},
+{
+axesValues = (
+700
+);
+id = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+name = Bold;
+}
+);
+glyphs = (
+{
+glyphname = space;
+layers = (
+{
+layerId = m01;
+width = 200;
+},
+{
+layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+width = 600;
+}
+);
+unicode = 32;
+}
+);
+properties = (
+{
+key = vendorID;
+value = RGHT;
+},
+);
+unitsPerEm = 1000;
+}


### PR DESCRIPTION
Fixes OS/2 and name diffs for `python resources/scripts/ttx_diff.py 'https://www.github.com/googlefonts/teko#sources/Teko.glyphs'`

JMM