### PR TITLE
Refactor kerning logic to make it more testable

### DIFF
--- a/fea-rs/src/compile/lookups.rs
+++ b/fea-rs/src/compile/lookups.rs
@@ -1201,7 +1201,7 @@ impl FeatureKey {
     ///
     /// If you already have a [`super::LanguageSystem`], you can create a [`FeatureKey`]
     /// with the [`super::LanguageSystem::to_feature_key`] method.
-    pub fn new(feature: Tag, language: Tag, script: Tag) -> Self {
+    pub const fn new(feature: Tag, language: Tag, script: Tag) -> Self {
         FeatureKey {
             feature,
             language,

--- a/fontbe/src/features/properties.rs
+++ b/fontbe/src/features/properties.rs
@@ -2,10 +2,8 @@
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
     hash::Hash,
-    sync::Arc,
 };
 
-use fontir::ir::Glyph;
 use icu_properties::{
     props::{BidiClass, Script},
     CodePointMapData, PropertyNamesShort, PropertyParser,
@@ -48,10 +46,9 @@ pub trait CharMap {
     fn iter_glyphs(&self) -> impl Iterator<Item = (GlyphId16, u32)>;
 }
 
-impl CharMap for Vec<(Arc<Glyph>, GlyphId16)> {
+impl CharMap for HashMap<u32, GlyphId16> {
     fn iter_glyphs(&self) -> impl Iterator<Item = (GlyphId16, u32)> {
-        self.iter()
-            .flat_map(|(glyph, gid)| glyph.codepoints.iter().map(|uv| (*gid, *uv)))
+        self.iter().map(|(k, v)| (*v, *k))
     }
 }
 

--- a/fontbe/src/orchestration.rs
+++ b/fontbe/src/orchestration.rs
@@ -495,6 +495,19 @@ impl FeaRsKerns {
     pub fn is_empty(&self) -> bool {
         self.lookups.is_empty()
     }
+
+    #[cfg(test)]
+    pub(crate) fn lookups_for_feature(
+        &self,
+        feature: &FeatureKey,
+    ) -> Vec<&PendingLookup<PairPosBuilder>> {
+        self.features
+            .get(feature)
+            .into_iter()
+            .flatten()
+            .map(|id| &self.lookups[*id])
+            .collect()
+    }
 }
 
 impl Persistable for FeaRsKerns {


### PR DESCRIPTION
No functional change.

I was never very happy with how kerning is tested; in particular there was no clean entry point for unit tests, since a lot of the logic was inside the `KerningGatherWork`, which we can't easily launch without running the whole compiler.

This teases things apart a bit, so that we now have a `finalize_kerning` free fn that takes the raw kerning pairs and various bits of other necessary state and generates the kerning features & lookups.

On top of this, I'm able to build a test harness that lets us set all of the state that can impact kerning, and then inspect the output. This will let me write more tests that are more tractable, and where we can have more confidence that they reflect what is actually happening at runtime.