### PR TITLE
Implement gasp for .glyphs

### DIFF
--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -637,7 +637,7 @@ mod tests {
     }
 
     #[test]
-    fn compile_obeys_gasp_records() {
+    fn compile_obeys_designspace_gasp_records() {
         let result = TestCompile::compile_source("fontinfo.designspace");
         let gasp = result.font().gasp().unwrap();
         assert_eq!(
@@ -645,6 +645,37 @@ mod tests {
                 (
                     7,
                     GaspRangeBehavior::GASP_DOGRAY | GaspRangeBehavior::GASP_SYMMETRIC_SMOOTHING
+                ),
+                (
+                    65535,
+                    GaspRangeBehavior::GASP_GRIDFIT
+                        | GaspRangeBehavior::GASP_DOGRAY
+                        | GaspRangeBehavior::GASP_SYMMETRIC_GRIDFIT
+                        | GaspRangeBehavior::GASP_SYMMETRIC_SMOOTHING
+                ),
+            ],
+            gasp.gasp_ranges()
+                .iter()
+                .map(|r| (r.range_max_ppem(), r.range_gasp_behavior()))
+                .collect::<Vec<_>>(),
+        )
+    }
+
+    #[test]
+    fn compile_obeys_glyphs_gasp_records() {
+        let result = TestCompile::compile_source("glyphs3/WghtVarGasp.glyphs");
+        let gasp = result.font().gasp().unwrap();
+        assert_eq!(
+            vec![
+                (
+                    8,
+                    GaspRangeBehavior::GASP_DOGRAY | GaspRangeBehavior::GASP_SYMMETRIC_SMOOTHING
+                ),
+                (
+                    20,
+                    GaspRangeBehavior::GASP_GRIDFIT
+                        | GaspRangeBehavior::GASP_DOGRAY
+                        | GaspRangeBehavior::GASP_SYMMETRIC_GRIDFIT,
                 ),
                 (
                     65535,

--- a/resources/testdata/glyphs3/WghtVarGasp.glyphs
+++ b/resources/testdata/glyphs3/WghtVarGasp.glyphs
@@ -1,0 +1,37 @@
+{
+.formatVersion = 3;
+customParameters = (
+{
+name = "gasp Table";
+value = {
+"20" = 7;
+"65535" = 15;
+"8" = 10;
+"65536" = 1;
+};
+},
+);
+familyName = WghtVar;
+fontMaster = (
+{
+id = m01;
+name = Regular;
+}
+);
+glyphs = (
+{
+glyphname = space;
+layers = (
+{
+layerId = m01;
+width = 200;
+}
+);
+unicode = 32;
+}
+);
+
+unitsPerEm = 1234;
+versionMajor = 42;
+versionMinor = 42;
+}


### PR DESCRIPTION
Makes `python resources/scripts/ttx_diff.py 'https://github.com/tokotype/PlusJakartaSans#sources/PlusJakartaSans-Italic.glyphs' --rebuild fontc` report the `gasp` table identical

JMM if happy