### PR TITLE
Tidy glyphs files a touch

### DIFF
--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -358,8 +358,6 @@ pub enum Shape {
 #[derive(Default, Debug, PartialEq, FromPlist)]
 #[allow(non_snake_case)]
 struct RawFont {
-    #[fromplist(key = ".appVersion")]
-    app_version: i64,
     #[fromplist(key = ".formatVersion")]
     format_version: i64,
     units_per_em: Option<i64>,

--- a/resources/scripts/tidy_glyphs.py
+++ b/resources/scripts/tidy_glyphs.py
@@ -1,0 +1,49 @@
+"""
+Removes elements from .glyphs files that we don't care about.
+"""
+
+from pathlib import Path
+import re
+
+
+_EXEMPTIONS = {
+    ("Dated.glyphs", "date"),
+}
+
+_DELETE_ME = {
+    ".appVersion",
+    "DisplayStrings"
+    "date"
+    "lastChange"
+}
+
+
+def delete_key(plist_file: Path, plist: str, key: str) -> str:
+    if (plist_file.name, key) in _EXEMPTIONS:
+        print("skip", plist_file, key)
+        return plist
+    return re.sub(f"(?sm)^{key} = .*?;\n", "", plist)
+
+
+def main():
+    testdata_dir = Path(__file__).parent.parent / "testdata"
+    assert testdata_dir.is_dir(), testdata_dir
+
+    plist_files = set()
+    for subdir in ("glyphs2", "glyphs3"):
+        for pat in ("*.glyphs", "*.plist"):
+            plist_files.update((testdata_dir / subdir).rglob(pat))
+
+    assert len(plist_files) > 0
+    
+    for plist_file in plist_files:
+        plist = plist_file.read_text()
+
+        for key in _DELETE_ME:
+            plist = delete_key(plist_file, plist, key)
+        
+        plist_file.write_text(plist)
+    
+
+if __name__ == "__main__":
+    main()

--- a/resources/testdata/glyphs2/BadIndexing.glyphs
+++ b/resources/testdata/glyphs2/BadIndexing.glyphs
@@ -1,9 +1,4 @@
 {
-.appVersion = "3148";
-DisplayStrings = (
-"-",
-"!"
-);
 customParameters = (
 {
 name = "Variable Font Origin";
@@ -23,7 +18,6 @@ Tag = wdth;
 );
 }
 );
-date = "2022-12-01 04:52:20 +0000";
 familyName = WghtVar;
 fontMaster = (
 {

--- a/resources/testdata/glyphs2/Component.glyphs
+++ b/resources/testdata/glyphs2/Component.glyphs
@@ -1,10 +1,4 @@
 {
-.appVersion = "3151";
-DisplayStrings = (
-".",
-","
-);
-date = "2023-01-20 20:20:30 +0000";
 familyName = "New Font";
 fontMaster = (
 {
@@ -26,7 +20,6 @@ xHeight = 500;
 glyphs = (
 {
 glyphname = period;
-lastChange = "2023-01-20 20:20:51 +0000";
 layers = (
 {
 layerId = m01;
@@ -48,7 +41,6 @@ unicode = 002E;
 },
 {
 glyphname = comma;
-lastChange = "2023-01-20 20:22:39 +0000";
 layers = (
 {
 components = (
@@ -65,7 +57,6 @@ unicode = 002C;
 },
 {
 glyphname = non_uniform_scale;
-lastChange = "2023-01-20 20:22:39 +0000";
 layers = (
 {
 components = (
@@ -82,7 +73,6 @@ unicode = 0030;
 },
 {
 glyphname = simple_transform;
-lastChange = "2023-01-20 20:22:39 +0000";
 layers = (
 {
 components = (
@@ -99,7 +89,6 @@ unicode = 0031;
 },
 {
 glyphname = simple_transform_again;
-lastChange = "2023-01-20 20:22:39 +0000";
 layers = (
 {
 components = (
@@ -120,7 +109,6 @@ unicode = 0032;
 },
 {
 glyphname = translate_only;
-lastChange = "2023-01-20 20:22:39 +0000";
 layers = (
 {
 components = (

--- a/resources/testdata/glyphs2/FeaLegacyName.glyphs
+++ b/resources/testdata/glyphs2/FeaLegacyName.glyphs
@@ -1,5 +1,4 @@
 {
-.appVersion = "3148";
 familyName = "legacy stylistic set names";
 features = (
 {

--- a/resources/testdata/glyphs2/Fea_Class.glyphs
+++ b/resources/testdata/glyphs2/Fea_Class.glyphs
@@ -1,5 +1,4 @@
 {
-.appVersion = "3148";
 classes = (
 {
 automatic = 1;

--- a/resources/testdata/glyphs2/Fea_Feature.glyphs
+++ b/resources/testdata/glyphs2/Fea_Feature.glyphs
@@ -1,5 +1,4 @@
 {
-.appVersion = "3148";
 customParameters = (
 {
 name = Axes;

--- a/resources/testdata/glyphs2/Fea_Order.glyphs
+++ b/resources/testdata/glyphs2/Fea_Order.glyphs
@@ -1,5 +1,4 @@
 {
-.appVersion = "3148";
 customParameters = (
 {
 name = Axes;

--- a/resources/testdata/glyphs2/Fea_Prefix.glyphs
+++ b/resources/testdata/glyphs2/Fea_Prefix.glyphs
@@ -1,5 +1,4 @@
 {
-.appVersion = "3148";
 customParameters = (
 {
 name = Axes;

--- a/resources/testdata/glyphs2/IntermediateLayer.glyphs
+++ b/resources/testdata/glyphs2/IntermediateLayer.glyphs
@@ -1,9 +1,4 @@
 {
-.appVersion = "3300";
-DisplayStrings = (
-I,
-ii
-);
 customParameters = (
 {
 name = "Disable Last Change";
@@ -62,7 +57,6 @@ Tag = wght;
 );
 }
 );
-date = "2023-07-20 13:49:39 +0000";
 familyName = "Intermediate Layer";
 fontMaster = (
 {

--- a/resources/testdata/glyphs2/KernImplicitAxes.glyphs
+++ b/resources/testdata/glyphs2/KernImplicitAxes.glyphs
@@ -27,7 +27,6 @@ xHeight = 500;
 glyphs = (
 {
 glyphname = hyphen;
-lastChange = "2023-06-05 23:23:03 +0000";
 layers = (
 {
 layerId = m01;

--- a/resources/testdata/glyphs2/MVAR.glyphs
+++ b/resources/testdata/glyphs2/MVAR.glyphs
@@ -1,5 +1,4 @@
 {
-.appVersion = "3228";
 customParameters = (
 {
 name = "Variable Font Origin";
@@ -15,7 +14,6 @@ Tag = slnt;
 );
 }
 );
-date = "2023-12-05 15:07:25 +0000";
 familyName = "MVAR Test";
 fontMaster = (
 {
@@ -296,7 +294,6 @@ xHeight = 505;
 glyphs = (
 {
 glyphname = space;
-lastChange = "2023-12-07 13:14:38 +0000";
 layers = (
 {
 layerId = m01;

--- a/resources/testdata/glyphs2/MasterNames-Italic.glyphs
+++ b/resources/testdata/glyphs2/MasterNames-Italic.glyphs
@@ -1,5 +1,4 @@
 {
-.appVersion = "3323";
 customParameters = (
 {
 name = "Disable Last Change";
@@ -19,7 +18,6 @@ Tag = wght;
 );
 }
 );
-date = "2024-10-08 16:36:05 +0000";
 familyName = "Master Names";
 fontMaster = (
 {

--- a/resources/testdata/glyphs2/MasterNames.glyphs
+++ b/resources/testdata/glyphs2/MasterNames.glyphs
@@ -1,5 +1,4 @@
 {
-.appVersion = "3323";
 customParameters = (
 {
 name = "Disable Last Change";
@@ -27,7 +26,6 @@ Tag = slnt;
 );
 }
 );
-date = "2024-10-08 14:26:05 +0000";
 familyName = "Master Names";
 fontMaster = (
 {

--- a/resources/testdata/glyphs2/MatrixComponent.glyphs
+++ b/resources/testdata/glyphs2/MatrixComponent.glyphs
@@ -1,5 +1,4 @@
 {
-.appVersion = "3219";
 familyName = MatrixComponent;
 fontMaster = (
 {

--- a/resources/testdata/glyphs2/MixedContourComponent.glyphs
+++ b/resources/testdata/glyphs2/MixedContourComponent.glyphs
@@ -1,5 +1,4 @@
 {
-.appVersion = "3151";
 familyName = "New Font";
 fontMaster = (
 {

--- a/resources/testdata/glyphs2/OpszWghtVar_AxisMappings.glyphs
+++ b/resources/testdata/glyphs2/OpszWghtVar_AxisMappings.glyphs
@@ -1,9 +1,4 @@
 {
-.appVersion = "3148";
-DisplayStrings = (
-"-",
-"!"
-);
 customParameters = (
 {
 name = Axes;
@@ -41,7 +36,6 @@ wght = {
 };
 }
 );
-date = "2022-12-01 04:52:20 +0000";
 familyName = WghtVar;
 fontMaster = (
 {
@@ -104,7 +98,6 @@ xHeight = 500;
 glyphs = (
 {
 glyphname = space;
-lastChange = "2022-12-01 04:58:12 +0000";
 layers = (
 {
 layerId = thin-12pt;
@@ -135,7 +128,6 @@ unicode = 0020;
 },
 {
 glyphname = hyphen;
-lastChange = "2022-12-01 04:57:39 +0000";
 layers = (
 {
 layerId = thin-12pt;

--- a/resources/testdata/glyphs2/QCurve.glyphs
+++ b/resources/testdata/glyphs2/QCurve.glyphs
@@ -1,16 +1,10 @@
 {
-.appVersion = "3208";
-DisplayStrings = (
-"",
-i
-);
 customParameters = (
 {
 name = "Disable Last Change";
 value = 1;
 }
 );
-date = "2023-07-20 13:49:39 +0000";
 familyName = "New Font";
 fontMaster = (
 {

--- a/resources/testdata/glyphs2/SlantedFont.glyphs
+++ b/resources/testdata/glyphs2/SlantedFont.glyphs
@@ -1,5 +1,4 @@
 {
-.appVersion = "3227";
 customParameters = (
 {
 name = "Variable Font Origin";
@@ -15,7 +14,6 @@ Tag = slnt;
 );
 }
 );
-date = "2023-12-05 14:28:33 +0000";
 familyName = "Slanted Font";
 fontMaster = (
 {
@@ -54,7 +52,6 @@ xHeight = 500;
 glyphs = (
 {
 glyphname = I;
-lastChange = "2023-12-05 14:31:49 +0000";
 layers = (
 {
 layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
@@ -91,7 +88,6 @@ unicode = 0049;
 },
 {
 glyphname = space;
-lastChange = "2023-12-05 14:44:13 +0000";
 layers = (
 {
 layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";

--- a/resources/testdata/glyphs2/TheBestNames.glyphs
+++ b/resources/testdata/glyphs2/TheBestNames.glyphs
@@ -1,9 +1,4 @@
 {
-.appVersion = "3151";
-DisplayStrings = (
-"-",
-"!"
-);
 copyright = "Copy!";
 customParameters = (
 {
@@ -64,7 +59,6 @@ Tag = wght;
 );
 }
 );
-date = "2022-12-01 04:52:20 +0000";
 designer = "Designed by me!";
 designerURL = "https://example.com/designer";
 familyName = FamilyName;
@@ -95,7 +89,6 @@ xHeight = 500;
 glyphs = (
 {
 glyphname = space;
-lastChange = "2022-12-01 04:58:12 +0000";
 layers = (
 {
 layerId = m01;
@@ -110,7 +103,6 @@ unicode = 0020;
 },
 {
 glyphname = exclam;
-lastChange = "2022-12-01 05:10:49 +0000";
 layers = (
 {
 layerId = m01;
@@ -165,7 +157,6 @@ unicode = 0021;
 },
 {
 glyphname = hyphen;
-lastChange = "2022-12-01 04:57:39 +0000";
 layers = (
 {
 layerId = m01;
@@ -202,7 +193,6 @@ unicode = 002D;
 },
 {
 glyphname = "manual-component";
-lastChange = "2022-12-01 04:57:39 +0000";
 layers = (
 {
 components = (

--- a/resources/testdata/glyphs2/WdthVar.glyphs
+++ b/resources/testdata/glyphs2/WdthVar.glyphs
@@ -1,5 +1,4 @@
 {
-.appVersion = "3323";
 copyright = "Copy!";
 customParameters = (
 {
@@ -28,7 +27,6 @@ Tag = wdth;
 );
 }
 );
-date = "2022-12-01 04:52:20 +0000";
 familyName = WdthVar;
 fontMaster = (
 {
@@ -60,7 +58,6 @@ xHeight = 500;
 glyphs = (
 {
 glyphname = space;
-lastChange = "2022-12-01 04:58:12 +0000";
 layers = (
 {
 layerId = m01;
@@ -75,7 +72,6 @@ unicode = 0020;
 },
 {
 glyphname = hyphen;
-lastChange = "2024-08-28 11:45:55 +0000";
 layers = (
 {
 layerId = m01;

--- a/resources/testdata/glyphs2/WghtVar.glyphs
+++ b/resources/testdata/glyphs2/WghtVar.glyphs
@@ -1,8 +1,4 @@
 {
-.appVersion = "3219";
-DisplayStrings = (
-"![]!"
-);
 copyright = "Copy!";
 customParameters = (
 {
@@ -39,7 +35,6 @@ Tag = wght;
 );
 }
 );
-date = "2022-12-01 04:52:20 +0000";
 familyName = WghtVar;
 fontMaster = (
 {
@@ -68,7 +63,6 @@ xHeight = 500;
 glyphs = (
 {
 glyphname = space;
-lastChange = "2022-12-01 04:58:12 +0000";
 layers = (
 {
 layerId = m01;
@@ -83,7 +77,6 @@ unicode = 0020;
 },
 {
 glyphname = exclam;
-lastChange = "2023-06-07 22:35:08 +0000";
 layers = (
 {
 layerId = m01;
@@ -138,7 +131,6 @@ unicode = 0021;
 },
 {
 glyphname = hyphen;
-lastChange = "2023-06-05 23:23:03 +0000";
 layers = (
 {
 layerId = m01;
@@ -175,7 +167,6 @@ unicode = 002D;
 },
 {
 glyphname = bracketleft;
-lastChange = "2023-06-07 22:37:02 +0000";
 layers = (
 {
 layerId = m01;
@@ -222,7 +213,6 @@ unicode = 005B;
 },
 {
 glyphname = bracketright;
-lastChange = "2023-06-07 22:35:47 +0000";
 layers = (
 {
 layerId = m01;
@@ -269,7 +259,6 @@ unicode = 005D;
 },
 {
 glyphname = "manual-component";
-lastChange = "2022-12-01 04:57:39 +0000";
 layers = (
 {
 components = (

--- a/resources/testdata/glyphs2/WghtVar.glyphspackage/fontinfo.plist
+++ b/resources/testdata/glyphs2/WghtVar.glyphspackage/fontinfo.plist
@@ -1,5 +1,4 @@
 {
-.appVersion = "3219";
 copyright = "Copy!";
 customParameters = (
 {
@@ -36,7 +35,6 @@ Tag = wght;
 );
 }
 );
-date = "2022-12-01 04:52:20 +0000";
 familyName = WghtVar;
 fontMaster = (
 {

--- a/resources/testdata/glyphs2/WghtVar_Anchors.glyphs
+++ b/resources/testdata/glyphs2/WghtVar_Anchors.glyphs
@@ -1,8 +1,4 @@
 {
-.appVersion = "3219";
-DisplayStrings = (
-A
-);
 customParameters = (
 {
 name = Axes;
@@ -14,7 +10,6 @@ Tag = wght;
 );
 }
 );
-date = "2022-12-01 04:52:20 +0000";
 familyName = WghtVar_Anchors;
 fontMaster = (
 {
@@ -43,7 +38,6 @@ xHeight = 500;
 glyphs = (
 {
 glyphname = A;
-lastChange = "2023-09-14 14:42:56 +0000";
 layers = (
 {
 anchors = (
@@ -110,7 +104,6 @@ unicode = 0041;
 },
 {
 glyphname = space;
-lastChange = "2022-12-01 04:58:12 +0000";
 layers = (
 {
 layerId = m01;
@@ -125,7 +118,6 @@ unicode = 0020;
 },
 {
 glyphname = macroncomb;
-lastChange = "2023-09-14 14:41:26 +0000";
 layers = (
 {
 anchors = (
@@ -174,7 +166,6 @@ unicode = 0304;
 },
 {
 glyphname = brevecomb;
-lastChange = "2023-09-14 14:41:26 +0000";
 layers = (
 {
 anchors = (

--- a/resources/testdata/glyphs2/WghtVar_Anchors.glyphspackage/fontinfo.plist
+++ b/resources/testdata/glyphs2/WghtVar_Anchors.glyphspackage/fontinfo.plist
@@ -1,5 +1,4 @@
 {
-.appVersion = "3219";
 customParameters = (
 {
 name = Axes;
@@ -11,7 +10,6 @@ Tag = wght;
 );
 }
 );
-date = "2022-12-01 04:52:20 +0000";
 familyName = WghtVar_Anchors;
 fontMaster = (
 {

--- a/resources/testdata/glyphs2/WghtVar_Avar.glyphs
+++ b/resources/testdata/glyphs2/WghtVar_Avar.glyphs
@@ -1,10 +1,4 @@
 {
-.appVersion = "3219";
-DisplayStrings = (
-"-",
-"!",
-"/space"
-);
 copyright = "Copy!";
 customParameters = (
 {
@@ -33,7 +27,6 @@ Tag = wght;
 );
 }
 );
-date = "2022-12-01 04:52:20 +0000";
 familyName = WghtVar;
 fontMaster = (
 {
@@ -71,7 +64,6 @@ xHeight = 500;
 glyphs = (
 {
 glyphname = space;
-lastChange = "2023-04-12 17:01:58 +0000";
 layers = (
 {
 layerId = m01;
@@ -90,7 +82,6 @@ unicode = 0020;
 },
 {
 glyphname = exclam;
-lastChange = "2023-04-12 16:55:39 +0000";
 layers = (
 {
 layerId = m01;
@@ -169,7 +160,6 @@ unicode = 0021;
 },
 {
 glyphname = hyphen;
-lastChange = "2023-04-12 17:01:20 +0000";
 layers = (
 {
 layerId = m01;
@@ -221,7 +211,6 @@ unicode = 002D;
 },
 {
 glyphname = "manual-component";
-lastChange = "2023-04-12 17:00:55 +0000";
 layers = (
 {
 components = (

--- a/resources/testdata/glyphs2/WghtVar_Avar.glyphspackage/fontinfo.plist
+++ b/resources/testdata/glyphs2/WghtVar_Avar.glyphspackage/fontinfo.plist
@@ -1,5 +1,4 @@
 {
-.appVersion = "3219";
 copyright = "Copy!";
 customParameters = (
 {
@@ -28,7 +27,6 @@ Tag = wght;
 );
 }
 );
-date = "2022-12-01 04:52:20 +0000";
 familyName = WghtVar;
 fontMaster = (
 {

--- a/resources/testdata/glyphs2/WghtVar_HeavyHyphen.glyphs
+++ b/resources/testdata/glyphs2/WghtVar_HeavyHyphen.glyphs
@@ -1,9 +1,4 @@
 {
-.appVersion = "3148";
-DisplayStrings = (
-"-",
-"!"
-);
 customParameters = (
 {
 name = Axes;
@@ -15,7 +10,6 @@ Tag = wght;
 );
 }
 );
-date = "2022-12-01 04:52:20 +0000";
 familyName = WghtVar;
 fontMaster = (
 {
@@ -44,7 +38,6 @@ xHeight = 500;
 glyphs = (
 {
 glyphname = space;
-lastChange = "2022-12-01 04:58:12 +0000";
 layers = (
 {
 layerId = m01;
@@ -59,7 +52,6 @@ unicode = 0020;
 },
 {
 glyphname = exclam;
-lastChange = "2022-12-01 05:10:49 +0000";
 layers = (
 {
 layerId = m01;
@@ -114,7 +106,6 @@ unicode = 0021;
 },
 {
 glyphname = hyphen;
-lastChange = "2022-12-01 22:53:02 +0000";
 layers = (
 {
 layerId = m01;

--- a/resources/testdata/glyphs2/WghtVar_ImplicitAxes.glyphs
+++ b/resources/testdata/glyphs2/WghtVar_ImplicitAxes.glyphs
@@ -1,8 +1,6 @@
 {
-.appVersion = "3340";
 customParameters = (
 );
-date = "2022-12-01 04:52:20 +0000";
 familyName = WghtVar;
 fontMaster = (
 {
@@ -33,7 +31,6 @@ xHeight = 500;
 glyphs = (
 {
 glyphname = space;
-lastChange = "2022-12-01 04:58:12 +0000";
 layers = (
 {
 layerId = m01;
@@ -48,7 +45,6 @@ unicode = 0020;
 },
 {
 glyphname = exclam;
-lastChange = "2025-02-13 12:27:02 +0000";
 layers = (
 {
 layerId = m01;
@@ -103,7 +99,6 @@ unicode = 0021;
 },
 {
 glyphname = hyphen;
-lastChange = "2025-02-13 12:26:44 +0000";
 layers = (
 {
 layerId = m01;

--- a/resources/testdata/glyphs2/WghtVar_Instances.glyphs
+++ b/resources/testdata/glyphs2/WghtVar_Instances.glyphs
@@ -1,9 +1,4 @@
 {
-.appVersion = "3219";
-DisplayStrings = (
-"-",
-"!"
-);
 copyright = "Copy!";
 customParameters = (
 {
@@ -32,7 +27,6 @@ Tag = wght;
 );
 }
 );
-date = "2022-12-01 04:52:20 +0000";
 familyName = WghtVar;
 fontMaster = (
 {
@@ -61,7 +55,6 @@ xHeight = 500;
 glyphs = (
 {
 glyphname = space;
-lastChange = "2022-12-01 04:58:12 +0000";
 layers = (
 {
 layerId = m01;
@@ -76,7 +69,6 @@ unicode = 0020;
 },
 {
 glyphname = exclam;
-lastChange = "2022-12-01 05:10:49 +0000";
 layers = (
 {
 layerId = m01;
@@ -131,7 +123,6 @@ unicode = 0021;
 },
 {
 glyphname = hyphen;
-lastChange = "2022-12-01 04:57:39 +0000";
 layers = (
 {
 layerId = m01;
@@ -168,7 +159,6 @@ unicode = 002D;
 },
 {
 glyphname = "manual-component";
-lastChange = "2022-12-01 04:57:39 +0000";
 layers = (
 {
 components = (

--- a/resources/testdata/glyphs2/WghtVar_Instances.glyphspackage/fontinfo.plist
+++ b/resources/testdata/glyphs2/WghtVar_Instances.glyphspackage/fontinfo.plist
@@ -1,5 +1,4 @@
 {
-.appVersion = "3219";
 copyright = "Copy!";
 customParameters = (
 {
@@ -28,7 +27,6 @@ Tag = wght;
 );
 }
 );
-date = "2022-12-01 04:52:20 +0000";
 familyName = WghtVar;
 fontMaster = (
 {

--- a/resources/testdata/glyphs2/WghtVar_NoExport.glyphs
+++ b/resources/testdata/glyphs2/WghtVar_NoExport.glyphs
@@ -1,8 +1,4 @@
 {
-.appVersion = "3226";
-DisplayStrings = (
-"![]!"
-);
 copyright = "Copy!";
 customParameters = (
 {
@@ -39,7 +35,6 @@ Tag = wght;
 );
 }
 );
-date = "2022-12-01 04:52:20 +0000";
 disablesAutomaticAlignment = 1;
 familyName = WghtVar_NoExport;
 fontMaster = (
@@ -69,7 +64,6 @@ xHeight = 500;
 glyphs = (
 {
 glyphname = space;
-lastChange = "2022-12-01 04:58:12 +0000";
 layers = (
 {
 layerId = m01;
@@ -84,7 +78,6 @@ unicode = 0020;
 },
 {
 glyphname = exclam;
-lastChange = "2023-06-07 22:35:08 +0000";
 layers = (
 {
 layerId = m01;
@@ -140,7 +133,6 @@ unicode = 0021;
 {
 export = 0;
 glyphname = hyphen;
-lastChange = "2023-11-09 16:34:37 +0000";
 layers = (
 {
 anchors = (
@@ -199,7 +191,6 @@ unicode = 002D;
 },
 {
 glyphname = bracketleft;
-lastChange = "2023-06-07 22:37:02 +0000";
 layers = (
 {
 layerId = m01;
@@ -246,7 +237,6 @@ unicode = 005B;
 },
 {
 glyphname = bracketright;
-lastChange = "2023-06-07 22:35:47 +0000";
 layers = (
 {
 layerId = m01;
@@ -293,7 +283,6 @@ unicode = 005D;
 },
 {
 glyphname = "manual-component";
-lastChange = "2023-11-09 15:45:41 +0000";
 layers = (
 {
 components = (

--- a/resources/testdata/glyphs2/WghtVar_OS2.glyphs
+++ b/resources/testdata/glyphs2/WghtVar_OS2.glyphs
@@ -1,9 +1,4 @@
 {
-.appVersion = "3340";
-DisplayStrings = (
-"-",
-"!"
-);
 copyright = "Copy!";
 customParameters = (
 {
@@ -51,7 +46,6 @@ value = (
 );
 }
 );
-date = "2022-12-01 04:52:20 +0000";
 familyName = WghtVarOS2;
 fontMaster = (
 {
@@ -124,7 +118,6 @@ xHeight = 500;
 glyphs = (
 {
 glyphname = space;
-lastChange = "2022-12-01 04:58:12 +0000";
 layers = (
 {
 layerId = m01;
@@ -139,7 +132,6 @@ unicode = 0020;
 },
 {
 glyphname = exclam;
-lastChange = "2022-12-01 05:10:49 +0000";
 layers = (
 {
 layerId = m01;
@@ -194,7 +186,6 @@ unicode = 0021;
 },
 {
 glyphname = hyphen;
-lastChange = "2022-12-01 04:57:39 +0000";
 layers = (
 {
 layerId = m01;
@@ -231,7 +222,6 @@ unicode = 002D;
 },
 {
 glyphname = "manual-component";
-lastChange = "2022-12-01 04:57:39 +0000";
 layers = (
 {
 components = (

--- a/resources/testdata/glyphs2/WghtVar_OS2.glyphspackage/fontinfo.plist
+++ b/resources/testdata/glyphs2/WghtVar_OS2.glyphspackage/fontinfo.plist
@@ -1,5 +1,4 @@
 {
-.appVersion = "3219";
 copyright = "Copy!";
 customParameters = (
 {
@@ -47,7 +46,6 @@ value = (
 );
 }
 );
-date = "2022-12-01 04:52:20 +0000";
 familyName = WghtVarOS2;
 fontMaster = (
 {

--- a/resources/testdata/glyphs2/alignment_zones_v2.glyphs
+++ b/resources/testdata/glyphs2/alignment_zones_v2.glyphs
@@ -1,6 +1,4 @@
 {
-.appVersion = "1365";
-date = "2024-07-18 16:00:55 +0000";
 familyName = "New Font";
 fontMaster = (
 {

--- a/resources/testdata/glyphs2/infinity.glyphs
+++ b/resources/testdata/glyphs2/infinity.glyphs
@@ -1,5 +1,4 @@
 {
-.appVersion = "3219";
 customParameters = (
 {
 name = Axes;
@@ -11,7 +10,6 @@ Tag = wght;
 );
 }
 );
-date = "2023-09-20 08:55:41 +0000";
 familyName = InfWght;
 fontMaster = (
 {

--- a/resources/testdata/glyphs2/infinity.glyphspackage/fontinfo.plist
+++ b/resources/testdata/glyphs2/infinity.glyphspackage/fontinfo.plist
@@ -1,5 +1,4 @@
 {
-.appVersion = "3219";
 customParameters = (
 {
 name = Axes;
@@ -11,7 +10,6 @@ Tag = wght;
 );
 }
 );
-date = "2023-09-20 08:55:41 +0000";
 familyName = InfWght;
 fontMaster = (
 {

--- a/resources/testdata/glyphs3/Component.glyphs
+++ b/resources/testdata/glyphs3/Component.glyphs
@@ -1,11 +1,5 @@
 {
-.appVersion = "3151";
 .formatVersion = 3;
-DisplayStrings = (
-".",
-","
-);
-date = "2023-01-20 20:20:30 +0000";
 familyName = "New Font";
 fontMaster = (
 {
@@ -40,7 +34,6 @@ name = Regular;
 glyphs = (
 {
 glyphname = period;
-lastChange = "2023-01-20 20:20:51 +0000";
 layers = (
 {
 layerId = m01;
@@ -62,7 +55,6 @@ unicode = 46;
 },
 {
 glyphname = comma;
-lastChange = "2023-01-20 20:22:39 +0000";
 layers = (
 {
 layerId = m01;
@@ -81,7 +73,6 @@ unicode = 44;
 },
 {
 glyphname = non_uniform_scale;
-lastChange = "2023-01-20 20:22:39 +0000";
 layers = (
 {
 layerId = m01;

--- a/resources/testdata/glyphs3/ComponentAnchor.glyphs
+++ b/resources/testdata/glyphs3/ComponentAnchor.glyphs
@@ -1,14 +1,5 @@
 {
-.appVersion = "3259";
 .formatVersion = 3;
-DisplayStrings = (
-"",
-"́",
-"",
-"/A_A",
-"/A_A/A_Aacute"
-);
-date = "2024-04-25 15:41:39 +0000";
 familyName = "New Font";
 fontMaster = (
 {
@@ -42,7 +33,6 @@ name = Regular;
 glyphs = (
 {
 glyphname = A_A;
-lastChange = "2024-04-25 20:33:02 +0000";
 layers = (
 {
 anchors = (
@@ -87,7 +77,6 @@ width = 600;
 },
 {
 glyphname = A_Aacute;
-lastChange = "2024-04-25 20:29:19 +0000";
 layers = (
 {
 layerId = m01;
@@ -107,7 +96,6 @@ width = 600;
 },
 {
 glyphname = acutecomb;
-lastChange = "2024-04-25 20:23:00 +0000";
 layers = (
 {
 anchors = (

--- a/resources/testdata/glyphs3/CustomOrigin.glyphs
+++ b/resources/testdata/glyphs3/CustomOrigin.glyphs
@@ -1,5 +1,4 @@
 {
-.appVersion = "3227";
 .formatVersion = 3;
 axes = (
 {
@@ -13,7 +12,6 @@ name = "Variable Font Origin";
 value = m01;
 }
 );
-date = "2023-12-05 15:07:25 +0000";
 familyName = "WghtVar Custom Origin";
 fontMaster = (
 {
@@ -34,7 +32,6 @@ name = "Master 2";
 glyphs = (
 {
 glyphname = space;
-lastChange = "2023-12-05 15:14:26 +0000";
 layers = (
 {
 layerId = m01;

--- a/resources/testdata/glyphs3/DuplicateNames.glyphs
+++ b/resources/testdata/glyphs3/DuplicateNames.glyphs
@@ -27,7 +27,6 @@ name = Bold;
 glyphs = (
 {
 glyphname = space;
-lastChange = "2022-12-01 04:58:12 +0000";
 layers = (
 {
 layerId = m01;

--- a/resources/testdata/glyphs3/EmptyMetaTable.glyphs
+++ b/resources/testdata/glyphs3/EmptyMetaTable.glyphs
@@ -1,5 +1,4 @@
 {
-.appVersion = "3260";
 .formatVersion = 3;
 customParameters = (
 {
@@ -8,7 +7,6 @@ value = (
 );
 }
 );
-date = "2024-12-03 00:05:48 +0000";
 familyName = EmptyMetaTable;
 fontMaster = (
 {

--- a/resources/testdata/glyphs3/Fea_Labels.glyphs
+++ b/resources/testdata/glyphs3/Fea_Labels.glyphs
@@ -1,10 +1,5 @@
 {
-.appVersion = "3317";
 .formatVersion = 3;
-DisplayStrings = (
-" "
-);
-date = "2024-09-11 20:25:35 +0000";
 familyName = "GlobalMetrics Font Test";
 features = (
 {
@@ -124,7 +119,6 @@ width = 600;
 },
 {
 glyphname = space;
-lastChange = "2024-09-11 21:06:25 +0000";
 layers = (
 {
 layerId = "0CAB57D4-4FC4-49C3-B456-FB7666EAA712";

--- a/resources/testdata/glyphs3/FixedPitch.glyphs
+++ b/resources/testdata/glyphs3/FixedPitch.glyphs
@@ -1,5 +1,4 @@
 {
-.appVersion = "3219";
 .formatVersion = 3;
 axes = (
 {

--- a/resources/testdata/glyphs3/GlobalMetrics_font_customParameters.glyphs
+++ b/resources/testdata/glyphs3/GlobalMetrics_font_customParameters.glyphs
@@ -1,10 +1,5 @@
 {
-.appVersion = "3316";
 .formatVersion = 3;
-DisplayStrings = (
-"",
-" "
-);
 axes = (
 {
 name = Weight;
@@ -62,7 +57,6 @@ name = underlinePosition;
 value = -300;
 }
 );
-date = "2024-09-11 20:25:35 +0000";
 familyName = "GlobalMetrics Font Test";
 fontMaster = (
 {
@@ -145,7 +139,6 @@ name = Black;
 glyphs = (
 {
 glyphname = space;
-lastChange = "2024-09-11 21:06:25 +0000";
 layers = (
 {
 layerId = "0CAB57D4-4FC4-49C3-B456-FB7666EAA712";

--- a/resources/testdata/glyphs3/IntermediateLayer.glyphs
+++ b/resources/testdata/glyphs3/IntermediateLayer.glyphs
@@ -1,10 +1,5 @@
 {
-.appVersion = "3300";
 .formatVersion = 3;
-DisplayStrings = (
-I,
-ii
-);
 axes = (
 {
 name = "Cap Height";
@@ -60,7 +55,6 @@ Location = 400;
 );
 }
 );
-date = "2023-07-20 13:49:39 +0000";
 familyName = "Intermediate Layer";
 fontMaster = (
 {

--- a/resources/testdata/glyphs3/InvalidVendorID.glyphs
+++ b/resources/testdata/glyphs3/InvalidVendorID.glyphs
@@ -1,5 +1,4 @@
 {
-.appVersion = "3219";
 .formatVersion = 3;
 axes = (
 {
@@ -13,7 +12,6 @@ name = vendorID;
 value = "    ";
 }
 );
-date = "2023-09-20 08:55:41 +0000";
 familyName = InvalidVendorID;
 fontMaster = (
 {

--- a/resources/testdata/glyphs3/MVAR.glyphs
+++ b/resources/testdata/glyphs3/MVAR.glyphs
@@ -1,5 +1,4 @@
 {
-.appVersion = "3228";
 .formatVersion = 3;
 axes = (
 {
@@ -13,7 +12,6 @@ name = "Variable Font Origin";
 value = m01;
 }
 );
-date = "2023-12-05 15:07:25 +0000";
 familyName = "MVAR Test";
 fontMaster = (
 {
@@ -337,7 +335,6 @@ name = "Slanted 5";
 glyphs = (
 {
 glyphname = space;
-lastChange = "2023-12-07 13:14:38 +0000";
 layers = (
 {
 layerId = m01;

--- a/resources/testdata/glyphs3/MasterNames-Italic.glyphs
+++ b/resources/testdata/glyphs3/MasterNames-Italic.glyphs
@@ -1,5 +1,4 @@
 {
-.appVersion = "3323";
 .formatVersion = 3;
 axes = (
 {
@@ -17,7 +16,6 @@ name = "Write DisplayStrings";
 value = 0;
 }
 );
-date = "2024-10-08 16:36:05 +0000";
 familyName = "Master Names";
 fontMaster = (
 {

--- a/resources/testdata/glyphs3/MasterNames.glyphs
+++ b/resources/testdata/glyphs3/MasterNames.glyphs
@@ -1,5 +1,4 @@
 {
-.appVersion = "3323";
 .formatVersion = 3;
 axes = (
 {
@@ -25,7 +24,6 @@ name = "Write DisplayStrings";
 value = 0;
 }
 );
-date = "2024-10-08 14:26:05 +0000";
 familyName = "Master Names";
 fontMaster = (
 {

--- a/resources/testdata/glyphs3/MetaTable.glyphs
+++ b/resources/testdata/glyphs3/MetaTable.glyphs
@@ -1,5 +1,4 @@
 {
-.appVersion = "3260";
 .formatVersion = 3;
 customParameters = (
 {
@@ -16,7 +15,6 @@ tag = slng;
 );
 }
 );
-date = "2024-12-03 00:05:48 +0000";
 familyName = MetaTable;
 fontMaster = (
 {

--- a/resources/testdata/glyphs3/NestedComponent.glyphs
+++ b/resources/testdata/glyphs3/NestedComponent.glyphs
@@ -1,17 +1,11 @@
 {
-.appVersion = "3151";
 .formatVersion = 3;
-DisplayStrings = (
-".",
-","
-);
 customParameters = (
 {
 name = "Write lastChange";
 value = 0;
 }
 );
-date = "2023-01-20 20:20:30 +0000";
 familyName = "New Font";
 fontMaster = (
 {

--- a/resources/testdata/glyphs3/NoMetaTable.glyphs
+++ b/resources/testdata/glyphs3/NoMetaTable.glyphs
@@ -1,7 +1,5 @@
 {
-.appVersion = "3260";
 .formatVersion = 3;
-date = "2024-12-03 00:05:48 +0000";
 familyName = NoMetaTable;
 fontMaster = (
 {

--- a/resources/testdata/glyphs3/Oswald-AE-comb.glyphs
+++ b/resources/testdata/glyphs3/Oswald-AE-comb.glyphs
@@ -1,13 +1,5 @@
 {
-.appVersion = "3223";
 .formatVersion = 3;
-DisplayStrings = (
-" 
- 
-  
-  
-"
-);
 axes = (
 {
 name = Weight;
@@ -49,7 +41,6 @@ wght = {
 };
 }
 );
-date = "2017-09-22 11:11:33 +0000";
 familyName = Oswald;
 featurePrefixes = (
 {

--- a/resources/testdata/glyphs3/Oswald-O.glyphs
+++ b/resources/testdata/glyphs3/Oswald-O.glyphs
@@ -1,9 +1,5 @@
 {
-.appVersion = "3192";
 .formatVersion = 3;
-DisplayStrings = (
-O
-);
 axes = (
 {
 name = Weight;
@@ -16,7 +12,6 @@ name = "Write lastChange";
 value = 0;
 }
 );
-date = "2023-05-05 15:11:55 +0000";
 familyName = OswaldO;
 fontMaster = (
 {

--- a/resources/testdata/glyphs3/Oswald-glyph-categories.glyphs
+++ b/resources/testdata/glyphs3/Oswald-glyph-categories.glyphs
@@ -1,17 +1,5 @@
 {
-.appVersion = "3260";
 .formatVersion = 3;
-DisplayStrings = (
-"áa",
-"̆",
-"ắ",
-"/brevecomb_acutecomb",
-"̆ă",
-"/f_a",
-a,
-b,
-"/U1C82"
-);
 axes = (
 {
 name = Weight;
@@ -46,7 +34,6 @@ wght = {
 };
 }
 );
-date = "2017-09-22 11:11:33 +0000";
 familyName = Oswald;
 featurePrefixes = (
 {

--- a/resources/testdata/glyphs3/PropagateAnchorsTest-propagated.glyphs
+++ b/resources/testdata/glyphs3/PropagateAnchorsTest-propagated.glyphs
@@ -1,5 +1,4 @@
 {
-.appVersion = "3300";
 .formatVersion = 3;
 axes = (
 {
@@ -17,7 +16,6 @@ name = "Write DisplayStrings";
 value = 0;
 }
 );
-date = "2024-02-08 12:03:09 +0000";
 familyName = "Propagate Anchors Test";
 fontMaster = (
 {

--- a/resources/testdata/glyphs3/PropagateAnchorsTest.glyphs
+++ b/resources/testdata/glyphs3/PropagateAnchorsTest.glyphs
@@ -1,5 +1,4 @@
 {
-.appVersion = "3300";
 .formatVersion = 3;
 axes = (
 {
@@ -17,7 +16,6 @@ name = "Write DisplayStrings";
 value = 0;
 }
 );
-date = "2024-02-08 12:03:09 +0000";
 familyName = "Propagate Anchors Test";
 fontMaster = (
 {

--- a/resources/testdata/glyphs3/QCurve.glyphs
+++ b/resources/testdata/glyphs3/QCurve.glyphs
@@ -1,17 +1,11 @@
 {
-.appVersion = "3208";
 .formatVersion = 3;
-DisplayStrings = (
-"",
-i
-);
 customParameters = (
 {
 name = "Write lastChange";
 value = 0;
 }
 );
-date = "2023-07-20 13:49:39 +0000";
 familyName = "New Font";
 fontMaster = (
 {

--- a/resources/testdata/glyphs3/SlantedFont.glyphs
+++ b/resources/testdata/glyphs3/SlantedFont.glyphs
@@ -1,5 +1,4 @@
 {
-.appVersion = "3227";
 .formatVersion = 3;
 axes = (
 {
@@ -13,7 +12,6 @@ name = "Variable Font Origin";
 value = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
 }
 );
-date = "2023-12-05 14:28:33 +0000";
 familyName = "Slanted Font";
 fontMaster = (
 {
@@ -81,7 +79,6 @@ name = Regular;
 glyphs = (
 {
 glyphname = I;
-lastChange = "2023-12-05 14:31:49 +0000";
 layers = (
 {
 layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
@@ -118,7 +115,6 @@ unicode = 73;
 },
 {
 glyphname = space;
-lastChange = "2023-12-05 14:44:13 +0000";
 layers = (
 {
 layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";

--- a/resources/testdata/glyphs3/StandardAxisNames.glyphs
+++ b/resources/testdata/glyphs3/StandardAxisNames.glyphs
@@ -1,5 +1,4 @@
 {
-.appVersion = "3324";
 .formatVersion = 3;
 axes = (
 {
@@ -27,7 +26,6 @@ name = foobarbaz;
 tag = FOOB;
 }
 );
-date = "2024-10-10 14:11:11 +0000";
 familyName = "New Font";
 fontMaster = (
 {
@@ -148,7 +146,6 @@ name = "Foo Bar Baz";
 glyphs = (
 {
 glyphname = space;
-lastChange = "2024-10-14 10:45:18 +0000";
 layers = (
 {
 layerId = m01;

--- a/resources/testdata/glyphs3/StaticBoldItalic.glyphs
+++ b/resources/testdata/glyphs3/StaticBoldItalic.glyphs
@@ -1,5 +1,4 @@
 {
-.appVersion = "3151";
 .formatVersion = 3;
 familyName = WghtVar;
 fontMaster = (
@@ -30,7 +29,6 @@ name = "Bold Italic";
 glyphs = (
 {
 glyphname = space;
-lastChange = "2022-12-01 04:58:12 +0000";
 layers = (
 {
 layerId = m01;

--- a/resources/testdata/glyphs3/StaticWithInstance.glyphs
+++ b/resources/testdata/glyphs3/StaticWithInstance.glyphs
@@ -1,5 +1,4 @@
 {
-.appVersion = "3151";
 .formatVersion = 3;
 familyName = WghtVar;
 fontMaster = (
@@ -11,7 +10,6 @@ name = "Regular";
 glyphs = (
 {
 glyphname = space;
-lastChange = "2022-12-01 04:58:12 +0000";
 layers = (
 {
 layerId = m01;

--- a/resources/testdata/glyphs3/TheBestNames.glyphs
+++ b/resources/testdata/glyphs3/TheBestNames.glyphs
@@ -1,10 +1,5 @@
 {
-.appVersion = "3151";
 .formatVersion = 3;
-DisplayStrings = (
-"-",
-"!"
-);
 axes = (
 {
 name = Weight;
@@ -17,7 +12,6 @@ name = "Variable Font Origin";
 value = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
 }
 );
-date = "2022-12-01 04:52:20 +0000";
 familyName = FamilyName;
 fontMaster = (
 {
@@ -72,7 +66,6 @@ name = Bold;
 glyphs = (
 {
 glyphname = space;
-lastChange = "2022-12-01 04:58:12 +0000";
 layers = (
 {
 layerId = m01;
@@ -87,7 +80,6 @@ unicode = 32;
 },
 {
 glyphname = exclam;
-lastChange = "2022-12-01 05:10:49 +0000";
 layers = (
 {
 layerId = m01;
@@ -142,7 +134,6 @@ unicode = 33;
 },
 {
 glyphname = hyphen;
-lastChange = "2022-12-01 04:57:39 +0000";
 layers = (
 {
 layerId = m01;
@@ -179,7 +170,6 @@ unicode = 45;
 },
 {
 glyphname = "manual-component";
-lastChange = "2022-12-01 04:57:39 +0000";
 layers = (
 {
 layerId = m01;

--- a/resources/testdata/glyphs3/TheBestV2NamesInAV3File.glyphs
+++ b/resources/testdata/glyphs3/TheBestV2NamesInAV3File.glyphs
@@ -1,5 +1,4 @@
 {
-.appVersion = "3151";
 .formatVersion = 3;
 axes = (
 {

--- a/resources/testdata/glyphs3/UnusualCustomParams.glyphs
+++ b/resources/testdata/glyphs3/UnusualCustomParams.glyphs
@@ -1,5 +1,4 @@
 {
-.appVersion = "3260";
 .formatVersion = 3;
 customParameters = (
 {

--- a/resources/testdata/glyphs3/WdthVar.glyphs
+++ b/resources/testdata/glyphs3/WdthVar.glyphs
@@ -1,5 +1,4 @@
 {
-.appVersion = "3316";
 .formatVersion = 3;
 axes = (
 {
@@ -7,7 +6,6 @@ name = Width;
 tag = wdth;
 }
 );
-date = "2022-12-01 04:52:20 +0000";
 familyName = WdthVar;
 fontMaster = (
 {
@@ -65,7 +63,6 @@ name = Expanded;
 glyphs = (
 {
 glyphname = space;
-lastChange = "2022-12-01 04:58:12 +0000";
 layers = (
 {
 layerId = m01;
@@ -80,7 +77,6 @@ unicode = 32;
 },
 {
 glyphname = hyphen;
-lastChange = "2024-08-28 11:45:55 +0000";
 layers = (
 {
 layerId = m01;

--- a/resources/testdata/glyphs3/WghtVar.glyphs
+++ b/resources/testdata/glyphs3/WghtVar.glyphs
@@ -1,9 +1,5 @@
 {
-.appVersion = "3219";
 .formatVersion = 3;
-DisplayStrings = (
-"![]!"
-);
 axes = (
 {
 name = Weight;
@@ -20,7 +16,6 @@ name = "Has WWS Names";
 value = 1;
 }
 );
-date = "2022-12-01 04:52:20 +0000";
 familyName = WghtVar;
 fontMaster = (
 {
@@ -77,7 +72,6 @@ name = Bold;
 glyphs = (
 {
 glyphname = space;
-lastChange = "2022-12-01 04:58:12 +0000";
 layers = (
 {
 layerId = m01;
@@ -92,7 +86,6 @@ unicode = 32;
 },
 {
 glyphname = exclam;
-lastChange = "2023-06-07 22:35:08 +0000";
 layers = (
 {
 layerId = m01;
@@ -147,7 +140,6 @@ unicode = 33;
 },
 {
 glyphname = hyphen;
-lastChange = "2023-06-05 23:23:03 +0000";
 layers = (
 {
 layerId = m01;
@@ -188,7 +180,6 @@ unicode = 45;
 glyphname = bracketleft;
 kernLeft = bracketleft_L;
 kernRight = bracketleft_R;
-lastChange = "2023-06-07 22:37:02 +0000";
 layers = (
 {
 layerId = m01;
@@ -235,7 +226,6 @@ unicode = 91;
 glyphname = bracketright;
 kernLeft = bracketright_L;
 kernRight = bracketright_R;
-lastChange = "2023-06-07 22:35:47 +0000";
 layers = (
 {
 layerId = m01;
@@ -280,7 +270,6 @@ unicode = 93;
 },
 {
 glyphname = "manual-component";
-lastChange = "2022-12-01 04:57:39 +0000";
 layers = (
 {
 layerId = m01;

--- a/resources/testdata/glyphs3/WghtVar.glyphspackage/fontinfo.plist
+++ b/resources/testdata/glyphs3/WghtVar.glyphspackage/fontinfo.plist
@@ -1,5 +1,4 @@
 {
-.appVersion = "3219";
 .formatVersion = 3;
 axes = (
 {
@@ -17,7 +16,6 @@ name = "Has WWS Names";
 value = 1;
 }
 );
-date = "2022-12-01 04:52:20 +0000";
 familyName = WghtVar;
 fontMaster = (
 {

--- a/resources/testdata/glyphs3/WghtVarWithStylisticSet.glyphs
+++ b/resources/testdata/glyphs3/WghtVarWithStylisticSet.glyphs
@@ -1,9 +1,5 @@
 {
-.appVersion = "3260";
 .formatVersion = 3;
-DisplayStrings = (
-"![]!"
-);
 axes = (
 {
 name = Weight;
@@ -20,7 +16,6 @@ name = "Has WWS Names";
 value = 1;
 }
 );
-date = "2022-12-01 04:52:20 +0000";
 familyName = WghtVar;
 features = (
 {
@@ -99,7 +94,6 @@ name = Bold;
 glyphs = (
 {
 glyphname = space;
-lastChange = "2022-12-01 04:58:12 +0000";
 layers = (
 {
 layerId = m01;
@@ -114,7 +108,6 @@ unicode = 32;
 },
 {
 glyphname = exclam;
-lastChange = "2023-06-07 22:35:08 +0000";
 layers = (
 {
 layerId = m01;
@@ -169,7 +162,6 @@ unicode = 33;
 },
 {
 glyphname = hyphen;
-lastChange = "2023-06-05 23:23:03 +0000";
 layers = (
 {
 layerId = m01;
@@ -210,7 +202,6 @@ unicode = 45;
 glyphname = bracketleft;
 kernLeft = bracketleft_L;
 kernRight = bracketleft_R;
-lastChange = "2023-06-07 22:37:02 +0000";
 layers = (
 {
 layerId = m01;
@@ -257,7 +248,6 @@ unicode = 91;
 glyphname = bracketright;
 kernLeft = bracketright_L;
 kernRight = bracketright_R;
-lastChange = "2023-06-07 22:35:47 +0000";
 layers = (
 {
 layerId = m01;
@@ -302,7 +292,6 @@ unicode = 93;
 },
 {
 glyphname = "manual-component";
-lastChange = "2022-12-01 04:57:39 +0000";
 layers = (
 {
 layerId = m01;

--- a/resources/testdata/glyphs3/WghtVar_3master_CustomOrigin.glyphs
+++ b/resources/testdata/glyphs3/WghtVar_3master_CustomOrigin.glyphs
@@ -1,10 +1,5 @@
 {
-.appVersion = "3148";
 .formatVersion = 3;
-DisplayStrings = (
-"-",
-"!"
-);
 axes = (
 {
 hidden = 1;
@@ -18,7 +13,6 @@ name = "Variable Font Origin";
 value = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
 }
 );
-date = "2022-12-01 04:52:20 +0000";
 familyName = WghtVar;
 fontMaster = (
 {
@@ -97,7 +91,6 @@ name = Bold;
 glyphs = (
 {
 glyphname = space;
-lastChange = "2022-12-09 01:38:15 +0000";
 layers = (
 {
 layerId = m01;
@@ -116,7 +109,6 @@ unicode = 32;
 },
 {
 glyphname = exclam;
-lastChange = "2022-12-09 01:39:12 +0000";
 layers = (
 {
 layerId = m01;
@@ -195,7 +187,6 @@ unicode = 33;
 },
 {
 glyphname = hyphen;
-lastChange = "2022-12-09 01:38:09 +0000";
 layers = (
 {
 layerId = m01;

--- a/resources/testdata/glyphs3/WghtVar_Anchors.glyphs
+++ b/resources/testdata/glyphs3/WghtVar_Anchors.glyphs
@@ -1,16 +1,11 @@
 {
-.appVersion = "3219";
 .formatVersion = 3;
-DisplayStrings = (
-A
-);
 axes = (
 {
 name = Weight;
 tag = wght;
 }
 );
-date = "2022-12-01 04:52:20 +0000";
 familyName = WghtVar_Anchors;
 fontMaster = (
 {
@@ -65,7 +60,6 @@ name = Bold;
 glyphs = (
 {
 glyphname = A;
-lastChange = "2023-09-14 14:42:56 +0000";
 layers = (
 {
 anchors = (
@@ -132,7 +126,6 @@ unicode = 65;
 },
 {
 glyphname = space;
-lastChange = "2022-12-01 04:58:12 +0000";
 layers = (
 {
 layerId = m01;
@@ -147,7 +140,6 @@ unicode = 32;
 },
 {
 glyphname = macroncomb;
-lastChange = "2023-09-14 14:41:26 +0000";
 layers = (
 {
 anchors = (
@@ -196,7 +188,6 @@ unicode = 772;
 },
 {
 glyphname = brevecomb;
-lastChange = "2023-09-14 14:41:26 +0000";
 layers = (
 {
 anchors = (

--- a/resources/testdata/glyphs3/WghtVar_Anchors.glyphspackage/fontinfo.plist
+++ b/resources/testdata/glyphs3/WghtVar_Anchors.glyphspackage/fontinfo.plist
@@ -1,5 +1,4 @@
 {
-.appVersion = "3219";
 .formatVersion = 3;
 axes = (
 {
@@ -7,7 +6,6 @@ name = Weight;
 tag = wght;
 }
 );
-date = "2022-12-01 04:52:20 +0000";
 familyName = WghtVar_Anchors;
 fontMaster = (
 {

--- a/resources/testdata/glyphs3/WghtVar_Avar.glyphs
+++ b/resources/testdata/glyphs3/WghtVar_Avar.glyphs
@@ -1,18 +1,11 @@
 {
-.appVersion = "3219";
 .formatVersion = 3;
-DisplayStrings = (
-"-",
-"!",
-" "
-);
 axes = (
 {
 name = Weight;
 tag = wght;
 }
 );
-date = "2022-12-01 04:52:20 +0000";
 familyName = WghtVar;
 fontMaster = (
 {
@@ -93,7 +86,6 @@ name = Bold;
 glyphs = (
 {
 glyphname = space;
-lastChange = "2023-04-12 17:01:58 +0000";
 layers = (
 {
 layerId = m01;
@@ -112,7 +104,6 @@ unicode = 32;
 },
 {
 glyphname = exclam;
-lastChange = "2023-04-12 16:55:39 +0000";
 layers = (
 {
 layerId = m01;
@@ -191,7 +182,6 @@ unicode = 33;
 },
 {
 glyphname = hyphen;
-lastChange = "2023-04-12 17:01:20 +0000";
 layers = (
 {
 layerId = m01;
@@ -243,7 +233,6 @@ unicode = 45;
 },
 {
 glyphname = "manual-component";
-lastChange = "2023-04-12 17:00:55 +0000";
 layers = (
 {
 layerId = m01;

--- a/resources/testdata/glyphs3/WghtVar_Avar.glyphspackage/fontinfo.plist
+++ b/resources/testdata/glyphs3/WghtVar_Avar.glyphspackage/fontinfo.plist
@@ -1,5 +1,4 @@
 {
-.appVersion = "3219";
 .formatVersion = 3;
 axes = (
 {
@@ -7,7 +6,6 @@ name = Weight;
 tag = wght;
 }
 );
-date = "2022-12-01 04:52:20 +0000";
 familyName = WghtVar;
 fontMaster = (
 {

--- a/resources/testdata/glyphs3/WghtVar_Avar_From_Instances.glyphs
+++ b/resources/testdata/glyphs3/WghtVar_Avar_From_Instances.glyphs
@@ -1,11 +1,5 @@
 {
-.appVersion = "3316";
 .formatVersion = 3;
-DisplayStrings = (
-"-",
-"!",
-" "
-);
 axes = (
 {
 name = Weight;
@@ -18,7 +12,6 @@ name = "Variable Font Origin";
 value = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
 }
 );
-date = "2022-12-01 04:52:20 +0000";
 familyName = WghtVar;
 fontMaster = (
 {
@@ -99,7 +92,6 @@ name = Bold;
 glyphs = (
 {
 glyphname = space;
-lastChange = "2023-04-12 17:01:58 +0000";
 layers = (
 {
 layerId = m01;
@@ -118,7 +110,6 @@ unicode = 32;
 },
 {
 glyphname = exclam;
-lastChange = "2023-04-12 16:55:39 +0000";
 layers = (
 {
 layerId = m01;
@@ -197,7 +188,6 @@ unicode = 33;
 },
 {
 glyphname = hyphen;
-lastChange = "2023-04-12 17:01:20 +0000";
 layers = (
 {
 layerId = m01;
@@ -249,7 +239,6 @@ unicode = 45;
 },
 {
 glyphname = "manual-component";
-lastChange = "2023-04-12 17:00:55 +0000";
 layers = (
 {
 layerId = m01;

--- a/resources/testdata/glyphs3/WghtVar_AxisLocation.glyphs
+++ b/resources/testdata/glyphs3/WghtVar_AxisLocation.glyphs
@@ -1,17 +1,11 @@
 {
-.appVersion = "3148";
 .formatVersion = 3;
-DisplayStrings = (
-"-",
-"!"
-);
 axes = (
 {
 name = Weight;
 tag = wght;
 }
 );
-date = "2022-12-01 04:52:20 +0000";
 familyName = WghtVar;
 fontMaster = (
 {
@@ -68,7 +62,6 @@ Location = 700;
 glyphs = (
 {
 glyphname = space;
-lastChange = "2022-12-01 04:58:12 +0000";
 layers = (
 {
 layerId = m01;
@@ -87,7 +80,6 @@ unicode = 32;
 },
 {
 glyphname = exclam;
-lastChange = "2022-12-01 05:10:49 +0000";
 layers = (
 {
 layerId = m01;
@@ -166,7 +158,6 @@ unicode = 33;
 },
 {
 glyphname = hyphen;
-lastChange = "2022-12-01 04:57:39 +0000";
 layers = (
 {
 layerId = m01;

--- a/resources/testdata/glyphs3/WghtVar_GlyphOrder.glyphs
+++ b/resources/testdata/glyphs3/WghtVar_GlyphOrder.glyphs
@@ -1,10 +1,5 @@
 {
-.appVersion = "3148";
 .formatVersion = 3;
-DisplayStrings = (
-"-",
-"!"
-);
 axes = (
 {
 name = Weight;
@@ -21,7 +16,6 @@ not-a-valid-name
 );
 }
 );
-date = "2022-12-01 04:52:20 +0000";
 familyName = WghtVar;
 fontMaster = (
 {
@@ -76,7 +70,6 @@ name = Bold;
 glyphs = (
 {
 glyphname = space;
-lastChange = "2022-12-01 04:58:12 +0000";
 layers = (
 {
 layerId = m01;
@@ -91,7 +84,6 @@ unicode = 32;
 },
 {
 glyphname = exclam;
-lastChange = "2022-12-01 05:10:49 +0000";
 layers = (
 {
 layerId = m01;
@@ -132,7 +124,6 @@ unicode = 33;
 },
 {
 glyphname = hyphen;
-lastChange = "2022-12-01 04:57:39 +0000";
 layers = (
 {
 layerId = m01;

--- a/resources/testdata/glyphs3/WghtVar_HeavyHyphen.glyphs
+++ b/resources/testdata/glyphs3/WghtVar_HeavyHyphen.glyphs
@@ -1,17 +1,11 @@
 {
-.appVersion = "3148";
 .formatVersion = 3;
-DisplayStrings = (
-"-",
-"!"
-);
 axes = (
 {
 name = Weight;
 tag = wght;
 }
 );
-date = "2022-12-01 04:52:20 +0000";
 familyName = WghtVar;
 fontMaster = (
 {
@@ -66,7 +60,6 @@ name = Bold;
 glyphs = (
 {
 glyphname = space;
-lastChange = "2022-12-01 04:58:12 +0000";
 layers = (
 {
 layerId = m01;
@@ -81,7 +74,6 @@ unicode = 32;
 },
 {
 glyphname = exclam;
-lastChange = "2022-12-01 05:10:49 +0000";
 layers = (
 {
 layerId = m01;
@@ -136,7 +128,6 @@ unicode = 33;
 },
 {
 glyphname = hyphen;
-lastChange = "2022-12-01 22:53:02 +0000";
 layers = (
 {
 layerId = m01;

--- a/resources/testdata/glyphs3/WghtVar_Instances.glyphs
+++ b/resources/testdata/glyphs3/WghtVar_Instances.glyphs
@@ -1,17 +1,11 @@
 {
-.appVersion = "3219";
 .formatVersion = 3;
-DisplayStrings = (
-"-",
-"!"
-);
 axes = (
 {
 name = Weight;
 tag = wght;
 }
 );
-date = "2022-12-01 04:52:20 +0000";
 familyName = WghtVar;
 fontMaster = (
 {
@@ -68,7 +62,6 @@ name = Bold;
 glyphs = (
 {
 glyphname = space;
-lastChange = "2022-12-01 04:58:12 +0000";
 layers = (
 {
 layerId = m01;
@@ -83,7 +76,6 @@ unicode = 32;
 },
 {
 glyphname = exclam;
-lastChange = "2022-12-01 05:10:49 +0000";
 layers = (
 {
 layerId = m01;
@@ -138,7 +130,6 @@ unicode = 33;
 },
 {
 glyphname = hyphen;
-lastChange = "2022-12-01 04:57:39 +0000";
 layers = (
 {
 layerId = m01;
@@ -175,7 +166,6 @@ unicode = 45;
 },
 {
 glyphname = "manual-component";
-lastChange = "2022-12-01 04:57:39 +0000";
 layers = (
 {
 layerId = m01;

--- a/resources/testdata/glyphs3/WghtVar_Instances.glyphspackage/fontinfo.plist
+++ b/resources/testdata/glyphs3/WghtVar_Instances.glyphspackage/fontinfo.plist
@@ -1,5 +1,4 @@
 {
-.appVersion = "3219";
 .formatVersion = 3;
 axes = (
 {
@@ -7,7 +6,6 @@ name = Weight;
 tag = wght;
 }
 );
-date = "2022-12-01 04:52:20 +0000";
 familyName = WghtVar;
 fontMaster = (
 {

--- a/resources/testdata/glyphs3/WghtVar_NoExport.glyphs
+++ b/resources/testdata/glyphs3/WghtVar_NoExport.glyphs
@@ -1,9 +1,5 @@
 {
-.appVersion = "3226";
 .formatVersion = 3;
-DisplayStrings = (
-"![]!"
-);
 axes = (
 {
 name = Weight;
@@ -20,7 +16,6 @@ name = "Has WWS Names";
 value = 1;
 }
 );
-date = "2022-12-01 04:52:20 +0000";
 familyName = WghtVar_NoExport;
 fontMaster = (
 {
@@ -77,7 +72,6 @@ name = Bold;
 glyphs = (
 {
 glyphname = space;
-lastChange = "2022-12-01 04:58:12 +0000";
 layers = (
 {
 layerId = m01;
@@ -92,7 +86,6 @@ unicode = 32;
 },
 {
 glyphname = exclam;
-lastChange = "2023-06-07 22:35:08 +0000";
 layers = (
 {
 layerId = m01;
@@ -150,7 +143,6 @@ export = 0;
 glyphname = hyphen;
 kernLeft = hyphen_L;
 kernRight = hyphen_R;
-lastChange = "2023-11-09 16:34:37 +0000";
 layers = (
 {
 anchors = (
@@ -211,7 +203,6 @@ unicode = 45;
 glyphname = bracketleft;
 kernLeft = bracketleft_L;
 kernRight = bracketleft_R;
-lastChange = "2023-06-07 22:37:02 +0000";
 layers = (
 {
 layerId = m01;
@@ -258,7 +249,6 @@ unicode = 91;
 glyphname = bracketright;
 kernLeft = bracketright_L;
 kernRight = bracketright_R;
-lastChange = "2023-06-07 22:35:47 +0000";
 layers = (
 {
 layerId = m01;
@@ -303,7 +293,6 @@ unicode = 93;
 },
 {
 glyphname = "manual-component";
-lastChange = "2023-11-09 15:45:41 +0000";
 layers = (
 {
 layerId = m01;

--- a/resources/testdata/glyphs3/WghtVar_OS2.glyphs
+++ b/resources/testdata/glyphs3/WghtVar_OS2.glyphs
@@ -1,10 +1,5 @@
 {
-.appVersion = "3219";
 .formatVersion = 3;
-DisplayStrings = (
-"-",
-"!"
-);
 axes = (
 {
 name = Weight;
@@ -32,7 +27,6 @@ value = (
 );
 }
 );
-date = "2022-12-01 04:52:20 +0000";
 familyName = WghtVarOS2;
 fontMaster = (
 {
@@ -129,7 +123,6 @@ name = Bold;
 glyphs = (
 {
 glyphname = space;
-lastChange = "2022-12-01 04:58:12 +0000";
 layers = (
 {
 layerId = m01;
@@ -144,7 +137,6 @@ unicode = 32;
 },
 {
 glyphname = exclam;
-lastChange = "2022-12-01 05:10:49 +0000";
 layers = (
 {
 layerId = m01;
@@ -199,7 +191,6 @@ unicode = 33;
 },
 {
 glyphname = hyphen;
-lastChange = "2022-12-01 04:57:39 +0000";
 layers = (
 {
 layerId = m01;
@@ -236,7 +227,6 @@ unicode = 45;
 },
 {
 glyphname = "manual-component";
-lastChange = "2022-12-01 04:57:39 +0000";
 layers = (
 {
 layerId = m01;

--- a/resources/testdata/glyphs3/WghtVar_OS2.glyphspackage/fontinfo.plist
+++ b/resources/testdata/glyphs3/WghtVar_OS2.glyphspackage/fontinfo.plist
@@ -1,5 +1,4 @@
 {
-.appVersion = "3219";
 .formatVersion = 3;
 axes = (
 {
@@ -28,7 +27,6 @@ value = (
 );
 }
 );
-date = "2022-12-01 04:52:20 +0000";
 familyName = WghtVarOS2;
 fontMaster = (
 {

--- a/resources/testdata/glyphs3/custom_param_disable.glyphs
+++ b/resources/testdata/glyphs3/custom_param_disable.glyphs
@@ -1,5 +1,4 @@
 {
-.appVersion = "3260";
 customParameters = (
 {
 disabled = 1;
@@ -10,7 +9,6 @@ value = (
 );
 }
 );
-date = "2024-07-18 16:00:55 +0000";
 familyName = "New Font";
 fontMaster = (
 {

--- a/resources/testdata/glyphs3/fstype_0x0000.glyphs
+++ b/resources/testdata/glyphs3/fstype_0x0000.glyphs
@@ -1,5 +1,4 @@
 {
-.appVersion = "3219";
 .formatVersion = 3;
 axes = (
 {
@@ -14,7 +13,6 @@ value = (
 );
 }
 );
-date = "2023-09-20 08:55:41 +0000";
 familyName = fstype;
 fontMaster = (
 {

--- a/resources/testdata/glyphs3/fstype_0x0104.glyphs
+++ b/resources/testdata/glyphs3/fstype_0x0104.glyphs
@@ -1,5 +1,4 @@
 {
-.appVersion = "3219";
 .formatVersion = 3;
 axes = (
 {
@@ -16,7 +15,6 @@ value = (
 );
 }
 );
-date = "2023-09-20 08:55:41 +0000";
 familyName = fstype;
 fontMaster = (
 {

--- a/resources/testdata/glyphs3/gdef_categories_no_layout.glyphs
+++ b/resources/testdata/glyphs3/gdef_categories_no_layout.glyphs
@@ -1,11 +1,5 @@
 {
-.appVersion = "3260";
 .formatVersion = 3;
-DisplayStrings = (
-"/space",
-"/mycustommark"
-);
-date = "2023-05-05 15:11:55 +0000";
 familyName = Dated;
 fontMaster = (
 {
@@ -16,7 +10,6 @@ name = Regular;
 glyphs = (
 {
 glyphname = space;
-lastChange = "2024-09-05 19:35:17 +0000";
 layers = (
 {
 layerId = m01;
@@ -27,7 +20,6 @@ width = 200;
 {
 category = Mark;
 glyphname = mycustommark;
-lastChange = "2024-09-05 19:36:39 +0000";
 layers = (
 {
 anchors = (

--- a/resources/testdata/glyphs3/infinity.glyphs
+++ b/resources/testdata/glyphs3/infinity.glyphs
@@ -1,5 +1,4 @@
 {
-.appVersion = "3219";
 .formatVersion = 3;
 axes = (
 {
@@ -7,7 +6,6 @@ name = Weight;
 tag = wght;
 }
 );
-date = "2023-09-20 08:55:41 +0000";
 familyName = InfWght;
 fontMaster = (
 {

--- a/resources/testdata/glyphs3/infinity.glyphspackage/fontinfo.plist
+++ b/resources/testdata/glyphs3/infinity.glyphspackage/fontinfo.plist
@@ -1,5 +1,4 @@
 {
-.appVersion = "3219";
 .formatVersion = 3;
 axes = (
 {
@@ -7,7 +6,6 @@ name = Weight;
 tag = wght;
 }
 );
-date = "2023-09-20 08:55:41 +0000";
 familyName = InfWght;
 fontMaster = (
 {

--- a/resources/testdata/glyphs3/number_value.glyphs
+++ b/resources/testdata/glyphs3/number_value.glyphs
@@ -1,5 +1,4 @@
 {
-.appVersion = "3260";
 .formatVersion = 3;
 axes = (
 {
@@ -17,7 +16,6 @@ value = (
 );
 }
 );
-date = "2024-07-18 16:00:55 +0000";
 familyName = "New Font";
 fontMaster = (
 {
@@ -105,7 +103,6 @@ unicode = 65;
 },
 {
 glyphname = a;
-lastChange = "2024-07-30 20:14:41 +0000";
 layers = (
 {
 layerId = "CEAF8881-3B30-4737-AC29-09BAEF72AFFD";


### PR DESCRIPTION
In poking at some of our .glyphs files I notice we have files with content no test needs, lets try to make them slightly more minimal. Manual editing can go much further but just deleting some stuff programmatically is a start.