### PR TITLE
Expose and fix off by one in bundled glyphs data

### DIFF
--- a/glyphs-reader/src/glyphdata_bundled.rs
+++ b/glyphs-reader/src/glyphdata_bundled.rs
@@ -105,7 +105,7 @@ fn custom_prod_name(idx: usize) -> (ProductionName, usize) {
 }
 
 fn bsearch<T: Ord>(len: usize, needle: T, get: impl Fn(usize) -> (T, usize)) -> Option<usize> {
-    let mut upper = len as i32;
+    let mut upper = len as i32 - 1;
     let mut lower = 0;
     while lower <= upper {
         let mid = ((lower + upper) / 2) as usize;
@@ -297,6 +297,18 @@ mod tests {
             ),
             result_for_idx(find_pos_by_prod_name(".null".into()).unwrap())
         );
+    }
+
+    #[test]
+    fn find_pos_by_name_zzz() {
+        // This was crashing
+        find_pos_by_name("zzz".into());
+    }
+
+    #[test]
+    fn find_pos_by_prod_name_zzz() {
+        // This was crashing
+        find_pos_by_prod_name("zzz".into());
     }
 
     #[test]

--- a/glyphs-reader/src/glyphdata_bundled.rs
+++ b/glyphs-reader/src/glyphdata_bundled.rs
@@ -302,7 +302,7 @@ mod tests {
     #[test]
     fn find_pos_by_name_zzz() {
         // This was crashing
-        find_pos_by_name("zzz".into());
+        find_pos_by_name("zzz");
     }
 
     #[test]


### PR DESCRIPTION
As is traditional #1357 included an off by one, leading to 108 fontc failures on https://googlefonts.github.io/fontc_crater/

JMM