### PR TITLE
glyphdata: support synthetic production names

### DIFF
--- a/fontbe/src/post.rs
+++ b/fontbe/src/post.rs
@@ -60,10 +60,11 @@ impl Work<Context, AnyWorkId, Error> for PostWork {
                     return g.to_string();
                 }
                 let mut name = rename_map.get(g).unwrap_or(g).to_string();
-                // Adobe Glyph List spec forbids any characters not in [A-Za-z0-9._]; it also say glyphs
+                // Adobe Glyph List spec forbids any characters not in [A-Za-z0-9._]; it also says glyphs
                 // must not start with a digit or period (except .notdef) and shouldn't exceed 63 chars,
                 // but ufo2ft only enforces the first rule so we simply follow that.
                 // https://github.com/googlefonts/ufo2ft/blob/2f11b0f/Lib/ufo2ft/postProcessor.py#L220-L233
+                // https://github.com/adobe-type-tools/agl-specification
                 name.retain(|c| c.is_ascii_alphanumeric() || c == '.' || c == '_');
                 // make duplicates unique by adding a number suffix to match fonttools/ufo2ft:
                 // https://github.com/googlefonts/ufo2ft/blob/2f11b0f/Lib/ufo2ft/postProcessor.py#L239-L248

--- a/fontbe/src/post.rs
+++ b/fontbe/src/post.rs
@@ -45,43 +45,43 @@ impl Work<Context, AnyWorkId, Error> for PostWork {
             .global_metrics
             .get()
             .at(static_metadata.default_location());
-        // Whether to rename glyphs for 'production' using the provided remame map
-        let do_production_names = context.flags.contains(Flags::PRODUCTION_NAMES);
-        let rename_map = &static_metadata.postscript_names;
-        let mut seen = HashMap::new();
-        let final_glyph_names: Vec<_> = context
-            .ir
-            .glyph_order
-            .get()
-            .names()
-            .map(|g| {
-                if !do_production_names {
-                    // pass through the original name
-                    return g.to_string();
-                }
-                let mut name = rename_map.get(g).unwrap_or(g).to_string();
-                // Adobe Glyph List spec forbids any characters not in [A-Za-z0-9._]; it also says glyphs
-                // must not start with a digit or period (except .notdef) and shouldn't exceed 63 chars,
-                // but ufo2ft only enforces the first rule so we simply follow that.
-                // https://github.com/googlefonts/ufo2ft/blob/2f11b0f/Lib/ufo2ft/postProcessor.py#L220-L233
-                // https://github.com/adobe-type-tools/agl-specification
-                name.retain(|c| c.is_ascii_alphanumeric() || c == '.' || c == '_');
-                // make duplicates unique by adding a number suffix to match fonttools/ufo2ft:
-                // https://github.com/googlefonts/ufo2ft/blob/2f11b0f/Lib/ufo2ft/postProcessor.py#L239-L248
-                if let Some(n) = seen.get(&name) {
-                    let mut n = *n;
-                    while seen.contains_key(&format!("{}.{}", name, n)) {
-                        n += 1;
-                    }
-                    seen.insert(name.clone(), n + 1);
-                    name = format!("{}.{}", name, n);
-                }
-                seen.insert(name.clone(), 1);
-                name
-            })
-            .collect();
+        let glyph_order = context.ir.glyph_order.get();
 
-        let mut post = Post::new_v2(final_glyph_names.iter().map(|g| g.as_str()));
+        let mut post = if context.flags.contains(Flags::PRODUCTION_NAMES) {
+            // rename glyphs for 'production' using the provided rename map
+            let rename_map = &static_metadata.postscript_names;
+            let mut seen = HashMap::new();
+            let final_glyph_names: Vec<_> = glyph_order
+                .names()
+                .map(|g| {
+                    let mut name = rename_map.get(g).unwrap_or(g).to_string();
+                    // Adobe Glyph List spec forbids any characters not in [A-Za-z0-9._];
+                    // it also says glyphs must not start with a digit or period (except
+                    // .notdef) and shouldn't exceed 63 chars, but ufo2ft only enforces
+                    // the first rule so we simply follow that.
+                    // https://github.com/googlefonts/ufo2ft/blob/2f11b0f/Lib/ufo2ft/postProcessor.py#L220-L233
+                    // https://github.com/adobe-type-tools/agl-specification
+                    name.retain(|c| c.is_ascii_alphanumeric() || c == '.' || c == '_');
+                    // make duplicates unique by adding a .N number suffix to match ufo2ft:
+                    if let Some(n) = seen.get(&name) {
+                        let mut n = *n;
+                        while seen.contains_key(&format!("{}.{}", name, n)) {
+                            n += 1;
+                        }
+                        seen.insert(name.clone(), n + 1);
+                        name = format!("{}.{}", name, n);
+                    }
+                    seen.insert(name.clone(), 1);
+                    name
+                })
+                .collect();
+
+            Post::new_v2(final_glyph_names.iter().map(|g| g.as_str()))
+        } else {
+            // use the original glyph names as-is
+            Post::new_v2(glyph_order.names().map(|g| g.as_str()))
+        };
+
         post.is_fixed_pitch = static_metadata.misc.is_fixed_pitch.unwrap_or_default() as u32;
         post.italic_angle = Fixed::from_f64(static_metadata.italic_angle.into_inner());
         post.underline_position = FWord::new(metrics.underline_position.ot_round());

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -3157,6 +3157,14 @@ mod tests {
                 post.glyph_name(result.get_gid("duplicate.2")),
                 Some("uniF8FF.1")
             );
+            assert_eq!(
+                post.glyph_name(result.get_gid("A_nbspace_idotless")),
+                Some("uni004100A00131")
+            );
+            assert_eq!(
+                post.glyph_name(result.get_gid("A_nbspace_idotless.ss01")),
+                Some("uni004100A00131.ss01")
+            );
         } else {
             // original names are preserved
             let glyph_order = result.fe_context.glyph_order.get();

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -3122,16 +3122,16 @@ mod tests {
     #[rstest]
     #[case::yes(true)]
     #[case::no(false)]
-    fn rename_glyphs_to_production_names(#[case] use_production_names: bool) {
+    fn rename_glyphs_to_production_names(#[case] use_adobe_style_post_names: bool) {
         let result = TestCompile::compile("glyphs3/ProductionNames.glyphs", |mut args| {
-            args.no_production_names = !use_production_names;
+            args.no_production_names = !use_adobe_style_post_names;
             args
         });
 
         let raw_post = dump_table(result.be_context.post.get().as_ref()).unwrap();
         let post = Post::read(FontData::new(&raw_post)).unwrap();
 
-        if use_production_names {
+        if use_adobe_style_post_names {
             assert_eq!(post.glyph_name(result.get_gid("A")), Some("A"));
             assert_eq!(post.glyph_name(result.get_gid("idotless")), Some("uni0131"));
             assert_eq!(post.glyph_name(result.get_gid("nbspace")), Some("uni00A0"));

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -3135,7 +3135,13 @@ mod tests {
             assert_eq!(post.glyph_name(result.get_gid("A")), Some("A"));
             assert_eq!(post.glyph_name(result.get_gid("idotless")), Some("uni0131"));
             assert_eq!(post.glyph_name(result.get_gid("nbspace")), Some("uni00A0"));
-            // hyphen is not valid PS character and gets stripped from final name
+            // We don't check if user-defined prod names actually follow AGL rules;
+            // e.g. in this case 'uni' prefix is NOT followed by groups of 4 hex digits
+            assert_eq!(
+                post.glyph_name(result.get_gid("invalid_prod_name")),
+                Some("uni99")
+            );
+            // We just strip invalid PS characters (e.g. hyphens)
             assert_eq!(
                 post.glyph_name(result.get_gid("foobar-cy")),
                 Some("foobarcy")

--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -4256,20 +4256,23 @@ mod tests {
     #[case::v3(glyphs3_dir())]
     fn glyph_production_names(#[case] glyphs_dir: PathBuf) {
         let font = Font::load(&glyphs_dir.join("ProductionNames.glyphs")).unwrap();
-        let glyphs = font.glyphs.values().collect::<Vec<_>>();
+        let glyphs = font.glyphs;
 
         // this glyph has no production name in GlyphData.xml nor in the .glyphs file
-        assert_eq!(glyphs[0].name, "A");
-        assert_eq!(glyphs[0].production_name, None);
+        assert_eq!(glyphs.get("A").unwrap().production_name, None);
 
         // this one would have 'dotlessi' in GlyphData.xml, but the .glyphs file overrides it
-        assert_eq!(glyphs[1].name, "idotless");
-        assert_eq!(glyphs[1].production_name, Some("uni0131".into()));
+        assert_eq!(
+            glyphs.get("idotless").unwrap().production_name,
+            Some("uni0131".into())
+        );
 
         // this has no custom production_name in the .glyphs file, and the one from
         // GlyphData.xml is used
-        assert_eq!(glyphs[2].name, "nbspace");
-        assert_eq!(glyphs[2].production_name, Some("uni00A0".into()));
+        assert_eq!(
+            glyphs.get("nbspace").unwrap().production_name,
+            Some("uni00A0".into())
+        );
     }
 
     #[test]

--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -2356,9 +2356,7 @@ impl RawGlyph {
                 // if they were manually set don't change them, otherwise do
                 category = category.or(Some(result.category));
                 sub_category = sub_category.or(result.subcategory);
-                production_name = production_name.or(result
-                    .production_name
-                    .map(|s| smol_str::format_smolstr!("{s}")));
+                production_name = production_name.or(result.production_name.map(Into::into));
             }
         }
 

--- a/glyphs-reader/src/glyphdata.rs
+++ b/glyphs-reader/src/glyphdata.rs
@@ -224,8 +224,8 @@ impl Display for ProductionName {
 impl From<ProductionName> for SmolStr {
     fn from(v: ProductionName) -> SmolStr {
         match v {
-            ProductionName::Bmp(cp) => format!("uni{:04X}", cp).into(),
-            ProductionName::NonBmp(cp) => format!("u{:X}", cp).into(),
+            ProductionName::Bmp(cp) => smol_str::format_smolstr!("uni{:04X}", cp),
+            ProductionName::NonBmp(cp) => smol_str::format_smolstr!("u{:X}", cp),
             ProductionName::Custom(s) => s,
         }
     }

--- a/glyphs-reader/src/glyphdata.rs
+++ b/glyphs-reader/src/glyphdata.rs
@@ -1266,7 +1266,13 @@ mod tests {
         case("moMa_underscore-thai", "uni0E21005F"),
         case("nno-khmer.below.narrow1", "uni17D2178E.narrow1"),
         case("nyo-khmer.full.below.narrow", "uni17D21789.full.below.narrow"),
-        case("sh_ra_iiMatra-tamil", "uni0BB60BCD0BB00BC0")
+        case("sh_ra_iiMatra-tamil", "uni0BB60BCD0BB00BC0"),
+        // plus some more tests that are not in glyphsLib
+        case("A_A", "A_A"),
+        case("a_a.sc", "a_a.sc"),
+        case("brevecomb_acutecomb", "uni03060301"),
+        case("brevecomb_acutecomb.case", "uni03060301.case"),
+        case("pileOfPoo_pileOfPoo", "u1F4A9_u1F4A9"),
     )]
     fn synthetic_production_names(name: &str, expected: &str) {
         let production_name = GlyphData::new(None)

--- a/resources/scripts/requirements.in
+++ b/resources/scripts/requirements.in
@@ -10,4 +10,4 @@ cdifflib
 glyphsLib
 # keep gftools pinned as well to ensure ttx_diff.py output is stable.
 # 0.9.74 is when experimental support for fontc was added to gftools.
-gftools==0.9.78
+gftools==0.9.83

--- a/resources/scripts/requirements.txt
+++ b/resources/scripts/requirements.txt
@@ -129,7 +129,7 @@ gflanguages==0.7.3
     #   glyphsets
 gfsubsets==2024.9.25
     # via gftools
-gftools==0.9.78
+gftools==0.9.83
     # via -r requirements.in
 gitdb==4.0.12
     # via gitpython

--- a/resources/scripts/ttx_diff.py
+++ b/resources/scripts/ttx_diff.py
@@ -116,6 +116,11 @@ flags.DEFINE_float(
 )
 flags.DEFINE_bool("json", False, "print results in machine-readable JSON format")
 flags.DEFINE_string("outdir", default=None, help="directory to store generated files")
+flags.DEFINE_bool(
+    "production_names",
+    True,
+    "rename glyphs to AGL-compliant names (uniXXXX, etc.) suitable for production. Disable to see the original glyph names.",
+)
 
 
 def to_xml_string(e) -> str:
@@ -226,8 +231,6 @@ def build_fontc(source: Path, fontc_bin: Path, build_dir: Path):
         fontc_bin,
         # uncomment this to compare output w/ fontmake --keep-direction
         # "--keep-direction",
-        # uncomment to get human-readable glyph names in diff
-        # "--no-production-names",
         "--build-dir",
         ".",
         "-o",
@@ -235,6 +238,8 @@ def build_fontc(source: Path, fontc_bin: Path, build_dir: Path):
         source,
         "--emit-debug",
     ]
+    if not FLAGS.production_names:
+        cmd.append("--no-production-names")
     build(cmd, build_dir)
 
 
@@ -255,12 +260,12 @@ def build_fontmake(source: Path, build_dir: Path):
         out_file.name,
         "--drop-implied-oncurves",
         # "--keep-direction",
-        # uncomment to get human-readable glyph names in diff
-        # "--no-production-names",
         # helpful for troubleshooting
         "--debug-feature-file",
         "debug.fea",
     ]
+    if not FLAGS.production_names:
+        cmd.append("--no-production-names")
     if not variable:
         # fontmake static builds perform overlaps removal, but fontc can't do that yet.
         # Disable the filter to make the diff less noisy.
@@ -293,6 +298,8 @@ def run_gftools(
         "--experimental-single-source",
         source.name,
     ]
+    if not FLAGS.production_names:
+        cmd.append("--experimental-extra-arg=--no-production-names")
     if fontc_bin is not None:
         cmd += ["--experimental-fontc", fontc_bin]
 

--- a/resources/scripts/ttx_diff.py
+++ b/resources/scripts/ttx_diff.py
@@ -44,10 +44,12 @@ import shutil
 import subprocess
 import sys
 import os
-import re
+import yaml
 from urllib.parse import urlparse
 from cdifflib import CSequenceMatcher as SequenceMatcher
-from typing import Any, Dict, Optional, Sequence, Tuple
+from contextlib import contextmanager
+from tempfile import NamedTemporaryFile
+from typing import Any, Dict, Generator, List, Optional, Sequence, Tuple
 from glyphsLib import GSFont
 from fontTools.designspaceLib import DesignSpaceDocument
 from fontTools.varLib.iup import iup_delta
@@ -277,6 +279,63 @@ def build_fontmake(source: Path, build_dir: Path):
     build(cmd, build_dir)
 
 
+@contextmanager
+def modified_gftools_config(
+    cmdline: List[str], extra_args: Sequence[str]
+) -> Generator[None, None, None]:
+    """Modify the gftools config file to add extra arguments.
+
+    A temporary config file is created with the extra args added to the
+    `extraFontmakeArgs` key, and replaces the original config file in the
+    command line arguments' list, which is modified in-place.
+    The temporary file is deleted after the context manager exits.
+    If the extra_args list is empty, the context manager does nothing.
+
+    Args:
+        cmdline: The command line arguments passed to gftools. This must include
+            the path to a config.yaml file.
+        extra_args: Extra arguments to add to the config file. Can be empty.
+    """
+    if extra_args:
+        try:
+            config_idx, config_path = next(
+                (
+                    (i, arg)
+                    for i, arg in enumerate(cmdline)
+                    if arg.endswith((".yaml", ".yml"))
+                )
+            )
+        except StopIteration:
+            raise ValueError(
+                "No config file found in command line arguments. "
+                "Please provide a config.yaml file."
+            )
+
+        with open(config_path, "r") as f:
+            config = yaml.safe_load(f)
+
+        config["extraFontmakeArgs"] = config.get("extraFontmakeArgs", "") + " ".join(
+            extra_args
+        )
+
+        with NamedTemporaryFile(
+            mode="w",
+            prefix="config_",
+            suffix=".yaml",
+            delete=False,
+            dir=Path(config_path).parent,
+        ) as f:
+            yaml.dump(config, f)
+        temp_path = Path(f.name)
+
+        cmdline[config_idx] = temp_path
+
+    yield
+
+    if extra_args:
+        temp_path.unlink()
+
+
 def run_gftools(
     source: Path, config: Path, build_dir: Path, fontc_bin: Optional[Path] = None
 ):
@@ -298,12 +357,15 @@ def run_gftools(
         "--experimental-single-source",
         source.name,
     ]
-    if not FLAGS.production_names:
-        cmd.append("--experimental-extra-arg=--no-production-names")
     if fontc_bin is not None:
         cmd += ["--experimental-fontc", fontc_bin]
 
-    build(cmd, None)
+    extra_args = []
+    if not FLAGS.production_names:
+        extra_args.append("--no-production-names")
+
+    with modified_gftools_config(cmd, extra_args):
+        build(cmd, None)
 
     # return a concise error if gftools produces != one output
     contents = list(out_dir.iterdir()) if out_dir.exists() else list()

--- a/resources/scripts/ttx_diff.py
+++ b/resources/scripts/ttx_diff.py
@@ -226,8 +226,8 @@ def build_fontc(source: Path, fontc_bin: Path, build_dir: Path):
         fontc_bin,
         # uncomment this to compare output w/ fontmake --keep-direction
         # "--keep-direction",
-        # no longer required, still useful to get human-readable glyph names in diff
-        "--no-production-names",
+        # uncomment to get human-readable glyph names in diff
+        # "--no-production-names",
         "--build-dir",
         ".",
         "-o",
@@ -255,8 +255,8 @@ def build_fontmake(source: Path, build_dir: Path):
         out_file.name,
         "--drop-implied-oncurves",
         # "--keep-direction",
-        # no longer required, still useful to get human-readable glyph names in diff
-        "--no-production-names",
+        # uncomment to get human-readable glyph names in diff
+        # "--no-production-names",
         # helpful for troubleshooting
         "--debug-feature-file",
         "debug.fea",

--- a/resources/testdata/glyphs3/ProductionNames.glyphs
+++ b/resources/testdata/glyphs3/ProductionNames.glyphs
@@ -20,6 +20,28 @@ width = 600;
 unicode = 65;
 },
 {
+glyphname = A_nbspace_idotless;
+layers = (
+{
+layerId = m01;
+width = 1200;
+}
+);
+metricLeft = A;
+metricRight = idotless;
+},
+{
+glyphname = A_nbspace_idotless.ss01;
+layers = (
+{
+layerId = m01;
+width = 1200;
+}
+);
+metricLeft = A_nbspace_idotless;
+metricRight = A_nbspace_idotless;
+},
+{
 glyphname = idotless;
 layers = (
 {

--- a/resources/testdata/glyphs3/ProductionNames.glyphs
+++ b/resources/testdata/glyphs3/ProductionNames.glyphs
@@ -81,6 +81,16 @@ width = 600;
 );
 },
 {
+glyphname = invalid_prod_name;
+layers = (
+{
+layerId = m01;
+width = 600;
+}
+);
+production = uni99;
+},
+{
 glyphname = duplicate.1;
 layers = (
 {

--- a/resources/testdata/glyphs3/ProductionNames.glyphs
+++ b/resources/testdata/glyphs3/ProductionNames.glyphs
@@ -39,6 +39,53 @@ width = 600;
 }
 );
 unicode = 160;
+},
+{
+glyphname = "foobar-cy";
+layers = (
+{
+layerId = m01;
+width = 600;
+}
+);
+},
+{
+glyphname = foobarcy;
+layers = (
+{
+layerId = m01;
+width = 600;
+}
+);
+},
+{
+glyphname = duplicate.1;
+layers = (
+{
+layerId = m01;
+width = 600;
+}
+);
+production = uniF8FF;
+},
+{
+glyphname = duplicate.2;
+layers = (
+{
+layerId = m01;
+width = 600;
+}
+);
+production = uniF8FF;
+},
+{
+glyphname = foobarcy.1;
+layers = (
+{
+layerId = m01;
+width = 600;
+}
+);
 }
 );
 unitsPerEm = 1000;


### PR DESCRIPTION
Meant to fix https://github.com/googlefonts/fontc/issues/248 and #1299 

by "synthetic" production names I mean production names for glyphs that, even though they have no direct entry in GlyphData, their production name can be derived (e.g. alternate glyphs ending with a suffix or ligatures where each ligature component does have an explicit production name).

I also disabled --no-production-name flag in ttx_diff.py, which means fontc_crater will apply the final glyph renaming after this PR, for both DS and .glyphs sources.

This build GSC and Oswald without ttx diffs (I haven't tried a full local fontc_crater run).
