### PR TITLE
Reorder `gvar` points to match normalized `glyf`

### DIFF
--- a/resources/scripts/ttx_diff.py
+++ b/resources/scripts/ttx_diff.py
@@ -446,14 +446,15 @@ def normalize_gvar_contours(ttx: etree.ElementTree, point_orders: dict[str, list
         # apply the same order to every tuple
         for tup in glyph.xpath("./tuple"):
             deltas = tup.xpath("./delta")
-            by_order = {int(delta.attrib["pt"]): delta for delta in deltas}
+            assert len(order) + 4 == len(deltas), "gvar is not dense"
 
             # reorder and change index to match new position
             reordered = []
             for new_idx, old_idx in enumerate(order):
-                delta = by_order[old_idx]  # always present as gvars are densified
+                delta = deltas[old_idx]  # always present as gvars are densified
                 delta.attrib["pt"] = str(new_idx)
                 reordered.append(delta)
+            reordered += deltas[-4:]  # phantom points
 
             # normalized points should be inserted after any other tuple
             # subelements (e.g. coordinates)


### PR DESCRIPTION
This PR extends the normalization in #1107 to `gvar`, which can be reordered in tandem to avoid equivalent diffs.

This patch improved the `gvar` percentage significantly in most crater projects I tested with, but there is still a remaining discrepancy that stems from there being more `gvar` deltas than points in `glyf` in some cases.

I have not had time to investigate further yet – and suspect anything from phantom points to me straight-up introducing bugs ; ) – hence the draft status. Does this difference sound familiar to anyone?

<sub>Note: this is a personal contribution independent of my employer, and so I've submitted from a fork under my personal profile and email to make this distinction</sub>