### PR TITLE
Use new `gvar` coordinates type with upstream intermediates optimisation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ rayon = "1.6"
 icu_properties = "2.0.0-beta1"
 
 # fontations etc
-write-fonts = { version = "0.35.0", features = ["serde", "read"] }
+write-fonts = { version = "0.35.1", features = ["serde", "read"] }
 skrifa = "0.28.0"
 norad = { version = "0.15.0", default-features = false }
 

--- a/fontbe/src/gvar.rs
+++ b/fontbe/src/gvar.rs
@@ -86,10 +86,7 @@ impl Work<Context, AnyWorkId, Error> for GvarWork {
 mod tests {
     use fontir::ir::GlyphOrder;
     use write_fonts::{
-        tables::{
-            gvar::{GlyphDelta, GlyphDeltas},
-            variations::Tuple,
-        },
+        tables::gvar::{AxisCoordinates, GlyphDelta, GlyphDeltas},
         types::F2Dot14,
     };
 
@@ -110,9 +107,8 @@ mod tests {
                 v if v == glyph_without_var => Vec::new(),
                 // At the maximum extent (normalized pos 1.0) of our axis, add +1, +1
                 v if v == glyph_with_var => vec![GlyphDeltas::new(
-                    Tuple::new(vec![F2Dot14::from_f32(1.0)]),
+                    vec![AxisCoordinates::new(F2Dot14::from_f32(1.0), None)],
                     vec![GlyphDelta::new(1, 1, false)],
-                    None,
                 )],
                 v => panic!("unexpected {v}"),
             }

--- a/fontbe/src/gvar.rs
+++ b/fontbe/src/gvar.rs
@@ -86,7 +86,7 @@ impl Work<Context, AnyWorkId, Error> for GvarWork {
 mod tests {
     use fontir::ir::GlyphOrder;
     use write_fonts::{
-        tables::gvar::{AxisCoordinates, GlyphDelta, GlyphDeltas},
+        tables::gvar::{self, GlyphDelta, GlyphDeltas},
         types::F2Dot14,
     };
 
@@ -107,7 +107,7 @@ mod tests {
                 v if v == glyph_without_var => Vec::new(),
                 // At the maximum extent (normalized pos 1.0) of our axis, add +1, +1
                 v if v == glyph_with_var => vec![GlyphDeltas::new(
-                    vec![AxisCoordinates::new(F2Dot14::from_f32(1.0), None)],
+                    vec![gvar::Tent::new(F2Dot14::from_f32(1.0), None)],
                     vec![GlyphDelta::new(1, 1, false)],
                 )],
                 v => panic!("unexpected {v}"),

--- a/fontir/src/variations.rs
+++ b/fontir/src/variations.rs
@@ -15,7 +15,7 @@ use ordered_float::OrderedFloat;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use write_fonts::{
-    tables::variations::RegionAxisCoordinates,
+    tables::{gvar, variations::RegionAxisCoordinates},
     types::{F2Dot14, Tag},
 };
 
@@ -590,7 +590,7 @@ impl VariationRegion {
 ///
 /// Visualize as a tent of influence, starting at min, peaking at peak,
 /// and dropping off to zero at max.
-#[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
 pub struct Tent {
     pub min: NormalizedCoord,
     pub peak: NormalizedCoord,
@@ -677,6 +677,16 @@ impl From<(f64, f64, f64)> for Tent {
     }
 }
 
+impl From<Tent> for gvar::AxisCoordinates {
+    fn from(val: Tent) -> Self {
+        let Tent { peak, min, max } = val;
+        gvar::AxisCoordinates::new(
+            peak.into(),
+            Some(gvar::Intermediate::explicit(min.into(), max.into())),
+        )
+    }
+}
+
 /// Split space into regions.
 ///
 /// VariationModel::_locationsToRegions in Python.
@@ -756,7 +766,7 @@ fn master_influence(axis_order: &[Tag], regions: &[VariationRegion]) -> Vec<Vari
                     continue;
                 }
                 let prev_peak = prev_region.axis_tents[tag].peak;
-                let mut axis_region = region.axis_tents[tag].clone();
+                let mut axis_region = region.axis_tents[tag];
                 let ratio;
                 match prev_peak.cmp(&axis_region.peak) {
                     Ordering::Less => {

--- a/fontir/src/variations.rs
+++ b/fontir/src/variations.rs
@@ -677,13 +677,10 @@ impl From<(f64, f64, f64)> for Tent {
     }
 }
 
-impl From<Tent> for gvar::AxisCoordinates {
+impl From<Tent> for gvar::Tent {
     fn from(val: Tent) -> Self {
         let Tent { peak, min, max } = val;
-        gvar::AxisCoordinates::new(
-            peak.into(),
-            Some(gvar::Intermediate::explicit(min.into(), max.into())),
-        )
+        gvar::Tent::new(peak.into(), Some((min.into(), max.into())))
     }
 }
 


### PR DESCRIPTION
Hello all!

This is the companion pull request for the upstream googlefonts/fontations#1345, after we rehomed the initial attempt to conditionally write `gvar` intermediates (#1225); thank you for your patience.

We will close the older PR in favour of this.

Until we land upstream this is still a draft, so happy to use it to guide that PR in terms of naming, documentation, and any other finishing touches.