### PR TITLE
[fea-rs] Match fonttools sorting for feature variations

### DIFF
--- a/resources/testdata/dspace_rules/Basic.designspace
+++ b/resources/testdata/dspace_rules/Basic.designspace
@@ -8,8 +8,15 @@
       <conditionset>
         <condition name="Weight" minimum="550" maximum="700"/>
       </conditionset>
+      <sub name="plus" with="bar"/>
+    </rule>
+    <rule name="BRACKET.600.900">
+      <conditionset>
+        <condition name="Weight" minimum="600" maximum="700"/>
+      </conditionset>
       <sub name="bar" with="plus"/>
     </rule>
+
   </rules>
   <sources>
       <source filename="../WghtVar-Regular.ufo" name="Wght Var Regular" familyname="Wght Var" stylename="Regular">

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -2591,7 +2591,7 @@ mod tests {
             build_static_metadata("dspace_rules/Basic.designspace", default_test_flags());
         let variations = context.static_metadata.get().variations.clone().unwrap();
         assert_eq!(variations.features, [Tag::new(b"rvrn")]);
-        assert_eq!(variations.rules.len(), 1);
+        assert_eq!(variations.rules.len(), 2);
         let condition = &variations.rules[0].conditions[0][0];
         assert_eq!(condition.axis, "wght");
         assert_eq!(condition.min.unwrap(), 550.0);


### PR DESCRIPTION
This is a funny special case because it isn't handled by the usual FEA codepaths; however it is fairly easy to match fonttools and the resulting code is pretty self-contained, so I think it's reasonable.


This doesn't do much now, but becomes important when we land the bracket layers stuff.