### PR TITLE
Sketch out how we might cfg-out timing code on wasm

### DIFF
--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -57,7 +57,6 @@ fn create_source(source: &Path) -> Result<Box<dyn Source>, Error> {
 pub fn run(args: Args, mut timer: JobTimer) -> Result<(), Error> {
     let time = timer
         .create_timer(AnyWorkId::InternalTiming("Init config"), 0)
-        .queued()
         .run();
     let (ir_paths, be_paths) = init_paths(&args)?;
     timer.add(time.complete());


### PR DESCRIPTION
I haven't tried to run this but it's a sketch of how I might making the timing code compile (as a nop) on wasm, without needing to change any any of the call-sites.