### PR TITLE
Fix duplicate glyphs3 GSMetrics; take the first and ignore 'filter'

### DIFF
--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -3586,6 +3586,19 @@ mod tests {
     }
 
     #[test]
+    fn v3_duplicate_metrics_first_wins() {
+        // In this test font, the default master contains two 'x-height' metric values,
+        // the first (501) that applies globally, and a second one (450) that applies
+        // only to small-caps, using GSMetric's `filter` attribute which we ignore as
+        // it is not relevant to build OS/2 and MVAR tables.
+        // We match glyphsLib and only consider the first metric with a given name.
+        let font = Font::load(&glyphs3_dir().join("WghtVar_OS2.glyphs")).unwrap();
+        let master = font.default_master();
+
+        assert_eq!(master.get_metric("x-height"), Some((Some(501.), None)));
+    }
+
+    #[test]
     fn v2_preserve_custom_alignment_zones() {
         let font = Font::load(&glyphs2_dir().join("alignment_zones_v2.glyphs")).unwrap();
         let master = font.default_master();

--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -2534,7 +2534,13 @@ impl TryFrom<RawFont> for Font {
                             metric_names.get(&idx).map(|name| (name.clone(), value))
                         })
                         .filter(|(_, metric)| !metric.is_empty())
-                        .collect(),
+                        .fold(BTreeMap::new(), |mut acc, (name, value)| {
+                            // only insert a metric if one with the same name hasn't been added
+                            // yet; matches glyphsLib's behavior where the first duplicate wins
+                            // https://github.com/googlefonts/fontc/issues/1269
+                            acc.entry(name).or_insert(value);
+                            acc
+                        }),
                     number_values: from
                         .numbers
                         .iter()

--- a/resources/testdata/glyphs2/WghtVar_OS2.glyphs
+++ b/resources/testdata/glyphs2/WghtVar_OS2.glyphs
@@ -1,5 +1,5 @@
 {
-.appVersion = "3219";
+.appVersion = "3340";
 DisplayStrings = (
 "-",
 "!"
@@ -94,6 +94,10 @@ value = -290;
 {
 name = hheaLineGap;
 value = 43;
+},
+{
+name = smallCapHeight;
+value = 450;
 }
 );
 descender = -42;
@@ -104,6 +108,12 @@ xHeight = 501;
 {
 ascender = 800;
 capHeight = 700;
+customParameters = (
+{
+name = smallCapHeight;
+value = 480;
+}
+);
 descender = -200;
 id = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
 weight = Bold;

--- a/resources/testdata/glyphs3/WghtVar_OS2.glyphs
+++ b/resources/testdata/glyphs3/WghtVar_OS2.glyphs
@@ -91,6 +91,9 @@ pos = 702;
 },
 {
 pos = 501;
+},
+{
+pos = 450;
 }
 );
 name = Regular;
@@ -115,6 +118,9 @@ pos = 700;
 },
 {
 pos = 500;
+},
+{
+pos = 480;
 }
 );
 name = Bold;
@@ -277,6 +283,10 @@ type = descender;
 type = "cap height";
 },
 {
+type = "x-height";
+},
+{
+filter = "case == 3";
 type = "x-height";
 }
 );


### PR DESCRIPTION
GSMetric's `filter` attribute (that restrict a given metric to a group of glyphs, e.g. small caps) is not relevant to build OS/2 and MVAR tables. Some source contains those, normally following the same-named metric which is supposed to apply globally (and thus be stored in font wide metric tables).
glyphsLib does parse these filter attributes but doesn't even use them, when looking up a metric by name it simply returns the first one it finds. Similarly here when we collect metrics by name, we only take the first one we find and ignore any duplicate that may follow.

Fixes #1269  

After the fix, the following gives "output is identical"

```
$ python resources/scripts/ttx_diff.py 'https://github.com/Etcetera-Type-Co/Epilogue#sources/Epilogue.glyphs' --compare gftools --config ~/.fontc_crater_cache/Etcetera-Type-Co/Epilogue/sources/config.yaml
```