### PR TITLE
[glyphs] read production names from GlyphData to populate glyph postscript names

### DIFF
--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -265,6 +265,7 @@ pub struct Glyph {
     pub right_kern: Option<SmolStr>,
     pub category: Option<Category>,
     pub sub_category: Option<Subcategory>,
+    pub production_name: Option<SmolStr>,
 }
 
 impl Glyph {
@@ -909,6 +910,8 @@ struct RawGlyph {
     unicode: Option<String>,
     category: Option<SmolStr>,
     sub_category: Option<SmolStr>,
+    #[fromplist(alt_name = "production")]
+    production_name: Option<SmolStr>,
     #[fromplist(ignore)]
     other_stuff: BTreeMap<String, Plist>,
 }
@@ -2303,17 +2306,21 @@ impl RawGlyph {
 
         let mut category = parse_category(self.category.as_deref(), &self.glyphname);
         let mut sub_category = parse_category(self.sub_category.as_deref(), &self.glyphname);
+        let mut production_name = self.production_name;
 
         let codepoints = self
             .unicode
             .map(|s| parse_codepoint_str(&s, codepoint_radix))
             .unwrap_or_default();
 
-        if category.is_none() || sub_category.is_none() {
+        if category.is_none() || sub_category.is_none() || production_name.is_none() {
             if let Some(result) = glyph_data.query(&self.glyphname, Some(&codepoints)) {
                 // if they were manually set don't change them, otherwise do
                 category = category.or(Some(result.category));
                 sub_category = sub_category.or(result.subcategory);
+                production_name = production_name.or(
+                    result.production_name.map(|s| smol_str::format_smolstr!("{s}"))
+                );
             }
         }
 
@@ -2326,6 +2333,7 @@ impl RawGlyph {
             unicode: codepoints,
             category,
             sub_category,
+            production_name,
         })
     }
 }
@@ -4196,5 +4204,26 @@ mod tests {
     fn names_from_instances() {
         let font = Font::load(&glyphs3_dir().join("InstanceNames.glyphs")).unwrap();
         assert_eq!(font.names.get("preferredSubfamilyNames").unwrap(), "Italic")
+    }
+
+    #[rstest]
+    #[case::v2(glyphs2_dir())]
+    #[case::v3(glyphs3_dir())]
+    fn glyph_production_names(#[case] glyphs_dir: PathBuf) {
+        let font = Font::load(&glyphs_dir.join("ProductionNames.glyphs")).unwrap();
+        let glyphs = font.glyphs.values().collect::<Vec<_>>();
+
+        // this glyph has no production name in GlyphData.xml nor in the .glyphs file
+        assert_eq!(glyphs[0].name, "A");
+        assert_eq!(glyphs[0].production_name, None);
+
+        // this one would have 'dotlessi' in GlyphData.xml, but the .glyphs file overrides it
+        assert_eq!(glyphs[1].name, "idotless");
+        assert_eq!(glyphs[1].production_name, Some("uni0131".into()));
+
+        // this has no custom production_name in the .glyphs file, and the one from
+        // GlyphData.xml is used
+        assert_eq!(glyphs[2].name, "nbspace");
+        assert_eq!(glyphs[2].production_name, Some("uni00A0".into()));
     }
 }

--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -2318,9 +2318,9 @@ impl RawGlyph {
                 // if they were manually set don't change them, otherwise do
                 category = category.or(Some(result.category));
                 sub_category = sub_category.or(result.subcategory);
-                production_name = production_name.or(
-                    result.production_name.map(|s| smol_str::format_smolstr!("{s}"))
-                );
+                production_name = production_name.or(result
+                    .production_name
+                    .map(|s| smol_str::format_smolstr!("{s}")));
             }
         }
 

--- a/glyphs-reader/src/glyphdata.rs
+++ b/glyphs-reader/src/glyphdata.rs
@@ -200,6 +200,26 @@ impl From<&str> for ProductionName {
     }
 }
 
