### PR TITLE
Drop quotes from names parsed from fea earlier so we detect empty ones correctly

### DIFF
--- a/fea-rs/src/compile/compile_ctx.rs
+++ b/fea-rs/src/compile/compile_ctx.rs
@@ -1819,28 +1819,7 @@ impl<'a, F: FeatureProvider, V: VariationInfo> CompilationCtx<'a, F, V> {
     }
 
     fn resolve_name_spec(&mut self, node: &typed::NameSpec) -> super::tables::NameSpec {
-        const WIN_DEFAULT_IDS: (u16, u16) = (1, 0x0409);
-        const MAC_DEFAULT_IDS: (u16, u16) = (0, 0);
-
-        let platform_id = node
-            .platform_id()
-            .map(|n| n.parse().unwrap())
-            .unwrap_or(tags::WIN_PLATFORM_ID);
-
-        let (encoding_id, language_id) = match node.platform_and_language_ids() {
-            Some((platform, language)) => (platform.parse().unwrap(), language.parse().unwrap()),
-            None => match platform_id {
-                tags::MAC_PLATFORM_ID => MAC_DEFAULT_IDS,
-                tags::WIN_PLATFORM_ID => WIN_DEFAULT_IDS,
-                _ => panic!("missed validation"),
-            },
-        };
-        super::tables::NameSpec {
-            platform_id,
-            encoding_id,
-            language_id,
-            string: node.string().text.clone(),
-        }
+        resolve_name_spec(node)
     }
 
     fn resolve_lookup_ref(&mut self, lookup: typed::LookupRef) {
@@ -2140,6 +2119,43 @@ impl<'a, F: FeatureProvider, V: VariationInfo> CompilationCtx<'a, F, V> {
     }
 }
 
+// testing and free fn's, friends forever
+fn resolve_name_spec(node: &typed::NameSpec) -> super::tables::NameSpec {
+    const WIN_DEFAULT_IDS: (u16, u16) = (1, 0x0409);
+    const MAC_DEFAULT_IDS: (u16, u16) = (0, 0);
+
+    let platform_id = node
+        .platform_id()
+        .map(|n| n.parse().unwrap())
+        .unwrap_or(tags::WIN_PLATFORM_ID);
+
+    let (encoding_id, language_id) = match node.platform_and_language_ids() {
+        Some((platform, language)) => (platform.parse().unwrap(), language.parse().unwrap()),
+        None => match platform_id {
+            tags::MAC_PLATFORM_ID => MAC_DEFAULT_IDS,
+            tags::WIN_PLATFORM_ID => WIN_DEFAULT_IDS,
+            _ => panic!("missed validation"),
+        },
+    };
+
+    // Drop wrapping quotes around names if present, it confuses subsequent processing of string
+    let string = match &node.string().text {
+        quoted if quoted.starts_with('"') && quoted.ends_with('"') && quoted.len() > 1 => quoted
+            .strip_prefix('"')
+            .unwrap()
+            .strip_suffix('"')
+            .unwrap()
+            .into(),
+        unquoted => unquoted.clone(),
+    };
+    super::tables::NameSpec {
+        platform_id,
+        encoding_id,
+        language_id,
+        string,
+    }
+}
+
 fn sequence_enumerator(sequence: &[GlyphOrClass]) -> Vec<Vec<GlyphId16>> {
     assert!(sequence.len() >= 2);
     let split = sequence.split_first();
@@ -2219,6 +2235,23 @@ mod tests {
                 glyph_id_vec([1, 3, 9]),
                 glyph_id_vec([1, 4, 8]),
                 glyph_id_vec([1, 4, 9]),
+            ]
+        );
+    }
+
+    fn parse_name_spec(fea: &str) -> crate::compile::tables::NameSpec {
+        resolve_name_spec(&typed::NameSpec {
+            inner: crate::parse::parse_string(fea).0.root,
+        })
+    }
+
+    #[test]
+    fn parse_name_spec_drop_quotes() {
+        assert_eq!(
+            vec!["", "duck"],
+            vec![
+                parse_name_spec("3 1 0x409 \"\"").string,
+                parse_name_spec("3 1 0x409 \"duck\"").string
             ]
         );
     }

