### PR TITLE
[glyphs] If a metric is defined, it has a value

### DIFF
--- a/resources/testdata/glyphs2/WghtVar.glyphs
+++ b/resources/testdata/glyphs2/WghtVar.glyphs
@@ -47,6 +47,7 @@ alignmentZones = (
 ascender = 737;
 capHeight = 702;
 descender = -42;
+baseline = 0;
 id = m01;
 weightValue = 400;
 xHeight = 501;

--- a/resources/testdata/glyphs2/WghtVar.glyphspackage/fontinfo.plist
+++ b/resources/testdata/glyphs2/WghtVar.glyphspackage/fontinfo.plist
@@ -54,6 +54,7 @@ xHeight = 501;
 {
 ascender = 800;
 capHeight = 700;
+baseline = 0;
 descender = -200;
 id = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
 weight = Bold;

--- a/resources/testdata/glyphs2/WghtVar_Anchors.glyphs
+++ b/resources/testdata/glyphs2/WghtVar_Anchors.glyphs
@@ -21,6 +21,7 @@ alignmentZones = (
 );
 ascender = 800;
 capHeight = 0;
+baseline = 0;
 descender = -200;
 id = m01;
 weightValue = 400;

--- a/resources/testdata/glyphs2/WghtVar_Anchors.glyphspackage/fontinfo.plist
+++ b/resources/testdata/glyphs2/WghtVar_Anchors.glyphspackage/fontinfo.plist
@@ -20,6 +20,7 @@ alignmentZones = (
 "{-200, -16}"
 );
 ascender = 800;
+baseline = 0;
 capHeight = 0;
 descender = -200;
 id = m01;

--- a/resources/testdata/glyphs2/WghtVar_Avar.glyphs
+++ b/resources/testdata/glyphs2/WghtVar_Avar.glyphs
@@ -46,6 +46,7 @@ alignmentZones = (
 "{-42, -16}"
 );
 ascender = 737;
+baseline = 0;
 capHeight = 702;
 descender = -42;
 id = m01;

--- a/resources/testdata/glyphs2/WghtVar_Avar.glyphspackage/fontinfo.plist
+++ b/resources/testdata/glyphs2/WghtVar_Avar.glyphspackage/fontinfo.plist
@@ -34,6 +34,7 @@ fontMaster = (
 ascender = 800;
 capHeight = 700;
 descender = -200;
+baseline = 0;
 id = "A7771C0D-4005-44AE-9B1F-ED6CCEC719DA";
 weight = Light;
 weightValue = 300;

--- a/resources/testdata/glyphs2/WghtVar_Instances.glyphs
+++ b/resources/testdata/glyphs2/WghtVar_Instances.glyphs
@@ -39,6 +39,7 @@ alignmentZones = (
 ascender = 737;
 capHeight = 702;
 descender = -42;
+baseline = 0;
 id = m01;
 weightValue = 400;
 xHeight = 501;

--- a/resources/testdata/glyphs2/WghtVar_Instances.glyphspackage/fontinfo.plist
+++ b/resources/testdata/glyphs2/WghtVar_Instances.glyphspackage/fontinfo.plist
@@ -38,6 +38,7 @@ alignmentZones = (
 );
 ascender = 737;
 capHeight = 702;
+baseline = 0;
 descender = -42;
 id = m01;
 weightValue = 400;

--- a/resources/testdata/glyphs2/WghtVar_NoExport.glyphs
+++ b/resources/testdata/glyphs2/WghtVar_NoExport.glyphs
@@ -46,6 +46,7 @@ alignmentZones = (
 "{-42, -16}"
 );
 ascender = 737;
+baseline = 0;
 capHeight = 702;
 descender = -42;
 id = m01;

--- a/resources/testdata/glyphs2/WghtVar_OS2.glyphs
+++ b/resources/testdata/glyphs2/WghtVar_OS2.glyphs
@@ -57,6 +57,7 @@ alignmentZones = (
 );
 ascender = 737;
 capHeight = 702;
+baseline = 0;
 customParameters = (
 {
 name = typoAscender;

--- a/resources/testdata/glyphs2/WghtVar_OS2.glyphspackage/fontinfo.plist
+++ b/resources/testdata/glyphs2/WghtVar_OS2.glyphspackage/fontinfo.plist
@@ -56,6 +56,7 @@ alignmentZones = (
 "{-42, -16}"
 );
 ascender = 737;
+baseline = 0;
 capHeight = 702;
 customParameters = (
 {

--- a/resources/testdata/glyphs2/alignment_zones_v2.glyphs
+++ b/resources/testdata/glyphs2/alignment_zones_v2.glyphs
@@ -15,6 +15,7 @@ alignmentZones = (
 ascender = 800;
 capHeight = 700;
 descender = -200;
+baseline = 0;
 id = "CEAF8881-3B30-4737-AC29-09BAEF72AFFD";
 xHeight = 500;
 }

--- a/resources/testdata/glyphs2/infinity.glyphs
+++ b/resources/testdata/glyphs2/infinity.glyphs
@@ -14,12 +14,8 @@ Tag = wght;
 familyName = InfWght;
 fontMaster = (
 {
-ascender = 0;
-capHeight = 0;
-descender = 0;
 id = m01;
 weightValue = 400;
-xHeight = 0;
 }
 );
 glyphs = (

--- a/resources/testdata/glyphs2/infinity.glyphspackage/fontinfo.plist
+++ b/resources/testdata/glyphs2/infinity.glyphspackage/fontinfo.plist
@@ -14,12 +14,8 @@ Tag = wght;
 familyName = InfWght;
 fontMaster = (
 {
-ascender = 0;
-capHeight = 0;
-descender = 0;
 id = m01;
 weightValue = 400;
-xHeight = 0;
 }
 );
 unitsPerEm = 1000;

--- a/resources/testdata/glyphs3/ZeroMetrics.glyphs
+++ b/resources/testdata/glyphs3/ZeroMetrics.glyphs
@@ -22,8 +22,6 @@ over = -16;
 over = -16;
 pos = -200;
 },
-{
-}
 );
 name = Regular;
 }
@@ -46,9 +44,6 @@ type = baseline;
 {
 type = descender;
 },
-{
-type = "italic angle";
-}
 );
 unitsPerEm = 1000;
 versionMajor = 1;

--- a/resources/testdata/glyphs3/infinity.glyphs
+++ b/resources/testdata/glyphs3/infinity.glyphs
@@ -1,5 +1,5 @@
 {
-.appVersion = "3219";
+.appVersion = "3343";
 .formatVersion = 3;
 axes = (
 {

--- a/resources/testdata/glyphs3/infinity.glyphspackage/fontinfo.plist
+++ b/resources/testdata/glyphs3/infinity.glyphspackage/fontinfo.plist
@@ -17,5 +17,6 @@ id = m01;
 name = Regular;
 }
 );
+
 unitsPerEm = 1000;
 }


### PR DESCRIPTION
That is, if a value is not defined for a particular master but is in the metrics list, we treat it as having a value of zero.

This more closely matches fonttools, and better handles the semantics of the glyphs format, which skips serializing `0` in some cases.