### PR TITLE
Normalize Ligature Caret List

### DIFF
--- a/otl-normalizer/src/args.rs
+++ b/otl-normalizer/src/args.rs
@@ -7,8 +7,8 @@ pub struct Args {
     /// Optional destination path for writing output. Default is stdout.
     pub out: Option<PathBuf>,
     /// Target table to print, one of gpos/gsub/all (case insensitive)
-    #[arg(short, long)]
-    pub table: Option<Table>,
+    #[arg(short, long, default_value_t)]
+    pub table: Table,
     /// Index of font to examine, if target is a font collection
     #[arg(short, long)]
     pub index: Option<u32>,
@@ -21,16 +21,29 @@ pub enum Table {
     All,
     Gpos,
     Gsub,
+    Gdef,
+}
+
+impl std::fmt::Display for Table {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Table::All => f.write_str("all"),
+            Table::Gpos => f.write_str("gpos"),
+            Table::Gsub => f.write_str("gsub"),
+            Table::Gdef => f.write_str("gdef"),
+        }
+    }
 }
 
 impl FromStr for Table {
     type Err = &'static str;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        static ERR_MSG: &str = "expected one of 'gsub', 'gpos', 'all'";
+        static ERR_MSG: &str = "expected one of 'gsub', 'gpos', 'gdef', 'all'";
         match s.to_ascii_lowercase().trim() {
             "gpos" => Ok(Self::Gpos),
             "gsub" => Ok(Self::Gsub),
+            "gdef" => Ok(Self::Gdef),
             "all" => Ok(Self::All),
             _ => Err(ERR_MSG),
         }

--- a/otl-normalizer/src/error.rs
+++ b/otl-normalizer/src/error.rs
@@ -17,7 +17,7 @@ pub enum Error {
     #[error("write error: '{0}'")]
     Write(#[from] std::io::Error),
     #[error("could not read font data: '{0}")]
-    FontRead(ReadError),
+    FontRead(#[from] ReadError),
     #[error("missing table '{0}'")]
     MissingTable(Tag),
 }

--- a/otl-normalizer/src/gdef.rs
+++ b/otl-normalizer/src/gdef.rs
@@ -1,0 +1,104 @@
+//! Normalizing the ligature caret table
+
+use std::{fmt::Display, io};
+
+use fontdrasil::types::GlyphName;
+use write_fonts::read::{
+    tables::gdef::{CaretValue, Gdef, LigGlyph},
+    ReadError,
+};
+
+use crate::{common::DeviceOrDeltas, variations::DeltaComputer, Error, NameMap};
+
+/// Print normalized GDEF ligature carets
+pub fn print(f: &mut dyn io::Write, table: &Gdef, names: &NameMap) -> Result<(), Error> {
+    let var_store = table
+        .item_var_store()
+        .map(|ivs| ivs.and_then(DeltaComputer::new))
+        .transpose()
+        .unwrap();
+
+    // so this is relatively simple; we're just looking at the ligature caret list.
+    // - realistically, we only care if this has variations? but I think it's simpler
+    // if we just always normalize, variations or no.
+
+    let Some(lig_carets) = table.lig_caret_list().transpose().unwrap() else {
+        return Ok(());
+    };
+
+    let coverage = lig_carets.coverage()?;
+    for (gid, lig_glyph) in coverage.iter().zip(lig_carets.lig_glyphs().iter()) {
+        let lig_glyph = lig_glyph?;
+        let name = names.get(gid);
+        print_lig_carets(f, name, lig_glyph, var_store.as_ref())?;
+    }
+
+    Ok(())
+}
+
+enum ResolvedCaret {
+    Coordinate {
+        pos: i16,
+        device_or_deltas: Option<DeviceOrDeltas>,
+    },
+    // basically never used?
+    ContourPoint {
+        idx: u16,
+    },
+}
+
+impl ResolvedCaret {
+    fn new(raw: CaretValue, computer: Option<&DeltaComputer>) -> Result<Self, ReadError> {
+        match raw {
+            CaretValue::Format1(table_ref) => Ok(Self::Coordinate {
+                pos: table_ref.coordinate(),
+                device_or_deltas: None,
+            }),
+            CaretValue::Format2(table_ref) => Ok(Self::ContourPoint {
+                idx: table_ref.caret_value_point_index(),
+            }),
+            CaretValue::Format3(table_ref) => {
+                let pos = table_ref.coordinate();
+                let device = table_ref.device()?;
+                let device_or_deltas = DeviceOrDeltas::new(pos, device, computer)?;
+                Ok(Self::Coordinate {
+                    pos,
+                    device_or_deltas: Some(device_or_deltas),
+                })
+            }
+        }
+    }
+}
+
+fn print_lig_carets(
+    f: &mut dyn io::Write,
+    gname: &GlyphName,
+    lig_glyph: LigGlyph,
+    computer: Option<&DeltaComputer>,
+) -> Result<(), Error> {
+    writeln!(f, "{gname}")?;
+    for (i, caret) in lig_glyph.caret_values().iter().enumerate() {
+        let resolved = caret.and_then(|caret| ResolvedCaret::new(caret, computer))?;
+        writeln!(f, "  {i}: {resolved}")?;
+    }
+
+    Ok(())
+}
+
+impl Display for ResolvedCaret {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ResolvedCaret::Coordinate {
+                pos,
+                device_or_deltas,
+            } => {
+                write!(f, "coord {pos}")?;
+                if let Some(device_or_deltas) = device_or_deltas {
+                    write!(f, "{device_or_deltas}")?;
+                }
+            }
+            ResolvedCaret::ContourPoint { idx } => write!(f, "idx {idx}")?,
+        }
+        Ok(())
+    }
+}

--- a/otl-normalizer/src/lib.rs
+++ b/otl-normalizer/src/lib.rs
@@ -5,6 +5,7 @@
 pub mod args;
 mod common;
 mod error;
+mod gdef;
 mod glyph_names;
 mod gpos;
 mod gsub;
@@ -12,5 +13,7 @@ mod variations;
 
 pub use error::Error;
 pub use glyph_names::NameMap;
+
+pub use gdef::print as print_gdef;
 pub use gpos::print as print_gpos;
 pub use gsub::print as print_gsub;

--- a/otl-normalizer/src/main.rs
+++ b/otl-normalizer/src/main.rs
@@ -16,6 +16,12 @@ fn main() -> Result<(), Error> {
         inner,
     })?;
 
