### PR TITLE
Use BASE table from FEA, if present

### DIFF
--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -2845,6 +2845,25 @@ mod tests {
     }
 
     #[test]
+    fn use_base_table_from_fea() {
+        let _ = env_logger::builder().is_test(true).try_init();
+        let result = TestCompile::compile_source("CustomBaseTableInFea.ufo");
+        let font = result.font();
+        let base = font.base().unwrap();
+        let horiz = base.horiz_axis().unwrap().unwrap();
+        let horiz_tags = horiz.base_tag_list().unwrap().unwrap().baseline_tags();
+        assert_eq!(horiz_tags, [Tag::new(b"ideo")]);
+        let horiz_scripts = horiz.base_script_list().unwrap();
+        assert_eq!(horiz_scripts.base_script_count(), 1);
+
+        let vert = base.vert_axis().unwrap().unwrap();
+        let vert_tags = vert.base_tag_list().unwrap().unwrap().baseline_tags();
+        assert_eq!(vert_tags, [Tag::new(b"romn")]);
+        let vert_scripts = vert.base_script_list().unwrap();
+        assert_eq!(vert_scripts.base_script_count(), 2);
+    }
+
+    #[test]
     fn generate_meta_table() {
         let result = TestCompile::compile_source("glyphs3/MetaTable.glyphs");
         let meta = result.be_context.meta.get();

--- a/resources/testdata/CustomBaseTableInFea.ufo/features.fea
+++ b/resources/testdata/CustomBaseTableInFea.ufo/features.fea
@@ -1,0 +1,11 @@
+languagesystem DFLT dflt;
+
+table BASE {
+  HorizAxis.BaseTagList                 ideo;
+  HorizAxis.BaseScriptList  DFLT    ideo   0;
+
+  VertAxis.BaseTagList                  romn;
+  VertAxis.BaseScriptList   DFLT    romn    1,
+                            latn    romn    5;
+} BASE;
+

--- a/resources/testdata/CustomBaseTableInFea.ufo/fontinfo.plist
+++ b/resources/testdata/CustomBaseTableInFea.ufo/fontinfo.plist
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>unitsPerEm</key>
+    <integer>1000</integer>
+    <key>ascender</key>
+    <real>799</real>
+    <key>familyName</key>
+    <string>Wght Var</string>
+    <key>openTypeHeadCreated</key>
+    <string>2023/05/05 15:11:55</string>
+  </dict>
+</plist>

--- a/resources/testdata/CustomBaseTableInFea.ufo/glyphs/bar.glif
+++ b/resources/testdata/CustomBaseTableInFea.ufo/glyphs/bar.glif
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="bar" format="2">
+  <advance width="517"/>
+  <unicode hex="007C"/>
+  <outline>
+    <contour>
+      <point x="222" y="-241" type="line"/>
+      <point x="295" y="-241" type="line"/>
+      <point x="295" y="760" type="line"/>
+      <point x="222" y="760" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/resources/testdata/CustomBaseTableInFea.ufo/glyphs/contents.plist
+++ b/resources/testdata/CustomBaseTableInFea.ufo/glyphs/contents.plist
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>bar</key>
+    <string>bar.glif</string>
+  </dict>
+</plist>

--- a/resources/testdata/CustomBaseTableInFea.ufo/layercontents.plist
+++ b/resources/testdata/CustomBaseTableInFea.ufo/layercontents.plist
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <array>
+    <array>
+      <string>public.default</string>
+      <string>glyphs</string>
+    </array>
+    <array>
+      <string>{600}</string>
+      <string>glyphs.{600}</string>
+    </array>
+  </array>
+</plist>

--- a/resources/testdata/CustomBaseTableInFea.ufo/lib.plist
+++ b/resources/testdata/CustomBaseTableInFea.ufo/lib.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>public.glyphOrder</key>
+    <array>
+      <string>bar</string>
+    </array>
+  </dict>
+</plist>

--- a/resources/testdata/CustomBaseTableInFea.ufo/metainfo.plist
+++ b/resources/testdata/CustomBaseTableInFea.ufo/metainfo.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>creator</key>
+    <string>com.github.fonttools.ufoLib</string>
+    <key>formatVersion</key>
+    <integer>3</integer>
+  </dict>
+</plist>


### PR DESCRIPTION
We don't currently compile this table ourselves, so the logic here is a bit funny; we just check right at the end of compilation if we FEA generated one, and if so we add it to the final font.

Progress on #1364 