### PR TITLE
Touchup name handling

### DIFF
--- a/resources/testdata/glyphs3/LightOriginNames.glyphs
+++ b/resources/testdata/glyphs3/LightOriginNames.glyphs
@@ -1,0 +1,64 @@
+{
+.appVersion = "3151";
+.formatVersion = 3;
+axes = (
+{
+name = Weight;
+tag = wght;
+}
+);
+customParameters = (
+{
+name = "Variable Font Origin";
+value = "light";
+}
+);
+familyName = FamilyName;
+fontMaster = (
+{
+axesValues = (
+200
+);
+id = light;
+name = Light;
+},
+{
+axesValues = (
+400
+);
+id = m01;
+name = Regular;
+},
+{
+axesValues = (
+700
+);
+iconName = Bold;
+id = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+glyphs = (
+{
+glyphname = space;
+layers = (
+{
+layerId = light;
+width = 100;
+},
+{
+layerId = m01;
+width = 200;
+},
+{
+layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+width = 600;
+}
+);
+unicode = 32;
+},
+);
+}
+);
+
+unitsPerEm = 1000;
+versionMajor = 42;
+versionMinor = 42;
+}


### PR DESCRIPTION
https://www.youtube.com/watch?v=zMF_jc5BFcs describes my feelings about name handling.

I updated a number of expected results based on ttx diff.

Spot-checking name failures from crater this seems to help with at least the following:

* `python resources/scripts/ttx_diff.py 'https://github.com/batsimadz/Sankofa-Display#sources/Sankofa.glyphs'`
* `python resources/scripts/ttx_diff.py 'https://github.com/CatharsisFonts/Cormorant#sources/generated/CormorantGaramond.glyphs'`