### PR TITLE
[fontir] Enforce that ConditionSet always sorted

### DIFF
--- a/fontbe/src/features/feature_variations.rs
+++ b/fontbe/src/features/feature_variations.rs
@@ -47,7 +47,7 @@ pub(super) fn make_gsub_feature_variations(
         let mut region = Region::default();
         for conditions in &rule.conditions {
             let mut space = NBox::default();
-            for condition in &conditions.0 {
+            for condition in conditions {
                 let axis = static_metadata
                     .axis(&condition.axis)
                     .expect("checked already");

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -2594,7 +2594,7 @@ mod tests {
         let variations = context.static_metadata.get().variations.clone().unwrap();
         assert_eq!(variations.features, [Tag::new(b"rvrn")]);
         assert_eq!(variations.rules.len(), 1);
-        let condition = &variations.rules[0].conditions[0].0[0];
+        let condition = &variations.rules[0].conditions[0][0];
         assert_eq!(condition.axis, "wght");
         assert_eq!(condition.min.unwrap(), 550.0);
         assert_eq!(condition.max.unwrap(), 700.0);


### PR DESCRIPTION
This was an oversight in the original implementation; order doens't matter here, so let's keep the innards private and sorted.