### PR TITLE
[crater] Work around diffs rounded to 100%

### DIFF
--- a/fontc_crater/src/ci/html.rs
+++ b/fontc_crater/src/ci/html.rs
@@ -410,7 +410,12 @@ fn make_diff_report(
                     k,
                     match v {
                         DiffOutput::Identical => 100.0,
-                        DiffOutput::Diffs(d) => d.get("total").unwrap().ratio().unwrap() * 100.0,
+                        DiffOutput::Diffs(d) => {
+                            // sometimes the output is rounded up to 100 but is
+                            // not actually identical: we want to not show that as 100!
+                            let diff_perc = d.get("total").unwrap().ratio().unwrap() * 100.0;
+                            diff_perc.min(99.999)
+                        }
                     },
                 )
             })


### PR DESCRIPTION
Sometimes ttx_diff reports a diff with ratio of 1.0, and we were treating this the same as if it was identical. This patch makes sure we are distinguishing between 'identical' and 'very very close' by manually nudging the percent in this case.

JMM