### PR TITLE
Add fontir::Axes type

### DIFF
--- a/fontbe/src/features/feature_variations.rs
+++ b/fontbe/src/features/feature_variations.rs
@@ -425,7 +425,7 @@ impl Debug for NBox {
 mod tests {
     use std::str::FromStr;
 
-    use fontdrasil::{coords::DesignCoord, types::Axis};
+    use fontdrasil::{coords::DesignCoord, types::Axes};
     use fontir::ir::{Condition, Rule, Substitution};
     use write_fonts::tables::{gsub::Gsub, layout::FeatureVariations};
 
@@ -664,7 +664,7 @@ mod tests {
     } test;
     "#,
             )
-            .with_axes(vec![Axis::for_test("wght")])
+            .with_axes(Axes::for_test(&["wght"]))
             .with_glyph_order(
                 ["one", "two", "a", "a.bracket600"]
                     .into_iter()

--- a/fontbe/src/features/marks.rs
+++ b/fontbe/src/features/marks.rs
@@ -1206,8 +1206,7 @@ mod tests {
                     hidden: false,
                     converter: CoordConverter::unmapped(min, default, max),
                 })
-                .collect::<Vec<_>>();
-            let axis_map = axes.iter().map(|a| (a.tag, a)).collect();
+                .collect();
             let named_instances = self
                 .locations
                 .iter()
@@ -1215,7 +1214,7 @@ mod tests {
                 .map(|(i, loc)| NamedInstance {
                     name: format!("instance{i}"),
                     postscript_name: None,
-                    location: loc.to_user(&axis_map),
+                    location: loc.to_user(&axes),
                 })
                 .collect();
             let glyph_locations = self.locations.iter().cloned().collect();

--- a/fontbe/src/features/test_helpers.rs
+++ b/fontbe/src/features/test_helpers.rs
@@ -3,7 +3,7 @@
 use std::{collections::HashSet, path::Path, sync::Arc};
 
 use fea_rs::compile::{Compilation, FeatureProvider};
-use fontdrasil::{coords::NormalizedLocation, types::Axis};
+use fontdrasil::{coords::NormalizedLocation, types::Axes};
 use fontir::ir::{GdefCategories, GlyphOrder, NamedInstance, StaticMetadata};
 
 use crate::orchestration::FeaFirstPassOutput;
@@ -12,7 +12,7 @@ use super::FeaVariationInfo;
 
 /// A builder for constructing  [`LayoutOutput`]
 pub(crate) struct LayoutOutputBuilder {
-    axes: Vec<Axis>,
+    axes: Axes,
     categories: Option<GdefCategories>,
     named_instances: Vec<NamedInstance>,
     glyph_locations: HashSet<NormalizedLocation>,
@@ -32,7 +32,7 @@ impl LayoutOutputBuilder {
         Default::default()
     }
 
-    pub(crate) fn with_axes(&mut self, axes: Vec<Axis>) -> &mut Self {
+    pub(crate) fn with_axes(&mut self, axes: Axes) -> &mut Self {
         self.axes = axes;
         self
     }
@@ -66,7 +66,7 @@ impl LayoutOutputBuilder {
         let static_metadata = StaticMetadata::new(
             1000,
             Default::default(),
-            self.axes.clone(),
+            self.axes.clone().into_inner(),
             self.named_instances.clone(),
             self.glyph_locations.clone(),
             Default::default(),

--- a/fontbe/src/mvar.rs
+++ b/fontbe/src/mvar.rs
@@ -7,7 +7,7 @@ use fontdrasil::orchestration::AccessBuilder;
 use fontdrasil::{
     coords::NormalizedLocation,
     orchestration::{Access, Work},
-    types::Axis,
+    types::Axes,
 };
 use fontir::{
     ir::GlobalMetricValues, orchestration::WorkId as FeWorkId, variations::VariationModel,
@@ -37,7 +37,7 @@ pub fn create_mvar_work() -> Box<BeWork> {
 /// Helper to build MVAR table from global metrics sources.
 struct MvarBuilder {
     /// Variation axes
-    axes: Vec<Axis>,
+    axes: Axes,
     /// Sparse variation models, keyed by the set of locations they define
     models: HashMap<BTreeSet<NormalizedLocation>, VariationModel>,
     /// Metrics deltas keyed by MVAR tag
@@ -46,7 +46,7 @@ struct MvarBuilder {
 
 impl MvarBuilder {
     fn new(global_model: VariationModel) -> Self {
-        let axes = global_model.axes().cloned().collect::<Vec<_>>();
+        let axes = global_model.axes().cloned().collect();
         let global_locations = global_model.locations().cloned().collect::<BTreeSet<_>>();
         let mut models = HashMap::new();
         models.insert(global_locations, global_model);
@@ -179,7 +179,7 @@ mod tests {
 
     fn new_mvar_builder(locations: Vec<&NormalizedLocation>, axes: Vec<Axis>) -> MvarBuilder {
         let locations = locations.into_iter().cloned().collect();
-        let model = VariationModel::new(locations, axes).unwrap();
+        let model = VariationModel::new(locations, axes.into()).unwrap();
         MvarBuilder::new(model)
     }
 

--- a/fontdrasil/src/coords.rs
+++ b/fontdrasil/src/coords.rs
@@ -3,7 +3,7 @@
 //! See <https://github.com/googlefonts/fontmake-rs/blob/main/resources/text/units.md>
 
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap},
+    collections::BTreeMap,
     fmt::{Debug, Write},
     marker::PhantomData,
     ops::Sub,
@@ -13,7 +13,7 @@ use ordered_float::OrderedFloat;
 use serde::{ser::SerializeSeq, Deserialize, Deserializer, Serialize};
 use write_fonts::types::{F2Dot14, Fixed, Tag};
 
-use crate::{piecewise_linear_map::PiecewiseLinearMap, types::Axis};
+use crate::{piecewise_linear_map::PiecewiseLinearMap, types::Axes};
 
 /// A trait for converting coordinates between coordinate spaces.
 ///
@@ -138,7 +138,7 @@ macro_rules! convert_convenience_methods {
         where
             Space: ConvertSpace<$space>,
         {
-            pub fn $fn_name(&self, axes: &HashMap<Tag, &Axis>) -> Location<$space> {
+            pub fn $fn_name(&self, axes: &Axes) -> Location<$space> {
                 self.convert(axes)
             }
         }
@@ -347,7 +347,7 @@ impl<Space> Location<Space> {
     }
 
     /// Creates a new `Location` containing only the axis tags contained in the given set.
-    pub fn subset_axes(&self, axis_tags: &BTreeSet<Tag>) -> Self {
+    pub fn subset_axes(&self, axis_tags: &Axes) -> Self {
         Self(
             self.0
                 .iter()
@@ -362,7 +362,7 @@ impl<Space> Location<Space> {
         )
     }
 
-    pub fn convert<ToSpace>(&self, axes: &HashMap<Tag, &Axis>) -> Location<ToSpace>
+    pub fn convert<ToSpace>(&self, axes: &Axes) -> Location<ToSpace>
     where
         Space: ConvertSpace<ToSpace>,
     {

--- a/fontra2fontir/src/toir.rs
+++ b/fontra2fontir/src/toir.rs
@@ -219,7 +219,7 @@ fn to_ir_path(glyph_name: GlyphName, contour: &FontraContour) -> Result<BezPath,
 mod tests {
     use std::collections::{HashMap, HashSet};
 
-    use fontdrasil::types::Axis;
+    use fontdrasil::types::Axes;
     use fontir::ir::Glyph;
     use kurbo::{BezPath, PathEl};
     use write_fonts::types::Tag;
@@ -232,7 +232,7 @@ mod tests {
 
     use super::to_ir_glyph;
 
-    fn axis_tuples(axes: &[Axis]) -> Vec<(&str, Tag, f64, f64, f64)> {
+    fn axis_tuples(axes: &Axes) -> Vec<(&str, Tag, f64, f64, f64)> {
         axes.iter()
             .map(|a| {
                 (

--- a/glyphs2fontir/src/toir.rs
+++ b/glyphs2fontir/src/toir.rs
@@ -141,7 +141,7 @@ pub(crate) fn to_ir_features(features: &[FeatureSnippet]) -> Result<ir::Features
 }
 
 pub(crate) fn design_location(
-    axes: &[fontdrasil::types::Axis],
+    axes: &fontdrasil::types::Axes,
     axes_values: &[OrderedFloat<f64>],
 ) -> DesignLocation {
     axes.iter()
@@ -222,7 +222,7 @@ fn to_ir_axis(
     })
 }
 
-fn ir_axes(font: &Font) -> Result<Vec<fontdrasil::types::Axis>, Error> {
+fn ir_axes(font: &Font) -> Result<fontdrasil::types::Axes, Error> {
     // Every master should have a value for every axis
     for master in font.masters.iter() {
         if font.axes.len() != master.axes_values.len() {
@@ -268,7 +268,7 @@ pub(crate) struct FontInfo {
     pub master_positions: HashMap<String, NormalizedLocation>,
     /// Axes values => location for every instance and master
     pub locations: HashMap<Vec<OrderedFloat<f64>>, NormalizedLocation>,
-    pub axes: Vec<fontdrasil::types::Axis>,
+    pub axes: fontdrasil::types::Axes,
 }
 
 impl TryFrom<Font> for FontInfo {
@@ -284,20 +284,19 @@ impl TryFrom<Font> for FontInfo {
 
         let axes = ir_axes(&font)?;
 
-        let axes_by_name = axes.iter().map(|a| (a.tag, a)).collect();
         let locations: HashMap<_, _> = font
             .masters
             .iter()
             .map(|m| {
                 (
                     m.axes_values.clone(),
-                    design_location(&axes, &m.axes_values).to_normalized(&axes_by_name),
+                    design_location(&axes, &m.axes_values).to_normalized(&axes),
                 )
             })
             .chain(font.instances.iter().map(|i| {
                 (
                     i.axes_values.clone(),
-                    design_location(&axes, &i.axes_values).to_normalized(&axes_by_name),
+                    design_location(&axes, &i.axes_values).to_normalized(&axes),
                 )
             }))
             .collect();

--- a/ufo2fontir/src/toir.rs
+++ b/ufo2fontir/src/toir.rs
@@ -99,23 +99,22 @@ fn to_ir_glyph_instance(glyph: &norad::Glyph, path: &PathBuf) -> Result<ir::Glyp
 
 /// Create a map from source filename (e.g. x.ufo) => normalized location
 pub fn master_locations<'a>(
-    axes: &[fontdrasil::types::Axis],
+    axes: &fontdrasil::types::Axes,
     sources: impl IntoIterator<Item = &'a designspace::Source>,
 ) -> HashMap<String, NormalizedLocation> {
     let tags_by_name: HashMap<_, _> = axes.iter().map(|a| (a.name.as_str(), a.tag)).collect();
-    let axes = axes.iter().map(|a| (a.tag, a)).collect();
     sources
         .into_iter()
         .map(|s| {
             (
                 s.name.clone().unwrap(),
-                to_design_location(&tags_by_name, &s.location).to_normalized(&axes),
+                to_design_location(&tags_by_name, &s.location).to_normalized(axes),
             )
         })
         .collect()
 }
 
-pub fn to_ir_axes(axes: &[designspace::Axis]) -> Result<Vec<fontdrasil::types::Axis>, Error> {
+pub fn to_ir_axes(axes: &[designspace::Axis]) -> Result<fontdrasil::types::Axes, Error> {
     axes.iter().map(to_ir_axis).collect()
 }
 


### PR DESCRIPTION
This serves as a collection of axes, and handles the very common task of providing a mapping from a tag to an axis.

I was noticing that each compilation was creating potentially thousands of duplicate transient mappings; now we hopefully only do it once.


No functional change.


JMM