### PR TITLE
Only write explicit tuple mins/maxes if there is an intermediate tent

### DIFF
--- a/fontbe/src/orchestration.rs
+++ b/fontbe/src/orchestration.rs
@@ -411,11 +411,11 @@ impl GvarFragment {
                         (min, max) != (peak.min(F2Dot14::ZERO), peak.max(F2Dot14::ZERO));
                 }
 
-                return Some(GlyphDeltas::new(
+                Some(GlyphDeltas::new(
                     Tuple::new(peaks),
                     deltas.clone(),
                     needs_intermediate.then(|| (Tuple::new(mins), Tuple::new(maxes))),
-                ));
+                ))
             })
             .collect()
     }

--- a/fontbe/src/orchestration.rs
+++ b/fontbe/src/orchestration.rs
@@ -405,7 +405,8 @@ impl GvarFragment {
                     peaks.push(peak);
                     maxes.push(max);
 
-                    // NOTE: Comparison must occur after type conversion.
+                    // NOTE: Comparison must occur after truncation, as f64s
+                    // that are not equal may result in F2Dot14s that are.
                     needs_intermediate |=
                         (min, max) != (peak.min(F2Dot14::ZERO), peak.max(F2Dot14::ZERO));
                 }

--- a/fontbe/src/orchestration.rs
+++ b/fontbe/src/orchestration.rs
@@ -30,7 +30,6 @@ use fontir::{
     },
     variations::VariationRegion,
 };
-use log::trace;
 
 use ordered_float::OrderedFloat;
 use serde::{Deserialize, Serialize};

--- a/fontbe/src/orchestration.rs
+++ b/fontbe/src/orchestration.rs
@@ -407,7 +407,7 @@ impl GvarFragment {
 
                     // NOTE: Comparison must occur after type conversion.
                     needs_intermediate |=
-                        (min, max) != (peak.min(Default::default()), peak.max(Default::default()));
+                        (min, max) != (peak.min(F2Dot14::ZERO), peak.max(F2Dot14::ZERO));
                 }
 
                 return Some(GlyphDeltas::new(


### PR DESCRIPTION
This is a lossless optimisation that is also implemented in fontTools, and reduced `gvar` table size by ~50% when testing locally on a large variable font.

I inlined `TupleBuilder` as there was a precise ordering needed for converting the types, comparing values, and making the output conditional that was tricky to represent in the existing abstraction without lots of zipping and unzipping.

I tried a few functional patterns but couldn't find anything elegant without wider changes to types owing to the previous ordering, so thought it would be better to leave it inline and imperative and reach out for feedback first before doing anything more opinionated 😄

Before merging, this new logic would benefit greatly from unit test coverage too.