### PR TITLE
[fea-rs] Ensure feature lookups are always sorted

### DIFF
--- a/fea-rs/src/compile/features.rs
+++ b/fea-rs/src/compile/features.rs
@@ -398,6 +398,7 @@ impl ActiveFeature {
                 None => &mut feature.base,
             };
             to_add.extend(lookups);
+            to_add.sort();
         }
     }
 

--- a/fea-rs/src/util/ttx.rs
+++ b/fea-rs/src/util/ttx.rs
@@ -427,6 +427,7 @@ fn write_lines(f: &mut impl Write, lines: &[&str], line_num: usize, prefix: char
     }
 }
 
+// NOTE: to generate a new expected_diff, use the ttx_test binary.
 static DIFF_PREAMBLE: &str = "\
 # generated automatically by fea-rs
 # this file represents an acceptable difference between the output of

--- a/fea-rs/test-data/compile-tests/mini-latin/good/always_sort_lookups.fea
+++ b/fea-rs/test-data/compile-tests/mini-latin/good/always_sort_lookups.fea
@@ -1,0 +1,16 @@
+feature derp {
+    lookup hi_mom {
+        sub x by z;
+        # sub a b' c by d;
+    } hi_mom;
+} derp;
+
+feature herp {
+    sub d by j;
+} herp;
+
+# this is added after 'sub d by j' but has a lower lookup id; it should
+# still be first in the lookuplist
+feature herp {
+    lookup hi_mom;
+} herp;

--- a/fea-rs/test-data/compile-tests/mini-latin/good/always_sort_lookups.ttx
+++ b/fea-rs/test-data/compile-tests/mini-latin/good/always_sort_lookups.ttx
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont>
+
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=2 -->
+            <FeatureIndex index="0" value="0"/>
+            <FeatureIndex index="1" value="1"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=2 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="derp"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="1">
+        <FeatureTag value="herp"/>
+        <Feature>
+          <!-- LookupCount=2 -->
+          <LookupListIndex index="0" value="0"/>
+          <LookupListIndex index="1" value="1"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=2 -->
+      <Lookup index="0">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0">
+          <Substitution in="x" out="z"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="1">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0">
+          <Substitution in="d" out="j"/>
+        </SingleSubst>
+      </Lookup>
+    </LookupList>
+  </GSUB>
+
+</ttFont>

--- a/fea-rs/test-data/fonttools-tests/GPOS_2.expected_diff
+++ b/fea-rs/test-data/fonttools-tests/GPOS_2.expected_diff
@@ -1,0 +1,12 @@
+# generated automatically by fea-rs
+# this file represents an acceptable difference between the output of
+# fonttools and the output of fea-rs for a given input.
+#
+# In this case, fonttools does not sort these lookups, but we do.
+#
+L26
+>            <LookupListIndex index="0" value="1"/>
+>            <LookupListIndex index="1" value="0"/>
+L26
+<            <LookupListIndex index="0" value="0"/>
+<            <LookupListIndex index="1" value="1"/>


### PR DESCRIPTION
The order of lookups within a feature don't matter. In general we end up with a sorted order via the implementation, but in the case where there are multiple declarations of a given feature this was not always the case.