### PR TITLE
[glyphs] Feature variations go under rvrn by default

### DIFF
--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -3188,22 +3188,22 @@ mod tests {
         let lookup_list = gsub.lookup_list().unwrap();
         assert_eq!(lookup_list.lookup_count(), 1);
         let feature_list = gsub.feature_list().unwrap();
-        // by default, glyphs puts feature variations in rlig
-        let rlig_idx = feature_list
+        // by default, glyphsLib puts feature variations in rvrn
+        let rvrn_idx = feature_list
             .feature_records()
             .iter()
-            .position(|rec| rec.feature_tag() == "rlig")
+            .position(|rec| rec.feature_tag() == "rvrn")
             .unwrap();
-        let rlig = feature_list.feature_records()[rlig_idx];
-        // base rlig feature has no lookups
-        assert!(rlig
+        let rvrn = feature_list.feature_records()[rvrn_idx];
+        // base rvrn feature has no lookups
+        assert!(rvrn
             .feature(feature_list.offset_data())
             .unwrap()
             .lookup_list_indices()
             .is_empty());
 
-        let rlig_replacement = get_first_feature_substitution(gsub, rlig_idx);
-        assert_eq!(rlig_replacement.lookup_list_indices(), [0]);
+        let rvrn_replacement = get_first_feature_substitution(gsub, rvrn_idx);
+        assert_eq!(rvrn_replacement.lookup_list_indices(), [0]);
     }
 
     #[test]

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -467,7 +467,9 @@ impl Work<Context, WorkId, Error> for StaticMetadataWork {
 fn make_feature_variations(fontinfo: &FontInfo) -> Option<VariableFeature> {
     // by default, glyphs registers feature variations under 'rlig'
     // https://glyphsapp.com/learn/switching-shapes#g-1-alternate-layers-bracket-layers__feature-variations
-    const DEFAULT_FEATURE: Tag = Tag::new(b"rlig");
+    // but glyphsLib uses rvrn, so we go with that?
+    // https://github.com/googlefonts/glyphsLib/blob/c4db6b981d/Lib/glyphsLib/builder/bracket_layers.py#L63
+    const DEFAULT_FEATURE: Tag = Tag::new(b"rvrn");
     let mut conditions = HashMap::new();
     for glyph in fontinfo.font.glyphs.values().filter(|g| g.export) {
         for (condset, (sub_name, _layers)) in bracket_glyphs(glyph, &fontinfo.axes) {


### PR DESCRIPTION
see https://github.com/googlefonts/glyphsLib/issues/1081; glyphs.app puts these under rlig, but glyphsLib does not, so let's match glyphsLib for now.