### PR TITLE
[glyphs] Skip inconsitent anchors instead of erroring

### DIFF
--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -1499,19 +1499,20 @@ impl AnchorBuilder {
     }
 
     pub fn build(self) -> Result<GlyphAnchors, BadGlyph> {
-        // It would be nice if everyone was defined at default
-        for (anchor, positions) in &self.anchors {
-            if !positions.keys().any(|loc| !loc.has_any_non_zero()) {
-                return Err(BadGlyph::new(
-                    self.glyph_name.clone(),
-                    BadAnchor::new(anchor.clone(), BadAnchorReason::NoDefault),
-                ));
-            }
-        }
-
         let anchors = self
             .anchors
             .into_iter()
+            .filter(|(name, positions)| {
+                if !positions.keys().any(|loc| !loc.has_any_non_zero()) {
+                    log::warn!(
+                        "anchor '{name}' in glyph '{}' missing value for default location",
+                        self.glyph_name
+                    );
+                    false
+                } else {
+                    true
+                }
+            })
             .map(|(name, positions)| {
                 AnchorKind::new(&name)
                     .map(|type_| Anchor {

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -2052,4 +2052,11 @@ mod tests {
         // this is a spacing-combining mark, so we shouldn't zero it's width
         assert!(glyph.default_instance().width != 0.0);
     }
+
+    #[test]
+    fn skip_inconsistent_anchors() {
+        let (source, context) =
+            build_static_metadata(glyphs3_dir().join("IncompatibleUnexported.glyphs"));
+        build_glyphs(&source, &context).unwrap();
+    }
 }

--- a/resources/testdata/glyphs3/IncompatibleUnexported.glyphs
+++ b/resources/testdata/glyphs3/IncompatibleUnexported.glyphs
@@ -1,0 +1,198 @@
+{
+.appVersion = "3217";
+.formatVersion = 3;
+axes = (
+{
+name = Weight;
+tag = wght;
+}
+);
+familyName = "Incompatible Unexported";
+fontMaster = (
+{
+axesValues = (
+400
+);
+id = m01;
+metricValues = (
+{
+over = 16;
+pos = 800;
+},
+{
+over = 16;
+pos = 700;
+},
+{
+over = 16;
+pos = 500;
+},
+{
+over = -16;
+},
+{
+over = -16;
+pos = -200;
+},
+{
+}
+);
+name = Regular;
+},
+{
+axesValues = (
+800
+);
+id = "96BF320B-D509-417D-A49A-02D51FD1CC94";
+metricValues = (
+{
+over = 16;
+pos = 800;
+},
+{
+over = 16;
+pos = 700;
+},
+{
+over = 16;
+pos = 500;
+},
+{
+over = -16;
+},
+{
+over = -16;
+pos = -200;
+},
+{
+}
+);
+name = Bold;
+}
+);
+glyphs = (
+{
+glyphname = A;
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(0,0,l),
+(200,0,l),
+(200,200,l),
+(0,200,l)
+);
+}
+);
+width = 600;
+},
+{
+layerId = "96BF320B-D509-417D-A49A-02D51FD1CC94";
+shapes = (
+{
+closed = 1;
+nodes = (
+(0,0,l),
+(500,0,l),
+(500,500,l),
+(0,500,l)
+);
+}
+);
+width = 600;
+}
+);
+unicode = 65;
+},
+{
+export = 0;
+glyphname = doesnt_matter;
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(105,102,l),
+(518,102,l),
+(518,515,l),
+(105,515,l)
+);
+}
+);
+width = 600;
+},
+{
+anchors = (
+{
+name = doesntmatter;
+pos = (294,632);
+}
+);
+layerId = "96BF320B-D509-417D-A49A-02D51FD1CC94";
+shapes = (
+{
+closed = 1;
+nodes = (
+(451,109,o),
+(539,197,o),
+(539,305,cs),
+(539,412,o),
+(451,500,o),
+(344,500,cs),
+(236,500,o),
+(148,412,o),
+(148,305,cs),
+(148,197,o),
+(236,109,o),
+(344,109,cs)
+);
+}
+);
+width = 600;
+}
+);
+},
+{
+glyphname = space;
+layers = (
+{
+layerId = m01;
+width = 200;
+},
+{
+layerId = "96BF320B-D509-417D-A49A-02D51FD1CC94";
+width = 600;
+}
+);
+unicode = 32;
+}
+);
+metrics = (
+{
+type = ascender;
+},
+{
+type = "cap height";
+},
+{
+type = "x-height";
+},
+{
+type = baseline;
+},
+{
+type = descender;
+},
+{
+type = "italic angle";
+}
+);
+unitsPerEm = 1000;
+versionMajor = 1;
+versionMinor = 0;
+}


### PR DESCRIPTION
That is, if a glyph has an anchor on some layers but not on the default layer we will just skip that anchor.


Does this make sense? I don't think it should hurt, but I'm open to other opinions.

This kind of addresses #1397, in that it fixes the crash. @simoncozens would this address your actual problem, or was your actual issue different from the test?