### PR TITLE
[crater] Add flag to skip gftools builds

### DIFF
--- a/fontc_crater/src/args.rs
+++ b/fontc_crater/src/args.rs
@@ -41,6 +41,9 @@ pub(super) struct CiArgs {
     /// This should be consistent between runs.
     #[arg(short = 'o', long = "out")]
     pub(super) out_dir: PathBuf,
+    /// gftools mode (disable to reduce target count when running locally)
+    #[arg(long, default_value_t = true)]
+    pub(super) gftools: bool,
     /// only generate html (for the provided out_dir)
     #[arg(long)]
     pub(super) html_only: bool,

--- a/fontc_crater/src/ci.rs
+++ b/fontc_crater/src/ci.rs
@@ -126,10 +126,14 @@ fn run_crater_and_save_results(args: &CiArgs) -> Result<(), Error> {
     log::info!("compiled otl-normalizeer to {}", normalizer_path.display());
 
     let ResolvedTargets {
-        targets,
+        mut targets,
         source_repos,
         failures,
     } = make_targets(&cache_dir, &inputs);
+
+    if !args.gftools {
+        targets.retain(|t| t.build == BuildType::Default);
+    }
 
     let n_targets = targets.len();
 


### PR DESCRIPTION
I often like to run crater locally, but runtime is starting to get prohibitive. This option lets us skip all the gftools builds, which cuts the number of targets in half, but means we're at least still trying to build all the fonts we know of.