### PR TITLE
[fea-rs] Remap ids after inserting rvrn lookups

### DIFF
--- a/fea-rs/src/compile/feature_writer.rs
+++ b/fea-rs/src/compile/feature_writer.rs
@@ -423,6 +423,13 @@ impl MergeCtx<'_> {
             .iter()
             .partition(|(id, _)| matches!(id, LookupId::ExternalFrontOfList(_)));
 
+        if !start.is_empty() {
+            // if we're adding items at the start, we need to go and remap all the existing ids
+            for old_id in 0..self.all_lookups.next_gsub_id().to_raw() {
+                id_map.insert(LookupId::Gsub(old_id), LookupId::Gsub(old_id + start.len()));
+            }
+        }
+
         self.all_lookups
             .splice_gsub(0, start.iter().map(|(_, lk)| (*lk).clone()));
 

--- a/resources/testdata/WghtVar-Bold.ufo/features.fea
+++ b/resources/testdata/WghtVar-Bold.ufo/features.fea
@@ -1,0 +1,5 @@
+# for testing that rvrn lookups go to front of list,
+# we need to have at least one other lookup
+feature liga {
+    sub bar plus by plus;
+} liga;

--- a/resources/testdata/WghtVar-Regular.ufo/features.fea
+++ b/resources/testdata/WghtVar-Regular.ufo/features.fea
@@ -1,0 +1,5 @@
+# for testing that rvrn lookups go to front of list,
+# we need to have at least one other lookup
+feature liga {
+    sub bar plus by plus;
+} liga;


### PR DESCRIPTION
In the course of the bracket layers work I've been finding a few little bugs in the original designspace-based work.

It turns out we only have one font in the crater collection that both uses designspace feature variation rules, _and_ has other GSUB features (Geologica) so this slipped through the cracks.