### PR TITLE
Make name reuse deterministic, and use smallest ID as fonttools does

### DIFF
--- a/fontbe/src/fvar.rs
+++ b/fontbe/src/fvar.rs
@@ -31,11 +31,18 @@ fn generate_fvar(static_metadata: &StaticMetadata) -> Option<Fvar> {
         return None;
     }
 
-    let reverse_names: HashMap<_, _> = static_metadata
-        .names
-        .iter()
-        .map(|(key, name)| (name.as_str(), key.name_id))
-        .collect();
+    // Prefer the smallest ID if an existing name can be reused
+    let reverse_names =
+        static_metadata
+            .names
+            .iter()
+            .fold(HashMap::new(), |mut accum, (key, name)| {
+                accum
+                    .entry(name.as_str())
+                    .and_modify(|value| *value = key.name_id.min(*value))
+                    .or_insert(key.name_id);
+                accum
+            });
 
     let axes_and_instances = AxisInstanceArrays::new(
         static_metadata

--- a/fontbe/src/fvar.rs
+++ b/fontbe/src/fvar.rs
@@ -1,7 +1,6 @@
 //! Generates a [fvar](https://learn.microsoft.com/en-us/typography/opentype/spec/fvar) table.
 
 use log::trace;
-use std::collections::HashMap;
 
 use fontdrasil::orchestration::{Access, Work};
 use fontir::{ir::StaticMetadata, orchestration::WorkId as FeWorkId};
@@ -31,18 +30,10 @@ fn generate_fvar(static_metadata: &StaticMetadata) -> Option<Fvar> {
         return None;
     }
 
-    // Prefer the smallest ID if an existing name can be reused
-    let reverse_names =
-        static_metadata
-            .names
-            .iter()
-            .fold(HashMap::new(), |mut accum, (key, name)| {
-                accum
-                    .entry(name.as_str())
-                    .and_modify(|value| *value = key.name_id.min(*value))
-                    .or_insert(key.name_id);
-                accum
-            });
+    // If possible, reuse a matching name with the smallest ID to follow fonttools:
+    // https://github.com/fonttools/fonttools/blob/d5aec1b9/Lib/fontTools/varLib/__init__.py#L133-L135
+    // https://github.com/fonttools/fonttools/blob/d5aec1b9/Lib/fontTools/ttLib/tables/_n_a_m_e.py#L326-L329
+    let reverse_names = static_metadata.reverse_names();
 
     let axes_and_instances = AxisInstanceArrays::new(
         static_metadata

--- a/fontbe/src/fvar.rs
+++ b/fontbe/src/fvar.rs
@@ -30,9 +30,7 @@ fn generate_fvar(static_metadata: &StaticMetadata) -> Option<Fvar> {
         return None;
     }
 
-    // If possible, reuse a matching name with the smallest ID to follow fonttools:
-    // https://github.com/fonttools/fonttools/blob/d5aec1b9/Lib/fontTools/varLib/__init__.py#L133-L135
-    // https://github.com/fonttools/fonttools/blob/d5aec1b9/Lib/fontTools/ttLib/tables/_n_a_m_e.py#L326-L329
+    // Reuse an existing name record if possible.
     let reverse_names = static_metadata.reverse_names();
 
     let axes_and_instances = AxisInstanceArrays::new(

--- a/fontbe/src/stat.rs
+++ b/fontbe/src/stat.rs
@@ -62,9 +62,7 @@ impl Work<Context, AnyWorkId, Error> for StatWork {
 }
 
 fn make_stat(static_metadata: &StaticMetadata) -> Stat {
-    // If possible, reuse a matching name with the smallest ID to follow fonttools:
-    // https://github.com/fonttools/fonttools/blob/d5aec1b9/Lib/fontTools/otlLib/builder.py#L2884-L2886
-    // https://github.com/fonttools/fonttools/blob/d5aec1b9/Lib/fontTools/ttLib/tables/_n_a_m_e.py#L326-L329
+    // Reuse an existing name record if possible.
     let reverse_names = static_metadata.reverse_names();
 
     Stat {

--- a/fontbe/src/stat.rs
+++ b/fontbe/src/stat.rs
@@ -64,11 +64,18 @@ impl Work<Context, AnyWorkId, Error> for StatWork {
 }
 
 fn make_stat(static_metadata: &StaticMetadata) -> Stat {
-    let reverse_names: HashMap<_, _> = static_metadata
-        .names
-        .iter()
-        .map(|(key, name)| (name.as_str(), key.name_id))
-        .collect();
+    // Prefer the smallest ID if an existing name can be reused
+    let reverse_names =
+        static_metadata
+            .names
+            .iter()
+            .fold(HashMap::new(), |mut accum, (key, name)| {
+                accum
+                    .entry(name.as_str())
+                    .and_modify(|value| *value = key.name_id.min(*value))
+                    .or_insert(key.name_id);
+                accum
+            });
 
     Stat {
         design_axes: static_metadata

--- a/fontir/src/ir/static_metadata.rs
+++ b/fontir/src/ir/static_metadata.rs
@@ -383,6 +383,7 @@ impl StaticMetadata {
     /// Calculate a deterministic mapping of existing name text to the smallest
     /// name ID that provides it.
     pub fn reverse_names(&self) -> HashMap<&str, NameId> {
+        // https://github.com/fonttools/fonttools/blob/d5aec1b9/Lib/fontTools/ttLib/tables/_n_a_m_e.py#L326-L329
         self.names
             .iter()
             .fold(HashMap::new(), |mut accum, (key, name)| {

--- a/fontir/src/ir/static_metadata.rs
+++ b/fontir/src/ir/static_metadata.rs
@@ -385,7 +385,7 @@ impl StaticMetadata {
     pub fn reverse_names(&self) -> HashMap<&str, NameId> {
         self.names
             .iter()
-            .fold(HashMap::new(), |mut accum: HashMap<&str, NameId>, (key, name)| {
+            .fold(HashMap::new(), |mut accum, (key, name)| {
                 accum
                     .entry(name.as_str())
                     .and_modify(|value| *value = key.name_id.min(*value))
@@ -475,6 +475,10 @@ mod tests {
                     "Fam".to_string(),
                 ),
                 (
+                    NameKey::new_bmp_only(NameId::TYPOGRAPHIC_FAMILY_NAME),
+                    "Fam".to_string(),
+                ),
+                (
                     NameKey::new_bmp_only(NameId::new(256)),
                     "Weight".to_string(),
                 ),
@@ -556,5 +560,12 @@ mod tests {
     #[test]
     fn static_metadata_bincode() {
         assert_bincode_round_trip(test_static_metadata());
+    }
+
+    #[test]
+    fn static_metadata_smallest_id() {
+        let static_metadata = test_static_metadata();
+        let reverse_names = static_metadata.reverse_names();
+        assert_eq!(reverse_names.get("Fam").unwrap(), &NameId::FAMILY_NAME);
     }
 }

--- a/fontir/src/ir/static_metadata.rs
+++ b/fontir/src/ir/static_metadata.rs
@@ -379,6 +379,20 @@ impl StaticMetadata {
     pub fn axis(&self, tag: &Tag) -> Option<&Axis> {
         self.axes.iter().find(|a| &a.tag == tag)
     }
+
+    /// Calculate a deterministic mapping of existing name text to the smallest
+    /// name ID that provides it.
+    pub fn reverse_names(&self) -> HashMap<&str, NameId> {
+        self.names
+            .iter()
+            .fold(HashMap::new(), |mut accum: HashMap<&str, NameId>, (key, name)| {
+                accum
+                    .entry(name.as_str())
+                    .and_modify(|value| *value = key.name_id.min(*value))
+                    .or_insert(key.name_id);
+                accum
+            })
+    }
 }
 
 impl From<[u8; 10]> for Panose {


### PR DESCRIPTION
In the case where multiple existing name records are applicable for reuse, the non-deterministic order of HashMap meant that either could be chosen. This PR explicitly prefers the smallest ID, which makes the process deterministic, and matches [fonttools' behaviour](https://github.com/fonttools/fonttools/blob/d5aec1b9dbcbaa3f97d0d553fe85a92927b48faa/Lib/fontTools/ttLib/tables/_n_a_m_e.py#L326-L329).

(I think this covers everywhere, but is there anywhere else that needs updating?)