--- a/fea-rs/src/compile/tables/name.rs
+++ b/fea-rs/src/compile/tables/name.rs
@@ -89,7 +89,7 @@ impl NameSpec {
     }
 
     pub fn build(&self, name_id: NameId) -> write_fonts::tables::name::NameRecord {
-        let string = parse_string(self.platform_id, self.string.trim_matches('"'));
+        let string = parse_string(self.platform_id, &self.string);
         write_fonts::tables::name::NameRecord::new(
             self.platform_id,
             self.encoding_id,

--- a/fea-rs/src/compile/validate.rs
+++ b/fea-rs/src/compile/validate.rs
@@ -486,7 +486,7 @@ impl<'a, V: VariationInfo> ValidationCtx<'a, V> {
 
         let platform = platform.unwrap_or(WIN_PLATFORM_ID);
 
-        if let Err((range, err)) = validate_name_string_encoding(platform, spec.string()) {
+        if let Err((range, err)) = validate_name_string_encoding(platform, spec.string_token()) {
             self.error(range, err);
         }
         if let Some((platspec, language)) = spec.platform_and_language_ids() {

--- a/fea-rs/src/parse/grammar/metrics.rs
+++ b/fea-rs/src/parse/grammar/metrics.rs
@@ -516,4 +516,22 @@ mod tests {
         assert!(valrecord.advance().is_none());
         assert!(valrecord.placement().is_some());
     }
+
+    #[test]
+    fn name_string_omits_quotes() {
+        let parse_name = |fea| {
+            let (token, _err, _) = debug_parse_output(fea, |parser| {
+                expect_name_record(parser, TokenSet::EMPTY);
+            });
+
+            crate::typed::NameSpec::cast(&token).unwrap()
+        };
+        assert_eq!(
+            ["", "duck"],
+            [
+                parse_name("3 1 0x409 \"\"").string(),
+                parse_name("3 1 0x409 \"duck\"").string(),
+            ]
+        );
+    }
 }

--- a/fea-rs/src/token_tree/typed.rs
+++ b/fea-rs/src/token_tree/typed.rs
@@ -89,7 +89,7 @@ macro_rules! ast_node {
         #[derive(Clone, Debug)]
         #[allow(missing_docs)]
         pub struct $typ {
-            inner: Node,
+            pub(crate) inner: Node,
         }
 
         impl $typ {

--- a/fea-rs/src/token_tree/typed.rs
+++ b/fea-rs/src/token_tree/typed.rs
@@ -89,7 +89,7 @@ macro_rules! ast_node {
         #[derive(Clone, Debug)]
         #[allow(missing_docs)]
         pub struct $typ {
-            pub(crate) inner: Node,
+            inner: Node,
         }
 
         impl $typ {
@@ -1487,8 +1487,15 @@ impl NameSpec {
         }
     }
 
-    pub(crate) fn string(&self) -> &Token {
+    pub(crate) fn string_token(&self) -> &Token {
+        // There is always a string
         self.find_token(Kind::String).unwrap()
+    }
+
+    pub(crate) fn string(&self) -> &str {
+        // The value is always doublequoted so slice out the actual string
+        let s = self.string_token().as_str();
+        &s[1..s.len() - 1]
     }
 }
 


### PR DESCRIPTION
Parsing NameSpec from fea retains the double quotes, dropping them only when generating final `name` records. That causes fontc to produce unwanted empty name records because it filters using is_empty. Naive solution: drop the quotes earlier so is_empty works as expected.

Makes `name` identical for `python resources/scripts/ttx_diff.py 'https://github.com/marcologous/hanken-grotesk#sources/HankenGrotesk.glyphs'`.