### PR TITLE
[kern] Manual kern feature without insert mark wins

### DIFF
--- a/fea-rs/src/token_tree/typed.rs
+++ b/fea-rs/src/token_tree/typed.rs
@@ -667,8 +667,14 @@ impl FloatLike {
 }
 
 impl Feature {
-    pub(crate) fn tag(&self) -> Tag {
+    /// The name (tag) of this feature (kern, merk, etc)
+    pub fn tag(&self) -> Tag {
         self.iter().find_map(Tag::cast).unwrap()
+    }
+
+    /// Returns `true` if this feature block contains an '# Automatic Code' comment
+    pub fn has_insert_marker(&self) -> bool {
+        self.statements().any(|s| s.kind() == Kind::Comment)
     }
 
     pub(crate) fn statements(&self) -> impl Iterator<Item = &NodeOrToken> {


### PR DESCRIPTION
That is, if the user FEA has a `kern` feature and there is no '# Automatic Code' comment, we will skip generating kerning rules based on non-FEA font data.

(on top of #1338)