### PR TITLE
Remove ansi_term dep, impedes google3 and unused

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ norad = { version = "0.15.0", default-features = false }
 
 # dev dependencies
 diff = "0.1.12"
-ansi_term = "0.12.1"
 tempfile = "3.3.0"
 more-asserts = "0.3.1"
 pretty_assertions = "1.3.0"

--- a/fontbe/Cargo.toml
+++ b/fontbe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fontbe"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "the backend for fontc, a font compiler."
@@ -39,7 +39,6 @@ chrono.workspace = true
 
 [dev-dependencies]
 diff.workspace = true
-ansi_term.workspace = true
 tempfile.workspace = true
 more-asserts.workspace = true
 temp-env.workspace = true

--- a/fontc/Cargo.toml
+++ b/fontc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fontc"
-version = "0.1.0"
+version = "0.1.1"
 build = "build.rs"
 edition = "2021"
 license = "MIT/Apache-2.0"
@@ -43,7 +43,6 @@ crossbeam-channel = "0.5.6"
 
 [dev-dependencies]
 diff.workspace = true
-ansi_term.workspace = true
 tempfile.workspace = true
 pretty_assertions.workspace = true
 skrifa.workspace = true

--- a/fontdrasil/Cargo.toml
+++ b/fontdrasil/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fontdrasil"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Common types and utilites used by fontc, a font compiler."
@@ -18,5 +18,4 @@ write-fonts.workspace = true
 
 [dev-dependencies]
 diff.workspace = true
-ansi_term.workspace = true
 tempfile.workspace = true

--- a/fontir/Cargo.toml
+++ b/fontir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fontir"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Intermediate Representation used by fontc, a font compiler."
@@ -35,6 +35,5 @@ smol_str.workspace = true
 
 [dev-dependencies]
 diff.workspace = true
-ansi_term.workspace = true
 tempfile.workspace = true
 pretty_assertions.workspace = true

--- a/fontra2fontir/Cargo.toml
+++ b/fontra2fontir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fontra2fontir"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Converts fontra.xyz/ files to font ir for compilation."
@@ -30,6 +30,5 @@ serde_json.workspace = true
 
 [dev-dependencies]
 diff.workspace = true
-ansi_term.workspace = true
 tempfile.workspace = true
 pretty_assertions.workspace = true

--- a/glyphs2fontir/Cargo.toml
+++ b/glyphs2fontir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glyphs2fontir"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Converts www.glyphsapp.com files to font ir for compilation."
@@ -31,6 +31,5 @@ chrono.workspace = true
 
 [dev-dependencies]
 diff.workspace = true
-ansi_term.workspace = true
 tempfile.workspace = true
 pretty_assertions.workspace = true

--- a/ufo2fontir/Cargo.toml
+++ b/ufo2fontir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ufo2fontir"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Converts UFO or UFO+designspace to font ir for compilation."
@@ -36,6 +36,5 @@ plist = { version =  "1.3.1", features = ["serde"] }
 
 [dev-dependencies]
 diff.workspace = true
-ansi_term.workspace = true
 tempfile.workspace = true
 pretty_assertions.workspace = true


### PR DESCRIPTION
Patch bump impacted things so they can be deployed.

Fontations ran into this, fixed in https://github.com/googlefonts/fontations/pull/1408 by using nu-ansi-term. Since we seemingly don't use it I just dropped it here.