### PR TITLE
[ci/release] pip pip<25.1 due to incompatibility with pip-compile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -226,8 +226,12 @@ jobs:
       # this requirements.txt can be used to pip install fontc more securely
       # https://pip.pypa.io/en/stable/topics/secure-installs/
       - name: Generate requirements.txt with SHA256 hashes
+        # Pin pip due to incompatibility of later releases with pip-tools
+        # https://github.com/jazzband/pip-tools/issues/2176
         run: |
-          echo fontc | pipx run --spec pip-tools pip-compile - --no-index --find-links wheels/ --no-emit-find-links --generate-hashes --pip-args '--only-binary=:all:' --no-annotate --no-header --output-file requirements.txt
+          pipx install pip-tools
+          pipx runpip pip-tools install 'pip==25.0.1'
+          echo fontc | pip-compile - --no-index --find-links wheels/ --no-emit-find-links --generate-hashes --pip-args '--only-binary=:all:' --no-annotate --no-header --output-file requirements.txt
 
       - name: Compute checksums of release assets
         run: |


### PR DESCRIPTION
the release workflow failed because of an incompatibility between pip-compile and the latest pip
https://github.com/jazzband/pip-tools/issues/2176

https://github.com/googlefonts/fontc/actions/runs/15186515318/job/42708565488#step:4:37

(we use pip-compile to generate the requirements.txt to be used by the Glyphs.app fontc plugin)

The current workaround is to pin pip to the version immediately preciding the offending one.

Note that the fontc-v0.2.0 wheels were successfully published to PyPI, only the creation of the Github Release (and upload of the binary artifacts to the GH release page) failed. I'll do a manual run of the release workflow after this is merged and hopefully it will just work.