### PR TITLE
bump fea-rs, fontc and related crates' minor version

### DIFF
--- a/fea-rs/Cargo.toml
+++ b/fea-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fea-rs"
-version = "0.19.1"
+version = "0.20.0"
 license = "MIT/Apache-2.0"
 authors = ["Colin Rofls <colin@cmyr.net>"]
 description = "Tools for working with Adobe OpenType Feature files."
@@ -12,7 +12,7 @@ edition = "2021"
 exclude = ["test-data"]
 
 [dependencies]
-fontdrasil = { version = "0.1.0", path = "../fontdrasil" }
+fontdrasil = { version = "0.2.0", path = "../fontdrasil" }
 ansi_term = "0.12.1"
 serde_json = {version = "1.0.87", optional = true }
 

--- a/fontbe/Cargo.toml
+++ b/fontbe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fontbe"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "the backend for fontc, a font compiler."
@@ -11,9 +11,9 @@ categories = ["text-processing", "parsing", "graphics"]
 [features]
 
 [dependencies]
-fontdrasil = { version = "0.1.0", path = "../fontdrasil" }
-fontir = { version = "0.1.0", path = "../fontir" }
-fea-rs = { version = "0.19.0", path = "../fea-rs", features = ["serde"] }
+fontdrasil = { version = "0.2.0", path = "../fontdrasil" }
+fontir = { version = "0.2.0", path = "../fontir" }
+fea-rs = { version = "0.20.0", path = "../fea-rs", features = ["serde"] }
 tinystr = {version = "0.8.0", features = ["serde"] }
 
 icu_properties.workspace = true

--- a/fontc/Cargo.toml
+++ b/fontc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fontc"
-version = "0.1.1"
+version = "0.2.0"
 build = "build.rs"
 edition = "2021"
 license = "MIT/Apache-2.0"
@@ -12,12 +12,12 @@ default-run = "fontc"
 
 
 [dependencies]
-fontdrasil = { version = "0.1.0", path = "../fontdrasil" }
-fontbe = { version = "0.1.0", path = "../fontbe" }
-fontir = { version = "0.1.0", path = "../fontir" }
-glyphs2fontir = { version = "0.1.0", path = "../glyphs2fontir" }
-fontra2fontir = { version = "0.1.0", path = "../fontra2fontir" }
-ufo2fontir = { version = "0.1.0", path = "../ufo2fontir" }
+fontdrasil = { version = "0.2.0", path = "../fontdrasil" }
+fontbe = { version = "0.2.0", path = "../fontbe" }
+fontir = { version = "0.2.0", path = "../fontir" }
+glyphs2fontir = { version = "0.2.0", path = "../glyphs2fontir" }
+fontra2fontir = { version = "0.2.0", path = "../fontra2fontir" }
+ufo2fontir = { version = "0.2.0", path = "../ufo2fontir" }
 
 bitflags.workspace = true
 bincode.workspace = true

--- a/fontc_crater/Cargo.toml
+++ b/fontc_crater/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fontc_crater"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "A compiler for fonts."
@@ -8,7 +8,7 @@ repository = "https://github.com/googlefonts/fontc"
 readme = "README.md"
 
 [dependencies]
-fontc = { version = "0.1.0", path = "../fontc" }
+fontc = { version = "0.2.0", path = "../fontc" }
 
 google-fonts-sources = "0.7.1"
 maud = "0.27.0"

--- a/fontdrasil/Cargo.toml
+++ b/fontdrasil/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fontdrasil"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Common types and utilites used by fontc, a font compiler."

--- a/fontir/Cargo.toml
+++ b/fontir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fontir"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Intermediate Representation used by fontc, a font compiler."
@@ -11,7 +11,7 @@ categories = ["text-processing", "parsing", "graphics"]
 [features]
 
 [dependencies]
-fontdrasil = { version = "0.1.0", path = "../fontdrasil" }
+fontdrasil = { version = "0.2.0", path = "../fontdrasil" }
 
 bitflags.workspace = true
 serde.workspace = true

--- a/fontra2fontir/Cargo.toml
+++ b/fontra2fontir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fontra2fontir"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Converts fontra.xyz/ files to font ir for compilation."
@@ -11,8 +11,8 @@ categories = ["text-processing", "parsing", "graphics"]
 [features]
 
 [dependencies]
-fontdrasil = { version = "0.1.0", path = "../fontdrasil" }
-fontir = { version = "0.1.0", path = "../fontir" }
+fontdrasil = { version = "0.2.0", path = "../fontdrasil" }
+fontir = { version = "0.2.0", path = "../fontir" }
 
 write-fonts.workspace = true
 

