### PR TITLE
[ttx_diff] Be more defensive when filling deltas

### DIFF
--- a/resources/scripts/ttx_diff.py
+++ b/resources/scripts/ttx_diff.py
@@ -756,6 +756,8 @@ def densify_one_glyph(coords, ends, variations: etree.ElementTree):
         deltas = [None] * len(coords)
         for delta in tuple_.findall("delta"):
             idx = int(delta.attrib["pt"])
+            if idx >= len(deltas):
+                continue
             deltas[idx] = (int(delta.attrib["x"]), int(delta.attrib["y"]))
 
         if any(d is None for d in deltas):


### PR DESCRIPTION
There is some non-deterministic crash on CI where we are out of bounds on an array access; this will check that condition and skip if a delta is out of bounds.

~based on #1381, which should go in first~

JMM