### PR TITLE
[kern] Skip class/class kern rules with zero values

### DIFF
--- a/fea-rs/src/compile/metrics.rs
+++ b/fea-rs/src/compile/metrics.rs
@@ -189,7 +189,7 @@ impl ValueRecord {
     }
 
     /// `true` if we are not null, but our set values are all 0
-    fn is_all_zeros(&self) -> bool {
+    pub fn is_all_zeros(&self) -> bool {
         let device_mask = ValueFormat::X_PLACEMENT_DEVICE
             | ValueFormat::Y_PLACEMENT_DEVICE
             | ValueFormat::X_ADVANCE_DEVICE

--- a/fontbe/src/orchestration.rs
+++ b/fontbe/src/orchestration.rs
@@ -555,6 +555,10 @@ impl KernSide {
         matches!(self, KernSide::Group(items) if items.is_empty())
     }
 
+    pub(crate) fn is_group(&self) -> bool {
+        matches!(self, KernSide::Group(_))
+    }
+
     /// Convert from IR (which uses glyph names) to our representation (using ids)
     pub(crate) fn from_ir_side(
         ir: &ir::KernSide,


### PR DESCRIPTION
Since these are always a noop.

We had a test for this apparently, but it was wasn't failing as expected since it was using normalizer output, and normalizer doesn't bother showing us anything (since it's a noop).