### PR TITLE
[fontbe] Don't generate vf tables for static font

### DIFF
--- a/fontbe/src/gvar.rs
+++ b/fontbe/src/gvar.rs
@@ -52,6 +52,10 @@ impl Work<Context, AnyWorkId, Error> for GvarWork {
         // We built the gvar fragments alongside glyphs, now we need to glue them together into a gvar table
         let static_metadata = context.ir.static_metadata.get();
         let axis_order: Vec<_> = static_metadata.axes.iter().map(|a| a.tag).collect();
+        if axis_order.is_empty() {
+            log::debug!("skipping gvar, font has no axes");
+            return Ok(());
+        }
         let axis_count: u16 = axis_order
             .len()
             .try_into()

--- a/fontbe/src/hvar.rs
+++ b/fontbe/src/hvar.rs
@@ -177,6 +177,10 @@ impl Work<Context, AnyWorkId, Error> for HvarWork {
     /// Generate [HVAR](https://learn.microsoft.com/en-us/typography/opentype/spec/HVAR)
     fn exec(&self, context: &Context) -> Result<(), Error> {
         let static_metadata = context.ir.static_metadata.get();
+        if static_metadata.axes.is_empty() {
+            log::debug!("skipping HVAR, font has no axes");
+            return Ok(());
+        }
         let var_model = &static_metadata.variation_model;
         let glyph_order = context.ir.glyph_order.get();
         let axis_count = var_model.axes().count().try_into().unwrap();


### PR DESCRIPTION
Previously we would always generate some of these tables and then just skip them when we were assembling the final font; now we skip them earlier.

In the case of gvar there is probably some additional optimization possible, since we are still generating and storing all the empty gvar fragments, but the plumbing there is complicated so I've left that be for now.

Concretely this was motivated by me wanting to write a very simple test font that would include a STAT font from FEA, and for the purposes of my test I don't need this font to actually be variable.