### PR TITLE
[ci] skip Build GS job if PR is coming from a fork

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -168,6 +168,8 @@ jobs:
   build-gs-repeatably:
     runs-on: ubuntu-latest
     name: Build GS and check the result
+    # Skip if PR is from a fork, instead of failing due to missing token
+    if: github.event.pull_request.head.repo.fork == false
     steps:
       - name: Check out fontc source repository
         uses: actions/checkout@v4


### PR DESCRIPTION
It doesn't help that CI always fails with PRs coming from forks with 'Error: Input required and not supplied: token'.
We can just skip that for forks.

JMM