### PR TITLE
Make GlyphOrder methods work with &str

### DIFF
--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -302,7 +302,7 @@ mod tests {
             self.fe_context
                 .glyph_order
                 .get()
-                .glyph_id(&name.into())
+                .glyph_id(name)
                 .map(|v| v.to_u16() as u32)
         }
 
@@ -2788,13 +2788,13 @@ mod tests {
         let expected_rot60more_bbox = Rect::new(50.0, 149.0, 150.0, 449.0);
 
         let gids = ["rot30", "rot60more"]
-            .iter()
+            .into_iter()
             .map(|gn| {
                 compile
                     .fe_context
                     .glyph_order
                     .get()
-                    .glyph_id(&GlyphName::new(gn))
+                    .glyph_id(gn)
                     .map(|gid16| GlyphId::new(gid16.to_u32()))
                     .unwrap()
             })

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -245,18 +245,21 @@ impl GlyphOrder {
         GlyphOrder(IndexSet::new())
     }
 
-    pub fn glyph_id(&self, name: &GlyphName) -> Option<GlyphId16> {
-        self.0
-            .get_index_of(name)
-            .map(|i| i as u32)
-            .map(|gid| GlyphId16::new(gid as u16))
+    pub fn glyph_id<Q>(&self, name: &Q) -> Option<GlyphId16>
+    where
+        Q: std::hash::Hash + indexmap::Equivalent<GlyphName> + ?Sized,
+    {
+        self.0.get_index_of(name).map(|i| GlyphId16::new(i as _))
     }
 
     pub fn glyph_name(&self, index: usize) -> Option<&GlyphName> {
         self.0.get_index(index)
     }
 
-    pub fn contains(&self, name: &GlyphName) -> bool {
+    pub fn contains<Q>(&self, name: &Q) -> bool
+    where
+        Q: std::hash::Hash + indexmap::Equivalent<GlyphName> + ?Sized,
+    {
         self.0.contains(name)
     }
 


### PR DESCRIPTION
In tests I want to be able to write,

   ```
   let gid = glyph_order.glyph_id("Aacute")
   // instead of
   let gid = glyph_order.glyph_id(&GlyphName::new("Aacute"));
   ```

So this just changes the argument of 'contains' and 'glyph_id' to use the same trait bounds as are used on the underlying collection.

JMM