### PR TITLE
[glyphs] Parse 'axis rules'

### DIFF
--- a/resources/testdata/glyphs3/AxisRules.glyphs
+++ b/resources/testdata/glyphs3/AxisRules.glyphs
@@ -1,0 +1,36 @@
+{
+.appVersion = "3260";
+.formatVersion = 3;
+familyName = NoMetaTable;
+fontMaster = (
+{
+id = master01;
+name = Regular;
+}
+);
+glyphs = (
+{
+glyphname = space;
+layers = (
+{
+attr = {
+axisRules = (
+{
+max = 400;
+},
+{
+min = 100;
+},
+{
+}
+);
+};
+layerId = master01;
+width = 600;
+}
+);
+unicode = 32;
+}
+);
+unitsPerEm = 1000;
+}


### PR DESCRIPTION
This is split out from the work on bracket layers.

This will parse the `axisRule` layer attribute in glyphs3, and will parse rules out of layer names for glyphs2.