+impl From<u32> for ProductionName {
+    fn from(v: u32) -> ProductionName {
+        if v <= 0xFFFF {
+            ProductionName::Bmp(v)
+        } else {
+            ProductionName::NonBmp(v)
+        }
+    }
+}
+
+impl Display for ProductionName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ProductionName::Bmp(cp) => write!(f, "uni{:04X}", cp),
+            ProductionName::NonBmp(cp) => write!(f, "u{:X}", cp),
+            ProductionName::Custom(s) => write!(f, "{}", s),
+        }
+    }
+}
+
 /// A queryable set of glyph data
 ///
 /// Always queries static data from glyphsLib. Optionally includes a set of override values as well.

--- a/glyphs-reader/src/glyphdata.rs
+++ b/glyphs-reader/src/glyphdata.rs
@@ -261,12 +261,13 @@ impl GlyphData {
 /// The category and subcategory to use
 ///
 /// Used for overrides and as the result of [`GlyphData::query`]
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct QueryResult {
     pub category: Category,
     pub subcategory: Option<Subcategory>,
     pub codepoint: Option<u32>,
     pub script: Option<Script>,
+    pub production_name: Option<ProductionName>,
 }
 
 #[derive(Clone, Debug, thiserror::Error)]
@@ -345,6 +346,7 @@ pub(crate) fn parse_entries(xml: &[u8]) -> Result<HashMap<SmolStr, QueryResult>,
                 subcategory: info.subcategory,
                 codepoint: info.codepoint,
                 script: info.script,
+                production_name: info.production_name.clone(),
             },
         );
         for alt in info.alt_names {
@@ -355,6 +357,7 @@ pub(crate) fn parse_entries(xml: &[u8]) -> Result<HashMap<SmolStr, QueryResult>,
                     subcategory: info.subcategory,
                     codepoint: None,
                     script: info.script,
+                    production_name: info.production_name.clone(),
                 },
             ));
         }
@@ -385,6 +388,7 @@ struct GlyphInfoFromXml {
     subcategory: Option<Subcategory>,
     codepoint: Option<u32>,
     script: Option<Script>,
+    production_name: Option<ProductionName>,
 }
 
 fn parse_glyph_xml(item: BytesStart) -> Result<GlyphInfoFromXml, GlyphDataError> {
@@ -394,6 +398,7 @@ fn parse_glyph_xml(item: BytesStart) -> Result<GlyphInfoFromXml, GlyphDataError>
     let mut unicode = None;
     let mut alt_names = None;
     let mut script = None;
+    let mut production_name = None;
 
     for attr in item.attributes() {
         let attr = attr?;
@@ -405,7 +410,8 @@ fn parse_glyph_xml(item: BytesStart) -> Result<GlyphInfoFromXml, GlyphDataError>
             b"unicode" => unicode = Some(value),
             b"altNames" => alt_names = Some(value),
             b"script" => script = Some(value),
-            b"production" | b"unicodeLegacy" | b"case" | b"direction" | b"description" => (),
+            b"production" => production_name = Some(value.as_ref().into()),
+            b"unicodeLegacy" | b"case" | b"direction" | b"description" => (),
             other => {
                 return Err(GlyphDataError::UnknownAttribute(
                     String::from_utf8_lossy(other).into_owned(),
@@ -454,6 +460,7 @@ fn parse_glyph_xml(item: BytesStart) -> Result<GlyphInfoFromXml, GlyphDataError>
         subcategory,
         codepoint,
         script,
+        production_name,
     })
 }
 
@@ -502,6 +509,7 @@ impl GlyphData {
                     subcategory: override_result.subcategory,
                     codepoint: override_result.codepoint,
                     script: override_result.script,
+                    production_name: override_result.production_name.clone(),
                 });
             }
         }
@@ -557,6 +565,7 @@ impl GlyphData {
                         subcategory: first_attr.subcategory,
                         codepoint: None,
                         script: None,
+                        production_name: None,
                     });
                 } else if first_attr.category == Category::Letter {
                     // if first is letter and rest are marks/separators, we use info from first
@@ -571,6 +580,7 @@ impl GlyphData {
                             subcategory: first_attr.subcategory,
                             codepoint: None,
                             script: None,
+                            production_name: None,
                         });
                     } else {
                         return Some(QueryResult {
@@ -578,6 +588,7 @@ impl GlyphData {
                             subcategory: Some(Subcategory::Ligature),
                             codepoint: None,
                             script: None,
+                            production_name: None,
                         });
                     }
                 }
