### PR TITLE
[glyphs] More preciesly match glyphsLib bracket logic 

### DIFF
--- a/fontbe/src/features/feature_variations.rs
+++ b/fontbe/src/features/feature_variations.rs
@@ -147,10 +147,8 @@ impl FeatureProvider for FeatureVariationsProvider {
 
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
-
-    use fontdrasil::{coords::DesignCoord, types::Axes};
-    use fontir::ir::{Condition, Rule, Substitution};
+    use fontdrasil::types::Axes;
+    use fontir::ir::Rule;
     use write_fonts::tables::{gsub::Gsub, layout::FeatureVariations};
 
     use crate::features::test_helpers::{LayoutOutput, LayoutOutputBuilder};
@@ -158,31 +156,6 @@ mod tests {
     use super::*;
 
     const RCLT: Tag = Tag::new(b"rclt");
-
-    fn make_rule(condition_sets: &[&[(&str, (f64, f64))]], subs: &[(&str, &str)]) -> Rule {
-        Rule {
-            conditions: condition_sets
-                .iter()
-                .map(|cond_set| {
-                    cond_set
-                        .iter()
-                        .map(|(tag, (min, max))| Condition {
-                            axis: Tag::from_str(tag).unwrap(),
-                            min: Some(DesignCoord::new(*min)),
-                            max: Some(DesignCoord::new(*max)),
-                        })
-                        .collect()
-                })
-                .collect(),
-            substitutions: subs
-                .iter()
-                .map(|(a, b)| Substitution {
-                    replace: GlyphName::new(a),
-                    with: GlyphName::new(b),
-                })
-                .collect(),
-        }
-    }
 
     trait FeatureVariationsOutput {
         fn compile_feature_variations(&self, variations: VariableFeature) -> Gsub;
@@ -200,7 +173,7 @@ mod tests {
     fn simple_feature_variations(feature: Tag) -> FeatureVariations {
         let variations = VariableFeature {
             features: vec![feature],
-            rules: vec![make_rule(
+            rules: vec![Rule::for_test(
                 &[&[("wght", (600.0, 700.0))]],
                 &[("a", "a.bracket600")],
             )],

--- a/fontir/src/ir/static_metadata.rs
+++ b/fontir/src/ir/static_metadata.rs
@@ -291,6 +291,35 @@ impl Condition {
     }
 }
 
+impl Rule {
+    /// `condition_sets` is a slice of slices of (axis, (min, max))
+    #[doc(hidden)]
+    pub fn for_test(condition_sets: &[&[(&str, (f64, f64))]], subs: &[(&str, &str)]) -> Rule {
+        Rule {
+            conditions: condition_sets
+                .iter()
+                .map(|cond_set| {
+                    cond_set
+                        .iter()
+                        .map(|(tag, (min, max))| Condition {
+                            axis: std::str::FromStr::from_str(tag).unwrap(),
+                            min: Some(DesignCoord::new(*min)),
+                            max: Some(DesignCoord::new(*max)),
+                        })
+                        .collect()
+                })
+                .collect(),
+            substitutions: subs
+                .iter()
+                .map(|(a, b)| Substitution {
+                    replace: GlyphName::new(a),
+                    with: GlyphName::new(b),
+                })
+                .collect(),
+        }
+    }
+}
+
 impl FromIterator<Condition> for ConditionSet {
     fn from_iter<T: IntoIterator<Item = Condition>>(iter: T) -> Self {
         let mut inner: Vec<_> = iter.into_iter().collect();

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -2451,4 +2451,45 @@ mod tests {
             .iter()
             .all(|a| a.default_pos().x as u32 % 2 == 1));
     }
+
+    #[test]
+    fn bracket_glyphs_to_dspace_rules() {
+        // this is taken from a real world font that didn't compile correctly
+        // unless we did overlay_feature_variations as part of generating the dspace rules.
+        let (_, context) =
+            build_static_metadata(glyphs2_dir().join("Alexandria-bracketglyphs.glyphs"));
+        let feat_vars = context.static_metadata.get().variations.clone().unwrap();
+
+        assert_eq!(
+            feat_vars.rules,
+            vec![
+                Rule::for_test(
+                    &[&[("wght", (130., 215.))]],
+                    &[
+                        ("Udieresis.alt", "Udieresis.alt.BRACKET.varAlt01"),
+                        ("Udieresis.ss01.alt", "Udieresis.ss01.alt.BRACKET.varAlt01"),
+                        ("naira", "naira.BRACKET.varAlt01"),
+                        ("peso", "peso.BRACKET.varAlt01"),
+                        ("won", "won.BRACKET.varAlt01")
+                    ]
+                ),
+                Rule::for_test(
+                    &[&[("wght", (125., 130.))]],
+                    &[
+                        ("Udieresis.alt", "Udieresis.alt.BRACKET.varAlt01"),
+                        ("Udieresis.ss01.alt", "Udieresis.ss01.alt.BRACKET.varAlt01"),
+                        ("naira", "naira.BRACKET.varAlt01"),
+                        ("peso", "peso.BRACKET.varAlt01"),
+                    ]
+                ),
+                Rule::for_test(
+                    &[&[("wght", (120., 130.))]],
+                    &[
+                        ("naira", "naira.BRACKET.varAlt01"),
+                        ("peso", "peso.BRACKET.varAlt01"),
+                    ]
+                ),
+            ]
+        )
+    }
 }

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -14,6 +14,7 @@ use fontdrasil::{
 };
 use fontir::{
     error::{BadGlyph, BadGlyphKind, BadSource, Error},
+    feature_variations::{overlay_feature_variations, NBox},
     ir::{
         self, AnchorBuilder, Color, ColorPalettes, Condition, ConditionSet, GdefCategories,
         GlobalMetric, GlobalMetrics, GlyphInstance, GlyphOrder, KernGroup, KernSide, KerningGroups,
@@ -470,21 +471,21 @@ fn make_feature_variations(fontinfo: &FontInfo) -> Option<VariableFeature> {
     // but glyphsLib uses rvrn, so we go with that?
     // https://github.com/googlefonts/glyphsLib/blob/c4db6b981d/Lib/glyphsLib/builder/bracket_layers.py#L63
     const DEFAULT_FEATURE: Tag = Tag::new(b"rvrn");
-    let mut conditions = HashMap::new();
+    let mut rules = Vec::new();
     for glyph in fontinfo.font.glyphs.values().filter(|g| g.export) {
         for (condset, (sub_name, _layers)) in bracket_glyphs(glyph, &fontinfo.axes) {
-            conditions
-                .entry(condset)
-                .or_insert(Vec::new())
-                .push(Substitution {
-                    replace: glyph.name.clone().into(),
-                    with: sub_name,
-                });
+            let nbox = condset_to_nbox(condset, &fontinfo.axes);
+            rules.push((
+                vec![nbox].into(),
+                BTreeMap::from([(glyph.name.clone().into(), sub_name)]),
+            ));
         }
     }
-    if conditions.is_empty() {
+    if rules.is_empty() {
         return None;
     }
+
+    let overlayed = overlay_feature_variations(rules);
 
     let raw_feature = fontinfo
         .font
@@ -496,15 +497,54 @@ fn make_feature_variations(fontinfo: &FontInfo) -> Option<VariableFeature> {
         log::warn!("invalid or missing param 'Feature for Feature Variations': {raw_feature:?}");
     }
     let features = vec![feature.unwrap_or(DEFAULT_FEATURE)];
-    let rules = conditions
+    let rules = overlayed
         .into_iter()
         .map(|(condset, substitutions)| Rule {
-            conditions: vec![condset],
-            substitutions,
+            conditions: vec![nbox_to_condset(condset, &fontinfo.axes)],
+            substitutions: substitutions
+                .into_iter()
+                .flatten()
+                .map(|(replace, with)| Substitution { replace, with })
+                .collect(),
         })
         .collect();
 
     Some(VariableFeature { features, rules })
+}
+
+fn nbox_to_condset(nbox: NBox, axes: &Axes) -> ConditionSet {
+    nbox.iter()
+        .map(|(tag, (min, max))| {
+            let axis = axes.get(&tag).unwrap();
+
+            Condition::new(
+                tag,
+                Some(min.to_design(&axis.converter)),
+                Some(max.to_design(&axis.converter)),
+            )
+        })
+        .collect()
+}
+
+fn condset_to_nbox(condset: ConditionSet, axes: &Axes) -> NBox {
+    condset
+        .iter()
+        .map(|cond| {
+            let axis = axes.get(&cond.axis).expect("checked already");
+
+            (
+                cond.axis,
+                (
+                    cond.min
+                        .map(|ds| ds.to_normalized(&axis.converter))
+                        .unwrap_or(NormalizedCoord::MIN),
+                    cond.max
+                        .map(|ds| ds.to_normalized(&axis.converter))
+                        .unwrap_or(NormalizedCoord::MAX),
+                ),
+            )
+        })
+        .collect()
 }
 
 pub(crate) fn bracket_glyph_names<'a>(

--- a/resources/testdata/glyphs2/Alexandria-bracketglyphs.glyphs
+++ b/resources/testdata/glyphs2/Alexandria-bracketglyphs.glyphs
@@ -1,0 +1,173 @@
+{
+.appVersion = "1363";
+customParameters = (
+{
+name = Axes;
+value = (
+{
+Name = Weight;
+Tag = wght;
+}
+);
+}
+);
+fontMaster = (
+{
+id = UUID0;
+weight = Light;
+weightValue = 20;
+},
+{
+id = "1C84A7F3-C40A-4DC1-B8B4-102D183C348F";
+weightValue = 110;
+},
+{
+id = "5DA6E103-6A94-47F2-987D-4952DB8EA68E";
+weight = Bold;
+weightValue = 215;
+}
+);
+glyphs = (
+{
+glyphname = Udieresis.alt;
+layers = (
+{
+layerId = UUID0;
+},
+{
+layerId = "1C84A7F3-C40A-4DC1-B8B4-102D183C348F";
+},
+{
+layerId = "5DA6E103-6A94-47F2-987D-4952DB8EA68E";
+},
+{
+associatedMasterId = "1C84A7F3-C40A-4DC1-B8B4-102D183C348F";
+layerId = "049E4371-81AA-402E-AF65-2D32396B523E";
+name = "Regular [125]";
+},
+{
+associatedMasterId = "5DA6E103-6A94-47F2-987D-4952DB8EA68E";
+layerId = "FE481E9E-4094-4A38-81EC-98BB99680946";
+name = "Bold [125]";
+}
+);
+},
+{
+glyphname = Udieresis.ss01.alt;
+layers = (
+{
+layerId = UUID0;
+},
+{
+layerId = "1C84A7F3-C40A-4DC1-B8B4-102D183C348F";
+},
+{
+layerId = "5DA6E103-6A94-47F2-987D-4952DB8EA68E";
+},
+{
+associatedMasterId = "1C84A7F3-C40A-4DC1-B8B4-102D183C348F";
+layerId = "47E90875-BBF6-4E40-86C6-431F3CA80C8C";
+name = "Regular [125]";
+},
+{
+associatedMasterId = "5DA6E103-6A94-47F2-987D-4952DB8EA68E";
+layerId = "2912AC44-6A61-4373-9D27-558A1DA1D877";
+name = "Bold [125]";
+}
+);
+},
+{
+glyphname = naira;
+layers = (
+{
+layerId = UUID0;
+},
+{
+layerId = "1C84A7F3-C40A-4DC1-B8B4-102D183C348F";
+},
+{
+layerId = "5DA6E103-6A94-47F2-987D-4952DB8EA68E";
+},
+{
+associatedMasterId = "1C84A7F3-C40A-4DC1-B8B4-102D183C348F";
+layerId = "D5AF31BD-131F-416D-8EDA-23071B3A13F8";
+name = "Regular [120]";
+},
+{
+associatedMasterId = "5DA6E103-6A94-47F2-987D-4952DB8EA68E";
+layerId = "4C2E7A21-4D7C-4DFD-9A3D-54BEADBE9DB7";
+name = "Bold [120]";
+},
+{
+associatedMasterId = UUID0;
+layerId = "8A4D0C3A-97C1-4EA7-A89A-26597E0CB43F";
+name = "Light [120]";
+}
+);
+unicode = 20A6;
+},
+{
+glyphname = peso;
+layers = (
+{
+layerId = UUID0;
+},
+{
+layerId = "1C84A7F3-C40A-4DC1-B8B4-102D183C348F";
+},
+{
+layerId = "5DA6E103-6A94-47F2-987D-4952DB8EA68E";
+},
+{
+associatedMasterId = "1C84A7F3-C40A-4DC1-B8B4-102D183C348F";
+layerId = "09FE2A56-35C3-46F4-A74D-DA6F330CAE95";
+name = "Regular [120]";
+},
+{
+associatedMasterId = "5DA6E103-6A94-47F2-987D-4952DB8EA68E";
+layerId = "02174D34-AD8E-4011-B712-378B407367BE";
+name = "Bold [120]";
+},
+{
+associatedMasterId = UUID0;
+layerId = "BBFE22AF-61BD-4617-9F28-CA14D0417169";
+name = "Light [120]";
+}
+);
+unicode = 20B1;
+},
+{
+glyphname = won;
+layers = (
+{
+layerId = UUID0;
+},
+{
+layerId = "1C84A7F3-C40A-4DC1-B8B4-102D183C348F";
+},
+{
+layerId = "5DA6E103-6A94-47F2-987D-4952DB8EA68E";
+},
+{
+associatedMasterId = "1C84A7F3-C40A-4DC1-B8B4-102D183C348F";
+layerId = "93D54325-EF3C-4090-9970-D02A3068BC82";
+name = "Regular [130]";
+},
+{
+associatedMasterId = "5DA6E103-6A94-47F2-987D-4952DB8EA68E";
+layerId = "37202506-6F3D-44E0-9589-DFEE2F311F31";
+name = "Bold [130]";
+},
+{
+associatedMasterId = UUID0;
+layerId = "7132EDE8-D0C7-48AA-B103-D641A651A508";
+name = "Light [130]";
+}
+);
+unicode = 20A9;
+}
+);
+unitsPerEm = 1000;
+versionMajor = 5;
+versionMinor = 100;
+}


### PR DESCRIPTION
_this is on top of #1476_

Specifically this means running the 'overlay_feature_variations' method
twice, once in glyphs2ir and then finally when generating the actual
feature variations tables.

To make this possible we had to refactor that code to work on glyph
names, instead of on GIDs.


With this patch we are showing identical for a number of new fonts on crater.