### PR TITLE
[fea-rs] Handle edge case in chain context compilation

### DIFF
--- a/fea-rs/src/common.rs
+++ b/fea-rs/src/common.rs
@@ -88,6 +88,15 @@ impl GlyphOrClass {
         }
     }
 
+    /// If this is a glyph or a class with exactly one, return it.
+    pub(crate) fn single_glyph(&self) -> Option<GlyphId16> {
+        match self {
+            GlyphOrClass::Glyph(gid) => Some(*gid),
+            GlyphOrClass::Class(class) if class.len() == 1 => class.iter().next(),
+            _ => None,
+        }
+    }
+
     pub(crate) fn iter(&self) -> impl Iterator<Item = GlyphId16> + '_ {
         let mut idx = 0;
         std::iter::from_fn(move || {

--- a/fea-rs/test-data/compile-tests/mini-latin/good/chain_sub_format_choice.fea
+++ b/fea-rs/test-data/compile-tests/mini-latin/good/chain_sub_format_choice.fea
@@ -1,0 +1,13 @@
+
+feature ccmp {
+    @one = [a];
+    @two = [b];
+
+    # this should compile to format 1, because the class has only a single glyph
+    lookup test {
+        sub @one' @two by @two;
+        sub @two @one' by @two;
+    } test;
+
+} ccmp;
+

--- a/fea-rs/test-data/compile-tests/mini-latin/good/chain_sub_format_choice.ttx
+++ b/fea-rs/test-data/compile-tests/mini-latin/good/chain_sub_format_choice.ttx
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont>
+
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=1 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="ccmp"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=2 -->
+      <Lookup index="0">
+        <LookupType value="6"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <ChainContextSubst index="0" Format="1">
+          <Coverage>
+            <Glyph value="a"/>
+          </Coverage>
+          <!-- ChainSubRuleSetCount=1 -->
+          <ChainSubRuleSet index="0">
+            <!-- ChainSubRuleCount=2 -->
+            <ChainSubRule index="0">
+              <!-- BacktrackGlyphCount=0 -->
+              <!-- InputGlyphCount=1 -->
+              <!-- LookAheadGlyphCount=1 -->
+              <LookAhead index="0" value="b"/>
+              <!-- SubstCount=1 -->
+              <SubstLookupRecord index="0">
+                <SequenceIndex value="0"/>
+                <LookupListIndex value="1"/>
+              </SubstLookupRecord>
+            </ChainSubRule>
+            <ChainSubRule index="1">
+              <!-- BacktrackGlyphCount=1 -->
+              <Backtrack index="0" value="b"/>
+              <!-- InputGlyphCount=1 -->
+              <!-- LookAheadGlyphCount=0 -->
+              <!-- SubstCount=1 -->
+              <SubstLookupRecord index="0">
+                <SequenceIndex value="0"/>
+                <LookupListIndex value="1"/>
+              </SubstLookupRecord>
+            </ChainSubRule>
+          </ChainSubRuleSet>
+        </ChainContextSubst>
+      </Lookup>
+      <Lookup index="1">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0">
+          <Substitution in="a" out="b"/>
+        </SingleSubst>
+      </Lookup>
+    </LookupList>
+  </GSUB>
+
+</ttFont>


### PR DESCRIPTION
The way format 1 subtables work means they don't support input classes, _unless_ those classes contain a single glyph, in which case we can pretend they aren't classes.