### PR TITLE
Fix OS/2 fsSelection for an italic-only font, to match ufo2ft

### DIFF
--- a/ufo2fontir/Cargo.toml
+++ b/ufo2fontir/Cargo.toml
@@ -38,3 +38,4 @@ plist = { version =  "1.3.1", features = ["serde"] }
 diff.workspace = true
 tempfile.workspace = true
 pretty_assertions.workspace = true
+rstest.workspace = true

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -2558,4 +2558,68 @@ mod tests {
             [Tag::new(b"derp"), Tag::new(b"merp"), Tag::new(b"burp")]
         );
     }
+
+    #[test]
+    fn selection_flags_implicit_no_fallback() {
+        let font_info = norad::FontInfo {
+            style_map_style_name: Some(StyleMapStyle::Italic),
+            open_type_name_preferred_subfamily_name: Some(String::from("Bold")),
+            style_name: Some(String::from("Bold")),
+            ..Default::default()
+        };
+        assert_eq!(selection_flags_implicit(&font_info), SelectionFlags::ITALIC);
+    }
+
+    #[test]
+    fn selection_flags_implicit_fallback_1_preferred() {
+        let font_info = norad::FontInfo {
+            style_map_style_name: None,
+            open_type_name_preferred_subfamily_name: Some(String::from("Bold Italic")),
+            style_name: Some(String::from("Bold")),
+            ..Default::default()
+        };
+        assert_eq!(
+            selection_flags_implicit(&font_info),
+            SelectionFlags::BOLD | SelectionFlags::ITALIC
+        );
+    }
+
+    #[test]
+    fn selection_flags_implicit_fallback_2_style_name_is_ribbi() {
+        let font_info = norad::FontInfo {
+            style_map_style_name: None,
+            open_type_name_preferred_subfamily_name: None,
+            style_name: Some(String::from("Bold")),
+            ..Default::default()
+        };
+        assert_eq!(selection_flags_implicit(&font_info), SelectionFlags::BOLD);
+    }
+
+    #[test]
+    fn selection_flags_implicit_fallback_2_style_name_not_ribbi() {
+        let font_info = norad::FontInfo {
+            style_map_style_name: None,
+            open_type_name_preferred_subfamily_name: None,
+            style_name: Some(String::from("Chiseled")),
+            ..Default::default()
+        };
+        assert_eq!(
+            selection_flags_implicit(&font_info),
+            SelectionFlags::REGULAR
+        );
+    }
+
+    #[test]
+    fn selection_flags_implicit_default() {
+        let font_info = norad::FontInfo {
+            style_map_style_name: None,
+            open_type_name_preferred_subfamily_name: None,
+            style_name: None,
+            ..Default::default()
+        };
+        assert_eq!(
+            selection_flags_implicit(&font_info),
+            SelectionFlags::REGULAR
+        );
+    }
 }


### PR DESCRIPTION
Hello, we're getting the whole team into fontc bug fixing. This was a bug spotted on one of our library fonts.