### PR TITLE
Push fontc to 0.1.0 to prepare for google3 import

### DIFF
--- a/fea-rs/Cargo.toml
+++ b/fea-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fea-rs"
-version = "0.19.0"
+version = "0.19.1"
 license = "MIT/Apache-2.0"
 authors = ["Colin Rofls <colin@cmyr.net>"]
 description = "Tools for working with Adobe OpenType Feature files."
@@ -12,7 +12,7 @@ edition = "2021"
 exclude = ["test-data"]
 
 [dependencies]
-fontdrasil = { version = "0.0.1", path = "../fontdrasil" }
+fontdrasil = { version = "0.1.0", path = "../fontdrasil" }
 ansi_term = "0.12.1"
 serde_json = {version = "1.0.87", optional = true }
 

--- a/fontbe/Cargo.toml
+++ b/fontbe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fontbe"
-version = "0.0.1"
+version = "0.1.0"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "the backend for fontc, a font compiler."
@@ -11,8 +11,8 @@ categories = ["text-processing", "parsing", "graphics"]
 [features]
 
 [dependencies]
-fontdrasil = { version = "0.0.1", path = "../fontdrasil" }
-fontir = { version = "0.0.1", path = "../fontir" }
+fontdrasil = { version = "0.1.0", path = "../fontdrasil" }
+fontir = { version = "0.1.0", path = "../fontir" }
 fea-rs = { version = "0.19.0", path = "../fea-rs", features = ["serde"] }
 tinystr = {version = "0.8.0", features = ["serde"] }
 

--- a/fontc/Cargo.toml
+++ b/fontc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fontc"
-version = "0.0.1"
+version = "0.1.0"
 build = "build.rs"
 edition = "2021"
 license = "MIT/Apache-2.0"
@@ -12,12 +12,12 @@ default-run = "fontc"
 
 
 [dependencies]
-fontdrasil = { version = "0.0.1", path = "../fontdrasil" }
-fontbe = { version = "0.0.1", path = "../fontbe" }
-fontir = { version = "0.0.1", path = "../fontir" }
-glyphs2fontir = { version = "0.0.1", path = "../glyphs2fontir" }
-fontra2fontir = { version = "0.0.1", path = "../fontra2fontir" }
-ufo2fontir = { version = "0.0.1", path = "../ufo2fontir" }
+fontdrasil = { version = "0.1.0", path = "../fontdrasil" }
+fontbe = { version = "0.1.0", path = "../fontbe" }
+fontir = { version = "0.1.0", path = "../fontir" }
+glyphs2fontir = { version = "0.1.0", path = "../glyphs2fontir" }
+fontra2fontir = { version = "0.1.0", path = "../fontra2fontir" }
+ufo2fontir = { version = "0.1.0", path = "../ufo2fontir" }
 
 bitflags.workspace = true
 bincode.workspace = true

--- a/fontc_crater/Cargo.toml
+++ b/fontc_crater/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fontc_crater"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "A compiler for fonts."
@@ -8,7 +8,7 @@ repository = "https://github.com/googlefonts/fontc"
 readme = "README.md"
 
 [dependencies]
-fontc = { version = "0.0.1", path = "../fontc" }
+fontc = { version = "0.1.0", path = "../fontc" }
 
 google-fonts-sources = "0.7.1"
 maud = "0.27.0"

--- a/fontdrasil/Cargo.toml
+++ b/fontdrasil/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fontdrasil"
-version = "0.0.1"
+version = "0.1.0"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Common types and utilites used by fontc, a font compiler."

--- a/fontir/Cargo.toml
+++ b/fontir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fontir"
-version = "0.0.1"
+version = "0.1.0"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Intermediate Representation used by fontc, a font compiler."
@@ -11,7 +11,7 @@ categories = ["text-processing", "parsing", "graphics"]
 [features]
 
 [dependencies]
-fontdrasil = { version = "0.0.1", path = "../fontdrasil" }
+fontdrasil = { version = "0.1.0", path = "../fontdrasil" }
 
 bitflags.workspace = true
 serde.workspace = true

--- a/fontra2fontir/Cargo.toml
+++ b/fontra2fontir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fontra2fontir"
-version = "0.0.1"
+version = "0.1.0"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Converts fontra.xyz/ files to font ir for compilation."
@@ -11,8 +11,8 @@ categories = ["text-processing", "parsing", "graphics"]
 [features]
 
 [dependencies]
-fontdrasil = { version = "0.0.1", path = "../fontdrasil" }
-fontir = { version = "0.0.1", path = "../fontir" }
+fontdrasil = { version = "0.1.0", path = "../fontdrasil" }
+fontir = { version = "0.1.0", path = "../fontir" }
 
 write-fonts.workspace = true
 

