### PR TITLE
Add --decompose-components option to turn all composites to simple glyphs

### DIFF
--- a/fontc/src/args.rs
+++ b/fontc/src/args.rs
@@ -50,6 +50,10 @@ pub struct Args {
     #[arg(long, default_value = "false")]
     pub decompose_transformed_components: bool,
 
+    /// Whether to decompose all components (superseding the above two flags).
+    #[arg(long, default_value = "false")]
+    pub decompose_components: bool,
+
     /// Whether to out timing data, notably a visualization of threadpool execution of tasks.
     ///
     /// See <https://github.com/googlefonts/fontc/pull/443>
@@ -117,6 +121,7 @@ impl Args {
             Flags::DECOMPOSE_TRANSFORMED_COMPONENTS,
             self.decompose_transformed_components,
         );
+        flags.set(Flags::DECOMPOSE_COMPONENTS, self.decompose_components);
         flags.set(Flags::EMIT_TIMING, self.emit_timing);
         flags.set(Flags::KEEP_DIRECTION, self.keep_direction);
         flags.set(Flags::PRODUCTION_NAMES, !self.no_production_names);
@@ -138,6 +143,7 @@ impl Args {
             flatten_components: Flags::default().contains(Flags::FLATTEN_COMPONENTS),
             decompose_transformed_components: Flags::default()
                 .contains(Flags::DECOMPOSE_TRANSFORMED_COMPONENTS),
+            decompose_components: Flags::default().contains(Flags::DECOMPOSE_COMPONENTS),
             skip_features: false,
             keep_direction: false,
             no_production_names: false,

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -856,6 +856,22 @@ mod tests {
     }
 
     #[test]
+    fn decompose_all_components() {
+        let result = TestCompile::compile("glyphs2/Component.glyphs", |mut args| {
+            args.decompose_components = true;
+            args
+        });
+
+        // We expect ALL composite glyphs to be simplified with --decompose-components
+        let glyph_data = result.glyphs();
+        for (i, glyph) in glyph_data.read().iter().enumerate() {
+            let Some(glyf::Glyph::Simple(_)) = glyph else {
+                panic!("Expected a simple glyph at index {}", i);
+            };
+        }
+    }
+
+    #[test]
     fn writes_cmap() {
         let result = TestCompile::compile_source("glyphs2/Component.glyphs");
 

--- a/fontir/src/orchestration.rs
+++ b/fontir/src/orchestration.rs
@@ -38,6 +38,8 @@ bitflags! {
         const KEEP_DIRECTION = 0b01000000;
         // If set, production names are read & used
         const PRODUCTION_NAMES = 0b10000000;
+        // If set, all the composite glyphs will be decomposed to simple glyphs
+        const DECOMPOSE_COMPONENTS = 0b100000000;
     }
 }
 


### PR DESCRIPTION
intended to match the functionality of fontmake's `--filter DecomposeComponentsFilter` option used by some of the fonts in our collections like Jacquard12.glyphs.

Fixes https://github.com/googlefonts/fontc/issues/1441

(note that for ttx_diff.py to work with this, we also need modify gftools builder to let this option through, currently it will still raise ValueError: unknown fontmake arg. See https://github.com/googlefonts/gftools/pull/1113).