### PR TITLE
[glyphs] match glyphsLib defaults if width is missing

### DIFF
--- a/resources/testdata/glyphs3/MissingWidth.glyphs
+++ b/resources/testdata/glyphs3/MissingWidth.glyphs
@@ -1,0 +1,25 @@
+{
+.appVersion = "3343";
+.formatVersion = 3;
+familyName = Cormorant;
+fontMaster = (
+{
+iconName = Light;
+id = "68864C9E-53B8-40CD-B419-4EDDE40154E2";
+name = Light;
+}
+);
+glyphs = (
+{
+glyphname = "widthless";
+layers = (
+{
+layerId = "68864C9E-53B8-40CD-B419-4EDDE40154E2";
+}
+);
+}
+);
+unitsPerEm = 1000;
+versionMajor = 4;
+versionMinor = 1;
+}


### PR DESCRIPTION
see https://github.com/googlefonts/glyphsLib/blob/c4db6b981d577f456d64ebe9993818770e170454/Lib/glyphsLib/classes.py#L3662