### PR TITLE
[chore] Update write-fonts version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ rayon = "1.6"
 icu_properties = "2.0.0-beta1"
 
 # fontations etc
-write-fonts = { version = "0.35.1", features = ["serde", "read"] }
+write-fonts = { version = "0.36.0", features = ["serde", "read"] }
 skrifa = "0.28.0"
 norad = { version = "0.15.0", default-features = false }
 


### PR DESCRIPTION
write-fonts 0.35.1 contained breaking changes from 0.35.0 and has been yanked. 0.36.0 is the correct next version.

JMM