### PR TITLE
Compile per-instance postscript names from Glyphs and designspaces

### DIFF
--- a/fontbe/src/features/marks.rs
+++ b/fontbe/src/features/marks.rs
@@ -1214,6 +1214,7 @@ mod tests {
                 .enumerate()
                 .map(|(i, loc)| NamedInstance {
                     name: format!("instance{i}"),
+                    postscript_name: None,
                     location: loc.to_user(&axis_map),
                 })
                 .collect();

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -3080,4 +3080,41 @@ mod tests {
             result.get_gid("plus").to_u16() as i16 - result.get_gid("bar").to_u16() as i16
         );
     }
+
+    #[test]
+    fn compile_instance_postscript_names() {
+        let result = TestCompile::compile_source("glyphs3/InstancePostscript.glyphs");
+        let font = result.font();
+
+        let fvar = font.fvar().unwrap();
+        let name = font.name().unwrap();
+
+        let actual = fvar
+            .instances()
+            .unwrap()
+            .iter()
+            .map(|instance| {
+                instance
+                    .unwrap()
+                    .post_script_name_id
+                    .map(|id| resolve_name(&name, id).unwrap())
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(actual, vec![None, Some("PostBold".to_string())]);
+    }
+
+    #[test]
+    fn dont_compile_instance_postscript_names_if_none() {
+        let result = TestCompile::compile_source("glyphs3/InstanceNoPostscript.glyphs");
+        let font = result.font();
+
+        let fvar = font.fvar().unwrap();
+
+        assert!(fvar
+            .instances()
+            .unwrap()
+            .iter()
+            .all(|instance| instance.unwrap().post_script_name_id.is_none()));
+    }
 }

--- a/fontir/src/ir/static_metadata.rs
+++ b/fontir/src/ir/static_metadata.rs
@@ -86,6 +86,7 @@ pub struct StaticMetadata {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct NamedInstance {
     pub name: String,
+    pub postscript_name: Option<String>,
     pub location: UserLocation,
 }
 
@@ -493,6 +494,7 @@ mod tests {
             axes: vec![axis.clone()],
             named_instances: vec![NamedInstance {
                 name: "Nobody".to_string(),
+                postscript_name: None,
                 location: vec![(WGHT, UserCoord::new(100.0))].into(),
             }],
             variation_model: VariationModel::new(

--- a/fontir/src/ir/static_metadata.rs
+++ b/fontir/src/ir/static_metadata.rs
@@ -353,6 +353,11 @@ impl StaticMetadata {
             .iter()
             .map(|axis| axis.ui_label_name())
             .chain(named_instances.iter().map(|ni| ni.name.as_ref()))
+            .chain(
+                named_instances
+                    .iter()
+                    .flat_map(|ni| ni.postscript_name.as_deref()),
+            )
             .for_each(|name| {
                 if !visited.insert(name.to_string()) {
                     return;

--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -2601,6 +2601,15 @@ impl Instance {
         // conversion..
         // https://github.com/googlefonts/glyphsLib/blob/c4db6b981d577/Lib/glyphsLib/classes.py#L3271
     }
+
+    /// Get the optional postscript name to use for the `fvar` named instance.
+    pub fn postscript_name(&self) -> Option<&str> {
+        // https://handbook.glyphsapp.com/custom-parameter-descriptions/
+        self.properties
+            .iter()
+            .find(|raw| raw.key == "variablePostscriptFontName")
+            .and_then(RawName::get_value)
+    }
 }
 
 /// Glyphs appears to use code page identifiers rather than bits

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -259,6 +259,7 @@ impl Work<Context, WorkId, Error> for StaticMetadataWork {
                 }
                 Some(NamedInstance {
                     name: inst.name.clone(),
+                    postscript_name: inst.postscript_name().map(str::to_string),
                     location: font_info
                         .locations
                         .get(&inst.axes_values)

--- a/resources/testdata/glyphs3/InstanceNoPostscript.glyphs
+++ b/resources/testdata/glyphs3/InstanceNoPostscript.glyphs
@@ -1,0 +1,69 @@
+{
+.appVersion = "3219";
+.formatVersion = 3;
+axes = (
+{
+name = Weight;
+tag = wght;
+}
+);
+familyName = WghtVar;
+fontMaster = (
+{
+axesValues = (
+400
+);
+id = m01;
+name = Regular;
+},
+{
+axesValues = (
+700
+);
+iconName = Bold;
+id = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+name = Bold;
+}
+);
+glyphs = (
+{
+glyphname = space;
+layers = (
+{
+layerId = m01;
+width = 200;
+},
+{
+layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+width = 600;
+}
+);
+unicode = 32;
+}
+);
+instances = (
+{
+axesValues = (
+400
+);
+instanceInterpolations = {
+m01 = 1;
+};
+name = Regular;
+},
+{
+axesValues = (
+700
+);
+instanceInterpolations = {
+"E09E0C54-128D-4FEA-B209-1B70BEFE300B" = 1;
+};
+isBold = 1;
+linkStyle = Regular;
+name = Bold;
+}
+);
+unitsPerEm = 1000;
+versionMajor = 42;
+versionMinor = 42;
+}

--- a/resources/testdata/glyphs3/InstancePostscript.glyphs
+++ b/resources/testdata/glyphs3/InstancePostscript.glyphs
@@ -1,0 +1,75 @@
+{
+.appVersion = "3219";
+.formatVersion = 3;
+axes = (
+{
+name = Weight;
+tag = wght;
+}
+);
+familyName = WghtVar;
+fontMaster = (
+{
+axesValues = (
+400
+);
+id = m01;
+name = Regular;
+},
+{
+axesValues = (
+700
+);
+iconName = Bold;
+id = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+name = Bold;
+}
+);
+glyphs = (
+{
+glyphname = space;
+layers = (
+{
+layerId = m01;
+width = 200;
+},
+{
+layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+width = 600;
+}
+);
+unicode = 32;
+}
+);
+instances = (
+{
+axesValues = (
+400
+);
+instanceInterpolations = {
+m01 = 1;
+};
+name = Regular;
+},
+{
+axesValues = (
+700
+);
+instanceInterpolations = {
+"E09E0C54-128D-4FEA-B209-1B70BEFE300B" = 1;
+};
+isBold = 1;
+linkStyle = Regular;
+name = Bold;
+properties = (
+{
+key = variablePostscriptFontName;
+value = "PostBold";
+}
+);
+}
+);
+unitsPerEm = 1000;
+versionMajor = 42;
+versionMinor = 42;
+}

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -781,6 +781,7 @@ impl Work<Context, WorkId, Error> for StaticMetadataWork {
                             None => inst.name.clone().unwrap(),
                         }
                     }),
+                    postscript_name: inst.postscriptfontname.clone(),
                     location: to_design_location(&tags_by_name, &inst.location)
                         .to_user(&axes_by_tag),
                 }


### PR DESCRIPTION
Implements https://github.com/googlefonts/fontc/issues/1371

([fonttools already supports this](https://github.com/fonttools/fonttools/blob/cc10bfc7d18e97efe1c5239ce5f47ba73050e3db/Lib/fontTools/varLib/__init__.py#L136-L138), although only from UFOs as glyphsLib does not parse this custom parameter yet)