### PR TITLE
Allow building on WASM

### DIFF
--- a/fontbe/Cargo.toml
+++ b/fontbe/Cargo.toml
@@ -27,8 +27,6 @@ indexmap.workspace = true
 log.workspace = true
 env_logger.workspace = true
 
-parking_lot.workspace = true
-
 write-fonts.workspace = true
 
 kurbo.workspace = true
@@ -36,6 +34,11 @@ kurbo.workspace = true
 smol_str.workspace = true
 
 chrono.workspace = true
+
+[target.'cfg(not(platform_family = "wasm"))'.dependencies]
+parking_lot.workspace = true
+[target.'cfg(platform_family = "wasm")'.dependencies]
+parking_lot = { version = "0.12.3", features=["nightly"] }
 
 [dev-dependencies]
 diff.workspace = true

--- a/fontc/src/args.rs
+++ b/fontc/src/args.rs
@@ -7,6 +7,8 @@ use fontir::orchestration::Flags;
 use regex::Regex;
 use serde::{Deserialize, Deserializer, Serialize};
 
+use crate::InMemorySource;
+
 /// What font can we build for you today?
 #[derive(Serialize, Deserialize, Parser, Debug, Clone, PartialEq)]
 #[command(version)]
@@ -22,6 +24,11 @@ pub struct Args {
     /// DEPRECATED: old name for positional input file
     #[arg(short, long)]
     source: Option<PathBuf>,
+
+    /// Used by WASM and other library consumers to pass in a source directly.
+    #[clap(skip)]
+    #[serde(skip)]
+    pub input_binary: Option<InMemorySource>,
 
     /// Whether to write IR to disk.
     #[arg(short, long, default_value = "false")]
@@ -133,6 +140,7 @@ impl Args {
         Args {
             glyph_name_filter: None,
             input_source: Some(input_source),
+            input_binary: None,
             source: None,
             emit_ir: false,
             output_file: None,

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -28,8 +28,7 @@ use fontir::{
     source::Source,
 };
 
-use fontbe::orchestration::Context as BeContext;
-use fontbe::paths::Paths as BePaths;
+use fontbe::{orchestration::Context as BeContext, paths::Paths as BePaths};
 use fontir::paths::Paths as IrPaths;
 
 use log::debug;
@@ -83,6 +82,7 @@ pub fn run(args: Args, mut timer: JobTimer) -> Result<(), Error> {
     let be_root = BeContext::new_root(args.flags(), be_paths, &fe_root);
     let mut timing = workload.exec(&fe_root, &be_root)?;
 
+    #[cfg(not(target_family = "wasm"))]
     if args.flags().contains(Flags::EMIT_TIMING) {
         let path = args.build_dir.join("threads.svg");
         let out_file = OpenOptions::new()

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -53,6 +53,22 @@ fn create_source(source: &Path) -> Result<Box<dyn Source>, Error> {
     }
 }
 
+/// Represents a source that is loaded in memory, e.g. for testing or
+/// when the source is not a file on disk (WASM or library use).
+///
+/// Currently only supports Glyphs sources, but could be extended to e.g. UFOZ or other formats.
+#[derive(Debug, Clone, PartialEq)]
+pub enum InMemorySource {
+    Glyphs(String),
+}
+
+/// Creates a [`Source`] from a source file loaded in memory
+fn create_in_memory_source(source: &InMemorySource) -> Result<Box<dyn Source>, Error> {
+    match source {
+        InMemorySource::Glyphs(source) => Ok(Box::new(GlyphsIrSource::new_from_memory(source)?)),
+    }
+}
+
 /// Run the compiler with the provided arguments
 pub fn run(args: Args, mut timer: JobTimer) -> Result<(), Error> {
     let time = timer

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -104,6 +104,18 @@ pub fn run(args: Args, mut timer: JobTimer) -> Result<(), Error> {
     write_font_file(&args, &be_root)
 }
 
+/// Run and return a binary
+///
+/// This is the library entry point to fontc.
+pub fn generate_binary(args: Args) -> Result<Vec<u8>, Error> {
+    let (ir_paths, be_paths) = init_paths(&args)?;
+    let workload = Workload::new(args.clone(), JobTimer::default())?;
+    let fe_root = FeContext::new_root(args.flags(), ir_paths);
+    let be_root = BeContext::new_root(args.flags(), be_paths, &fe_root);
+    workload.exec(&fe_root, &be_root)?;
+    Ok(be_root.font.get().get().to_vec())
+}
+
 pub fn require_dir(dir: &Path) -> Result<(), Error> {
     // skip empty paths
     if dir == Path::new("") {

--- a/fontc/src/timing.rs
+++ b/fontc/src/timing.rs
@@ -50,6 +50,7 @@ impl JobTimer {
             nth_wave,
             thread_id: std::thread::current().id(),
             queued: now,
+            #[cfg(not(target_family = "wasm"))]
             run: now,
             complete: now,
         };
@@ -70,6 +71,7 @@ impl JobTimer {
             .push(state);
     }
 
+    #[cfg(not(target_family = "wasm"))]
     pub fn write_svg(&mut self, out: &mut impl io::Write) -> Result<(), io::Error> {
         let names: HashMap<_, _> = self
             .job_times
@@ -225,6 +227,7 @@ pub struct JobTimeState {
     nth_wave: usize,
     thread_id: ThreadId,
     queued: Instant,
+    #[cfg(not(target_family = "wasm"))]
     run: Instant,
     complete: Instant,
 }
@@ -264,7 +267,10 @@ impl JobTime {
         match self {
             // you can call 'run' without queuing, if needed
             JobTime::Ready(mut state) | JobTime::Queued(mut state) => {
-                state.run = Instant::now();
+                #[cfg(not(target_family = "wasm"))]
+                {
+                    state.run = Instant::now();
+                }
                 state.thread_id = std::thread::current().id();
                 JobTime::Running(state)
             }

--- a/fontc/src/workload.rs
+++ b/fontc/src/workload.rs
@@ -49,7 +49,7 @@ use fontir::{
 use log::{debug, trace, warn};
 
 use crate::{
-    create_source,
+    create_in_memory_source, create_source,
     timing::{JobTime, JobTimer},
     work::{AnyAccess, AnyContext, AnyWork},
     Args, Error,
@@ -122,7 +122,11 @@ impl Workload {
             .create_timer(AnyWorkId::InternalTiming("create_source"), 0)
             .run();
 
-        let source = create_source(args.source())?;
+        let source = if let Some(binary) = args.input_binary.as_ref() {
+            create_in_memory_source(binary)?
+        } else {
+            create_source(args.source())?
+        };
 
         timer.add(time.complete());
         let time = timer

--- a/fontc/src/workload.rs
+++ b/fontc/src/workload.rs
@@ -566,13 +566,8 @@ impl Workload {
             AnyContext,
             Vec<Arc<AtomicUsize>>,
         )>::with_capacity(512)));
-        // use an explicit threadpool to avoid possible congestion if another
-        // library we use is using the global threadpool
-        let tp = rayon::ThreadPoolBuilder::new()
-            .build()
-            .expect("couldn't build threadpool");
 
-        tp.in_place_scope(|scope| {
+        let runner = |scope: &rayon::Scope| {
             // Whenever a task completes see if it was the last incomplete dependency of other task(s)
             // and spawn them if it was
             // TODO timeout and die it if takes too long to make forward progress or we're spinning w/o progress
@@ -599,7 +594,9 @@ impl Workload {
                 // Get launchables ready to run
                 if !launchable.is_empty() {
                     nth_wave += 1;
-                    let timing = self.timer.create_timer(AnyWorkId::InternalTiming("run_q"), nth_wave)
+                    let timing = self
+                        .timer
+                        .create_timer(AnyWorkId::InternalTiming("run_q"), nth_wave)
                         .run();
 
                     {
@@ -612,7 +609,8 @@ impl Workload {
                             log::trace!("Start {:?}", id);
                             job.running = true;
 
-                            let mut work = AnyWork::AlsoComplete(id.clone(), job.read_access.clone());
+                            let mut work =
+                                AnyWork::AlsoComplete(id.clone(), job.read_access.clone());
                             std::mem::swap(&mut job.work, &mut work);
                             let work_context = AnyContext::for_work(
                                 fe_root,
@@ -634,7 +632,9 @@ impl Workload {
                     self.timer.add(timing.complete());
 
                     // Spawn for every job that's executable. Each spawn will pull one item from the run queue.
-                    let timing = self.timer.create_timer(AnyWorkId::InternalTiming("spawn"), nth_wave)
+                    let timing = self
+                        .timer
+                        .create_timer(AnyWorkId::InternalTiming("spawn"), nth_wave)
                         .run();
                     for _ in 0..launchable.len() {
                         let send = send.clone();
@@ -698,11 +698,15 @@ impl Workload {
 
                 // Complete everything that has reported since our last check
                 if successes.is_empty() {
-                    let timing = self.timer.create_timer(AnyWorkId::InternalTiming("rc"), nth_wave)
+                    let timing = self
+                        .timer
+                        .create_timer(AnyWorkId::InternalTiming("rc"), nth_wave)
                         .run();
                     self.read_completions(&mut successes, &recv, RecvType::Blocking)?;
                     self.timer.add(timing.complete());
-                    let timing = self.timer.create_timer(AnyWorkId::InternalTiming("hs"), nth_wave)
+                    let timing = self
+                        .timer
+                        .create_timer(AnyWorkId::InternalTiming("hs"), nth_wave)
                         .run();
                     for (success, timing) in successes.iter() {
                         self.handle_success(fe_root, be_root, success.clone(), timing.clone())?;
@@ -715,7 +719,20 @@ impl Workload {
                 }
             }
             Ok::<(), Error>(())
-        })?;
+        };
+
+        // use an explicit threadpool to avoid possible congestion if another
+        // library we use is using the global threadpool
+        #[cfg(not(target_family = "wasm"))]
+        {
+            let tp = rayon::ThreadPoolBuilder::new()
+                .build()
+                .expect("couldn't build threadpool");
+            tp.in_place_scope(runner)?;
+        }
+        // WASM rayon uses a fall-back single threaded implementation
+        #[cfg(target_family = "wasm")]
+        rayon::in_place_scope(runner)?;
 
         // If ^ exited due to error the scope awaited any live tasks; capture their results
         self.read_completions(&mut Vec::new(), &recv, RecvType::NonBlocking)?;

--- a/fontir/Cargo.toml
+++ b/fontir/Cargo.toml
@@ -26,12 +26,16 @@ indexmap.workspace = true
 
 log.workspace = true
 env_logger.workspace = true
-parking_lot.workspace = true
 
 write-fonts.workspace = true  # for pens
 
 chrono.workspace = true
 smol_str.workspace = true
+
+[target.'cfg(not(platform_family = "wasm"))'.dependencies]
+parking_lot.workspace = true
+[target.'cfg(platform_family = "wasm")'.dependencies]
+parking_lot = { version = "0.12.3", features=["nightly"] }
 
 [dev-dependencies]
 diff.workspace = true

--- a/glyphs2fontir/src/toir.rs
+++ b/glyphs2fontir/src/toir.rs
@@ -132,7 +132,7 @@ fn to_ir_path(glyph_name: GlyphName, src_path: &Path) -> Result<BezPath, PathCon
 
 pub(crate) fn to_ir_features(
     features: &[FeatureSnippet],
-    include_dir: PathBuf,
+    include_dir: Option<PathBuf>,
 ) -> Result<ir::FeaturesSource, Error> {
     // Based on https://github.com/googlefonts/glyphsLib/blob/24b4d340e4c82948ba121dcfe563c1450a8e69c9/Lib/glyphsLib/builder/features.py#L74
     // TODO: token expansion
@@ -140,7 +140,7 @@ pub(crate) fn to_ir_features(
     let fea_snippets: Vec<_> = features.iter().filter_map(|f| f.str_if_enabled()).collect();
     Ok(ir::FeaturesSource::Memory {
         fea_content: fea_snippets.join("\n\n"),
-        include_dir: include_dir.into(),
+        include_dir,
     })
 }
 


### PR DESCRIPTION
There are three blockers to running fontc over WASM:

* The pervasive use of timers, which can be a pain when `Instant::now()` causes a crash; we either make them optional (`JobTimer`) or we conditionally hide the actual `instant` fields.
* The use of file paths, which can be a pain when you don't have a filesystem; we provide ways of getting pre-loaded binary data into the Args struct and using that instead, and provide an alternate `run` method which directly emits the binary file instead of writing it to disk.
* The use of threads in the workload orchestrator; we don't use a separate ThreadPool and use a nightly version of crossbeam while on WASM to make it all compatible with [wasm-bindgen-rayon](https://github.com/RReverser/wasm-bindgen-rayon).

The result is a web-based font compiler; code available on request, demo at http://www.corvelsoftware.co.uk/fontc (works best on Chrome).