### PR TITLE
[glyphdata.rs] simplify logic for glyph names with suffixes

### DIFF
--- a/glyphs-reader/src/glyphdata.rs
+++ b/glyphs-reader/src/glyphdata.rs
@@ -449,14 +449,6 @@ impl GlyphData {
     // See https://github.com/googlefonts/glyphsLib/blob/e2ebf5b517d/Lib/glyphsLib/glyphdata.py#L94
     pub fn query(&self, name: &str, codepoints: Option<&BTreeSet<u32>>) -> Option<QueryResult> {
         self.query_no_synthesis(name, codepoints)
-            .or_else(|| {
-                // Try without suffix, those can confuse matters. E.g. ogonek.A => ogonek
-                // <https://github.com/googlefonts/fontc/issues/780#issuecomment-2674853729>
-                match name.rfind('.') {
-                    Some(idx) if idx > 0 => self.query_no_synthesis(&name[..idx], codepoints),
-                    _ => None,
-                }
-            })
             // we don't have info for this glyph: can we synthesize it?
             .or_else(|| self.construct_category(name))
     }


### PR DESCRIPTION
This ``or_else`` which I removed here is actually not needed because the ``construct_category`` method already handles glyph names with a suffix basically the same way.

https://github.com/googlefonts/fontc/blob/e14ac32850aa5efdb0584f347be1fbfd8c9d8309/glyphs-reader/src/glyphdata.rs#L527-L533

In fact, even after removing the block, the method ``match_prod_name_with_suffix`` added with PR #1354 continues to pass, confirming the removed lines are unnecessary.

https://github.com/googlefonts/fontc/blob/e14ac32850aa5efdb0584f347be1fbfd8c9d8309/glyphs-reader/src/glyphdata.rs#L1093-L1102