### PR TITLE
[fea-rs] Tweak sort order of aalt rules

### DIFF
--- a/fea-rs/test-data/compile-tests/mini-latin/good/aalt_rule_order.fea
+++ b/fea-rs/test-data/compile-tests/mini-latin/good/aalt_rule_order.fea
@@ -1,0 +1,23 @@
+languagesystem DFLT dflt;
+languagesystem latn SRB;
+languagesystem cyrl MKD;
+
+feature aalt {
+    feature locl;
+} aalt;
+
+feature locl {
+    script latn;
+    language SRB;
+    lookup locl_1 {
+        # in aalt, this should occur before the rule below
+        sub a by b;
+    } locl_1;
+
+    # even though this script/language will sort ahead of latn/SRB
+    script cyrl;
+    language MKD;
+    lookup locl_2 {
+        sub a by c;
+    } locl_2;
+} locl;

--- a/fea-rs/test-data/compile-tests/mini-latin/good/aalt_rule_order.ttx
+++ b/fea-rs/test-data/compile-tests/mini-latin/good/aalt_rule_order.ttx
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont>
+
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=3 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+      <ScriptRecord index="1">
+        <ScriptTag value="cyrl"/>
+        <Script>
+          <!-- LangSysCount=1 -->
+          <LangSysRecord index="0">
+            <LangSysTag value="MKD "/>
+            <LangSys>
+              <ReqFeatureIndex value="65535"/>
+              <!-- FeatureCount=2 -->
+              <FeatureIndex index="0" value="0"/>
+              <FeatureIndex index="1" value="1"/>
+            </LangSys>
+          </LangSysRecord>
+        </Script>
+      </ScriptRecord>
+      <ScriptRecord index="2">
+        <ScriptTag value="latn"/>
+        <Script>
+          <!-- LangSysCount=1 -->
+          <LangSysRecord index="0">
+            <LangSysTag value="SRB "/>
+            <LangSys>
+              <ReqFeatureIndex value="65535"/>
+              <!-- FeatureCount=2 -->
+              <FeatureIndex index="0" value="0"/>
+              <FeatureIndex index="1" value="2"/>
+            </LangSys>
+          </LangSysRecord>
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=3 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="aalt"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="1">
+        <FeatureTag value="locl"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="2"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="2">
+        <FeatureTag value="locl"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="1"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=3 -->
+      <Lookup index="0">
+        <LookupType value="3"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <AlternateSubst index="0">
+          <AlternateSet glyph="a">
+            <Alternate glyph="b"/>
+            <Alternate glyph="c"/>
+          </AlternateSet>
+        </AlternateSubst>
+      </Lookup>
+      <Lookup index="1">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0">
+          <Substitution in="a" out="b"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="2">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0">
+          <Substitution in="a" out="c"/>
+        </SingleSubst>
+      </Lookup>
+    </LookupList>
+  </GSUB>
+
+</ttFont>


### PR DESCRIPTION
The aalt feature has special behaviour where rules are supposed to be added to aalt from other features, in the order that those features are listed in the aalt block.

Unfortunately, since a given feature can exist for multiple languagesystems and contain different lookups for each, there is still ambiguity to the order in which rules are to be added.

Previously (and without much intention) we were adding rules in the order that the features would end up in the feature list; that is, within a feature we were adding rules based on the sorting order of the language systems.

This didn't match fonttools, where rules are added in the order that they are declared in the target feature.

With this patch, we match fonttools by re-sorting the lookups for a given feature based on the lookup id, which is an effective proxy for "when was this rule declared".