### PR TITLE
[glyphs] Add 'Composition' subcategory

### DIFF
--- a/glyphs-reader/src/glyphdata.rs
+++ b/glyphs-reader/src/glyphdata.rs
@@ -69,6 +69,7 @@ pub enum Subcategory {
     SpacingCombining,
     Emoji,
     Enclosing,
+    Composition,
 }
 
 /// A queryable set of glyph data
@@ -671,6 +672,7 @@ impl FromStr for Subcategory {
             "Spacing Combining" => Ok(Self::SpacingCombining),
             "Emoji" => Ok(Self::Emoji),
             "Enclosing" => Ok(Self::Enclosing),
+            "Composition" => Ok(Self::Composition),
             _ => Err(s.into()),
         }
     }
@@ -722,6 +724,7 @@ impl Display for Subcategory {
             Self::SpacingCombining => write!(f, "Spacing Combining"),
             Self::Emoji => write!(f, "Emoji"),
             Self::Enclosing => write!(f, "Enclosing"),
+            Self::Composition => write!(f, "Composition"),
         }
     }
 }


### PR DESCRIPTION
Missing this was causing us to incorrectly treat some glyphs as ligatures, which was then causing us to not include them in mark-to-base.

The list of categories/subcategories seems to have changed over time and/or not be fully documented; the list that I initially included were those that were available in the version of glyphs I was using at the time, but I've seen some other ones in the wild, and we can add them as they're encountered. (this was encountered in [NotoSansSiddham](https://github.com/notofonts/siddham)).

JMM