### PR TITLE
Turn on lto and strip

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,3 +53,8 @@ members = [
     "otl-normalizer",
     "fontc_crater",
 ]
+
+[profile.release]
+codegen-units = 1
+lto = "fat"
+strip = "symbols"


### PR DESCRIPTION
Exploratory adjustment based on #1359.

Tested locally the impact on size and compile time is significant:

```shell
$ cargo clean && rm -rf build/ target/
$ time cargo build -p fontc --release
# branch real	2m41.823s
# main   real	0m37.618s
$ ls -l target/release/fontc | awk '{print $5" "$9}'
# branch 13048376 target/release/fontc
# main   19544344 target/release/fontc
```