### PR TITLE
[fea-rs] Better merging of contextual ligature rules

### DIFF
--- a/fea-rs/src/compile/lookups/contextual.rs
+++ b/fea-rs/src/compile/lookups/contextual.rs
@@ -236,7 +236,7 @@ impl ContextualLookupBuilder<SubstitutionLookup> {
                 SubstitutionLookup::Ligature(builder) => builder
                     .subtables
                     .iter()
-                    .all(|sub| !sub.contains_target(target.first().copied().unwrap())),
+                    .all(|sub| sub.can_add(&target, replacement)),
                 _ => false,
             },
             |flags, mark_set| SubstitutionLookup::Ligature(LookupBuilder::new(flags, mark_set)),

--- a/fea-rs/test-data/compile-tests/mini-latin/good/contextual_duplicate_lig.fea
+++ b/fea-rs/test-data/compile-tests/mini-latin/good/contextual_duplicate_lig.fea
@@ -1,0 +1,6 @@
+
+feature test {
+    sub a' a' by A;
+    sub a' b' by B;
+    sub a' a' by A; # this is a duplicate
+} test;

--- a/fea-rs/test-data/compile-tests/mini-latin/good/contextual_duplicate_lig.ttx
+++ b/fea-rs/test-data/compile-tests/mini-latin/good/contextual_duplicate_lig.ttx
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont>
+
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=1 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="test"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=2 -->
+      <Lookup index="0">
+        <LookupType value="5"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <ContextSubst index="0" Format="1">
+          <Coverage>
+            <Glyph value="a"/>
+          </Coverage>
+          <!-- SubRuleSetCount=1 -->
+          <SubRuleSet index="0">
+            <!-- SubRuleCount=3 -->
+            <SubRule index="0">
+              <!-- GlyphCount=2 -->
+              <!-- SubstCount=1 -->
+              <Input index="0" value="a"/>
+              <SubstLookupRecord index="0">
+                <SequenceIndex value="0"/>
+                <LookupListIndex value="1"/>
+              </SubstLookupRecord>
+            </SubRule>
+            <SubRule index="1">
+              <!-- GlyphCount=2 -->
+              <!-- SubstCount=1 -->
+              <Input index="0" value="b"/>
+              <SubstLookupRecord index="0">
+                <SequenceIndex value="0"/>
+                <LookupListIndex value="1"/>
+              </SubstLookupRecord>
+            </SubRule>
+            <SubRule index="2">
+              <!-- GlyphCount=2 -->
+              <!-- SubstCount=1 -->
+              <Input index="0" value="a"/>
+              <SubstLookupRecord index="0">
+                <SequenceIndex value="0"/>
+                <LookupListIndex value="1"/>
+              </SubstLookupRecord>
+            </SubRule>
+          </SubRuleSet>
+        </ContextSubst>
+      </Lookup>
+      <Lookup index="1">
+        <LookupType value="4"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <LigatureSubst index="0">
+          <LigatureSet glyph="a">
+            <Ligature components="a" glyph="A"/>
+            <Ligature components="b" glyph="B"/>
+          </LigatureSet>
+        </LigatureSubst>
+      </Lookup>
+    </LookupList>
+  </GSUB>
+
+</ttFont>


### PR DESCRIPTION
- Improves the logic for determining when we can reuse a lookup for an inline ligature sub rule, which will let us be much more aggressive in reusing these lookups,
- And adds logic to skip duplicate identical rules in ligature substitution tables.