### PR TITLE
[glyphs] Add test case for bracket glyph anchors

### DIFF
--- a/fontir/src/orchestration.rs
+++ b/fontir/src/orchestration.rs
@@ -511,4 +511,9 @@ impl Context {
         let id = WorkId::Glyph(name.into());
         self.glyphs.get(&id)
     }
+
+    pub fn get_anchor(&self, name: impl Into<GlyphName>) -> Arc<ir::GlyphAnchors> {
+        let id = WorkId::Anchor(name.into());
+        self.anchors.get(&id)
+    }
 }

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -2338,4 +2338,26 @@ mod tests {
             ["peso.BRACKET.varAlt01"]
         );
     }
+
+    #[test]
+    fn bracket_glyph_anchors() {
+        let (source, context) =
+            build_global_metrics(glyphs3_dir().join("LibreFranklin-bracketlayer.glyphs"));
+        build_glyphs(&source, &context).unwrap();
+
+        let peso_anchors = context.get_anchor("peso");
+
+        // non-bracket layer anchor x-positions are all even numbers
+        assert!(peso_anchors
+            .anchors
+            .iter()
+            .all(|a| a.default_pos().x as u32 % 2 == 0));
+
+        // bracket anchor x positions are odd numbers
+        let peso_bracket_anchors = context.get_anchor("peso.BRACKET.varAlt01");
+        assert!(peso_bracket_anchors
+            .anchors
+            .iter()
+            .all(|a| a.default_pos().x as u32 % 2 == 1));
+    }
 }

--- a/resources/testdata/glyphs3/LibreFranklin-bracketlayer.glyphs
+++ b/resources/testdata/glyphs3/LibreFranklin-bracketlayer.glyphs
@@ -30,6 +30,12 @@ glyphs = (
 glyphname = peso;
 layers = (
 {
+anchors = (
+{
+name = top;
+pos = (10,40);
+}
+);
 layerId = "91AB5BCA-6A50-42DA-B2F7-8181BF189245";
 shapes = (
 {
@@ -45,6 +51,12 @@ nodes = (
 width = 750;
 },
 {
+anchors = (
+{
+name = top;
+pos = (20,50);
+}
+);
 layerId = "258ED206-D907-4350-8EBA-CBDDA1C16BF7";
 shapes = (
 {
@@ -60,6 +72,12 @@ nodes = (
 width = 786;
 },
 {
+anchors = (
+{
+name = top;
+pos = (15,50);
+}
+);
 associatedMasterId = "258ED206-D907-4350-8EBA-CBDDA1C16BF7";
 attr = {
 axisRules = (
@@ -83,6 +101,12 @@ nodes = (
 width = 746;
 },
 {
+anchors = (
+{
+name = top;
+pos = (11,41);
+}
+);
 associatedMasterId = "91AB5BCA-6A50-42DA-B2F7-8181BF189245";
 attr = {
 axisRules = (


### PR DESCRIPTION
recycled from #1457, which is obsoleted by #1456 