### PR TITLE
[crater] Display repos for which we couldnt find targets

### DIFF
--- a/fontc_crater/Cargo.toml
+++ b/fontc_crater/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 [dependencies]
 fontc = { version = "0.0.1", path = "../fontc" }
 
-google-fonts-sources = "0.7.0"
+google-fonts-sources = "0.7.1"
 maud = "0.26.0"
 tidier = "0.5.3"
 


### PR DESCRIPTION
These are just displayed in a block at the top, after the summary but before the detailed report.

They aren't included as "other failures" because those are all associated with running particular targets, and this failure happens before we get a target. (A target is something specific in crater, and you can't create one wthout valid paths to the config and the source file.)

It's kind of ugly and we might want to iterate on that, but it at least gets the information out there.