### PR TITLE
[glyphs] Don't rotate nodes if all are off-curve

### DIFF
--- a/fontir/src/ir/path_builder.rs
+++ b/fontir/src/ir/path_builder.rs
@@ -188,7 +188,7 @@ impl GlyphPathBuilder {
     /// It's called automatically by `build()` thus can be
     /// omitted when building one BezPath per contour, but can be called manually in
     /// order to build multiple contours into a single BezPath.
-    pub fn end_path(&mut self) -> Result<(), PathConversionError> {
+    fn end_path(&mut self) -> Result<(), PathConversionError> {
         // a contour that does *not* start with a move is assumed to be closed
         // https://unifiedfontobject.org/versions/ufo3/glyphs/glif/#point-types
         if !self.first_oncurve.is_some_and(|on| on.is_move()) {

--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -888,6 +888,12 @@ pub struct Node {
     pub node_type: NodeType,
 }
 
+impl Node {
+    pub fn is_on_curve(&self) -> bool {
+        !matches!(self.node_type, NodeType::OffCurve)
+    }
+}
+
 impl PartialEq for Node {
     fn eq(&self, other: &Self) -> bool {
         Into::<PointForEqAndHash>::into(self.pt) == other.pt.into()


### PR DESCRIPTION
Although it isn't supported in the editor, the glyphs source format supports curves with only on-curves, using the truetype 'implied oncurve points' model.

When dealing with a contour of this type, we should skip rotating the nodes when generating the path, because the first point of these contours is already correct (being the off-curve point of the first segment).


- fixes #1207 