### PR TITLE
[glyphs] Rework corner erasure to delete in-place

### DIFF
--- a/glyphs2fontir/src/erase_open_corners.rs
+++ b/glyphs2fontir/src/erase_open_corners.rs
@@ -2,9 +2,9 @@
 //!
 //! see <https://github.com/googlefonts/glyphsLib/blob/74c63244fdb/Lib/glyphsLib/filters/eraseOpenCorners.py>
 
-use std::ops::Range;
+use std::{borrow::Cow, ops::Range};
 
-use kurbo::{BezPath, Line, ParamCurve, PathEl, PathSeg, Point, Shape};
+use kurbo::{BezPath, CubicBez, Line, ParamCurve, PathEl, PathSeg, Point, QuadBez, Shape};
 use ordered_float::OrderedFloat;
 
 /// Removes 'outside open corners'.
@@ -35,20 +35,85 @@ use ordered_float::OrderedFloat;
 /// - <https://github.com/googlefonts/glyphsLib/issues/255#issuecomment-339591136>
 /// - <https://github.com/googlefonts/glyphsLib/blob/74c63244fdb/Lib/glyphsLib/filters/eraseOpenCorners.py#L42>
 pub fn erase_open_corners(path: &BezPath) -> Option<BezPath> {
-    // first: this is generally a nop, so let's not actually mutate anything
-    // unless we have to; instead we will accumulate mutations and apply
-    // them at the end.
-    let mut todo = Vec::new();
+    CornerErasureCtx::new(path).erase_corners()
+}
 
