### PR TITLE
Add support for ufo openTypeOs2Weight/WidthClass

### DIFF
--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -1292,6 +1292,15 @@ mod tests {
     }
 
     #[test]
+    fn prefers_explicit_os_x_class() {
+        let result = TestCompile::compile_source("fontinfo.designspace");
+        let font = result.font();
+        let os2 = font.os2().unwrap();
+
+        assert_eq!((800, 8), (os2.us_weight_class(), os2.us_width_class(),),);
+    }
+
+    #[test]
     fn glyphs_app_ir_categories() {
         let result = TestCompile::compile_source("glyphs3/Oswald-glyph-categories.glyphs");
         let staticmeta = result.fe_context.static_metadata.get();

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -137,6 +137,15 @@ pub struct MiscMetadata {
     // Allows source to explicitly control bits. <https://github.com/googlefonts/fontc/issues/1027>
     pub codepage_range_bits: Option<HashSet<u32>>,
     pub meta_table: Option<MetaTableValues>,
+
+    /// <https://learn.microsoft.com/en-us/typography/opentype/spec/os2#usweightclass>
+    ///
+    /// If empty and there is a weight axis OS/2 will use the weight default
+    pub us_weight_class: Option<u16>,
+    /// <https://learn.microsoft.com/en-us/typography/opentype/spec/os2#uswidthclass>
+    ///
+    /// If empty and there is a width axis OS/2 will use the width default
+    pub us_width_class: Option<u16>,
 }
 
 /// PANOSE bytes
@@ -498,6 +507,8 @@ impl StaticMetadata {
                 unicode_range_bits: None,
                 codepage_range_bits: None,
                 meta_table: None,
+                us_weight_class: None,
+                us_width_class: None,
             },
         })
     }
@@ -1961,6 +1972,8 @@ mod tests {
                 unicode_range_bits: None,
                 codepage_range_bits: None,
                 meta_table: None,
+                us_weight_class: None,
+                us_width_class: None,
             },
             number_values: Default::default(),
         }

--- a/resources/testdata/FontInfo-Regular.ufo/fontinfo.plist
+++ b/resources/testdata/FontInfo-Regular.ufo/fontinfo.plist
@@ -34,5 +34,9 @@
     <integer>-290</integer>
     <key>openTypeHheaLineGap</key>
     <integer>43</integer>
+    <key>openTypeOS2WeightClass</key>
+    <integer>800</integer>
+    <key>openTypeOS2WidthClass</key>
+    <integer>8</integer>
   </dict>
 </plist>

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -604,6 +604,7 @@ fn names(font_info: &norad::FontInfo) -> HashMap<NameKey, String> {
             .into()
         }),
     );
+
     builder.add_if_present(NameId::UNIQUE_ID, &font_info.open_type_name_unique_id);
     builder.add_if_present(NameId::VERSION_STRING, &font_info.open_type_name_version);
     builder.add_if_present(NameId::POSTSCRIPT_NAME, &font_info.postscript_font_name);
@@ -817,6 +818,13 @@ impl Work<Context, WorkId, Error> for StaticMetadataWork {
                     cause,
                 })?;
         }
+
+        static_metadata.misc.us_weight_class = font_info_at_default
+            .open_type_os2_weight_class
+            .map(|v| v as u16);
+        static_metadata.misc.us_width_class = font_info_at_default
+            .open_type_os2_width_class
+            .map(|v| v as u16);
 
         // <https://github.com/googlefonts/glyphsLib/blob/cb8a4a914b0a33431f0a77f474bf57eec2f19bcc/Lib/glyphsLib/builder/custom_params.py#L1117-L1119>
         static_metadata.misc.fs_type = Some(


### PR DESCRIPTION
Reduces diff for `python resources/scripts/ttx_diff.py 'https://github.com/wix/wixmadefor#sources/WixMadeforText-SemiBoldItalic.ufo'`

JMM if happy