### PR TITLE
[features] Share more code, do less work

### DIFF
--- a/fontc/src/workload.rs
+++ b/fontc/src/workload.rs
@@ -15,7 +15,7 @@ use fontbe::{
     cmap::create_cmap_work,
     features::{
         create_gather_ir_kerning_work, create_kern_segment_work, create_kerns_work,
-        create_mark_work, FeatureCompilationWork, FeatureParsingWork,
+        create_mark_work, FeatureCompilationWork, FeatureFirstPassWork,
     },
     font::create_font_work,
     fvar::create_fvar_work,
@@ -156,7 +156,7 @@ impl Workload {
         workload.add(create_glyph_order_work());
 
         // BE: f(IR, maybe other BE work) => binary
-        workload.add_skippable_feature_work(FeatureParsingWork::create());
+        workload.add_skippable_feature_work(FeatureFirstPassWork::create());
         workload.add_skippable_feature_work(FeatureCompilationWork::create());
         workload.add(create_gasp_work());
         let ir_glyphs = workload


### PR DESCRIPTION
In order to compile both marks & kern we need to have already compiled the GSUB table. To avoid doing this repeatedly, we now compile it immediately after parsing the AST, and then make it available to the mark & kern feature writers.

We also similarly store the explicit GDEF classes, if they were in the FEA, and try to share more code between mark & kern generation in general.

This also includes a commit that makes us convert glyph names to glyph ids earlier in the marks compilation process, which similarly helps us share more code with kerning.

(all of this is motivated by work on abvm and blwm)