### PR TITLE
bump write-fonts 0.36.1: computes checksum_adjustment and sorts tables as recommended

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ rayon = "1.6"
 icu_properties = "2.0.0-beta1"
 
 # fontations etc
-write-fonts = { version = "0.36.0", features = ["serde", "read"] }
+write-fonts = { version = "0.36.1", features = ["serde", "read"] }
 skrifa = "0.28.0"
 norad = { version = "0.15.0", default-features = false }
 

--- a/fea-rs/src/util/ttx.rs
+++ b/fea-rs/src/util/ttx.rs
@@ -439,6 +439,8 @@ fn rewrite_ttx(input: &str) -> String {
     for line in input.lines() {
         if line.starts_with("<ttFont") {
             out.push_str("<ttFont>\n");
+        } else if line.starts_with("    <checkSumAdjustment value=\"0x") {
+            out.push_str("    <checkSumAdjustment value=\"0x0\"/>\n");
         } else {
             out.push_str(line);
             out.push('\n')


### PR DESCRIPTION
Fixes https://github.com/googlefonts/fontc/issues/945 and https://github.com/googlefonts/fontc/issues/1268

maybe since this was a patch (compatible) release, cargo should pick it up in any case, but I suppose it doesn't hurt if we explicitly do bump