### PR TITLE
Respect 'Propagate Anchors' custom parameter

### DIFF
--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -68,6 +68,7 @@ pub struct Font {
 /// Custom parameter options that can be set on a glyphs font
 #[derive(Clone, Debug, PartialEq, Hash, Default)]
 pub struct CustomParameters {
+    pub propagate_anchors: Option<bool>,
     pub use_typo_metrics: Option<bool>,
     pub is_fixed_pitch: Option<bool>,
     pub fs_type: Option<u16>,
@@ -598,6 +599,7 @@ impl RawCustomParameters {
                 continue;
             }
             match name.as_str() {
+                "Propagate Anchors" => add_and_report_issues!(propagate_anchors, Plist::as_bool),
                 "Use Typo Metrics" => add_and_report_issues!(use_typo_metrics, Plist::as_bool),
                 "isFixedPitch" => add_and_report_issues!(is_fixed_pitch, Plist::as_bool),
                 "Has WWS Names" => add_and_report_issues!(has_wws_names, Plist::as_bool),
@@ -2584,7 +2586,11 @@ fn preprocess_unparsed_plist(s: &str) -> Cow<str> {
 impl Font {
     pub fn load(glyphs_file: &path::Path) -> Result<Font, Error> {
         let mut font = Self::load_raw(glyphs_file)?;
-        font.propagate_all_anchors();
+
+        // propagate anchors by default unless explicitly set to false
+        if font.custom_parameters.propagate_anchors.unwrap_or(true) {
+            font.propagate_all_anchors();
+        }
         Ok(font)
     }
 

--- a/glyphs-reader/src/propagate_anchors.rs
+++ b/glyphs-reader/src/propagate_anchors.rs
@@ -1023,4 +1023,15 @@ mod tests {
         let sorted = depth_sorted_composite_glyphs(&glyphs);
         assert_eq!(sorted, ["A", "C", "E", "D", "B"]);
     }
+
+    #[test]
+    fn dont_propagate_anchors() {
+        let font = Font::load(std::path::Path::new(
+            "../resources/testdata/glyphs2/DontPropagateAnchors.glyphs",
+        ))
+        .unwrap();
+        assert_eq!(font.custom_parameters.propagate_anchors, Some(false));
+        let glyph = font.glyphs.get("Aacute").unwrap();
+        assert!(glyph.layers.first().unwrap().anchors.is_empty());
+    }
 }

--- a/resources/testdata/glyphs2/DontPropagateAnchors.glyphs
+++ b/resources/testdata/glyphs2/DontPropagateAnchors.glyphs
@@ -1,0 +1,90 @@
+{
+.appVersion = "1364";
+familyName = "New Font";
+customParameters = (
+{
+name = "Propagate Anchors";
+value = 0;
+}
+);
+fontMaster = (
+{
+ascender = 800;
+capHeight = 700;
+descender = -200;
+id = "89D5A646-9CD3-4D7D-B45A-59A2C21796F3";
+xHeight = 500;
+}
+);
+glyphs = (
+{
+glyphname = A;
+layers = (
+{
+layerId = "89D5A646-9CD3-4D7D-B45A-59A2C21796F3";
+paths = (
+{
+closed = 1;
+nodes = (
+"254 183 LINE",
+"426 35 LINE",
+"97 20 LINE"
+);
+}
+);
+width = 600;
+}
+);
+unicode = 0041;
+},
+{
+glyphname = Aacute;
+layers = (
+{
+components = (
+{
+name = A;
+},
+{
+name = acutecomb;
+transform = "{1, 0, 0, 1, 38, -161}";
+}
+);
+layerId = "89D5A646-9CD3-4D7D-B45A-59A2C21796F3";
+width = 600;
+}
+);
+unicode = 00C1;
+},
+{
+glyphname = acutecomb;
+layers = (
+{
+anchors = (
+{
+name = "new anchor";
+position = "{258, 593}";
+}
+);
+layerId = "89D5A646-9CD3-4D7D-B45A-59A2C21796F3";
+paths = (
+{
+closed = 1;
+nodes = (
+"263 376 LINE",
+"308 456 LINE",
+"239 471 LINE",
+"217 385 LINE"
+);
+}
+);
+width = 600;
+}
+);
+unicode = 0301;
+}
+);
+unitsPerEm = 1000;
+versionMajor = 1;
+versionMinor = 0;
+}


### PR DESCRIPTION
I've tested this by running ttx_diff on **notofonts/arabic/sources/NotoSansArabic.glyphspackage** and got these improvements:

|   COMPARISON  | Before  |   After   |
| ------------- | ------- | --------- |
| (mark / kern) | 29.249% | Identical |
|     GDEF      | 56.062% | Identical |
|     GPOS      | 87.500% | Identical |
|   ligcaret    | 34.043% | Identical |

(issue #889)