### PR TITLE
[fontbe] remove workaround for old macOS bug with composites with all-zero deltas

### DIFF
--- a/fontbe/src/glyphs.rs
+++ b/fontbe/src/glyphs.rs
@@ -303,7 +303,7 @@ fn process_composite_deltas(deltas: Vec<Vec2>) -> Vec<GlyphDelta> {
             (0, 0) => GlyphDelta::optional(0, 0),
             (x, y) => GlyphDelta::required(x, y),
         })
-        .collect::<Vec<_>>()
+        .collect()
 }
 
 impl Work<Context, AnyWorkId, Error> for GlyphWork {

--- a/fontbe/src/glyphs.rs
+++ b/fontbe/src/glyphs.rs
@@ -295,7 +295,7 @@ fn compute_deltas(
 
 /// convert raw deltas to the write-fonts representation (composite glyphs only)
 fn process_composite_deltas(deltas: Vec<Vec2>) -> Vec<GlyphDelta> {
-    let mut deltas = deltas
+    deltas
         .into_iter()
         .map(|delta| match delta.to_point().ot_round() {
             // IUP only applies to simple glyphs; for composites we
@@ -303,18 +303,7 @@ fn process_composite_deltas(deltas: Vec<Vec2>) -> Vec<GlyphDelta> {
             (0, 0) => GlyphDelta::optional(0, 0),
             (x, y) => GlyphDelta::required(x, y),
         })
-        .collect::<Vec<_>>();
-
-    // match fonttools behaviour, ensuring there is at least one
-    // delta required, to ensure we write an entry for the glyf.
-    // <https://github.com/fonttools/fonttools/blob/0a3360e52727cdefce2e9b28286b074faf99033c/Lib/fontTools/varLib/__init__.py#L351>
-    // <https://github.com/fonttools/fonttools/issues/1381>
-    if deltas.iter().all(|delta| !delta.required) {
-        if let Some(first) = deltas.first_mut() {
-            first.required = true;
-        }
-    }
-    deltas
+        .collect::<Vec<_>>()
 }
 
 impl Work<Context, AnyWorkId, Error> for GlyphWork {
@@ -935,11 +924,9 @@ mod tests {
     #[test]
     fn all_zero_composite_deltas() {
         let zeros = vec![Vec2::ZERO; 6];
-        // if a composite glyph has all zero deltas we want to finish with a single
-        // required zero delta, and skip the rest:
+        // if a composite glyph has all zero deltas we want to skip them all
         let deltas = process_composite_deltas(zeros);
-        assert!(deltas[0].required);
-        assert!(deltas.iter().skip(1).all(|d| !d.required));
+        assert!(deltas.iter().all(|d| !d.required));
     }
 
     #[test]

--- a/resources/scripts/requirements.in
+++ b/resources/scripts/requirements.in
@@ -10,4 +10,4 @@ cdifflib
 glyphsLib
 # keep gftools pinned as well to ensure ttx_diff.py output is stable.
 # 0.9.74 is when experimental support for fontc was added to gftools.
-gftools==0.9.77
+gftools==0.9.78

--- a/resources/scripts/requirements.txt
+++ b/resources/scripts/requirements.txt
@@ -23,7 +23,7 @@ axisregistry==0.4.12
     # via gftools
 babelfont==3.1.2
     # via gftools
-beautifulsoup4==4.12.3
+beautifulsoup4==4.13.3
     # via gftools
 booleanoperations==0.9.0
     # via
@@ -90,7 +90,7 @@ fontparts==0.12.3
     # via ufoprocessor
 fontpens==0.2.4
     # via defcon
-fonttools[lxml,repacker,ufo,unicode,woff]==4.55.8
+fonttools[lxml,repacker,ufo,unicode,woff]==4.56.0
     # via
     #   -r requirements.in
     #   afdko
@@ -123,13 +123,13 @@ fs==2.4.16
     # via
     #   fontfeatures
     #   fonttools
-gflanguages==0.7.2
+gflanguages==0.7.3
     # via
     #   gftools
     #   glyphsets
 gfsubsets==2024.9.25
     # via gftools
-gftools==0.9.77
+gftools==0.9.78
     # via -r requirements.in
 gitdb==4.0.12
     # via gitpython
@@ -265,7 +265,9 @@ tqdm==4.67.1
 ttfautohint-py==0.5.1
     # via gftools
 typing-extensions==4.12.2
-    # via pygithub
+    # via
+    #   beautifulsoup4
+    #   pygithub
 ufo2ft[cffsubr,compreffor]==3.4.1
     # via
     #   fontmake


### PR DESCRIPTION
Now that fonttools has also removed this old workaround, we shall remove it as well in fontc.

See https://github.com/fonttools/fonttools/pull/1788

Fixes https://github.com/googlefonts/fontc/issues/283