### PR TITLE
variable notdef glyph

### DIFF
--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -3898,4 +3898,19 @@ mod tests {
 
         assert_eq!(glyph.num_points(), 3); // instead of the 4 points in the source.
     }
+
+    #[test]
+    fn generate_variable_notdef() {
+        let result = TestCompile::compile_source("glyphs3/empty_font_needs_variable_notdef.glyphs");
+        let ir_notdef = result.fe_context.get_glyph(".notdef");
+        assert_eq!(ir_notdef.sources().len(), 2);
+        assert_eq!(
+            ir_notdef
+                .sources()
+                .values()
+                .map(|inst| inst.height.unwrap_or(0.) as u32)
+                .collect::<HashSet<_>>(),
+            HashSet::from([1000, 1100])
+        );
+    }
 }

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -1665,65 +1665,6 @@ impl GlyphBuilder {
         }
     }
 
-    /// * see <https://github.com/googlefonts/ufo2ft/blob/b3895a96ca910c1764df016bfee4719448cfec4a/Lib/ufo2ft/outlineCompiler.py#L1666-L1694>
-    pub fn new_notdef(
-        default_location: NormalizedLocation,
-        upem: u16,
-        ascender: f64,
-        descender: f64,
-    ) -> Self {
-        let upem = upem as f64;
-        let width: u16 = (upem * 0.5).ot_round();
-        let width = width as f64;
-        let stroke: u16 = (upem * 0.05).ot_round();
-        let stroke = stroke as f64;
-
-        let mut path = BezPath::new();
-
-        // outer box
-        let x_min = stroke;
-        let x_max = width - stroke;
-        let y_max = ascender;
-        let y_min = descender;
-        path.move_to((x_min, y_min));
-        path.line_to((x_max, y_min));
-        path.line_to((x_max, y_max));
-        path.line_to((x_min, y_max));
-        path.line_to((x_min, y_min));
-        path.close_path();
-
-        // inner, cut out, box
-        let x_min = x_min + stroke;
-        let x_max = x_max - stroke;
-        let y_max = y_max - stroke;
-        let y_min = y_min + stroke;
-        path.move_to((x_min, y_min));
-        path.line_to((x_min, y_max));
-        path.line_to((x_max, y_max));
-        path.line_to((x_max, y_min));
-        path.line_to((x_min, y_min));
-        path.close_path();
-
-        // TODO: Should this be None to match other glyphs' heights? This would deviate from ufo2ft
-        // See https://github.com/googlefonts/ufo2ft/blob/b3895a96/Lib/ufo2ft/outlineCompiler.py#L1656-L1658
-        let height = Some(ascender - descender);
-
-        Self {
-            name: GlyphName::NOTDEF.clone(),
-            emit_to_binary: true,
-            codepoints: HashSet::new(),
-            sources: HashMap::from([(
-                default_location,
-                GlyphInstance {
-                    width,
-                    height,
-                    contours: vec![path],
-                    ..Default::default()
-                },
-            )]),
-        }
-    }
-
     pub fn build(self) -> Result<Glyph, BadGlyph> {
         Glyph::new(
             self.name,
@@ -2008,7 +1949,7 @@ mod tests {
     use std::collections::HashMap;
 
     use fontdrasil::types::Axis;
-    use write_fonts::types::NameId;
+    use write_fonts::{types::NameId, OtRound};
 
     use pretty_assertions::assert_eq;
 

--- a/resources/testdata/glyphs3/empty_font_needs_variable_notdef.glyphs
+++ b/resources/testdata/glyphs3/empty_font_needs_variable_notdef.glyphs
@@ -1,0 +1,56 @@
+{
+.appVersion = "3343";
+.formatVersion = 3;
+axes = (
+{
+name = Weight;
+tag = wght;
+}
+);
+familyName = "New Font";
+fontMaster = (
+{
+axesValues = (
+400
+);
+id = m01;
+metricValues = (
+{
+pos = 800;
+},
+{
+pos = -200;
+}
+);
+name = Regular;
+},
+{
+axesValues = (
+600
+);
+id = "6C2558FA-FBC6-4335-8885-FD272BFC463F";
+metricValues = (
+{
+pos = 880;
+},
+{
+pos = -220;
+}
+);
+name = Bold;
+}
+);
+glyphs = (
+);
+metrics = (
+{
+type = ascender;
+},
+{
+type = descender;
+}
+);
+unitsPerEm = 1000;
+versionMajor = 1;
+versionMinor = 0;
+}


### PR DESCRIPTION
This attempts to generate a variable notdef glyph in cases where metrics differ between masters.

~This includes a test case that crashes as a result of an unexpected location ending up in the variation model.~

- closes #1262 




