### PR TITLE
[ttx_diff] Fixup class-based context reordering

### DIFF
--- a/resources/scripts/ttx_diff.py
+++ b/resources/scripts/ttx_diff.py
@@ -612,6 +612,7 @@ def reorder_contextual_class_based_rules(ttx: etree.ElementTree, tag: str):
             )
             for class_set in chain_ctx.findall(class_set_name):
                 for class_rule in class_set.findall(class_rule_name):
+                    remap_values(class_rule, input_class_order, "Input")
                     remap_values(class_rule, backtrack_class_order, "Backtrack")
                     remap_values(class_rule, lookahead_class_order, "LookAhead")
 


### PR DESCRIPTION
There was one thing I'd forgotten to remap, and which I guess isn't used super often?

JMM