@@ -605,6 +616,7 @@ impl GlyphData {
                     subcategory: Some(Subcategory::Ligature),
                     codepoint: None,
                     script: None,
+                    production_name: None,
                 });
             } else {
                 return Some(QueryResult {
@@ -612,6 +624,7 @@ impl GlyphData {
                     subcategory,
                     codepoint: None,
                     script: None,
+                    production_name: None,
                 });
             }
         }
@@ -935,11 +948,17 @@ mod tests {
                 subcategory: Some(Subcategory::SpacingCombining),
                 codepoint: Some(b'A' as u32),
                 script: Some(Script::Alchemical),
+                production_name: Some(ProductionName::Custom("MagicA".into())),
             },
         )]);
         let data = GlyphData::new(Some(overrides));
 
-        assert_eq!(data.query("A", None).unwrap().category, Category::Mark);
+        let result = data.query("A", None).unwrap();
+        assert_eq!(result.category, Category::Mark);
+        assert_eq!(result.subcategory, Some(Subcategory::SpacingCombining));
+        assert_eq!(result.codepoint, Some(b'A' as u32));
+        assert_eq!(result.script, Some(Script::Alchemical));
+        assert_eq!(result.production_name, Some("MagicA".into()));
     }
 
     #[test]
@@ -948,6 +967,10 @@ mod tests {
             GlyphData::with_override_file(Path::new("./data/GlyphData_override_test.xml")).unwrap();
         assert_eq!(data.query("zero", None).unwrap().category, Category::Other);
         assert_eq!(data.query("C", None).unwrap().category, Category::Number);
+        assert_eq!(
+            data.query("Yogh", None).unwrap().production_name,
+            Some("Yolo".into())
+        );
     }
 
     fn get_category(name: &str, codepoints: &[u32]) -> Option<(Category, Option<Subcategory>)> {

--- a/glyphs-reader/src/glyphdata_bundled.rs
+++ b/glyphs-reader/src/glyphdata_bundled.rs
@@ -1,10 +1,7 @@
 //! Accessors for bundled glyphsLib data
 
 use std::{
-    cmp::Ordering,
-    collections::HashMap,
-    marker::PhantomData,
-    str::from_utf8_unchecked,
+    cmp::Ordering, collections::HashMap, marker::PhantomData, str::from_utf8_unchecked,
     sync::LazyLock,
 };
 
@@ -197,10 +194,9 @@ pub(crate) fn get(i: usize) -> Option<QueryResult> {
     } else {
         None
     };
-    let production_name = if codepoint.is_some() && has_predictable_prod_name(codepoint.unwrap()) {
-        Some(ProductionName::from(codepoint.unwrap()))
-    } else {
-        REVERSE_PROD_NAMES.get(&i).map(|name| name.clone())
+    let production_name = match codepoint {
+        Some(cp) if has_predictable_prod_name(cp) => Some(ProductionName::from(cp)),
+        _ => REVERSE_PROD_NAMES.get(&i).cloned(),
     };
 
     Some(QueryResult {

--- a/resources/testdata/glyphs2/ProductionNames.glyphs
+++ b/resources/testdata/glyphs2/ProductionNames.glyphs
@@ -1,0 +1,56 @@
+{
+.appVersion = "3413";
+familyName = "Production Names";
+fontMaster = (
+{
+alignmentZones = (
+"{800, 16}",
+"{700, 16}",
+"{500, 16}",
+"{0, -16}",
+"{-200, -16}"
+);
+ascender = 800;
+capHeight = 700;
+descender = -200;
+id = m01;
+xHeight = 500;
+}
+);
+glyphs = (
+{
+glyphname = A;
+layers = (
+{
+layerId = m01;
+width = 600;
+}
+);
+unicode = 0041;
+},
+{
+glyphname = idotless;
+production = uni0131;
+layers = (
+{
+layerId = m01;
+width = 600;
+}
+);
+unicode = 0131;
+},
+{
+glyphname = nbspace;
+layers = (
+{
+layerId = m01;
+width = 600;
+}
+);
+unicode = 00A0;
+}
+);
+unitsPerEm = 1000;
+versionMajor = 1;
+versionMinor = 0;
+}

--- a/resources/testdata/glyphs2/ProductionNames.glyphs
+++ b/resources/testdata/glyphs2/ProductionNames.glyphs
@@ -3,18 +3,7 @@
 familyName = "Production Names";
 fontMaster = (
 {
-alignmentZones = (
-"{800, 16}",
-"{700, 16}",
-"{500, 16}",
-"{0, -16}",
-"{-200, -16}"
-);
-ascender = 800;
-capHeight = 700;
-descender = -200;
 id = m01;
-xHeight = 500;
 }
 );
 glyphs = (

--- a/resources/testdata/glyphs3/ProductionNames.glyphs
+++ b/resources/testdata/glyphs3/ProductionNames.glyphs
@@ -1,0 +1,90 @@
+{
+.appVersion = "3413";
+.formatVersion = 3;
+familyName = "Production Names";
+fontMaster = (
+{
+id = m01;
+metricValues = (
+{
+over = 16;
+pos = 800;
+},
+{
+over = 16;
+pos = 700;
+},
+{
+over = 16;
+pos = 500;
+},
+{
+over = -16;
+},
+{
+over = -16;
+pos = -200;
+},
+{
+}
+);
+name = Regular;
+}
+);
+glyphs = (
+{
+glyphname = A;
+layers = (
+{
+layerId = m01;
+width = 600;
+}
+);
+unicode = 65;
+},
+{
+glyphname = idotless;
+layers = (
+{
+layerId = m01;
+width = 600;
+}
+);
+production = uni0131;
+unicode = 305;
+},
+{
+glyphname = nbspace;
+layers = (
+{
+layerId = m01;
+width = 600;
+}
+);
+unicode = 160;
+}
+);
+metrics = (
+{
+type = ascender;
+},
+{
+type = "cap height";
+},
+{
+type = "x-height";
+},
+{
+type = baseline;
+},
+{
+type = descender;
+},
+{
+type = "italic angle";
+}
+);
+unitsPerEm = 1000;
+versionMajor = 1;
+versionMinor = 0;
+}

--- a/resources/testdata/glyphs3/ProductionNames.glyphs
+++ b/resources/testdata/glyphs3/ProductionNames.glyphs
@@ -5,29 +5,6 @@ familyName = "Production Names";
 fontMaster = (
 {
 id = m01;
-metricValues = (
-{
-over = 16;
-pos = 800;
-},
-{
-over = 16;
-pos = 700;
-},
-{
-over = 16;
-pos = 500;
-},
-{
-over = -16;
-},
-{
-over = -16;
-pos = -200;
-},
-{
-}
-);
 name = Regular;
 }
 );
@@ -62,26 +39,6 @@ width = 600;
 }
 );
 unicode = 160;
-}
-);
-metrics = (
-{
-type = ascender;
-},
-{
-type = "cap height";
-},
-{
-type = "x-height";
-},
-{
-type = baseline;
-},
-{
-type = descender;
-},
-{
-type = "italic angle";
 }
 );
 unitsPerEm = 1000;


### PR DESCRIPTION
Towards fixing https://github.com/googlefonts/fontc/issues/248

After #1354 we have the production names in our generated glyphdata but were using it only for looking up a glyph's category/subCategory using its production name.

This PR uses these same production names for their primary purpose i.e. renaming glyphs in the final font ready for 'production' (which means following the AGLFN rules).

The `--no-production-name` CLI flag is now being used for this when the inputs are .glyphs sources. Previously it was only having an effect when the input was a .designspace or .ufo.

I haven't implemented yet the additional logic in glyphsLib for those glyphs that have suffixes or comprise ligatures but do not have a predefined `production` name set in the GlyphData.xml. I will probably tackle that in a follow up.

I also have _not_ disabled the `--no-production-name` CLI flag in the ttx_diff.py script used by fontc_crater, since the glyph renaming doesn't match 100% fontmake for .glyphs source yet. Which means ttx_diff.py is still comparing fonts where the glyphs kept their original human-readable name (useful for debugging at times, but not reflecting real-world production).
