### PR TITLE
Revert "[kern] Manual kern feature without insert mark wins"

### DIFF
--- a/fea-rs/src/token_tree/typed.rs
+++ b/fea-rs/src/token_tree/typed.rs
@@ -667,14 +667,8 @@ impl FloatLike {
 }
 
 impl Feature {
-    /// The name (tag) of this feature (kern, merk, etc)
-    pub fn tag(&self) -> Tag {
+    pub(crate) fn tag(&self) -> Tag {
         self.iter().find_map(Tag::cast).unwrap()
-    }
-
-    /// Returns `true` if this feature block contains an '# Automatic Code' comment
-    pub fn has_insert_marker(&self) -> bool {
-        self.statements().any(|s| s.kind() == Kind::Comment)
     }
 
     pub(crate) fn statements(&self) -> impl Iterator<Item = &NodeOrToken> {

--- a/fontbe/src/features/kern.rs
+++ b/fontbe/src/features/kern.rs
@@ -7,7 +7,6 @@ use std::{
 
 use fea_rs::{
     compile::{FeatureKey, FeatureProvider, PairPosBuilder, ValueRecord as ValueRecordBuilder},
-    typed::AstNode,
     GlyphSet, ParseTree,
 };
 use fontdrasil::{
@@ -429,10 +428,9 @@ fn finalize_kerning(
     char_map: HashMap<u32, GlyphId16>,
     non_spacing_glyphs: HashSet<GlyphId16>,
 ) -> Result<FeaRsKerns, Error> {
-    if pairs.is_empty() || ast_has_kern_or_dist_but_no_markers(&ast.ast) {
+    if pairs.is_empty() {
         return Ok(Default::default());
     }
-
     let known_scripts = guess_font_scripts(&ast.ast, &char_map);
     let glyph_classes = super::get_gdef_classes(meta, ast, glyph_order);
 
@@ -461,25 +459,6 @@ fn finalize_kerning(
     let features = kern_features.into_iter().chain(dist_features).collect();
     debug_ordered_lookups(&features, &lookups);
     Ok(FeaRsKerns { lookups, features })
-}
-
-fn ast_has_kern_or_dist_but_no_markers(ast: &ParseTree) -> bool {
-    use fea_rs::typed;
-    for feature_block in ast
-        .typed_root()
-        .statements()
-        .filter_map(typed::Feature::cast)
-    {
-        let tag = feature_block.tag().to_raw();
-        if tag == "kern" || tag == "dist" && !feature_block.has_insert_marker() {
-            log::warn!(
-                "font has kerning, but also manually written '{tag}' features,\
-                        and no insertion comment. We will ignore the non-FEA kerning."
-            );
-            return true;
-        }
-    }
-    false
 }
 
 /// Given a map of `[scripts] -> [lookups]`, convert it into a map of
@@ -1856,33 +1835,6 @@ mod tests {
             # 1 PairPos rules
             # lookupflag LookupFlag(8)
             aaMatra_kannada 34 ailength_kannada
-            "#
-        );
-    }
-
-    #[test]
-    fn prefer_user_fea() {
-        let (_kerns, normalized) = KernInput::new(&['a', 'b', 'c', 'd'])
-            .with_user_fea(
-                r#"
-                feature kern {
-                    lookupflag IgnoreMarks;
-                    pos a b 20;
-                    pos a c 22;
-                } kern;
-                "#,
-            )
-            .with_rule('c', 'd', -5)
-            .build();
-
-        assert_eq_ignoring_ws!(
-            normalized,
-            r#"
-            # kern: DFLT/dflt
-            # 2 PairPos rules
-            # lookupflag LookupFlag(8)
-            a 20 b
-            a 22 c
             "#
         );
     }


### PR DESCRIPTION
This reverts commit 801de70e1de9570c40ceb5366e03d7e0eb6339ac.

This caused a bunch of regressions on crater. I think it's something where we want to do this for ufo but not for glyphs? But I'll revert while I investigate further.

JMM