### PR TITLE
Generate bracket glyphs

### DIFF
--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -3268,4 +3268,46 @@ mod tests {
         // this would have been 'uni00A0' if glyphs had been renamed to production names
         assert_eq!(post.glyph_name(result.get_gid("nbspace")), Some("nbspace"));
     }
+
+    #[test]
+    fn glyphs2_bracket_glyphs() {
+        let result = TestCompile::compile_source("glyphs2/WorkSans-minimal-bracketlayer.glyphs");
+        let glyphs = result
+            .fe_context
+            .glyph_order
+            .get()
+            .names()
+            .filter(|g| g.as_str().contains("colonsign"))
+            .cloned()
+            .collect::<Vec<_>>();
+        assert_eq!(
+            vec![
+                GlyphName::new("colonsign"),
+                GlyphName::new("colonsign.BRACKET.varAlt01")
+            ],
+            glyphs
+        );
+    }
+
+    #[test]
+    fn glyphs3_bracket_glyphs() {
+        let result = TestCompile::compile_source("glyphs3/LibreFranklin-bracketlayer.glyphs");
+        let glyphs = result
+            .fe_context
+            .glyph_order
+            .get()
+            .names()
+            .filter(|g| g.as_str().contains("peso") || g.as_str().contains("yen"))
+            .cloned()
+            .collect::<Vec<_>>();
+        assert_eq!(
+            vec![
+                GlyphName::new("peso"),
+                GlyphName::new("peso.BRACKET.varAlt01"),
+                GlyphName::new("yen"),
+                GlyphName::new("yen.BRACKET.varAlt01")
+            ],
+            glyphs
+        );
+    }
 }

