### PR TITLE
Match fontc's check for determining whether a designspace is variable

### DIFF
--- a/resources/scripts/ttx_diff.py
+++ b/resources/scripts/ttx_diff.py
@@ -316,7 +316,7 @@ def source_is_variable(path: Path) -> bool:
         return False
     if path.suffix == ".designspace":
         dspace = DesignSpaceDocument.fromfile(path)
-        return len(dspace.sources) > 1
+        return len(dspace.axes) > 0
     if path.suffix == ".glyphs" or path.suffix == ".glyphspackage":
         font = GSFont(path)
         return len(font.masters) > 1


### PR DESCRIPTION
Some of the larger diffs on crater come from designspaces that `ttx_diff.py` is instructing fontmake to build as statics, but which fontc will always build as variable (e.g. `docrepair-fonts/bacasime-antique-fonts`). This PR brings the condition in `ttx_diff.py` in line with the one in fontc, which resolves these.

## Trade-off

Any designspace that is single source is probably being instructed to be built as static by gftools. This means that after the change, the TTFs on crater would be less representative of those produced by gftools in the real world, even if as a superset of the tables and data that would be included in the statics. (UFOs are unaffected)

The alternative to this PR would be either:

1. Add a fontc argument that requests a static be built, irrespective of the sources and axes (undesirable); or
2. Implement in gftools the ability to instantiate the final statics from a variable TTF when `buildStatics` is enabled.