### PR TITLE
[ttx_diff] Mark adjusted points as 'diff_adjusted'

### DIFF
--- a/resources/scripts/ttx_diff.py
+++ b/resources/scripts/ttx_diff.py
@@ -425,8 +425,8 @@ def allow_some_off_by_ones(fontc, fontmake, container, name_attr, coord_holder):
                     float(fontmake_el.attrib[attr]) - float(fontc_el.attrib[attr])
                 )
                 if 0.0 < delta_x <= 1.0:
-                    fontc_el.attrib["adjusted"] = "1"
-                    fontmake_el.attrib["adjusted"] = "1"
+                    fontc_el.attrib["diff_adjusted"] = "1"
+                    fontmake_el.attrib["diff_adjusted"] = "1"
                     fontc_el.attrib[attr] = fontmake_el.attrib[attr]
                     spent += 1
                 if spent >= off_by_one_budget:


### PR DESCRIPTION
Previously it was just 'adjusted', which is general enough that it was unclear to me when I saw it in diffs that it had originated in the ttx_diff script, and not in the original ttx output.

This name will hopefully make it more clear that this is a diff-specific thing.

JMM