--- a/fontc/src/workload.rs
+++ b/fontc/src/workload.rs
@@ -385,14 +385,6 @@ impl Workload {
                 .get()
                 .difference(&preliminary_glyph_order)
             {
-                let id = AnyWorkId::Be(BeWorkIdentifier::GlyfFragment(glyph_name.clone()));
-                // bracket glyphs weren't in the perlim order, but because
-                // they exist in IR they get added along with the main BE glyph
-                // work.
-                if self.jobs_pending.contains_key(&id) || self.success.contains(&id) {
-                    log::debug!("job exists for {glyph_name}, skipping");
-                    continue;
-                }
                 debug!("Generating a BE job for {glyph_name}");
                 self.add(create_glyf_work(glyph_name.clone()));
 
@@ -443,25 +435,10 @@ impl Workload {
                 .into();
         }
 
-        if let AnyWorkId::Fe(FeWorkIdentifier::Glyph(glyph_name)) = &success {
-            self.update_be_glyph_work(fe_root, glyph_name.to_owned());
-            // we also need to update for any bracket glyphs that were finished
-            // alongside this glyph.
-            let bracket_glyphs = self
-                .also_completes
-                .get(&success)
-                .into_iter()
-                .flat_map(|ids| {
-                    ids.iter().filter_map(|id| match id {
-                        AnyWorkId::Fe(FeWorkIdentifier::Glyph(name)) => Some(name.clone()),
-                        _ => None,
-                    })
-                })
-                .collect::<Vec<_>>();
-            for bracket_glyph in bracket_glyphs {
-                self.update_be_glyph_work(fe_root, bracket_glyph);
-            }
+        if let AnyWorkId::Fe(FeWorkIdentifier::Glyph(glyph_name)) = success {
+            self.update_be_glyph_work(fe_root, glyph_name);
         }
+
         Ok(())
     }
 

--- a/fontir/src/glyph.rs
+++ b/fontir/src/glyph.rs
@@ -483,13 +483,16 @@ impl Work<Context, WorkId, Error> for GlyphOrderWork {
         let mut todo = VecDeque::new();
         for glyph_name in new_glyph_order.names() {
             let glyph = original_glyphs.get(glyph_name).unwrap();
-            if !glyph.has_consistent_components() {
+            let consistent_components = glyph.has_consistent_components();
+            let components_and_contours = has_components_and_contours(glyph);
+            trace!("{glyph_name} consistent components? {consistent_components} contours and components? {components_and_contours}");
+            if !consistent_components {
                 debug!(
                     "Coalescing '{glyph_name}' into a simple glyph because \
                         component 2x2s vary across the designspace"
                 );
                 todo.push_back((GlyphOp::ConvertToContour, glyph.clone()));
-            } else if has_components_and_contours(glyph) {
+            } else if components_and_contours {
                 if context.flags.contains(Flags::PREFER_SIMPLE_GLYPHS) {
                     todo.push_back((GlyphOp::ConvertToContour, glyph.clone()));
                     debug!(

--- a/fontir/src/glyph.rs
+++ b/fontir/src/glyph.rs
@@ -4,7 +4,7 @@
 //! the contours and one updated glyph with no contours that references the new gyph as a component.
 
 use std::{
-    collections::{HashMap, HashSet, VecDeque},
+    collections::{BTreeSet, HashMap, HashSet, VecDeque},
     sync::Arc,
 };
 
@@ -460,20 +460,35 @@ impl Work<Context, WorkId, Error> for GlyphOrderWork {
         // In particular, glyphs with both paths and components need to push the path into a component
         let arc_current = context.preliminary_glyph_order.get();
         let current_glyph_order = &*arc_current;
-        let original_glyphs: HashMap<_, _> = current_glyph_order
-            .names()
-            .map(|gn| (gn, context.get_glyph(gn.clone())))
-            .collect();
-
         // Anything the source specifically said not to retain shouldn't end up in the final font
         let mut new_glyph_order = current_glyph_order.clone();
+
+        // add any generated bracket glyphs
+        let bracket_glyphs = context
+            .glyphs
+            .all()
+            .iter()
+            .filter_map(|g| {
+                if g.1.emit_to_binary && g.1.name.as_str().contains(".BRACKET.") {
+                    Some(g.1.name.clone())
+                } else {
+                    None
+                }
+            })
+            .collect::<BTreeSet<_>>(); // so they're sorted
+        new_glyph_order.extend(bracket_glyphs);
+
+        let original_glyphs: HashMap<_, _> = new_glyph_order
+            .names()
+            .map(|gn| (gn.clone(), context.get_glyph(gn.clone())))
+            .collect();
+
         for glyph_name in current_glyph_order.names() {
             let glyph = original_glyphs.get(glyph_name).unwrap();
             if !glyph.emit_to_binary {
                 new_glyph_order.remove(glyph_name);
             }
         }
-
         // Glyphs with paths and components, and glyphs whose component 2x2
         // transforms vary over designspace are not directly supported in fonts.
         // To resolve we must do one of:

--- a/fontir/src/glyph.rs
+++ b/fontir/src/glyph.rs
@@ -4,7 +4,7 @@
 //! the contours and one updated glyph with no contours that references the new gyph as a component.
 
 use std::{
-    collections::{BTreeSet, HashMap, HashSet, VecDeque},
+    collections::{HashMap, HashSet, VecDeque},
     sync::Arc,
 };
 
@@ -460,35 +460,20 @@ impl Work<Context, WorkId, Error> for GlyphOrderWork {
         // In particular, glyphs with both paths and components need to push the path into a component
         let arc_current = context.preliminary_glyph_order.get();
         let current_glyph_order = &*arc_current;
-        // Anything the source specifically said not to retain shouldn't end up in the final font
-        let mut new_glyph_order = current_glyph_order.clone();
-
-        // add any generated bracket glyphs
-        let bracket_glyphs = context
-            .glyphs
-            .all()
-            .iter()
-            .filter_map(|g| {
-                if g.1.emit_to_binary && g.1.name.as_str().contains(".BRACKET.") {
-                    Some(g.1.name.clone())
-                } else {
-                    None
-                }
-            })
-            .collect::<BTreeSet<_>>(); // so they're sorted
-        new_glyph_order.extend(bracket_glyphs);
-
-        let original_glyphs: HashMap<_, _> = new_glyph_order
+        let original_glyphs: HashMap<_, _> = current_glyph_order
             .names()
-            .map(|gn| (gn.clone(), context.get_glyph(gn.clone())))
+            .map(|gn| (gn, context.get_glyph(gn.clone())))
             .collect();
 
+        // Anything the source specifically said not to retain shouldn't end up in the final font
+        let mut new_glyph_order = current_glyph_order.clone();
         for glyph_name in current_glyph_order.names() {
             let glyph = original_glyphs.get(glyph_name).unwrap();
             if !glyph.emit_to_binary {
                 new_glyph_order.remove(glyph_name);
             }
         }
+
         // Glyphs with paths and components, and glyphs whose component 2x2
         // transforms vary over designspace are not directly supported in fonts.
         // To resolve we must do one of:

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -104,6 +104,10 @@ impl GlyphOrder {
         self.0.insert(name)
     }
 
+    pub fn insert_sorted(&mut self, name: GlyphName) -> bool {
+        self.0.insert_sorted(name).1
+    }
+
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }

--- a/fontir/src/orchestration.rs
+++ b/fontir/src/orchestration.rs
@@ -509,4 +509,9 @@ impl Context {
         let id = WorkId::Glyph(name.into());
         self.glyphs.get(&id)
     }
+
+    pub fn get_anchor(&self, name: impl Into<GlyphName>) -> Arc<ir::GlyphAnchors> {
+        let id = WorkId::Anchor(name.into());
+        self.anchors.get(&id)
+    }
 }

--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -330,7 +330,7 @@ pub struct LayerAttributes {
     pub coordinates: Vec<OrderedFloat<f64>>,
     pub color: bool,
     // in the same order that axes are declared for the font
-    axis_rules: Vec<AxisRule>,
+    pub axis_rules: Vec<AxisRule>,
 }
 
 #[derive(Clone, Default, FromPlist, Debug, PartialEq, Hash)]

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -335,7 +335,7 @@ impl Work<Context, WorkId, Error> for StaticMetadataWork {
             .dont_use_production_names
             .unwrap_or(false);
 
-        let mut bracket_glyph_names = font
+        let bracket_glyph_names = font
             .glyphs
             .values()
             .filter_map(|g| {
@@ -484,14 +484,12 @@ impl Work<Context, WorkId, Error> for StaticMetadataWork {
             .iter()
             .map(GlyphName::new)
             .collect::<GlyphOrder>();
-        for i in (0..glyph_order.len()).rev() {
-            let glyph_name = glyph_order.glyph_name(i).unwrap();
-            let Some(bracket_glyph_names) = bracket_glyph_names.remove(glyph_name) else {
-                continue;
-            };
-            for bracket_glyph_name in bracket_glyph_names {
-                glyph_order.insert_sorted(bracket_glyph_name);
-            }
+
+        for bracket_glyph_name in bracket_glyph_names
+            .into_values()
+            .flat_map(|names| names.into_iter())
+        {
+            glyph_order.insert_sorted(bracket_glyph_name);
         }
 
         context.static_metadata.set(static_metadata);

--- a/resources/testdata/glyphs2/WorkSans-minimal-bracketlayer.glyphs
+++ b/resources/testdata/glyphs2/WorkSans-minimal-bracketlayer.glyphs
@@ -23,12 +23,15 @@ Tag = wght;
 fontMaster = (
 {
 id = "1C7CD022-87C7-4E11-B656-E47B18819458";
+weightValue = 16;
 },
 {
 id = "4A17B37A-CBFD-40E5-9E02-2080A0E1F76C";
+weightValue = 80;
 },
 {
 id = "99EB5860-B45A-4B60-BB0B-F826C8F71D42";
+weightValue = 230;
 }
 );
 glyphs = (


### PR DESCRIPTION
On top of #1437, this actually generates the alternate glyphs.

This does _not_ generate the FeatureVariations tables, but it does give us a whole bunch of targets on crater for which those are the only things missing...