### PR TITLE
[ttx_diff] Fix a pair of little things

### DIFF
--- a/resources/scripts/ttx_diff.py
+++ b/resources/scripts/ttx_diff.py
@@ -516,7 +516,7 @@ def remove_gdef_lig_caret_and_var_store(ttx: etree.ElementTree):
 
     for ident in ["LigCaretList", "VarStore"]:
         subtable = gdef.find(ident)
-        if subtable:
+        if subtable is not None:
             gdef.remove(subtable)
 
 
@@ -771,6 +771,7 @@ def delete_things_we_must_rebuild(rebuild: str, fontmake_ttf: Path, fontc_ttf: P
                 ttf_path,
                 ttf_path.with_suffix(".ttx"),
                 ttf_path.with_suffix(".markkern.txt"),
+                ttf_path.with_suffix(".ligcaret.txt"),
             ]:
                 if path.exists():
                     os.remove(path)


### PR DESCRIPTION
- we weren't always deleting ligcaret output, which means that when running locally, it was being reused between different fonts.
- fixed a python warning about checking for None


JMM