-    let is_closed = matches!(path.elements().last(), Some(PathEl::ClosePath));
-    // we could write this using iterators but I think it's cleaner this way
-    for candidate in iter_erasure_candidates(path.elements()) {
-        if !candidate.points_are_right_of_line() {
-            continue;
+/// Manages state during corner erasure.
+///
+/// When erasing corners, we need to modify the path after each erasure, So
+/// that each operation incorporates the changes from previous operations.
+///
+/// To handle this, we use a `Cow` of path elements; in the general case (where
+/// there are no open corners) this is borrowed, but if we need to erase anything
+/// then we use [`Cow::to_mut`] to create a new copy, and modify it in place.
+struct CornerErasureCtx<'a> {
+    els: Cow<'a, [PathEl]>,
+}
+
+impl<'a> CornerErasureCtx<'a> {
+    fn new(path: &'a BezPath) -> Self {
+        CornerErasureCtx {
+            els: path.elements().into(),
         }
-        let Some(Intersection { t0, t1, .. }) = candidate.intersection() else {
-            continue;
-        };
+    }
+
+    fn is_closed(&self) -> bool {
+        matches!(self.els.last(), Some(PathEl::ClosePath))
+    }
+
+    /// the number of possible open corners; this is a function of the number
+    /// of path segments.
+    fn n_possible_candidates(&self) -> usize {
+        // if closed, there is no candidate for the close node or the node before
+        // (which ends at the start, which was already handled)
+        if self.els.last() == Some(&PathEl::ClosePath) {
+            self.els.len() - 2
+        } else {
+            // if open, the three last elements aren't candidates (because
+            // they do not have enough following elements)
+            self.els.len().saturating_sub(3)
+        }
+    }
+
+    /// loop through possible open corners, erasing any we find.
+    fn erase_corners(mut self) -> Option<BezPath> {
+        if self.els.len() < 4 {
+            // we need at least four elements (including moveto) to have an open corner
+            return None;
+        }
+        let mut made_changes = false;
+        let mut ix = 0;
+        // we don't use `for _ in 0..self.n_possible_candidates()` because
+        // if we erase a corner the number of candidates changes
+        while ix <= self.n_possible_candidates() {
+            if let Some((candidate, hit)) = self.open_corner_at(ix) {
+                self.erase_corner(candidate, hit);
+                made_changes = true;
+            }
+            ix += 1;
+        }
+
+        if !made_changes {
+            return None;
+        }
+
+        Some(BezPath::from_vec(self.els.into_owned()))
+    }
+
+    /// Check for an open corner for the three segments starting at element `i`.
+    ///
+    /// The last point of the element at index `i` is the start point of
+    /// the middle segment, which must be a line for this operation to make sense.
+    ///
+    /// (This is complicated because of 'moveto', which is an element but which
+    /// is redundant in a closed path, which should finish at the same point.)
+    fn open_corner_at(&self, i: usize) -> Option<(PossibleCorner, Intersection)> {
+        let candidate = self.candidate_at_i(i)?;
+        if !candidate.points_are_right_of_line() {
+            return None;
+        }
+        let intersection = candidate.intersection()?;
+        let Intersection { t0, t1, .. } = intersection;
         // invert value of t0 so for both values '0' means at the open corner
         // <https://github.com/googlefonts/glyphsLib/blob/74c63244fdbef1da5/Lib/glyphsLib/filters/eraseOpenCorners.py#L105>
         let t0_inv = 1.0 - t0;
@@ -56,128 +121,192 @@ pub fn erase_open_corners(path: &BezPath) -> Option<BezPath> {
             && t1 > 0.0001
             && t0_inv > 0.0001
         {
-            let ix = candidate.ix;
-            todo.extend([
-                (ix, SegmentOp::Replace(candidate.prev.subsegment(0.0..t0))),
-                (ix + 1, SegmentOp::Delete),
-                (
-                    ix + 2,
-                    SegmentOp::Replace(candidate.next.subsegment(t1..1.0)),
-                ),
-            ]);
+            return Some((candidate, intersection));
+        }
+        None
+    }
+
+    /// Erase an open corner, in place.
+    ///
+    /// Called from the erase_corners loop; modifications made here are reflected
+    /// in subsequent passes of that loop.
+    fn erase_corner(&mut self, candidate: PossibleCorner, intersection: Intersection) {
+        // for the 'prev' segment, the start point doesn't change
+        let new_prev = candidate.one.subsegment(0.0..intersection.t0);
+        let first_ix = candidate.first_el_idx;
+        self.overwrite_el(first_ix, new_prev);
+
+        let new_next = candidate.two.subsegment(intersection.t1..1.0);
+
+        let next_seg_el_ix = self.wrapping_el_idx(first_ix + 2);
+        // for the 'next' segment, the start point is the end point of 'prev', so we're good
+        self.overwrite_el(next_seg_el_ix, new_next);
+
+        // this is the open corner line, which we remove
+        let line_seg_el_ix = self.wrapping_el_idx(first_ix + 1);
+        self.els.to_mut().remove(line_seg_el_ix);
+
+        // finally always make sure that start/end line up in a closed curve:
+        if self.is_closed() {
+            let second_last = self.els.len() - 2;
+            let last_pt = self.els[second_last].end_point().unwrap();
+            *self.els.to_mut().get_mut(0).unwrap() = PathEl::MoveTo(last_pt);
         }
     }
-    if todo.is_empty() {
-        return None;
+
+    fn overwrite_el(&mut self, el_ix: usize, new_seg: PathSeg) {
+        match (new_seg, self.els.to_mut().get_mut(el_ix).unwrap()) {
+            (PathSeg::Line(new), PathEl::LineTo(end)) => {
+                *end = new.p1;
+            }
+            (PathSeg::Quad(new), PathEl::QuadTo(p1, p2)) => {
+                *p1 = new.p1;
+                *p2 = new.p2;
+            }
+            (PathSeg::Cubic(new), PathEl::CurveTo(p1, p2, p3)) => {
+                *p1 = new.p1;
+                *p2 = new.p2;
+                *p3 = new.p3;
+            }
+            // should not be reachable
+            _ => panic!("el/seg mismatch"),
+        }
     }
 
-    // it will be simpler to operate on segments:
-    let segments = kurbo::segments(path.elements().iter().copied()).collect::<Vec<_>>();
-    // and then we will make an equal number of ops as segments, also to simplify:
-    let mut ops = vec![SegmentOp::Retain; segments.len()];
-    for (ix, op) in todo {
-        // ix isn't always right because we didn't know the number of segments
-        // before, and we handle the first two points at the end
-        ops[ix % segments.len()] = op;
+    fn candidate_at_i(&self, i: usize) -> Option<PossibleCorner> {
+        // if we're a closed path, the second-last element (the element before 'close')
+        // brings us back to the start, which we've already handled.
+        // (in an open path there's no wrapping so this can also never be a candidate)
+        if i >= self.els.len().saturating_sub(2) {
+            return None;
+        }
+        // the index of the element containing the start point of the prevoius segment.
+        // this is two elements before element[i], not counting moveto/close
+        let prev_seg_start = match i {
+            // open path can't start with a corner
+            0 if !self.is_closed() => return None,
+            0 => self.els.len() - 3,
+            _ => i - 1,
+        };
+        // stash this to use later if we delete, so we don't need to duplicate
+        // this logic
+        let first_el_idx = self.wrapping_el_idx(prev_seg_start + 1);
+
+        let start = self.els.get(prev_seg_start).and_then(PathEl::end_point)?;
+        let one = self
+            .wrapping_get_el(prev_seg_start + 1)
+            .and_then(|el| make_seg(el, start))?;
+        if let PathEl::LineTo(line_to) = self.wrapping_get_el(prev_seg_start + 2)? {
+            let two = self
+                .wrapping_get_el(prev_seg_start + 3)
+                .and_then(|el| make_seg(el, line_to))?;
+            return Some(PossibleCorner {
+                one,
+                two,
+                first_el_idx,
+            });
+        }
+        None
     }
 
-    let segs = segments
-        .iter()
-        .zip(ops)
-        .filter_map(|(seg, op)| op.apply(*seg))
-        .collect::<Vec<_>>();
-
-    let mut els = Vec::with_capacity(path.elements().len());
-
-    // now handle the move_to; for a closed path this is the last point,
-    // for an open path it was the start point of the first segment (which is
-    // ignored when converting segment->element)
-    let first_pt = if is_closed {
-        // unwrap is fine, we must have at least two segments if we had an open corner
-        segs.last().unwrap().end()
-    } else {
-        segs.first().unwrap().start()
-    };
-
-    els.push(PathEl::MoveTo(first_pt));
-    els.extend(segs.iter().map(PathSeg::as_path_el));
-    if is_closed {
-        els.push(PathEl::ClosePath);
+    fn wrapping_get_el(&self, i: usize) -> Option<PathEl> {
+        self.els.get(self.wrapping_el_idx(i)).copied()
     }
-    Some(BezPath::from_vec(els))
-}
 
-#[derive(Clone, Debug)]
-enum SegmentOp {
-    Retain,
-    Delete,
-    Replace(PathSeg),
-}
+    /// Determine the correct element index for a 'naive' index, wrapping if necessary.
+    ///
+    /// Specifically, if the path is closed and `i` is >= the last index, wrap
+    /// around, skipping the `Close` and `MoveTo` elements.
+    fn wrapping_el_idx(&self, i: usize) -> usize {
+        // open path means no wrapping, just return an element
+        if !self.is_closed() {
+            return i;
+        }
 
-impl SegmentOp {
-    fn apply(self, seg: PathSeg) -> Option<PathSeg> {
-        match self {
-            SegmentOp::Retain => Some(seg),
-            SegmentOp::Delete => None,
-            SegmentOp::Replace(seg) => Some(seg),
+        if i == 0 {
+            // we don't care about the moveto in a closed path, since it is
+            // always the same point as the end of the last element, so we return that
+            return self.els.len().saturating_sub(2);
+        }
+
+        // otherwise, wrapping.
+        // when we wrap, we need to skip the first el (moveto) and the last (close)
+        if i >= self.els.len() - 1 {
+            // modulo length - 1 (for the close element) + 1 to skip move
+            i % (self.els.len() - 1) + 1
+        } else {
+            i
         }
     }
 }
 
-/// A potentially open corner.
+/// Two segments that are connected by a line.
 ///
-/// This is any line segment, along with the preceding and following path segments.
-struct ErasureCandidate {
-    // index of the *first* participating segment, i.e 'prev'.
-    ix: usize,
-    seg: Line,
-    prev: PathSeg,
-    next: PathSeg,
+/// The line is not encoded explicitly, as it always starts at the last point
+/// of `one` and ends at the first point of `two`.
+#[derive(Clone, Debug)]
+struct PossibleCorner {
+    /// The actual index of the element describing `one`.
+    ///
+    /// This is the first element we need to modify in closing a corner; we
+    /// can compute the other elements from it.
+    first_el_idx: usize,
+    /// The segment leading into the corner.
+    one: PathSeg,
+    /// The segment leading out of the corner.
+    two: PathSeg,
 }
 
-impl ErasureCandidate {
-    // Are the incoming point from the previous segment and the outgoing point
-    // from the next segment both on the right side of the line?
-    // (see discussion at https://github.com/googlefonts/glyphsLib/pull/663)
-    // https://github.com/googlefonts/glyphsLib/blob/74c63244fdb/Lib/glyphsLib/filters/eraseOpenCorners.py#L66-L71
-    fn points_are_right_of_line(&self) -> bool {
-        // return the last point in this segment not shared with the next segment
-        // (i.e., ignoring the final point)
-        fn last_non_shared_point(seg: PathSeg) -> Point {
-            match seg {
-                PathSeg::Line(line) => line.p0,
-                PathSeg::Quad(quad_bez) => quad_bez.p1,
-                PathSeg::Cubic(cubic_bez) => cubic_bez.p2,
-            }
+impl PossibleCorner {
+    /// Return the point (on-or-off-curve) immediately before the start of the line
+    fn point_before_line(&self) -> Point {
+        match self.one {
+            PathSeg::Line(line) => line.p0,
+            PathSeg::Quad(quad) => quad.p1,
+            PathSeg::Cubic(cube) => cube.p2,
         }
-
-        // return the first point in this segment not shared with the previous
-        // segment (i.e, ignoring the first point)
-        fn first_non_shared_point(seg: PathSeg) -> Point {
-            match seg {
-                PathSeg::Line(line) => line.p1,
-                PathSeg::Quad(quad_bez) => quad_bez.p1,
-                PathSeg::Cubic(cubic_bez) => cubic_bez.p1,
-            }
-        }
-        let prev_point = last_non_shared_point(self.prev);
-        let next_point = first_non_shared_point(self.next);
-        !(point_is_left_of_line(self.seg, prev_point)
-            || point_is_left_of_line(self.seg, next_point))
     }
 
-    /// The intersection of the two path segments
+    /// Return the point (on-or-off-curve) immediately following the line
+    fn point_after_line(&self) -> Point {
+        match self.two {
+            PathSeg::Line(line) => line.p1,
+            PathSeg::Quad(quad) => quad.p1,
+            PathSeg::Cubic(cube) => cube.p1,
+        }
+    }
+
+    // the line part of the corner; this is what will be erased
+    fn line(&self) -> Line {
+        Line::new(self.one.end(), self.two.start())
+    }
+
+    /// Are the incoming point from the previous segment and the outgoing point
+    /// from the next segment both on the right side of the line?
+    ///
+    /// (see discussion at <https://github.com/googlefonts/glyphsLib/pull/663>)
+    /// <https://github.com/googlefonts/glyphsLib/blob/74c63244fdb/Lib/glyphsLib/filters/eraseOpenCorners.py#L66-L71>
+    fn points_are_right_of_line(&self) -> bool {
+        let prev_point = self.point_before_line();
+        let next_point = self.point_after_line();
+        let line = self.line();
+
+        !(point_is_left_of_line(line, prev_point) || point_is_left_of_line(line, next_point))
+    }
+
+    /// Find the intersection of the two segments, if one exists.
     ///
     /// If this is an open corner, the intersection point will be the new corner.
     fn intersection(&self) -> Option<Intersection> {
-        let candidate = seg_seg_intersection(self.prev, self.next)?;
+        let candidate = seg_seg_intersection(self.one, self.two)?;
+
         // there is a bug in kurbo that can cause it to report spurious intersections
         // (see https://github.com/linebender/kurbo/issues/411).
         // as a temporary workaround here we check that the point of intersection
         // on each segment are relatively close to one another, and discard
         // if not.
-        let p1 = self.prev.eval(candidate.t0);
-        let p2 = self.next.eval(candidate.t1);
+        let p1 = self.one.eval(candidate.t0);
+        let p2 = self.two.eval(candidate.t1);
         let dist = p1.distance(p2);
         // the value of 0.2 was chosen experimentally (it lets our tests pass,
         // but doesn't seem to hurt any fonts in crater)
@@ -189,6 +318,15 @@ impl ErasureCandidate {
     }
 }
 
+fn make_seg(element: PathEl, p0: Point) -> Option<PathSeg> {
+    match element {
+        PathEl::LineTo(p1) => Some(Line::new(p0, p1).into()),
+        PathEl::QuadTo(p1, p2) => Some(QuadBez::new(p0, p1, p2).into()),
+        PathEl::CurveTo(p1, p2, p3) => Some(CubicBez::new(p0, p1, p2, p3).into()),
+        _ => None,
+    }
+}
+
 //https://github.com/googlefonts/glyphsLib/blob/74c63244fdbe/Lib/glyphsLib/filters/eraseOpenCorners.py#L14
 // 'left' from the perspective of an observer standing on line.p0 and lookign at line.p1?
 fn point_is_left_of_line(line: Line, point: Point) -> bool {
@@ -196,66 +334,12 @@ fn point_is_left_of_line(line: Line, point: Point) -> bool {
     (b.x - a.x) * (point.y - a.y) - (b.y - a.y) * (point.x - a.x) >= 0.0
 }
 
-/// given a slice of path elements, determine which *segments* might be open corners.
-fn iter_erasure_candidates(els: &[PathEl]) -> impl Iterator<Item = ErasureCandidate> + use<'_> {
-    iter_segment_triplets(els)
-        .enumerate()
-        .filter_map(|(ix, (prev, seg, next))| {
-            if let PathSeg::Line(seg) = seg {
-                Some(ErasureCandidate {
-                    ix,
-                    seg,
-                    prev,
-                    next,
-                })
-            } else {
-                None
-            }
-        })
-}
-
-/// Iterate over all the length-three windows of segments.
-///
-/// This will loop once, so that the last segment begins the last window, e.g.
-///
-/// For the segments `s0, s1, s2, s3` this will produce
-/// `(s0, s1, s2), (s1, s2, s3), (s2, s3, s0), and (s3, s0, s1)`
-fn iter_segment_triplets(
-    els: &[PathEl],
-) -> impl Iterator<Item = (PathSeg, PathSeg, PathSeg)> + use<'_> {
-    const EMPTY_SEG: PathSeg = PathSeg::Line(Line {
-        p0: Point::ZERO,
-        p1: Point::ZERO,
-    });
-
-    let is_closed = matches!(els.last(), Some(PathEl::ClosePath));
-
-    // if the path is closed, we want to loop around to consider the first two segments
-    // following the last.
-    let n_loop_around = if is_closed { 2 } else { 0 };
-    let mut iter = kurbo::segments(els.iter().copied())
-        .chain(kurbo::segments(els.iter().copied()).take(n_loop_around))
-        .peekable();
-
-    // if this is none we will end iteration on the first call to `next` anyway,
-    // and the code is simpler without this being an option
-    let mut prev = iter.next().unwrap_or(EMPTY_SEG);
-    std::iter::from_fn(move || {
-        let seg = iter.next()?;
-        let next = iter.peek()?;
-        let result = (prev, seg, *next);
-        prev = seg;
-        Some(result)
-    })
-}
-
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 struct Intersection {
     // location of hit on first segment, in range 0..=1
     t0: f64,
     // location on second segment
     t1: f64,
-    point: Point,
 }
 
 /// Find an intersection of two segments, if any exist
@@ -271,7 +355,6 @@ fn seg_seg_intersection(seg1: PathSeg, seg2: PathSeg) -> Option<Intersection> {
             .map(|hit| Intersection {
                 t0: hit.line_t,
                 t1: hit.segment_t,
-                point: line.eval(hit.line_t),
             }),
         (seg, PathSeg::Line(line)) => seg
             .intersect_line(line)
@@ -280,7 +363,6 @@ fn seg_seg_intersection(seg1: PathSeg, seg2: PathSeg) -> Option<Intersection> {
             .map(|hit| Intersection {
                 t0: hit.segment_t,
                 t1: hit.line_t,
-                point: line.eval(hit.line_t),
             }),
         (bez0, bez1) => curve_curve_intersection_py(bez0, bez1),
     }
@@ -297,11 +379,7 @@ fn curve_curve_intersection_py(seg1: PathSeg, seg2: PathSeg) -> Option<Intersect
     curve_curve_py_impl(seg1, seg2, &(0.0..1.0), &(0.0..1.0), &mut result);
     result.sort_by_key(|hit| (OrderedFloat(hit.t0), OrderedFloat(hit.t1)));
     result.dedup_by_key(|hit| ((hit.t0 / PY_ACCURACY) as i64, (hit.t1 / PY_ACCURACY) as i64));
-    result.first().cloned().map(|mut hit| {
-        // set the point now, by eval'ing the whole input segment.
-        hit.point = seg1.eval(hit.t0);
-        hit
-    })
+    result.first().copied()
 }
 
 fn curve_curve_py_impl(
@@ -325,9 +403,6 @@ fn curve_curve_py_impl(
         buf.push(Intersection {
             t0: midpoint(range1),
             t1: midpoint(range2),
-            // we use a dummy point now, we will set the correct point at base
-            // when we have the original segment
-            point: Point::ZERO,
         });
         return;
     }
@@ -348,7 +423,7 @@ fn curve_curve_py_impl(
 #[cfg(test)]
 mod tests {
 
-    use kurbo::CubicBez;
+    use write_fonts::OtRound;
 
     use super::*;
 
@@ -455,6 +530,81 @@ mod tests {
         ($left:expr, $right:expr) => {
             assert!(($left - $right).abs() < 1e-4, "{} !~= {}", $left, $right)
         };
+    }
+
+    #[test]
+    fn ctx_test_open() {
+        let mut path = kurbo::BezPath::new();
+        path.move_to((10., 10.));
+        path.line_to((20., 20.));
+        path.line_to((30., 30.));
+        path.line_to((40., 40.));
+        let ctx = CornerErasureCtx::new(&path);
+        assert!(ctx.candidate_at_i(0).is_none());
+        let first = ctx.candidate_at_i(1).unwrap();
+        assert_eq!(first.one, Line::new((10., 10.), (20., 20.)).into());
+        assert_eq!(first.two, Line::new((30., 30.), (40., 40.,)).into());
+        // not a closed path so we don't wrap around; only a single segment exists
+        assert!(ctx.candidate_at_i(2).is_none());
+    }
+
+    #[test]
+    fn ctx_test_closed() {
+        let mut path = kurbo::BezPath::new();
+        path.move_to((10., 10.));
+        path.line_to((20., 20.));
+        path.line_to((30., 30.));
+        path.quad_to((50., 50.), (100., 100.));
+        path.line_to((10., 10.));
+        path.close_path();
+
+        let ctx = CornerErasureCtx::new(&path);
+        assert_eq!(
+            ctx.wrapping_get_el(1).unwrap(),
+            PathEl::LineTo((20., 20.).into())
+        );
+        assert_eq!(
+            ctx.wrapping_get_el(2).unwrap(),
+            PathEl::LineTo((30., 30.).into())
+        );
+        assert_eq!(
+            ctx.wrapping_get_el(3).unwrap(),
+            PathEl::QuadTo((50., 50.).into(), (100., 100.).into())
+        );
+
+        assert_eq!(
+            ctx.wrapping_get_el(4).unwrap(),
+            PathEl::LineTo((10., 10.).into())
+        );
+
+        assert_eq!(
+            ctx.wrapping_get_el(5).unwrap(),
+            PathEl::LineTo((20., 20.).into())
+        );
+        assert_eq!(
+            ctx.wrapping_get_el(6).unwrap(),
+            PathEl::LineTo((30., 30.).into())
+        );
+
+        let candi = ctx.candidate_at_i(0).unwrap();
+        assert_eq!(candi.line(), Line::new((10., 10.), (20., 20.)));
+        assert_eq!(candi.one.start(), (100., 100.).into());
+        assert_eq!(candi.two.end(), (30., 30.).into());
+
+        let candi = ctx.candidate_at_i(1).unwrap();
+        assert_eq!(candi.line(), Line::new((20., 20.), (30., 30.)));
+        assert_eq!(candi.one.start(), (10., 10.).into());
+        assert_eq!(candi.two.end(), (100., 100.).into());
+
+        // no candidate, the middle seg is a quad not a line
+        assert!(ctx.candidate_at_i(2).is_none());
+
+        let candi = ctx.candidate_at_i(3).unwrap();
+        assert_eq!(candi.line(), Line::new((100., 100.), (10., 10.)));
+        assert_eq!(candi.one.start(), (30., 30.).into());
+        assert_eq!(candi.two.end(), (20., 20.).into());
+
+        assert!(ctx.candidate_at_i(4).is_none());
     }
 
     #[test]
@@ -571,18 +721,59 @@ mod tests {
     // https://github.com/linebender/kurbo/issues/411
     #[test]
     fn kurbo_411() {
-        let candidate = ErasureCandidate {
-            ix: 0,
-            seg: Line::new((385.0, 146.0), (438.0, 243.0)),
-            prev: CubicBez::new(
+        let candidate = PossibleCorner {
+            first_el_idx: 0,
+            one: CubicBez::new(
                 (452.0, 240.0),
                 (462.667, 78.667),
                 (480.667, -146.333),
                 (506.0, -435.0),
             )
             .into(),
-            next: Line::new((385.0, 146.0), (438.0, 243.0)).into(),
+            two: Line::new((385.0, 146.0), (438., 243.)).into(),
         };
         assert!(candidate.intersection().is_none());
+    }
+
+    /// a closed triangle with an open corner at each vertex
+    #[test]
+    fn joan_four_sc_ss10() {
+        let mut path = BezPath::new();
+        path.move_to((332.0, 155.0));
+        path.line_to((317.0, 184.0));
+        path.line_to((509.0, 184.0)); // real line
+        path.line_to((493.0, 168.0));
+        path.line_to((493.0, 412.0)); // real line
+        path.line_to((514.0, 405.0));
+        path.line_to((332.0, 155.0)); // real line
+        path.close_path();
+
+        let after = erase_open_corners(&path).unwrap();
+        let pts = after
+            .segments()
+            .map(|seg| seg.start().ot_round())
+            .collect::<Vec<_>>();
+
+        assert_eq!(pts, [(353, 184), (493, 184), (493, 376)]);
+    }
+
+    #[test]
+    fn closed_curved_triangle() {
+        let mut path = BezPath::new();
+        path.move_to((332.0, 155.0));
+        path.line_to((317.0, 184.0));
+        path.curve_to((317., 202.), (509., 206.), (509.0, 184.0)); // real line
+        path.line_to((493.0, 168.0));
+        path.curve_to((470., 168.), (501., 402.), (493.0, 412.0)); // real line
+        path.line_to((514.0, 405.0));
+        path.curve_to((505., 405.), (332., 238.), (332.0, 155.0)); // real line
+        path.close_path();
+        let after = erase_open_corners(&path).unwrap();
+        let pts = after
+            .segments()
+            .map(|seg| seg.start().ot_round())
+            .collect::<Vec<_>>();
+
+        assert_eq!(pts, [(341, 194), (485, 195), (494, 389)]);
     }
 }

--- a/glyphs2fontir/src/toir.rs
+++ b/glyphs2fontir/src/toir.rs
@@ -110,6 +110,7 @@ fn to_ir_path(glyph_name: GlyphName, src_path: &Path) -> Result<BezPath, PathCon
     };
 
     let path = path_builder.build()?;
+
     let path = match crate::erase_open_corners::erase_open_corners(&path) {
         Some(changes) => {
             log::debug!("erased open contours for {glyph_name}");


### PR DESCRIPTION
My initial implementation of corner erasure had a significant problem: in an attempt to be clever I was not erasing corners as they were found, but instead collecting 'deletion operations' that could be applied all at once at the end.

The problem with this, in hindsight, is obvious: In a closed path, it is possible for a single segment to have an open corner at both ends, and correctly handling this requires applying the deletion of the first corner before trying to calculate the position of the second.

This new approach solves this by modifying the path in place, as corners are found. To do this efficiently it uses a copy-on-write type so that we only ever allocate if we actually are going to erase a corner, which is not the common case.

Doing it this was makes the logic tricky, because of how `BezPath` and `PathEl` work. In particular, the presence of `ClosePath` elements (which are significant in postscript but are essentially metadata for our purposes) makes indexing tricky; similarly in a closed path the first `MoveTo` element is redundant, and we need to account for that as well.

In hindsight, if I were tasked with writing this again tomorrow, I would probably not do it this way; instead I would try work with `PathSeg`s, which are easier to reason about, and I would just figure out some way of writing it so that we still only allocated as needed.