### PR TITLE
[glyphs] Skip empty stylistic set names

### DIFF
--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -2909,7 +2909,7 @@ mod tests {
 
         let gsub = font.gsub().unwrap();
         let feature_list = gsub.feature_list().unwrap();
-        assert_eq!(feature_list.feature_records().len(), 1);
+        assert_eq!(feature_list.feature_records().len(), 2);
         let feature = feature_list.feature_records()[0]
             .feature(feature_list.offset_data())
             .unwrap();
@@ -2920,6 +2920,19 @@ mod tests {
 
         // matches what is in the name table
         assert_eq!(params.ui_name_id().to_u16(), 257);
+    }
+
+    #[test]
+    fn skip_empty_stylistic_set_names() {
+        let result = TestCompile::compile_source("glyphs3/WghtVarWithStylisticSet.glyphs");
+        let font = result.font();
+        let gsub = font.gsub().unwrap();
+        let feature_list = gsub.feature_list().unwrap();
+        assert_eq!(feature_list.feature_records().len(), 2);
+        let ss02 = feature_list.feature_records()[1]
+            .feature(feature_list.offset_data())
+            .unwrap();
+        assert!(ss02.feature_params().is_none());
     }
 
     #[test]

--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -2244,6 +2244,12 @@ impl RawFeature {
 
 impl RawNameValue {
     fn to_fea(&self) -> Option<String> {
+        if self.value.is_empty() {
+            // skip empty names:
+            // https://github.com/googlefonts/glyphsLib/blob/c4db6b981d577f/Lib/glyphsLib/builder/features.py#L155
+            return None;
+        }
+
         match GLYPHS_TO_OPENTYPE_LANGUAGE_ID
             .binary_search_by_key(&self.language.as_str(), |entry| entry.0)
         {

--- a/resources/testdata/glyphs3/WghtVarWithStylisticSet.glyphs
+++ b/resources/testdata/glyphs3/WghtVarWithStylisticSet.glyphs
@@ -32,6 +32,16 @@ value = "my fun feature";
 }
 );
 tag = ss01;
+},
+{
+code = "sub space by hyphen;";
+labels = (
+{
+language = dflt;
+value = "";
+}
+);
+tag = ss02;
 }
 );
 fontMaster = (


### PR DESCRIPTION
It looks like the glyphsLib impl was updated to do this since our original implementation.

Gives us at least a +1 on crater.