### PR TITLE
Try to implement Colin's original approach to bracket layers

### DIFF
--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -3221,4 +3221,46 @@ mod tests {
         // this would have been 'uni00A0' if glyphs had been renamed to production names
         assert_eq!(post.glyph_name(result.get_gid("nbspace")), Some("nbspace"));
     }
+
+    #[test]
+    fn glyphs2_bracket_glyphs() {
+        let result = TestCompile::compile_source("glyphs2/WorkSans-minimal-bracketlayer.glyphs");
+        let glyphs = result
+            .fe_context
+            .glyph_order
+            .get()
+            .names()
+            .filter(|g| g.as_str().contains("colonsign"))
+            .cloned()
+            .collect::<Vec<_>>();
+        assert_eq!(
+            vec![
+                GlyphName::new("colonsign"),
+                GlyphName::new("colonsign.BRACKET.varAlt01")
+            ],
+            glyphs
+        );
+    }
+
+    #[test]
+    fn glyphs3_bracket_glyphs() {
+        let result = TestCompile::compile_source("glyphs3/LibreFranklin-bracketlayer.glyphs");
+        let glyphs = result
+            .fe_context
+            .glyph_order
+            .get()
+            .names()
+            .filter(|g| g.as_str().contains("peso") || g.as_str().contains("yen"))
+            .cloned()
+            .collect::<Vec<_>>();
+        assert_eq!(
+            vec![
+                GlyphName::new("peso"),
+                GlyphName::new("peso.BRACKET.varAlt01"),
+                GlyphName::new("yen"),
+                GlyphName::new("yen.BRACKET.varAlt01")
+            ],
+            glyphs
+        );
+    }
 }

--- a/fontc/src/workload.rs
+++ b/fontc/src/workload.rs
@@ -385,14 +385,6 @@ impl Workload {
                 .get()
                 .difference(&preliminary_glyph_order)
             {
-                let id = AnyWorkId::Be(BeWorkIdentifier::GlyfFragment(glyph_name.clone()));
-                // bracket glyphs weren't in the perlim order, but because
-                // they exist in IR they get added along with the main BE glyph
-                // work.
-                if self.jobs_pending.contains_key(&id) || self.success.contains(&id) {
-                    log::debug!("job exists for {glyph_name}, skipping");
-                    continue;
-                }
                 debug!("Generating a BE job for {glyph_name}");
                 self.add(create_glyf_work(glyph_name.clone()));
 
@@ -443,25 +435,10 @@ impl Workload {
                 .into();
         }
 
-        if let AnyWorkId::Fe(FeWorkIdentifier::Glyph(glyph_name)) = &success {
-            self.update_be_glyph_work(fe_root, glyph_name.to_owned());
-            // we also need to update for any bracket glyphs that were finished
-            // alongside this glyph.
-            let bracket_glyphs = self
-                .also_completes
-                .get(&success)
-                .into_iter()
-                .flat_map(|ids| {
-                    ids.iter().filter_map(|id| match id {
-                        AnyWorkId::Fe(FeWorkIdentifier::Glyph(name)) => Some(name.clone()),
-                        _ => None,
-                    })
-                })
-                .collect::<Vec<_>>();
-            for bracket_glyph in bracket_glyphs {
-                self.update_be_glyph_work(fe_root, bracket_glyph);
-            }
+        if let AnyWorkId::Fe(FeWorkIdentifier::Glyph(glyph_name)) = success {
+            self.update_be_glyph_work(fe_root, glyph_name);
         }
+
         Ok(())
     }
 

--- a/fontir/src/glyph.rs
+++ b/fontir/src/glyph.rs
@@ -4,7 +4,7 @@
 //! the contours and one updated glyph with no contours that references the new gyph as a component.
 
 use std::{
-    collections::{BTreeSet, HashMap, HashSet, VecDeque},
+    collections::{HashMap, HashSet, VecDeque},
     sync::Arc,
 };
 
@@ -460,35 +460,20 @@ impl Work<Context, WorkId, Error> for GlyphOrderWork {
         // In particular, glyphs with both paths and components need to push the path into a component
         let arc_current = context.preliminary_glyph_order.get();
         let current_glyph_order = &*arc_current;
-        // Anything the source specifically said not to retain shouldn't end up in the final font
-        let mut new_glyph_order = current_glyph_order.clone();
-
-        // add any generated bracket glyphs
-        let bracket_glyphs = context
-            .glyphs
-            .all()
-            .iter()
-            .filter_map(|g| {
-                if g.1.emit_to_binary && g.1.name.as_str().contains(".BRACKET.") {
-                    Some(g.1.name.clone())
-                } else {
-                    None
-                }
-            })
-            .collect::<BTreeSet<_>>(); // so they're sorted
-        new_glyph_order.extend(bracket_glyphs);
-
-        let original_glyphs: HashMap<_, _> = new_glyph_order
+        let original_glyphs: HashMap<_, _> = current_glyph_order
             .names()
-            .map(|gn| (gn.clone(), context.get_glyph(gn.clone())))
+            .map(|gn| (gn, context.get_glyph(gn.clone())))
             .collect();
 
+        // Anything the source specifically said not to retain shouldn't end up in the final font
+        let mut new_glyph_order = current_glyph_order.clone();
         for glyph_name in current_glyph_order.names() {
             let glyph = original_glyphs.get(glyph_name).unwrap();
             if !glyph.emit_to_binary {
                 new_glyph_order.remove(glyph_name);
             }
         }
+
         // Glyphs with paths and components, and glyphs whose component 2x2
         // transforms vary over designspace are not directly supported in fonts.
         // To resolve we must do one of:

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -104,6 +104,10 @@ impl GlyphOrder {
         self.0.insert(name)
     }
 
+    pub fn insert_sorted(&mut self, name: GlyphName) -> bool {
+        self.0.insert_sorted(name).1
+    }
+
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }

--- a/fontir/src/orchestration.rs
+++ b/fontir/src/orchestration.rs
@@ -509,4 +509,9 @@ impl Context {
         let id = WorkId::Glyph(name.into());
         self.glyphs.get(&id)
     }
+
+    pub fn get_anchor(&self, name: impl Into<GlyphName>) -> Arc<ir::GlyphAnchors> {
+        let id = WorkId::Anchor(name.into());
+        self.anchors.get(&id)
+    }
 }


### PR DESCRIPTION
Tl;dr just do it in glyphs2fontir, don't fiddle with core processing

Reverts changes to core processing.

glyphs2fontir now presents bracket glyphs as normal glyphs it produces in the preliminary glyph order. It then produces two distinct implementations of work for glyphs, one for not-brackets and one for brackets. This enables things like don't run the bracket until the parent (terminology?) is done.