+    let font = get_font(&data, args.index)?;
+    // exit early if there's no work, so we don't bother creating an empty file
+    if !is_there_something_to_do(&font, &args) {
+        return Ok(());
+    }
+
     let mut write_target: Box<dyn Write> = match args.out.as_ref() {
         Some(path) => File::create(path)
             .map_err(|inner| Error::FileWrite {
@@ -26,10 +32,17 @@ fn main() -> Result<(), Error> {
         None => Box::new(std::io::stdout()),
     };
 
-    let font = get_font(&data, args.index)?;
     let name_map = NameMap::from_font(&font)?;
-    let to_print = args.table.unwrap_or_default();
+    let to_print = args.table;
     let gdef = font.gdef().ok();
+
+    if matches!(to_print, args::Table::All | args::Table::Gdef) {
+        if let Some(gdef) = gdef.as_ref().filter(|gdef| gdef.lig_caret_list().is_some()) {
+            writeln!(&mut write_target, "# GDEF #")?;
+            otl_normalizer::print_gdef(&mut write_target, gdef, &name_map)?;
+        }
+    }
+
     if matches!(to_print, args::Table::All | args::Table::Gpos) {
         if let Ok(gpos) = font.gpos() {
             writeln!(&mut write_target, "# GPOS #")?;
@@ -55,5 +68,18 @@ fn get_font(bytes: &[u8], idx: Option<u32>) -> Result<FontRef, Error> {
         (FileRef::Font(font), 0) => Ok(font),
         (FileRef::Font(_), other) => Err(Error::FontRead(ReadError::InvalidCollectionIndex(other))),
         (FileRef::Collection(collection), idx) => collection.get(idx).map_err(Error::FontRead),
+    }
+}
+
+fn is_there_something_to_do(font: &FontRef, args: &args::Args) -> bool {
+    match args.table {
+        // gdef is meaningless without one of these two
+        args::Table::All => font.gpos().is_ok() || font.gsub().is_ok(),
+        args::Table::Gpos => font.gpos().is_ok(),
+        args::Table::Gsub => font.gsub().is_ok(),
+        args::Table::Gdef => font
+            .gdef()
+            .map(|gdef| gdef.lig_caret_list().is_some())
+            .unwrap_or(false),
     }
 }


### PR DESCRIPTION
This table is a lot like mark/kern rules, in that it contains scalar values that can have variations applied. Like with those structures, this is an excellent case for normalization, since it means we can ignore differences related to the order in which deltas are stored.

This patch adds the ability to normalize this table, and updates ttx_diff to do that and to remove it as well as the VarStore from GDEF.


This gives us another +20 or so on crater.