### PR TITLE
Let's not name things Thing Italic Italic

### DIFF
--- a/resources/testdata/glyphs2/ItalicItalic.glyphs
+++ b/resources/testdata/glyphs2/ItalicItalic.glyphs
@@ -1,0 +1,34 @@
+{
+customParameters = (
+{
+name = Axes;
+value = (
+{
+Name = Weight;
+Tag = wght;
+}
+);
+}
+);
+familyName = "Master Names";
+fontMaster = (
+{
+custom = "Thin Italic";
+id = m01;
+italicAngle = 10;
+}
+);
+glyphs = (
+{
+glyphname = space;
+layers = (
+{
+layerId = m01;
+width = 200;
+}
+);
+unicode = 0020;
+}
+);
+unitsPerEm = 1000;
+}


### PR DESCRIPTION
A custom name of "X Italic" for an Italic would result in "X Italic Italic".

Fixes `name` diff for `python resources/scripts/ttx_diff.py 'https://github.com/googlefonts/genos#sources/Genos-Italic.glyphs' --compare gftools --config ~/.fontc_crater_cache/googlefonts/genos/sources/config.yml` (though sadly GSUB remains)

Fixes #1175 

JMM