### PR TITLE
[glyphs] Only non-spacing marks are non-spacing

### DIFF
--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -268,10 +268,7 @@ impl Glyph {
     pub fn is_nonspacing_mark(&self) -> bool {
         matches!(
             (self.category, self.sub_category),
-            (
-                Some(Category::Mark),
-                Some(Subcategory::Nonspacing) | Some(Subcategory::SpacingCombining)
-            )
+            (Some(Category::Mark), Some(Subcategory::Nonspacing))
         )
     }
 

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -1851,4 +1851,13 @@ mod tests {
             static_metadata.misc.panose
         );
     }
+
+    #[test]
+    fn mark_width_zeroing() {
+        let (source, context) = build_static_metadata(glyphs3_dir().join("SpacingMark.glyphs"));
+        build_glyphs(&source, &context).unwrap();
+        let glyph = context.get_glyph("descender-cy");
+        // this is a spacing-combining mark, so we shouldn't zero it's width
+        assert!(glyph.default_instance().width != 0.0);
+    }
 }

--- a/resources/testdata/glyphs3/SpacingMark.glyphs
+++ b/resources/testdata/glyphs3/SpacingMark.glyphs
@@ -1,0 +1,26 @@
+{
+.appVersion = "3343";
+.formatVersion = 3;
+familyName = Cormorant;
+fontMaster = (
+{
+iconName = Light;
+id = "68864C9E-53B8-40CD-B419-4EDDE40154E2";
+name = Light;
+}
+);
+glyphs = (
+{
+glyphname = "descender-cy";
+layers = (
+{
+layerId = "68864C9E-53B8-40CD-B419-4EDDE40154E2";
+width = 243;
+}
+);
+}
+);
+unitsPerEm = 1000;
+versionMajor = 4;
+versionMinor = 1;
+}


### PR DESCRIPTION
Confused by what I was thinking when I wrote this, since I remember intentionally including SpacingCombining in this statement, based on some reference? but it isn't what python is doing, and it's a source of diff so... no clue.

JMM