### PR TITLE
Parse quoted numbers as bools, consistent with how normal numbers are handled

### DIFF
--- a/glyphs-reader/src/plist.rs
+++ b/glyphs-reader/src/plist.rs
@@ -898,6 +898,7 @@ impl FromPlist for bool {
     fn parse(tokenizer: &mut Tokenizer<'_>) -> Result<Self, Error> {
         match tokenizer.lex()? {
             Token::Atom(val) => parse_int(val).map(|v| v == 1),
+            Token::String(val) => parse_int(&val).map(|v| v == 1),
             _ => Err(Error::ExpectedNumber),
         }
     }
@@ -1171,5 +1172,20 @@ mod tests {
             assert_eq!(token, Token::String(Cow::Borrowed(expected)));
             assert_eq!(len, expected_len);
         }
+    }
+
+    #[test]
+    fn parse_quoted_and_unquoted_ints_and_bools() {
+        assert_eq!(
+            (Ok(1), Ok(1), Ok(true), Ok(true), Ok(false), Ok(false)),
+            (
+                Tokenizer::new("1").parse::<i64>(),
+                Tokenizer::new("\"1\"").parse::<i64>(),
+                Tokenizer::new("1").parse::<bool>(),
+                Tokenizer::new("\"1\"").parse::<bool>(),
+                Tokenizer::new("0").parse::<bool>(),
+                Tokenizer::new("\"0\"").parse::<bool>(),
+            )
+        );
     }
 }


### PR DESCRIPTION
Helps with FoldIt which does things like `color = "1"`, though FoldIt will still fail due to color tuples that don't have 4 values:

```
# we don't understand this yet
gradient = {
colors = (
(
(64,255),
0
),
(
(191,255),
1
)
);
end = (0.4489,0.0368);
start = (0.4192,0.8964);
};
```

Edit: 2 part colors appear to be grayscale per https://github.com/googlefonts/glyphsLib/blob/c4db6b981d577f456d64ebe9993818770e170454/Lib/glyphsLib/builder/common.py#L41-L50, will add that in a followon

JMM