### PR TITLE
[crater] Make summary sort order deterministic

### DIFF
--- a/fontc_crater/src/ci/html.rs
+++ b/fontc_crater/src/ci/html.rs
@@ -367,7 +367,7 @@ fn make_summary_report(current: &DiffResults) -> Markup {
         })
         .into_iter()
         .collect::<Vec<_>>();
-    results.sort_by_key(|(_, count)| -*count);
+    results.sort_by_key(|(item, count)| (-*count, *item));
 
     if results.is_empty() {
         return html!();


### PR DESCRIPTION
Because these came from a hashmap and we then sorted only by the count, if counts were equal the ordering could change between runs, which was causing us to push a bunch of unnecessary commits.


just noticed this when I went to pull crater changes locally and saw a whole load of new commits that were just shuffling this list. JMM.