--- a/glyphs-reader/Cargo.toml
+++ b/glyphs-reader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glyphs-reader"
-version = "0.1.0"
+version = "0.2.0"
 license = "MIT/Apache-2.0"
 authors = ["Raph Levien <raph.levien@gmail.com>"]
 repository = "https://github.com/googlefonts/fontc"
@@ -13,7 +13,7 @@ readme = "README.md"
 
 [dependencies]
 ascii_plist_derive = { version = "0.1.0", path = "ascii_plist_derive" }
-fontdrasil = { version = "0.1.0", path = "../fontdrasil" }
+fontdrasil = { version = "0.2.0", path = "../fontdrasil" }
 quick-xml = "0.37"
 ordered-float.workspace = true
 kurbo.workspace = true

--- a/glyphs2fontir/Cargo.toml
+++ b/glyphs2fontir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glyphs2fontir"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Converts www.glyphsapp.com files to font ir for compilation."
@@ -11,9 +11,9 @@ categories = ["text-processing", "parsing", "graphics"]
 [features]
 
 [dependencies]
-fontdrasil = { version = "0.1.0", path = "../fontdrasil" }
-fontir = { version = "0.1.0", path = "../fontir" }
-glyphs-reader = { version = "0.1.0", path = "../glyphs-reader" }
+fontdrasil = { version = "0.2.0", path = "../fontdrasil" }
+fontir = { version = "0.2.0", path = "../fontir" }
+glyphs-reader = { version = "0.2.0", path = "../glyphs-reader" }
 
 smol_str.workspace = true
 log.workspace = true

--- a/otl-normalizer/Cargo.toml
+++ b/otl-normalizer/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 
 
 [dependencies]
-fontdrasil = { version = "0.1.0", path = "../fontdrasil" }
+fontdrasil = { version = "0.2.0", path = "../fontdrasil" }
 clap.workspace = true
 thiserror.workspace = true
 smol_str.workspace = true
@@ -17,5 +17,5 @@ write-fonts.workspace = true
 indexmap.workspace = true
 
 [dev-dependencies]
-fea-rs = { version = "0.19.0", path = "../fea-rs" }
+fea-rs = { version = "0.20.0", path = "../fea-rs" }
 

--- a/ufo2fontir/Cargo.toml
+++ b/ufo2fontir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ufo2fontir"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Converts UFO or UFO+designspace to font ir for compilation."
@@ -11,8 +11,8 @@ categories = ["text-processing", "parsing", "graphics"]
 [features]
 
 [dependencies]
-fontdrasil = { version = "0.1.0", path = "../fontdrasil" }
-fontir = { version = "0.1.0", path = "../fontir" }
+fontdrasil = { version = "0.2.0", path = "../fontdrasil" }
+fontir = { version = "0.2.0", path = "../fontir" }
 
 kurbo.workspace = true
 serde.workspace = true


### PR DESCRIPTION
Bumping all the published crates' minor version in preparation for a fontc v0.2.0 release. This is the list of changes per crate

