### PR TITLE
Add IR types for FeatureVarations, parse from dspace

### DIFF
--- a/fontir/src/error.rs
+++ b/fontir/src/error.rs
@@ -81,6 +81,11 @@ pub enum Error {
         n: usize,
         size_n: usize,
     },
+    // Look ma, I replace UnknownAxis as well!
+    #[error("Unknown {0}: {1}")]
+    UnknownEntry(&'static str, String),
+    #[error("Invalid {0}: {1}")]
+    InvalidEntry(&'static str, String),
 }
 
 /// An error related to loading source input files

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -29,8 +29,8 @@ mod static_metadata;
 
 pub use path_builder::GlyphPathBuilder;
 pub use static_metadata::{
-    GdefCategories, MetaTableValues, MiscMetadata, NameKey, NamedInstance, Panose, PostscriptNames,
-    StaticMetadata,
+    Condition, ConditionSet, GdefCategories, MetaTableValues, MiscMetadata, NameKey, NamedInstance,
+    Panose, PostscriptNames, Rule, StaticMetadata, Substitution, VariableFeature,
 };
 
 pub const DEFAULT_VENDOR_ID: &str = "NONE";

--- a/resources/testdata/dspace_rules/Basic.designspace
+++ b/resources/testdata/dspace_rules/Basic.designspace
@@ -1,0 +1,26 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<designspace format="5.0">
+  <axes>
+    <axis tag="wght" name="Weight" minimum="400" maximum="700" default="400"/>
+  </axes>
+  <rules>
+    <rule name="BRACKET.550.900">
+      <conditionset>
+        <condition name="Weight" minimum="550" maximum="700"/>
+      </conditionset>
+      <sub name="bar" with="plus"/>
+    </rule>
+  </rules>
+  <sources>
+      <source filename="../WghtVar-Regular.ufo" name="Wght Var Regular" familyname="Wght Var" stylename="Regular">
+      <location>
+        <dimension name="Weight" xvalue="400"/>
+      </location>
+    </source>
+    <source filename="../WghtVar-Bold.ufo" name="Wght Var Bold" familyname="Wght Var" stylename="Bold">
+      <location>
+        <dimension name="Weight" xvalue="700"/>
+      </location>
+    </source>
+  </sources>
+</designspace>

--- a/resources/testdata/dspace_rules/CustomFeatures.designspace
+++ b/resources/testdata/dspace_rules/CustomFeatures.designspace
@@ -1,0 +1,32 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<designspace format="5.0">
+  <axes>
+    <axis tag="wght" name="Weight" minimum="400" maximum="700" default="400"/>
+  </axes>
+  <rules>
+    <rule name="BRACKET.550.900">
+      <conditionset>
+        <condition name="Weight" minimum="550" maximum="700"/>
+      </conditionset>
+      <sub name="bar" with="plus"/>
+    </rule>
+  </rules>
+  <sources>
+    <source filename="../WghtVar-Regular.ufo" name="Wght Var Regular" familyname="Wght Var" stylename="Regular">
+      <location>
+        <dimension name="Weight" xvalue="400"/>
+      </location>
+    </source>
+    <source filename="../WghtVar-Bold.ufo" name="Wght Var Bold" familyname="Wght Var" stylename="Bold">
+      <location>
+        <dimension name="Weight" xvalue="700"/>
+      </location>
+    </source>
+  </sources>
+  <lib>
+    <dict>
+        <key>com.github.fonttools.varLib.featureVarsFeatureTag</key>
+        <string>derp,merp,burp</string>
+    </dict>
+</lib>
+</designspace>

--- a/resources/testdata/dspace_rules/Last.designspace
+++ b/resources/testdata/dspace_rules/Last.designspace
@@ -1,0 +1,26 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<designspace format="5.0">
+  <axes>
+    <axis tag="wght" name="Weight" minimum="400" maximum="700" default="400"/>
+  </axes>
+  <rules processing="last">
+    <rule name="BRACKET.550.900">
+      <conditionset>
+        <condition name="Weight" minimum="550" maximum="700"/>
+      </conditionset>
+      <sub name="bar" with="plus"/>
+    </rule>
+  </rules>
+  <sources>
+    <source filename="../WghtVar-Regular.ufo" name="Wght Var Regular" familyname="Wght Var" stylename="Regular">
+      <location>
+        <dimension name="Weight" xvalue="400"/>
+      </location>
+    </source>
+    <source filename="../WghtVar-Bold.ufo" name="Wght Var Bold" familyname="Wght Var" stylename="Bold">
+      <location>
+        <dimension name="Weight" xvalue="700"/>
+      </location>
+    </source>
+  </sources>
+</designspace>

--- a/resources/testdata/dspace_rules/README.md
+++ b/resources/testdata/dspace_rules/README.md
@@ -1,0 +1,2 @@
+This directory contains designspace files that are used to test our parsing of
+'rules' that describe feature variations.


### PR DESCRIPTION
This is the first step towards supporting `rvrn` (and other feature variations features) from designspace files.