### PR TITLE
Work around icu4x issue with unicode 16 scriptext

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ env_logger = "0.11.0"
 parking_lot = "0.12.1"
 clap = { version = "4.0.32", features = ["derive"] }
 rayon = "1.6"
-icu_properties = "1.4"
+icu_properties = "2.0.0-beta1"
 
 # fontations etc
 write-fonts = { version = "0.33.1", features = ["serde", "read"] }

--- a/fontbe/src/features/kern.rs
+++ b/fontbe/src/features/kern.rs
@@ -23,7 +23,7 @@ use fontir::{
     ir::{self, Glyph, KernGroup, KerningGroups, KerningInstance},
     orchestration::WorkId as FeWorkId,
 };
-use icu_properties::BidiClass;
+use icu_properties::props::BidiClass;
 use log::debug;
 use ordered_float::OrderedFloat;
 use write_fonts::{

--- a/glyphs-reader/src/glyphdata.rs
+++ b/glyphs-reader/src/glyphdata.rs
@@ -15,7 +15,7 @@ use std::{
     str::FromStr,
 };
 
-use icu_properties::GeneralCategory;
+use icu_properties::props::GeneralCategory;
 
 use smol_str::SmolStr;
 
@@ -583,7 +583,7 @@ impl GlyphData {
 
 // https://github.com/googlefonts/glyphsLib/blob/e2ebf5b517d/Lib/glyphsLib/glyphdata.py#L261
 fn category_from_icu(c: char) -> (Category, Option<Subcategory>) {
-    match icu_properties::maps::general_category().get(c) {
+    match icu_properties::CodePointMapData::<GeneralCategory>::new().get(c) {
         GeneralCategory::Unassigned | GeneralCategory::OtherSymbol => (Category::Symbol, None),
         GeneralCategory::UppercaseLetter
         | GeneralCategory::LowercaseLetter


### PR DESCRIPTION
This also bumps us to use the new icu4x 2.0 beta.

icu4x is not currently returning the correct script values for codepoints that were added to ScriptExtensions.txt in Unicode 16, so we have a temporary workaround that manually checks for those specific values before calling out to icu4x.


Note: this will cause a a big crater drop until we merge and bring in https://github.com/fonttools/fonttools/pull/3756.