### PR TITLE
Write variable vertical metrics

### DIFF
--- a/fontbe/src/font.rs
+++ b/fontbe/src/font.rs
@@ -9,7 +9,7 @@ use write_fonts::{
         avar::Avar, cmap::Cmap, colr::Colr, cpal::Cpal, fvar::Fvar, gasp::Gasp, gdef::Gdef,
         glyf::Glyf, gpos::Gpos, gsub::Gsub, gvar::Gvar, head::Head, hhea::Hhea, hmtx::Hmtx,
         hvar::Hvar, loca::Loca, maxp::Maxp, meta::Meta, mvar::Mvar, name::Name, os2::Os2,
-        post::Post, stat::Stat, vhea::Vhea, vmtx::Vmtx,
+        post::Post, stat::Stat, vhea::Vhea, vmtx::Vmtx, vvar::Vvar,
     },
     types::Tag,
     FontBuilder,
@@ -30,7 +30,13 @@ pub fn create_font_work() -> Box<BeWork> {
 fn is_variable_only(workid: &WorkId) -> bool {
     matches!(
         workid,
-        WorkId::Avar | WorkId::Fvar | WorkId::Gvar | WorkId::Stat | WorkId::Hvar | WorkId::Mvar
+        WorkId::Avar
+            | WorkId::Fvar
+            | WorkId::Gvar
+            | WorkId::Stat
+            | WorkId::Hvar
+            | WorkId::Vvar
+            | WorkId::Mvar
     )
 }
 
@@ -60,6 +66,7 @@ const TABLES_TO_MERGE: &[(WorkId, Tag)] = &[
     (WorkId::Meta, Meta::TAG),
     (WorkId::Vhea, Vhea::TAG),
     (WorkId::Vmtx, Vmtx::TAG),
+    (WorkId::Vvar, Vvar::TAG),
 ];
 
 fn has(context: &Context, id: WorkId) -> bool {
@@ -89,6 +96,7 @@ fn has(context: &Context, id: WorkId) -> bool {
         WorkId::Meta => context.meta.try_get().is_some(),
         WorkId::Vhea => context.vhea.try_get().is_some(),
         WorkId::Vmtx => context.vmtx.try_get().is_some(),
+        WorkId::Vvar => context.vvar.try_get().is_some(),
         _ => false,
     }
 }
@@ -121,6 +129,7 @@ fn bytes_for(context: &Context, id: WorkId) -> Result<Option<Vec<u8>>, Error> {
         WorkId::Meta => to_bytes(context.meta.get().as_ref()),
         WorkId::Vhea => to_bytes(context.vhea.get().as_ref()),
         WorkId::Vmtx => Some(context.vmtx.get().as_ref().get().to_vec()),
+        WorkId::Vvar => to_bytes(context.vvar.get().as_ref()),
         _ => panic!("Missing a match for {id:?}"),
     };
     Ok(bytes)
@@ -159,6 +168,7 @@ impl Work<Context, AnyWorkId, Error> for FontWork {
             .variant(WorkId::LocaFormat)
             .variant(WorkId::Vhea)
             .variant(WorkId::Vmtx)
+            .variant(WorkId::Vvar)
             .variant(FeWorkId::StaticMetadata)
             .variant(WorkId::ExtraFeaTables)
             .build()

--- a/fontbe/src/glyphs.rs
+++ b/fontbe/src/glyphs.rs
@@ -203,7 +203,7 @@ fn create_composite(
 fn add_phantom_points(
     instance: &GlyphInstance,
     metrics: &GlobalMetricsInstance,
-    vertical: bool,
+    build_vertical: bool,
     points: &mut Vec<Point>,
 ) {
     // FontTools says
@@ -214,7 +214,7 @@ fn add_phantom_points(
     points.push(Point::new(0.0, 0.0)); // leftSideX, 0
     points.push(Point::new(advance_width as f64, 0.0)); // rightSideX, 0
 
-    let (top, bottom) = vertical
+    let (top, bottom) = build_vertical
         .then(|| {
             // FontTools says
             //      topSideY = topSideBearing + glyph.yMax
@@ -235,7 +235,7 @@ fn point_seqs_for_simple_glyph(
     ir_glyph: &ir::Glyph,
     instances: HashMap<NormalizedLocation, SimpleGlyph>,
     global_metrics: &GlobalMetrics,
-    vertical: bool,
+    build_vertical: bool,
 ) -> HashMap<NormalizedLocation, Vec<Point>> {
     instances
         .into_iter()
@@ -250,7 +250,7 @@ fn point_seqs_for_simple_glyph(
             let instance = &ir_glyph.sources()[&loc];
             let metrics = global_metrics.at(&loc);
 
-            add_phantom_points(instance, &metrics, vertical, &mut points);
+            add_phantom_points(instance, &metrics, build_vertical, &mut points);
 
             (loc, points)
         })
@@ -261,7 +261,7 @@ fn point_seqs_for_simple_glyph(
 fn point_seqs_for_composite_glyph(
     ir_glyph: &ir::Glyph,
     global_metrics: &GlobalMetrics,
-    vertical: bool,
+    build_vertical: bool,
 ) -> HashMap<NormalizedLocation, Vec<Point>> {
     ir_glyph
         .sources()
@@ -276,7 +276,7 @@ fn point_seqs_for_composite_glyph(
             }
 
             let metrics = global_metrics.at(loc);
-            add_phantom_points(inst, &metrics, vertical, &mut points);
+            add_phantom_points(inst, &metrics, build_vertical, &mut points);
 
             (loc.clone(), points)
         })

--- a/fontbe/src/glyphs.rs
+++ b/fontbe/src/glyphs.rs
@@ -14,7 +14,7 @@ use fontdrasil::{
     types::GlyphName,
 };
 use fontir::{
-    ir::{self, GlyphOrder},
+    ir::{self, GlobalMetricsInstance, GlyphInstance, GlyphOrder},
     orchestration::{Flags, WorkId as FeWorkId},
     variations::{VariationModel, VariationRegion},
 };
@@ -200,23 +200,42 @@ fn create_composite(
 
 /// * <https://github.com/fonttools/fonttools/blob/3b9a73ff8379ab49d3ce35aaaaf04b3a7d9d1655/Lib/fontTools/ttLib/tables/_g_l_y_f.py#L335-L367>
 /// * <https://docs.microsoft.com/en-us/typography/opentype/spec/tt_instructing_glyphs#phantoms>
-fn add_phantom_points(advance: u16, points: &mut Vec<Point>) {
+fn add_phantom_points(
+    instance: &GlyphInstance,
+    metrics: &GlobalMetricsInstance,
+    vertical: bool,
+    points: &mut Vec<Point>,
+) {
     // FontTools says
     //      leftSideX = glyph.xMin - leftSideBearing
     //      rightSideX = leftSideX + horizontalAdvanceWidth
     // We currently always set lsb to xMin so leftSideX = 0, rightSideX = advance.
+    let advance_width: u16 = instance.width.ot_round();
     points.push(Point::new(0.0, 0.0)); // leftSideX, 0
-    points.push(Point::new(advance as f64, 0.0)); // rightSideX, 0
+    points.push(Point::new(advance_width as f64, 0.0)); // rightSideX, 0
 
-    // TODO: vertical phantom points
-    points.push(Point::new(0.0, 0.0));
-    points.push(Point::new(0.0, 0.0));
+    let (top, bottom) = vertical
+        .then(|| {
+            // FontTools says
+            //      topSideY = topSideBearing + glyph.yMax
+            //      bottomSideY = topSideY - verticalAdvanceWidth
+            // We currently always set tsb to vertical_origin - yMax so topSideY = verticalOrigin.
+            let top = instance.vertical_origin(metrics) as f64;
+            let bottom = top - instance.height(metrics) as f64;
+            (top, bottom)
+        })
+        .unwrap_or_default();
+
+    points.push(Point::new(0.0, top));
+    points.push(Point::new(0.0, bottom));
 }
 
 /// See <https://github.com/fonttools/fonttools/blob/86291b6ef62ad4bdb48495a4b915a597a9652dcf/Lib/fontTools/ttLib/tables/_g_l_y_f.py#L369>
 fn point_seqs_for_simple_glyph(
     ir_glyph: &ir::Glyph,
     instances: HashMap<NormalizedLocation, SimpleGlyph>,
+    metrics: &GlobalMetricsInstance,
+    vertical: bool,
 ) -> HashMap<NormalizedLocation, Vec<Point>> {
     instances
         .into_iter()
@@ -228,7 +247,10 @@ fn point_seqs_for_simple_glyph(
                 .map(|cp| Point::new(cp.x as f64, cp.y as f64))
                 .collect();
 
-            add_phantom_points(ir_glyph.sources()[&loc].width.ot_round(), &mut points);
+            let instance = &ir_glyph.sources()[&loc];
+
+            // TODO: Use metrics at location - blocked on interpolated metrics.
+            add_phantom_points(instance, metrics, vertical, &mut points);
 
             (loc, points)
         })
@@ -236,7 +258,11 @@ fn point_seqs_for_simple_glyph(
 }
 
 /// See <https://github.com/fonttools/fonttools/blob/86291b6ef62ad4bdb48495a4b915a597a9652dcf/Lib/fontTools/ttLib/tables/_g_l_y_f.py#L369>
-fn point_seqs_for_composite_glyph(ir_glyph: &ir::Glyph) -> HashMap<NormalizedLocation, Vec<Point>> {
+fn point_seqs_for_composite_glyph(
+    ir_glyph: &ir::Glyph,
+    metrics: &GlobalMetricsInstance,
+    vertical: bool,
+) -> HashMap<NormalizedLocation, Vec<Point>> {
     ir_glyph
         .sources()
         .iter()
@@ -248,7 +274,9 @@ fn point_seqs_for_composite_glyph(ir_glyph: &ir::Glyph) -> HashMap<NormalizedLoc
                 let [.., dx, dy] = component.transform.as_coeffs();
                 points.push((dx, dy).into());
             }
-            add_phantom_points(inst.width.ot_round(), &mut points);
+
+            // TODO: Use metrics at location - blocked on interpolated metrics.
+            add_phantom_points(inst, metrics, vertical, &mut points);
 
             (loc.clone(), points)
         })
@@ -337,6 +365,11 @@ impl Work<Context, AnyWorkId, Error> for GlyphWork {
 
         let static_metadata = context.ir.static_metadata.get();
         let default_location = static_metadata.default_location();
+        let default_metrics = context
+            .ir
+            .global_metrics
+            .get()
+            .at(static_metadata.default_location());
         let ir_glyph = &*context
             .ir
             .glyphs
@@ -358,7 +391,11 @@ impl Work<Context, AnyWorkId, Error> for GlyphWork {
                 context
                     .glyphs
                     .set_unconditionally(Glyph::new(name.clone(), composite));
-                let point_seqs = point_seqs_for_composite_glyph(ir_glyph);
+                let point_seqs = point_seqs_for_composite_glyph(
+                    ir_glyph,
+                    &default_metrics,
+                    static_metadata.build_vertical,
+                );
                 (name, point_seqs, Vec::new())
             }
             CheckedGlyph::Contour { name, paths } => {
@@ -399,7 +436,12 @@ impl Work<Context, AnyWorkId, Error> for GlyphWork {
                 }
                 (
                     name,
-                    point_seqs_for_simple_glyph(ir_glyph, instances),
+                    point_seqs_for_simple_glyph(
+                        ir_glyph,
+                        instances,
+                        &default_metrics,
+                        static_metadata.build_vertical,
+                    ),
                     contour_ends,
                 )
             }

--- a/fontbe/src/lib.rs
+++ b/fontbe/src/lib.rs
@@ -24,3 +24,4 @@ pub mod stat;
 #[cfg(test)]
 mod test_util;
 pub mod vertical_metrics;
+pub mod vvar;

--- a/fontbe/src/orchestration.rs
+++ b/fontbe/src/orchestration.rs
@@ -64,6 +64,7 @@ use write_fonts::{
         post::Post,
         stat::Stat,
         vhea::Vhea,
+        vvar::Vvar,
     },
     types::{GlyphId16, Tag},
     validate::Validate,
@@ -103,6 +104,7 @@ pub enum WorkId {
     Meta,
     Vhea,
     Vmtx,
+    Vvar,
     GatherIrKerning,
     KernFragment(KernBlock),
     GatherBeKerning,
@@ -164,6 +166,7 @@ impl Identifier for WorkId {
             WorkId::Stat => "BeStat",
             WorkId::Vhea => "BeVhea",
             WorkId::Vmtx => "BeVmtx",
+            WorkId::Vvar => "BeVvar",
             WorkId::ExtraFeaTables => "ExtraFeaTables",
         }
     }
@@ -895,6 +898,7 @@ pub struct Context {
     pub mvar: BeContextItem<Mvar>,
     pub vhea: BeContextItem<Vhea>,
     pub vmtx: BeContextItem<Bytes>,
+    pub vvar: BeContextItem<Vvar>,
     pub all_kerning_pairs: BeContextItem<AllKerningPairs>,
     pub kern_fragments: BeContextMap<KernFragment>,
     pub fea_ast: BeContextItem<FeaFirstPassOutput>,
@@ -939,6 +943,7 @@ impl Context {
             meta: self.meta.clone_with_acl(acl.clone()),
             vhea: self.vhea.clone_with_acl(acl.clone()),
             vmtx: self.vmtx.clone_with_acl(acl.clone()),
+            vvar: self.vvar.clone_with_acl(acl.clone()),
             all_kerning_pairs: self.all_kerning_pairs.clone_with_acl(acl.clone()),
             kern_fragments: self.kern_fragments.clone_with_acl(acl.clone()),
             fea_rs_kerns: self.fea_rs_kerns.clone_with_acl(acl.clone()),
@@ -991,6 +996,7 @@ impl Context {
             meta: ContextItem::new(WorkId::Meta.into(), acl.clone(), persistent_storage.clone()),
             vhea: ContextItem::new(WorkId::Vhea.into(), acl.clone(), persistent_storage.clone()),
             vmtx: ContextItem::new(WorkId::Vmtx.into(), acl.clone(), persistent_storage.clone()),
+            vvar: ContextItem::new(WorkId::Vvar.into(), acl.clone(), persistent_storage.clone()),
             all_kerning_pairs: ContextItem::new(
                 WorkId::GatherIrKerning.into(),
                 acl.clone(),

--- a/fontbe/src/paths.rs
+++ b/fontbe/src/paths.rs
@@ -100,6 +100,7 @@ impl Paths {
             WorkId::Meta => self.build_dir.join("meta.table"),
             WorkId::Vhea => self.build_dir.join("vhea.table"),
             WorkId::Vmtx => self.build_dir.join("vmtx.table"),
+            WorkId::Vvar => self.build_dir.join("vvar.table"),
             WorkId::ExtraFeaTables => self.build_dir.join("extra_tables.bin"),
             WorkId::Font => self
                 .output_file

--- a/fontbe/src/vvar.rs
+++ b/fontbe/src/vvar.rs
@@ -5,6 +5,7 @@ use fontdrasil::orchestration::{Access, AccessBuilder, Work};
 use fontdrasil::types::GlyphName;
 use fontir::orchestration::WorkId as FeWorkId;
 use write_fonts::tables::vvar::Vvar;
+use write_fonts::OtRound;
 
 use crate::hvar::AdvanceDeltasBuilder;
 use crate::{
@@ -70,7 +71,7 @@ impl Work<Context, AnyWorkId, Error> for VvarWork {
                     let loc = loc.subset_axes(&static_metadata.axes);
                     let metrics = global_metrics.at(&loc);
 
-                    let height = src.height(&metrics) as f64;
+                    let height = (src.height(&metrics) as f64).ot_round();
 
                     (loc, vec![height])
                 })

--- a/fontbe/src/vvar.rs
+++ b/fontbe/src/vvar.rs
@@ -1,0 +1,91 @@
+//! Generates a [VVAR](https://learn.microsoft.com/en-us/typography/opentype/spec/VVAR) table.
+
+use fontdrasil::orchestration::{Access, AccessBuilder, Work};
+
+use fontdrasil::types::GlyphName;
+use fontir::orchestration::WorkId as FeWorkId;
+use write_fonts::tables::vvar::Vvar;
+
+use crate::hvar::AdvanceDeltasBuilder;
+use crate::{
+    error::Error,
+    orchestration::{AnyWorkId, BeWork, Context, WorkId},
+};
+
+#[derive(Debug)]
+struct VvarWork {}
+
+pub fn create_vvar_work() -> Box<BeWork> {
+    Box::new(VvarWork {})
+}
+
+impl Work<Context, AnyWorkId, Error> for VvarWork {
+    fn id(&self) -> AnyWorkId {
+        WorkId::Vvar.into()
+    }
+
+    fn read_access(&self) -> Access<AnyWorkId> {
+        AccessBuilder::new()
+            .variant(FeWorkId::StaticMetadata)
+            .variant(FeWorkId::GlobalMetrics)
+            .variant(FeWorkId::GlyphOrder)
+            .variant(FeWorkId::Glyph(GlyphName::NOTDEF)) // Assumed in AdvanceDeltasBuilder
+            .build()
+    }
+
+    /// Generate [VVAR](https://learn.microsoft.com/en-us/typography/opentype/spec/VVAR)
+    fn exec(&self, context: &Context) -> Result<(), Error> {
+        let static_metadata = context.ir.static_metadata.get();
+
+        if static_metadata.axes.is_empty() {
+            log::debug!("skipping VVAR, font has no axes");
+            return Ok(());
+        }
+        if !static_metadata.build_vertical {
+            log::debug!("skipping VVAR, font is not vertical");
+            return Ok(());
+        }
+
+        let var_model = &static_metadata.variation_model;
+
+        let glyph_order = context.ir.glyph_order.get();
+        let glyphs: Vec<_> = glyph_order
+            .names()
+            .map(|name| context.ir.glyphs.get(&FeWorkId::Glyph(name.clone())))
+            .collect();
+        let glyph_locations = glyphs.iter().flat_map(|glyph| glyph.sources().keys());
+
+        let default_metrics = context
+            .ir
+            .global_metrics
+            .get()
+            .at(static_metadata.default_location());
+
+        let mut glyph_advance_deltas =
+            AdvanceDeltasBuilder::new(var_model.clone(), glyph_locations);
+        for glyph in glyphs.into_iter() {
+            let name = glyph.name.clone();
+            let advances = glyph
+                .sources()
+                .iter()
+                // advances must be rounded before the computing deltas to match fontmake
+                // https://github.com/googlefonts/fontc/issues/1043
+                .map(|(loc, src)| {
+                    (
+                        loc.subset_axes(&static_metadata.axes),
+                        // TODO: Use metrics at location - blocked on interpolated metrics.
+                        vec![src.height(&default_metrics) as f64],
+                    )
+                })
+                .collect();
+            glyph_advance_deltas.add(name, advances)?;
+        }
+
+        let (varstore, varidx_map) = glyph_advance_deltas.build(glyph_order.len())?;
+
+        let vvar = Vvar::new(varstore, varidx_map, None, None, None);
+        context.vvar.set(vvar);
+
+        Ok(())
+    }
+}

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -396,6 +396,7 @@ mod tests {
             BeWorkIdentifier::Stat.into(),
             BeWorkIdentifier::Vhea.into(),
             BeWorkIdentifier::Vmtx.into(),
+            BeWorkIdentifier::Vvar.into(),
         ];
 
         expected.extend(

--- a/fontc/src/timing.rs
+++ b/fontc/src/timing.rs
@@ -190,6 +190,7 @@ fn short_name(id: &AnyWorkId) -> &'static str {
         AnyWorkId::Be(BeWorkIdentifier::Stat) => "STAT",
         AnyWorkId::Be(BeWorkIdentifier::Vhea) => "vhea",
         AnyWorkId::Be(BeWorkIdentifier::Vmtx) => "vmtx",
+        AnyWorkId::Be(BeWorkIdentifier::Vvar) => "VVAR",
         AnyWorkId::Be(BeWorkIdentifier::ExtraFeaTables) => "ExtraFeaTables",
         AnyWorkId::InternalTiming(name) => name,
     }

--- a/fontc/src/workload.rs
+++ b/fontc/src/workload.rs
@@ -35,6 +35,7 @@ use fontbe::{
     post::create_post_work,
     stat::create_stat_work,
     vertical_metrics::create_vertical_metrics_work,
+    vvar::create_vvar_work,
 };
 use fontdrasil::{
     coords::NormalizedLocation,
@@ -197,6 +198,7 @@ impl Workload {
         workload.add(create_name_work());
         workload.add(create_os2_work());
         workload.add(create_post_work());
+        workload.add(create_vvar_work());
 
         // Make a damn font
         workload.add(create_font_work());

--- a/fontc/src/workload.rs
+++ b/fontc/src/workload.rs
@@ -346,7 +346,9 @@ impl Workload {
             return;
         }
 
-        let mut deps = AccessBuilder::<AnyWorkId>::new().variant(FeWorkIdentifier::StaticMetadata);
+        let mut deps = AccessBuilder::<AnyWorkId>::new()
+            .variant(FeWorkIdentifier::StaticMetadata)
+            .variant(FeWorkIdentifier::GlobalMetrics);
 
         let mut has_components = false;
         for inst in glyph.sources().values() {


### PR DESCRIPTION
This is the final puzzle piece from #1388 (🎊): writing **variable** heights to eliminate the remaining diffs for vertical fonts on crater. In particular, the main changes in this PR are to:

- Refactor `HVAR` for reuse to write `VVAR`
- Populate vertical `gvar` phantom points

## Question before merging

This PR will need furnishing with tests. However, before doing so, there is one issue I would like to address:

When a glyph instance's height or vertical origin is absent, the default value must be derived from the global metrics _at that location_. This can sometimes crash fontc, as outlines may be at positions where global metrics are undefined, e.g. for designspace sparse layers or Glyphsapp brace layers, and [fontc does not implement metrics interpolation yet](https://github.com/googlefonts/fontc/blob/ec53b31eac40a9f5e5977817d8918e8aa2d04b75/fontir/src/ir.rs#L504).

What solution do we want to get vertical metrics over the line?

1. If we fetch metrics as lazily as possible, we can limit present-day panics to a much rarer and avoidable case that is unlikely to appear on crater
    - i.e. by only getting metrics when a default is really needed, only vertical fonts that define sparse glyphs but do not give explicit heights or origins are affected
2. Alternatively, we  wait for interpolated metrics
3. ...or is there a third option?