### PR TITLE
Parse basic linear/radial gradient specifications from .glyphs

### DIFF
--- a/glyphs-reader/src/plist.rs
+++ b/glyphs-reader/src/plist.rs
@@ -67,6 +67,12 @@ pub enum Error {
     },
     #[error("Unexpected token '{name}'")]
     UnexpectedToken { name: &'static str },
+    #[error("Expected {expected} {value_type},, found '{actual}'")]
+    UnexpectedNumberOfValues {
+        value_type: &'static str,
+        expected: usize,
+        actual: usize,
+    },
     #[error("parsing failed: '{0}'")]
     Parse(String),
 }

--- a/glyphs-reader/src/propagate_anchors.rs
+++ b/glyphs-reader/src/propagate_anchors.rs
@@ -536,7 +536,7 @@ mod tests {
                 .push(Shape::Component(Component {
                     name: name.into(),
                     transform: Affine::translate((pos.0 as f64, pos.1 as f64)),
-                    anchor: None,
+                    ..Default::default()
                 }));
             self
         }

--- a/glyphs2fontir/src/toir.rs
+++ b/glyphs2fontir/src/toir.rs
@@ -371,6 +371,7 @@ mod tests {
         let path = Path {
             closed: true,
             nodes,
+            ..Default::default()
         };
 
         let bez = to_ir_path("hello".into(), &path).unwrap();

--- a/resources/testdata/glyphs3/COLRv1-simple.glyphs
+++ b/resources/testdata/glyphs3/COLRv1-simple.glyphs
@@ -193,66 +193,6 @@ width = 600;
 unicode = 68;
 },
 {
-glyphname = E;
-layers = (
-{
-layerId = m01;
-width = 600;
-}
-);
-unicode = 69;
-},
-{
-glyphname = F;
-layers = (
-{
-layerId = m01;
-width = 600;
-}
-);
-unicode = 70;
-},
-{
-glyphname = G;
-layers = (
-{
-layerId = m01;
-width = 600;
-}
-);
-unicode = 71;
-},
-{
-glyphname = H;
-layers = (
-{
-layerId = m01;
-width = 600;
-}
-);
-unicode = 72;
-},
-{
-glyphname = I;
-layers = (
-{
-layerId = m01;
-width = 600;
-}
-);
-unicode = 73;
-},
-{
-glyphname = J;
-layers = (
-{
-layerId = m01;
-width = 600;
-}
-);
-unicode = 74;
-},
-{
 glyphname = K;
 layers = (
 {


### PR DESCRIPTION
Read the example provided in #1284