### PR TITLE
[glyphs] Treat null metric as zero if overshoot exists

### DIFF
--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -1052,8 +1052,7 @@ impl FontMaster {
     fn read_metric(&self, metric_name: &str) -> Option<f64> {
         self.metric_values
             .get(metric_name)
-            .and_then(|metric| metric.pos)
-            .map(|x| x.into_inner())
+            .map(|metric| metric.pos.unwrap_or_default().into_inner())
     }
 
     pub fn ascender(&self) -> Option<f64> {
@@ -4046,5 +4045,16 @@ mod tests {
                     .map(|s| s.as_str()),
             ]
         );
+    }
+
+    #[test]
+    fn zero_value_metrics() {
+        let font = Font::load(&glyphs3_dir().join("ZeroMetrics.glyphs")).unwrap();
+        let master = font.default_master();
+        assert_eq!(master.ascender(), Some(789.));
+        // this has no value set, but has overshoot set, so this should be a 0
+        assert_eq!(master.cap_height(), Some(0.));
+        // this has neither value nor overshoot, so it should be ignored
+        assert_eq!(master.x_height(), None);
     }
 }

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -509,7 +509,7 @@ impl Work<Context, WorkId, Error> for GlobalMetricWork {
         for master in font.masters.iter() {
             let pos = font_info.locations.get(&master.axes_values).unwrap();
 
-            // glyphsLib <https://github.com/googlefonts/glyphsLib/blob/1cb4fc5ae2cf385df95d2b7768e7ab4eb60a5ac3/Lib/glyphsLib/classes.py#L1590-L1601>
+            // glyphsLib <https://github.com/googlefonts/glyphsLib/blob/1cb4fc5ae2/Lib/glyphsLib/classes.py#L1590-L1601>
             let cap_height = master.cap_height().unwrap_or(700.0);
             let x_height = master.x_height().unwrap_or(500.0);
             let ascender = master.ascender().unwrap_or(800.0);

--- a/resources/testdata/glyphs3/ZeroMetrics.glyphs
+++ b/resources/testdata/glyphs3/ZeroMetrics.glyphs
@@ -1,0 +1,56 @@
+{
+.appVersion = "3343";
+.formatVersion = 3;
+familyName = "New Font";
+fontMaster = (
+{
+id = m01;
+metricValues = (
+{
+over = 12;
+pos = 789;
+},
+{
+over = 16;
+},
+{
+},
+{
+over = -16;
+},
+{
+over = -16;
+pos = -200;
+},
+{
+}
+);
+name = Regular;
+}
+);
+glyphs = (
+);
+metrics = (
+{
+type = ascender;
+},
+{
+type = "cap height";
+},
+{
+type = "x-height";
+},
+{
+type = baseline;
+},
+{
+type = descender;
+},
+{
+type = "italic angle";
+}
+);
+unitsPerEm = 1000;
+versionMajor = 1;
+versionMinor = 0;
+}


### PR DESCRIPTION
Glyphs does not serialize metric values if they are zero, but sometimes metric values are _intentionally_ zero, when they would otherwise be meaningless; we can distinguish (at least some of?) these cases because although the metric value is zero the overshoot is (often?) a non-zero value.

With this patch we distinguish between a metric which is missing and a metric that exists but has no value; in this latter case we treat it as having a value of zero.


----

This patch is an improvement, and gives us a +small on crater, but I don't think it goes far enough; I believe that a missing value for a metric should be treated as a `0`. Doing this breaks a bunch of tests, though, so I'm opening this smaller PR first, since it is at least some improvement; opened #1379 to discuss the larger change.