### PR TITLE
Prefer variable default for usXClass when variable

### DIFF
--- a/fontbe/src/os2.rs
+++ b/fontbe/src/os2.rs
@@ -537,15 +537,13 @@ impl Work<Context, AnyWorkId, Error> for Os2Work {
         // set the OS/2.us{Weight,Width}Class to the default value of 'wght'/'wdth' axes
         // in the same way fontmake does when building a VF:
         // https://github.com/fonttools/fonttools/blob/770917d8/Lib/fontTools/varLib/__init__.py#L1016-L1032
+        // If variable prefer the axis as per <https://github.com/fonttools/fonttools/blob/cb159dea72703e88b42353a45757f629b9593ede/Lib/fontTools/varLib/__init__.py#L1031C5-L1053>
         let us_x_class = |misc_value: Option<u16>, axis_tag, default, clamp: fn(f64) -> u16| {
-            misc_value.unwrap_or_else(|| {
-                clamp(
-                    static_metadata
-                        .axis(&Tag::new(axis_tag))
-                        .map(|axis| axis.default.into_inner().0)
-                        .unwrap_or(default),
-                )
-            })
+            static_metadata
+                .axis(&Tag::new(axis_tag))
+                .map(|axis| clamp(axis.default.into_inner().0))
+                .or(misc_value)
+                .unwrap_or(clamp(default))
         };
         let us_weight_class =
             us_x_class(static_metadata.misc.us_weight_class, b"wght", 400.0, |v| {

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -635,6 +635,17 @@ mod tests {
     }
 
     #[test]
+    fn compile_prefers_variable_default_to_fontinfo_value() {
+        let result = TestCompile::compile_source("fontinfo_var.designspace");
+        let os2 = result.font().os2().unwrap();
+        assert_eq!(
+            100,
+            os2.us_weight_class(),
+            "We should use wght default, NOT openTypeOS2WeightClass"
+        );
+    }
+
+    #[test]
     fn compile_variable_simple_glyph_with_implied_oncurves() {
         let result = TestCompile::compile_source("glyphs3/Oswald-O.glyphs");
 

--- a/resources/testdata/FontInfo-Thin.ufo/fontinfo.plist
+++ b/resources/testdata/FontInfo-Thin.ufo/fontinfo.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>unitsPerEm</key>
+    <integer>1000</integer>
+    <key>openTypeOS2WeightClass</key>
+    <integer>300</integer>
+  </dict>
+</plist>

--- a/resources/testdata/FontInfo-Thin.ufo/glyphs/contents.plist
+++ b/resources/testdata/FontInfo-Thin.ufo/glyphs/contents.plist
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+  </dict>
+</plist>

--- a/resources/testdata/FontInfo-Thin.ufo/layercontents.plist
+++ b/resources/testdata/FontInfo-Thin.ufo/layercontents.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <array>
+    <array>
+      <string>public.default</string>
+      <string>glyphs</string>
+    </array>
+  </array>
+</plist>

--- a/resources/testdata/FontInfo-Thin.ufo/lib.plist
+++ b/resources/testdata/FontInfo-Thin.ufo/lib.plist
@@ -1,0 +1,9 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>public.glyphOrder</key>
+    <array>
+    </array>
+  </dict>
+</plist>

--- a/resources/testdata/FontInfo-Thin.ufo/metainfo.plist
+++ b/resources/testdata/FontInfo-Thin.ufo/metainfo.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>creator</key>
+    <string>com.github.fonttools.ufoLib</string>
+    <key>formatVersion</key>
+    <integer>3</integer>
+  </dict>
+</plist>

--- a/resources/testdata/fontinfo_var.designspace
+++ b/resources/testdata/fontinfo_var.designspace
@@ -1,0 +1,39 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Derived from Noto Sans Adlam -->
+<designspace format="4.1">
+  <axes>
+    <axis tag="wght" name="Weight" minimum="100" maximum="400" default="100"/>
+  </axes>
+  <sources>
+    <source filename="FontInfo-Thin.ufo" name="FontInfo Thin" familyname="FontInfo" stylename="Thin">
+      <lib copy="1"/>
+      <groups copy="1"/>
+      <features copy="1"/>
+      <info copy="1"/>
+      <location>
+        <dimension name="Weight" xvalue="100"/>
+      </location>
+    </source>
+    <source filename="FontInfo-Regular.ufo" name="FontInfo Regular" familyname="FontInfo" stylename="Regular">
+      <lib copy="1"/>
+      <groups copy="1"/>
+      <features copy="1"/>
+      <info copy="1"/>
+      <location>
+        <dimension name="Weight" xvalue="400"/>
+      </location>
+    </source>
+  </sources>
+  <instances>
+    <instance name="FontInfo Thin" familyname="FontInfo" stylename="Thin" filename="instance_ufos/FontInfo-Thin.ufo" stylemapfamilyname="FontInfo" stylemapstylename="thin">
+      <location>
+        <dimension name="Weight" xvalue="100"/>
+      </location>
+    </instance>
+    <instance name="FontInfo Regular" familyname="FontInfo" stylename="Regular" filename="instance_ufos/FontInfo-Regular.ufo" stylemapfamilyname="FontInfo" stylemapstylename="regular">
+      <location>
+        <dimension name="Weight" xvalue="400"/>
+      </location>
+    </instance>
+  </instances>
+</designspace>


### PR DESCRIPTION
#1191 had a bug, add a test to expose and fix.

Makes `python resources/scripts/ttx_diff.py 'https://github.com/TypeNetwork/Josefinslab#sources/JosefinSlab.designspace'` identical.

JMM if happy.