### PR TITLE
[kern] If a manual kern/dist exists, don't generate one

### DIFF
--- a/fea-rs/src/token_tree/typed.rs
+++ b/fea-rs/src/token_tree/typed.rs
@@ -667,8 +667,14 @@ impl FloatLike {
 }
 
 impl Feature {
-    pub(crate) fn tag(&self) -> Tag {
+    /// The name (tag) of this feature (kern, merk, etc)
+    pub fn tag(&self) -> Tag {
         self.iter().find_map(Tag::cast).unwrap()
+    }
+
+    /// Returns `true` if this feature block contains an '# Automatic Code' comment
+    pub fn has_insert_marker(&self) -> bool {
+        self.statements().any(|s| s.kind() == Kind::Comment)
     }
 
     pub(crate) fn statements(&self) -> impl Iterator<Item = &NodeOrToken> {


### PR DESCRIPTION
Specifically if it exists and there is no '# Automatic Code' insert marker.

We'll also want to do this for marks & curs, but that can be a followup PR.

- reworked from #1339 (which I reverted)
- based on #1344; without that patch merging this causes a significant regression.