### PR TITLE
Bump write-fonts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ rayon = "1.6"
 icu_properties = "2.0.0-beta1"
 
 # fontations etc
-write-fonts = { version = "0.36.1", features = ["serde", "read"] }
+write-fonts = { version = "0.36.2", features = ["serde", "read"] }
 skrifa = "0.28.0"
 norad = { version = "0.15.0", default-features = false }
 


### PR DESCRIPTION
This brings in a fix that for a problem where we did not preserve the markFilterSet id when splitting GPOS subtables.