--- a/glyphs-reader/Cargo.toml
+++ b/glyphs-reader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glyphs-reader"
-version = "0.0.1"
+version = "0.1.0"
 license = "MIT/Apache-2.0"
 authors = ["Raph Levien <raph.levien@gmail.com>"]
 repository = "https://github.com/googlefonts/fontc"
@@ -12,8 +12,8 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ascii_plist_derive = { version = "0.0.1", path = "ascii_plist_derive" }
-fontdrasil = { version = "0.0.1", path = "../fontdrasil" }
+ascii_plist_derive = { version = "0.1.0", path = "ascii_plist_derive" }
+fontdrasil = { version = "0.1.0", path = "../fontdrasil" }
 quick-xml = "0.37"
 ordered-float.workspace = true
 kurbo.workspace = true

--- a/glyphs-reader/ascii_plist_derive/Cargo.toml
+++ b/glyphs-reader/ascii_plist_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ascii_plist_derive"
-version = "0.0.1"
+version = "0.1.0"
 authors = ["Raph Levien <raph.levien@gmail.com>"]
 edition = "2021"
 description = "A derive macro for parsing NeXTSTEP (ASCII) plist files"

--- a/glyphs2fontir/Cargo.toml
+++ b/glyphs2fontir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glyphs2fontir"
-version = "0.0.1"
+version = "0.1.0"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Converts www.glyphsapp.com files to font ir for compilation."
@@ -11,9 +11,9 @@ categories = ["text-processing", "parsing", "graphics"]
 [features]
 
 [dependencies]
-fontdrasil = { version = "0.0.1", path = "../fontdrasil" }
-fontir = { version = "0.0.1", path = "../fontir" }
-glyphs-reader = { version = "0.0.1", path = "../glyphs-reader" }
+fontdrasil = { version = "0.1.0", path = "../fontdrasil" }
+fontir = { version = "0.1.0", path = "../fontir" }
+glyphs-reader = { version = "0.1.0", path = "../glyphs-reader" }
 
 smol_str.workspace = true
 log.workspace = true

--- a/otl-normalizer/Cargo.toml
+++ b/otl-normalizer/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 
 
 [dependencies]
-fontdrasil = { version = "0.0.1", path = "../fontdrasil" }
+fontdrasil = { version = "0.1.0", path = "../fontdrasil" }
 clap.workspace = true
 thiserror.workspace = true
 smol_str.workspace = true

--- a/ufo2fontir/Cargo.toml
+++ b/ufo2fontir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ufo2fontir"
-version = "0.0.1"
+version = "0.1.0"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Converts UFO or UFO+designspace to font ir for compilation."
@@ -11,8 +11,8 @@ categories = ["text-processing", "parsing", "graphics"]
 [features]
 
 [dependencies]
-fontdrasil = { version = "0.0.1", path = "../fontdrasil" }
-fontir = { version = "0.0.1", path = "../fontir" }
+fontdrasil = { version = "0.1.0", path = "../fontdrasil" }
+fontir = { version = "0.1.0", path = "../fontir" }
 
 kurbo.workspace = true
 serde.workspace = true


### PR DESCRIPTION
Proof:

```shell
$ cargo tree | grep 0.0.1
├── otl-normalizer v0.0.1
otl-normalizer v0.0.1
$ cargo tree | grep 0.1.0
$ cargo tree | grep "v0.1.0 "
ascii_plist_derive v0.1.0 
fea-lsp v0.1.0 
│   ├── fontdrasil v0.1.0 
fontbe v0.1.0 
├── fontdrasil v0.1.0 
├── fontir v0.1.0 
│   ├── fontdrasil v0.1.0 
│   ├── fontdrasil v0.1.0 
fontc v0.1.0 
├── fontbe v0.1.0 
├── fontdrasil v0.1.0 
├── fontir v0.1.0 
├── fontra2fontir v0.1.0 
│   ├── fontdrasil v0.1.0 
│   ├── fontir v0.1.0 
├── glyphs2fontir v0.1.0 
│   ├── fontdrasil v0.1.0 
│   ├── fontir v0.1.0 
│   ├── glyphs-reader v0.1.0 
│   │   ├── ascii_plist_derive v0.1.0 
│   │   ├── fontdrasil v0.1.0 
├── ufo2fontir v0.1.0 
│   ├── fontdrasil v0.1.0 
│   ├── fontir v0.1.0 
├── fontc v0.1.0 
fontdrasil v0.1.0 
fontir v0.1.0 
fontra2fontir v0.1.0 
glyphs-reader v0.1.0 
glyphs2fontir v0.1.0 
ufo2fontir v0.1.0 
```