### PR TITLE
Update Python requirements to bump fonttools

### DIFF
--- a/resources/scripts/requirements.txt
+++ b/resources/scripts/requirements.txt
@@ -23,7 +23,7 @@ axisregistry==0.4.12
     # via gftools
 babelfont==3.1.2
     # via gftools
-beautifulsoup4==4.13.3
+beautifulsoup4==4.13.4
     # via gftools
 booleanoperations==0.9.0
     # via
@@ -44,7 +44,7 @@ cattrs==24.1.3
     #   ufolib2
 cdifflib==1.2.9
     # via -r requirements.in
-certifi==2025.1.31
+certifi==2025.4.26
     # via requests
 cffi==1.17.1
     # via
@@ -53,11 +53,11 @@ cffi==1.17.1
     #   pynacl
 cffsubr==0.3.0
     # via ufo2ft
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via requests
 compreffor==0.5.6
     # via ufo2ft
-cryptography==44.0.2
+cryptography==44.0.3
     # via pyjwt
 defcon[lxml,pens]==0.12.1
     # via
@@ -86,11 +86,11 @@ fontmath==0.9.4
     #   mutatormath
     #   ufo2ft
     #   ufoprocessor
-fontparts==0.12.3
+fontparts==0.12.5
     # via ufoprocessor
 fontpens==0.2.4
     # via defcon
-fonttools[lxml,repacker,ufo,unicode,woff]==4.57.0
+fonttools[lxml,repacker,ufo,unicode,woff]==4.58.0
     # via
     #   -r requirements.in
     #   afdko
@@ -150,7 +150,7 @@ importlib-resources==6.5.2
     # via gfsubsets
 jinja2==3.1.6
     # via gftools
-lxml==5.3.1
+lxml==5.4.0
     # via
     #   -r requirements.in
     #   afdko
@@ -166,7 +166,7 @@ mdurl==0.1.2
     # via markdown-it-py
 mutatormath==3.0.1
     # via ufoprocessor
-nanoemoji==0.15.1
+nanoemoji==0.15.3
     # via gftools
 networkx==3.4.2
     # via gftools
@@ -181,15 +181,15 @@ openstep-plist==0.5.0
     #   glyphslib
 opentype-sanitizer==9.2.0
     # via gftools
-orjson==3.10.16
+orjson==3.10.18
     # via
     #   babelfont
     #   ufolib2
-packaging==24.2
+packaging==25.0
     # via gftools
-picosvg==0.22.1
+picosvg==0.22.3
     # via nanoemoji
-pillow==11.1.0
+pillow==11.2.1
     # via
     #   gftools
     #   nanoemoji
@@ -248,7 +248,7 @@ skia-pathops==0.8.0.post2
     #   picosvg
 smmap==5.0.2
     # via gitdb
-soupsieve==2.6
+soupsieve==2.7
     # via beautifulsoup4
 statmake==1.0.1
     # via gftools
@@ -264,11 +264,11 @@ tqdm==4.67.1
     # via afdko
 ttfautohint-py==0.5.1
     # via gftools
-typing-extensions==4.13.1
+typing-extensions==4.13.2
     # via
     #   beautifulsoup4
     #   pygithub
-ufo2ft[cffsubr,compreffor]==3.4.2
+ufo2ft[cffsubr,compreffor]==3.4.3
     # via
     #   fontmake
     #   nanoemoji
@@ -281,7 +281,7 @@ ufolib2[json]==0.17.1
     #   nanoemoji
     #   ufomerge
     #   vttlib
-ufomerge==1.8.2
+ufomerge==1.9.1
     # via
     #   babelfont
     #   gftools
@@ -289,7 +289,7 @@ ufonormalizer==0.6.2
     # via afdko
 ufoprocessor==1.13.3
     # via afdko
-uharfbuzz==0.48.0
+uharfbuzz==0.50.2
     # via
     #   fonttools
     #   vharfbuzz
@@ -297,9 +297,9 @@ unicodedata2==16.0.0
     # via
     #   fonttools
     #   glyphsets
-unidecode==1.3.8
+unidecode==1.4.0
     # via gftools
-urllib3==2.3.0
+urllib3==2.4.0
     # via
     #   pygithub
     #   requests


### PR DESCRIPTION
Updated using [the usual procedure](https://github.com/googlefonts/fontc/tree/main/fontc_crater#ci) – mostly hoping to bump fonttools to see fonttools/fonttools#3797 through to completion, which should give a nice crater boost :)