```
     Changes for fontdrasil from fontdrasil-v0.1.1 to 0.2.0
             92b9570 bump fea-rs, fontc and related crates' minor version
             a37a6fa [glyphs] Factor out layer->ir logic
             98348f8 Add fontir::Axes type
             7dcb264 Fix typo in normalized space coord maximum
             bcbf2dd Wire up FeatureVariations support
             a8da93d Simplify creating Axes for testing
     Changes for fea-rs from fea-rs-v0.19.1 to 0.20.0
             92b9570 bump fea-rs, fontc and related crates' minor version
             a09320f [fea-rs] Update fonttools test case with new glyphs
             60ff232 [fea-rs] Combine mixed single & liga sub rules
             6b30dd9 [fea-rs] Add some docs
             4f3db12 [fea-rs] Error on conflicting lig sub rules
             74d853f [fea-rs] Sort rvrn lookups ahead of aalt
             3c2ab83 [chore] Push the rock back up the hill
             2f43061 [fea-rs] Remap ids after inserting rvrn lookups
             bcbf2dd Wire up FeatureVariations support
             ff440b7 [fea-rs] Support for merging in feature variations
     Changes for fontir from fontir-v0.1.1 to 0.2.0
             92b9570 bump fea-rs, fontc and related crates' minor version
             e4a16f1 [glyphs] Add test case for bracket glyph anchors
             ddfff2b [glyphs] Include bracket glyphs in prelim order
             8a2d78b [glyphs] Wire up the bracket glyph logic
             23d9911 Add --decompose-components option to turn all composites to simple glyphs
             1fef76c Revert "Generate bracket glyphs"
             d49a0ab Fix dumbitude
             698cb33 Process brackets as their own distinct glyphs
             dce4d85 [glyphs] Wire up the bracket glyph logic
             9c15343 support 'Don't use Production Names' custom param and useProductionNames UFO lib key
             98348f8 Add fontir::Axes type
             6872b79 Write per-instance postscript names to the fvar and name tables
             d7dd246 Parse per-instance postscript names and pass to IR
             41b5006 [fontir] Enforce that ConditionSet always sorted
             2515bbc Move explanatory references to method
             c844817 Test that the reverse name map deterministically uses the smallest ID
             7fa28f5 Move reverse name map creation into a shared function
             70d839a Only derive strikeout position from UPM when x-height is explicitly zero
             7e39abe Tentatively match ufo2ft's height for .notdef
             d90fd34 Derive default height and vertical origin from typo metrics
             e65e44d Draft initial support for interpreting vertical data
             5991eaa Add IR types for FeatureVarations, parse from dspace
             a8da93d Simplify creating Axes for testing
     Changes for fontbe from fontbe-v0.1.1 to 0.2.0
             92b9570 bump fea-rs, fontc and related crates' minor version
             ea183d2 Fix flakiness with explicit dependency on calculated composite bboxes
             6f2b4c2 Improve and expand comments
             6f3589f Use saturating cast everywhere else extra precision is needed too
             f85539f Split out vertical work, and reduce mutability and repetition in builder
             7f6fa64 Initial support for writing metrics for vertical typesetting
             ac46f98 Fix a typo in a warning message
             50d38f5 [fea-rs] Match fonttools sorting for feature variations
             9c15343 support 'Don't use Production Names' custom param and useProductionNames UFO lib key
             73c68b5 avoid copying glyph names when the --no-production-names flag is off
             6af6511 add link to AGL spec in comment
             a7bfe1e fontbe/post: strip invalid PS chars and dedup production names
             156e6dc [chore] Update fontations
             98348f8 Add fontir::Axes type
             6872b79 Write per-instance postscript names to the fvar and name tables
             d7dd246 Parse per-instance postscript names and pass to IR
             41b5006 [fontir] Enforce that ConditionSet always sorted
             2515bbc Move explanatory references to method
             7fa28f5 Move reverse name map creation into a shared function
             1caa8ad Make name reuse deterministic, and use smallest ID as fonttools does
             e65e44d Draft initial support for interpreting vertical data
             bcbf2dd Wire up FeatureVariations support
             a8da93d Simplify creating Axes for testing
             596d922 [fontbe] Add common harness for testing layout providers
     Changes for glyphs-reader from glyphs-reader-v0.1.0 to 0.2.0
             92b9570 bump fea-rs, fontc and related crates' minor version
             d54d908 [glyphs] Generate feature variations
             98da7e9 glyphdata: add new 'Yezidi' to Scripts enum
             c179d6a fix formatting of glyphslib_enums.rs
             e78a597 glyphs-reader: update to latest GlyphData from glyphsLib 6.10.2
             8a2d78b [glyphs] Wire up the bracket glyph logic
             bdbe052 Fix typo in custom parameter name for vertical global metrics
             1fef76c Revert "Generate bracket glyphs"
             dce4d85 [glyphs] Wire up the bracket glyph logic
             2373316 glyphdata: fast path for prod names of base.suffix
             e0b3c26 [glyphs] Split out bracket layers during parsing
             9c15343 support 'Don't use Production Names' custom param and useProductionNames UFO lib key
             4640ce6 use format_smolstr instead of format(...).into()
             2508518 use Cow<str> to avoid to_string() and borrow &str when possible while making hex parts of uni ligature name
             a37a6fa [glyphs] Factor out layer->ir logic
             5bd84bd glyphdata: some additional unit tests
             a7bfe1e fontbe/post: strip invalid PS chars and dedup production names
             7df582b glyphdata: support synthetic production names
             6dcfa70 [glyphs] Parse Axis values from layer names
             f7ec6ce [glyphs] Parse axisRules attr
             d7dd246 Parse per-instance postscript names and pass to IR
             be39296 glyphs-reader/update.py: must set production_name/script for altNames as well
             3e97c92 glyphdata: add more unit tests
             2263985 clippy/rustfmt fixes
             7a6ab3d glyphs-reader: set Glyph.production_name from glyphdata
             c3066c9 glyphdata: expose production_name in QueryResult
             79e350e glyphdata: impl From<u32> and Display traits for ProductionName
             c656be3 [glyphs] Add FormatVersion type
             564dd28 glyphdata.rs: simplify logic for glyph names with suffixes
             e65e44d Draft initial support for interpreting vertical data
             f2f9852 run black on glyphs-reader/update.py
     Changes for glyphs2fontir from glyphs2fontir-v0.1.1 to 0.2.0
             92b9570 bump fea-rs, fontc and related crates' minor version
             d54d908 [glyphs] Generate feature variations
             e4a16f1 [glyphs] Add test case for bracket glyph anchors
             4227279 [glyphs] Generate bracket glyphs as normal work item
             ddfff2b [glyphs] Include bracket glyphs in prelim order
             9baf2d5 [glyphs] Production names for bracket glyphs
             0ce96bf [glyphs] Update bracket layer components
             8a2d78b [glyphs] Wire up the bracket glyph logic
             1fef76c Revert "Generate bracket glyphs"
             d49a0ab Fix dumbitude
             698cb33 Process brackets as their own distinct glyphs
             74ff84b [glyphs] Production names for bracket glyphs
             55d728a [glyphs] Update bracket layer components
             dce4d85 [glyphs] Wire up the bracket glyph logic
             e0b3c26 [glyphs] Split out bracket layers during parsing
             9c15343 support 'Don't use Production Names' custom param and useProductionNames UFO lib key
             a37a6fa [glyphs] Factor out layer->ir logic
             98348f8 Add fontir::Axes type
             fbdb72a [glyphs] Remove redundant glyph_names map
             d7dd246 Parse per-instance postscript names and pass to IR
             c2bf645 glyphs2fontir: populate StaticMetadata.postscript_names, unless --no-production-names flag
             7679efc Provide access to global metrics in Glyphs glyph building tests
             4f56003 Calculate default vertical origin consistently with height
             1c6b688 Subtract vertical origin from typo ascender to match fontir's definition
             e65e44d Draft initial support for interpreting vertical data
             7f980d0 Don't collect anchors from glyphs marked non-exportable
     Changes for fontra2fontir from fontra2fontir-v0.1.0 to 0.2.0
             92b9570 bump fea-rs, fontc and related crates' minor version
             98348f8 Add fontir::Axes type
             e65e44d Draft initial support for interpreting vertical data
             a7bd70e Remove ansi_term dep, impedes google3 and unused
     Changes for ufo2fontir from ufo2fontir-v0.1.1 to 0.2.0
             92b9570 bump fea-rs, fontc and related crates' minor version
             50d38f5 [fea-rs] Match fonttools sorting for feature variations
             9c15343 support 'Don't use Production Names' custom param and useProductionNames UFO lib key
             98348f8 Add fontir::Axes type
             d7dd246 Parse per-instance postscript names and pass to IR
             41b5006 [fontir] Enforce that ConditionSet always sorted
             80e0c05 Explain instead of panicking when the vertical origin type is incorrect
             e65e44d Draft initial support for interpreting vertical data
             06a8674 Parameterize implicit selection flags tests
             db85bbe Add test: fix OS/2 fsSelection for an italic-only font, to match ufo2ft
             a20d86a Fix OS/2 fsSelection for an italic-only font, to match ufo2ft
             5991eaa Add IR types for FeatureVarations, parse from dspace
             7f980d0 Don't collect anchors from glyphs marked non-exportable
     Changes for fontc from fontc-v0.1.1 to 0.2.0
             92b9570 bump fea-rs, fontc and related crates' minor version
             d54d908 [glyphs] Generate feature variations
             4227279 [glyphs] Generate bracket glyphs as normal work item
             9ec789c [glyphs] Top-level bracket glyph test case
             ddfff2b [glyphs] Include bracket glyphs in prelim order
             8a2d78b [glyphs] Wire up the bracket glyph logic
             23d9911 Add --decompose-components option to turn all composites to simple glyphs
             c2e7ba1 Test end-to-end that Glyphs and UFO `vhea` and `vmtx` build correctly
             f85539f Split out vertical work, and reduce mutability and repetition in builder
             7f6fa64 Initial support for writing metrics for vertical typesetting
             1fef76c Revert "Generate bracket glyphs"
             698cb33 Process brackets as their own distinct glyphs
             dce4d85 [glyphs] Wire up the bracket glyph logic
             74d853f [fea-rs] Sort rvrn lookups ahead of aalt
             3c2ab83 [chore] Push the rock back up the hill
             50d38f5 [fea-rs] Match fonttools sorting for feature variations
             2f43061 [fea-rs] Remap ids after inserting rvrn lookups
             fc07444 appease overly (case-)sensitive file systems
             835d560 test 'Don't use Production Names' custom parameter
             c9b2e60 test non-AGL-compliant user-defined prod name is passed through unvalidated
             018af00 rename parameter to use_adobe_style_post_names in unit test for clarity
             5bd84bd glyphdata: some additional unit tests
             a7bfe1e fontbe/post: strip invalid PS chars and dedup production names
             9a8a682 Test that fvar postscript names compile based on the custom parameters
             bcbf2dd Wire up FeatureVariations support
             67b5ae8 add tests to repro #1397
     Changes for fontc_crater from fontc_crater-v0.1.1 to 0.2.0
             92b9570 bump fea-rs, fontc and related crates' minor version
             32b6209 [crater] Clear caches if ttx_diff changes
```