### PR TITLE
[fea-rs] Use correct magic number in head table

### DIFF
--- a/fea-rs/src/compile/tables.rs
+++ b/fea-rs/src/compile/tables.rs
@@ -74,7 +74,6 @@ impl HeadBuilder {
 
                 // I think we should still use the known default values but this matches
                 // feaLib tests so :shrug:
-                head.magic_number = 0;
                 head.font_direction_hint = 0;
                 head
             });

--- a/fea-rs/test-data/fonttools-tests/spec9c1.ttx
+++ b/fea-rs/test-data/fonttools-tests/spec9c1.ttx
@@ -6,7 +6,7 @@
     <tableVersion value="1.0"/>
     <fontRevision value="1.1"/>
     <checkSumAdjustment value="0x0"/>
-    <magicNumber value="0x0"/>
+    <magicNumber value="0x5f0f3cf5"/>
     <flags value="00000000 00000000"/>
     <unitsPerEm value="0"/>
     <created value="Tue Dec 13 11:22:33 2011"/>

--- a/fea-rs/test-data/fonttools-tests/spec9c2.ttx
+++ b/fea-rs/test-data/fonttools-tests/spec9c2.ttx
@@ -6,7 +6,7 @@
     <tableVersion value="1.0"/>
     <fontRevision value="1.001"/>
     <checkSumAdjustment value="0x0"/>
-    <magicNumber value="0x0"/>
+    <magicNumber value="0x5f0f3cf5"/>
     <flags value="00000000 00000000"/>
     <unitsPerEm value="0"/>
     <created value="Tue Dec 13 11:22:33 2011"/>

--- a/fea-rs/test-data/fonttools-tests/spec9c3.ttx
+++ b/fea-rs/test-data/fonttools-tests/spec9c3.ttx
@@ -6,7 +6,7 @@
     <tableVersion value="1.0"/>
     <fontRevision value="1.5"/>
     <checkSumAdjustment value="0x0"/>
-    <magicNumber value="0x0"/>
+    <magicNumber value="0x5f0f3cf5"/>
     <flags value="00000000 00000000"/>
     <unitsPerEm value="0"/>
     <created value="Tue Dec 13 11:22:33 2011"/>


### PR DESCRIPTION
This had been zero'd out to match fonttools, but fonttools now uses the expected value.

(This also brings in updated fonttools test files.)

JMM