### PR TITLE
[glyphs] Don't error on invalid vendorID value

### DIFF
--- a/resources/testdata/glyphs3/InvalidVendorID.glyphs
+++ b/resources/testdata/glyphs3/InvalidVendorID.glyphs
@@ -1,0 +1,39 @@
+{
+.appVersion = "3219";
+.formatVersion = 3;
+axes = (
+{
+name = Weight;
+tag = wght;
+}
+);
+customParameters = (
+{
+name = vendorID;
+value = "    ";
+}
+);
+date = "2023-09-20 08:55:41 +0000";
+familyName = InvalidVendorID;
+fontMaster = (
+{
+axesValues = (
+400
+);
+id = m01;
+name = Regular;
+}
+);
+glyphs = (
+{
+glyphname = himom;
+layers = (
+{
+layerId = m01;
+width = 600;
+}
+);
+}
+);
+unitsPerEm = 1000;
+}


### PR DESCRIPTION
Since this is allowed to be missing; we can just log the error and continue.

This gets us compiling at least one more font, `madimi.glyphs`.

As a followup, the only diff between us and fontmake for this font is that we have the OS/2 `achVendID` value of `NONE` while fontmake has `    ` (0x20 * 4)`. I think fontmake is wrong here, since all spaces is not a valid tag, and the [spec clearly says that this should be a tag](https://learn.microsoft.com/en-us/typography/opentype/spec/os2#achvendid).