### PR TITLE
Patch libtidy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,3 +53,6 @@ members = [
     "otl-normalizer",
     "fontc_crater",
 ]
+
+[patch.crates-io]
+tidy-sys = { version = "0.8.2", git = "https://github.com/cmyr/tidy-sys.git", branch = "cmake-hotfix" }


### PR DESCRIPTION
Cmake 4.0 can't build the tidy-sys crate, and cmake 4.0 is now what we get in CI. This is a quickfix that patches the tidy-sys crate to a version that cmake 4.0 will build; this will hold us over until we know what's going on upstream.

opened https://github.com/insomnimus/tidy-sys/issues/1 to discuss.