### PR TITLE
Fix a typo in a warning message

### DIFF
--- a/fontbe/src/features.rs
+++ b/fontbe/src/features.rs
@@ -471,7 +471,7 @@ fn write_debug_glyph_order(context: &Context, glyphs: &GlyphOrder) {
 fn write_debug_fea(context: &Context, is_error: bool, why: &str, fea_content: &str) {
     if !context.flags.contains(Flags::EMIT_DEBUG) {
         if is_error {
-            warn!("Debug fea not written for '{why}' because --emit_debug is off");
+            warn!("Debug fea not written for '{why}' because --emit-debug is off");
         }
         return;
     }


### PR DESCRIPTION
The command line option is --emit-debug not --emit_debug.