### PR TITLE
Fix typo in normalized space coord maximum

### DIFF
--- a/fontdrasil/src/coords.rs
+++ b/fontdrasil/src/coords.rs
@@ -157,7 +157,7 @@ impl Coord<NormalizedSpace> {
 
     /// 1.0
     pub const MAX: Self = Coord {
-        coord: OrderedFloat(-1.0),
+        coord: OrderedFloat(1.0),
         space: PhantomData,
     };
 }


### PR DESCRIPTION
Hello! Just a measly -1 byte PR to make the constant match 🚀