### PR TITLE
[glyphs] Support 'Other' subcategory

### DIFF
--- a/glyphs-reader/src/glyphdata.rs
+++ b/glyphs-reader/src/glyphdata.rs
@@ -70,6 +70,7 @@ pub enum Subcategory {
     Emoji,
     Enclosing,
     Composition,
+    Other,
 }
 
 /// A queryable set of glyph data
@@ -673,6 +674,7 @@ impl FromStr for Subcategory {
             "Emoji" => Ok(Self::Emoji),
             "Enclosing" => Ok(Self::Enclosing),
             "Composition" => Ok(Self::Composition),
+            "Other" => Ok(Self::Other),
             _ => Err(s.into()),
         }
     }
@@ -725,6 +727,7 @@ impl Display for Subcategory {
             Self::Emoji => write!(f, "Emoji"),
             Self::Enclosing => write!(f, "Enclosing"),
             Self::Composition => write!(f, "Composition"),
+            Self::Other => write!(f, "Other"),
         }
     }
 }


### PR DESCRIPTION
Gets at least one more GDEF matching.

Khaled mentioned elsewhere that we may want to be more permissive in what we accept for these values, since it _can_ just be a freeform field and we falling back to `None` might be a source of bugs, but I'm avoiding making that larger change in favour of simple forward progress.

JMM