### PR TITLE
[fea-rs] Add ability to filter ttx tests with env var

### DIFF
--- a/fea-rs/src/bin/ttx_test.rs
+++ b/fea-rs/src/bin/ttx_test.rs
@@ -12,7 +12,7 @@ fn main() {
     env_logger::init();
     let args = Args::parse();
 
-    let results = ttx::run_fonttools_tests(args.test_filter.as_ref());
+    let results = ttx::run_fonttools_tests(args.test_filter);
 
     if let Some(to_compare) = args
         .compare

--- a/fea-rs/src/tests/compile.rs
+++ b/fea-rs/src/tests/compile.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 
 use crate::{
     compile::{error::CompilerError, Compiler, MockVariationInfo, NopFeatureProvider, Opts},
-    util::ttx::{self as test_utils, Report, TestCase, TestResult},
+    util::ttx::{self as test_utils, Filter, Report, TestCase, TestResult},
     GlyphMap,
 };
 use fontdrasil::types::GlyphName;
@@ -74,7 +74,7 @@ fn iter_test_groups(
         let glyph_map = glyph_order.lines().map(GlyphName::new).collect();
         let var_info = test_utils::make_var_info();
         let tests_dir = dir.join(test_dir);
-        let tests = test_utils::iter_fea_files(tests_dir).collect::<Vec<_>>();
+        let tests = test_utils::iter_fea_files(tests_dir, Filter::from_env()).collect::<Vec<_>>();
         (glyph_map, var_info, tests)
     })
 }

--- a/fea-rs/src/tests/parse.rs
+++ b/fea-rs/src/tests/parse.rs
@@ -9,7 +9,7 @@
 use std::{env, path::PathBuf};
 
 use crate::{
-    util::ttx::{self as test_utils, Report, TestCase, TestResult},
+    util::ttx::{self as test_utils, Filter, Report, TestCase, TestResult},
     GlyphIdent, GlyphMap,
 };
 
@@ -30,7 +30,7 @@ fn parse_good() -> Result<(), Report> {
 
     let glyph_map = parse_test_glyph_order();
 
-    let results = test_utils::iter_fea_files(PARSE_GOOD)
+    let results = test_utils::iter_fea_files(PARSE_GOOD, Filter::from_env())
         .chain(OTHER_TESTS.iter().map(PathBuf::from))
         .map(|path| run_good_test(path, &glyph_map))
         .collect::<Vec<_>>();
@@ -40,7 +40,7 @@ fn parse_good() -> Result<(), Report> {
 #[test]
 fn parse_bad() -> Result<(), Report> {
     test_utils::finalize_results(
-        test_utils::iter_fea_files(PARSE_BAD)
+        test_utils::iter_fea_files(PARSE_BAD, Filter::from_env())
             .map(run_bad_test)
             .collect(),
     )

--- a/fea-rs/src/util.rs
+++ b/fea-rs/src/util.rs
@@ -17,3 +17,7 @@ pub static SPACES: &str = "                                                     
 pub(crate) static WRITE_RESULTS_VAR: &str = "FEA_WRITE_TEST_OUTPUT";
 #[cfg(any(test, feature = "test"))]
 pub(crate) static VERBOSE: &str = "FEA_VERBOSE";
+
+// pass a comma separated list of words, tests which contain those words are run
+#[cfg(any(test, feature = "test"))]
+pub(crate) static FEA_FILTER_TESTS: &str = "FEA_FILTER_TESTS";


### PR DESCRIPTION
This functionality existed but only worked for the bundled fonttools tests (for historical reasons) this expands on that so it can be used for all the ttx-based tests, and lets it be controlled via the FEA_FILTER_TESTS environment variable.

Also removes some redundant code, but otherwise no functional change.

JMM