### PR TITLE
Prefer axis (English) `<labelname>` over axis.name like fonttools does

### DIFF
--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -1290,6 +1290,47 @@ mod tests {
         )
     }
 
+    #[test]
+    fn custom_english_ui_label_name() {
+        // The 'weight' axis has a custom `<labelname xml:lang="en">Heaviness</labelname>`;
+        // we expect this to be used for the axis name for UI purposes (fvar, STAT).
+        let result = TestCompile::compile_source("wght_var_axis_label_names.designspace");
+        let static_metadata = result.fe_context.static_metadata.get();
+
+        assert_eq!(
+            vec!["weight".to_string()],
+            static_metadata
+                .axes
+                .iter()
+                .map(|axis| axis.name.clone())
+                .collect::<Vec<_>>()
+        );
+
+        let font = result.font();
+        let name = font.name().unwrap();
+        let fvar = font.fvar().unwrap();
+
+        assert_eq!(
+            vec!["Heaviness".to_string()],
+            fvar.axes()
+                .unwrap()
+                .iter()
+                .map(|axis| resolve_name(&name, axis.axis_name_id()).unwrap())
+                .collect::<Vec<_>>()
+        );
+
+        let stat = font.stat().unwrap();
+
+        assert_eq!(
+            vec!["Heaviness".to_string()],
+            stat.design_axes()
+                .unwrap()
+                .iter()
+                .map(|axis| resolve_name(&name, axis.axis_name_id()).unwrap())
+                .collect::<Vec<_>>()
+        )
+    }
+
     fn assert_named_instances(source: &str, expected: Vec<(String, Vec<(&str, f64)>)>) {
         let result = TestCompile::compile_source(source);
         let font = result.font();

--- a/resources/testdata/wght_var_axis_label_names.designspace
+++ b/resources/testdata/wght_var_axis_label_names.designspace
@@ -1,0 +1,30 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<designspace format="5.0">
+  <axes>
+    <axis tag="wght" name="weight" minimum="400" maximum="700" default="400">
+      <map input="400" output="10"/>
+      <map input="500" output="15"/>
+      <map input="700" output="20"/>
+      <labelname xml:lang="en">Heaviness</labelname>
+    </axis>
+  </axes>
+  <sources>
+    <source filename="WghtVar-Regular.ufo" name="Wght Var Regular" familyname="Wght Var" stylename="Regular">
+      <location>
+        <dimension name="weight" xvalue="10"/>
+      </location>
+    </source>
+    <source filename="WghtVar-Bold.ufo" name="Wght Var Bold" familyname="Wght Var" stylename="Bold">
+      <location>
+        <dimension name="weight" xvalue="20"/>
+      </location>
+    </source>
+  </sources>
+  <instances>
+    <instance name="Wght Var Medium" familyname="Wght Var" stylename="Medium" filename="WghtVar-Medium.ufo">
+      <location>
+        <dimension name="weight" xvalue="15"/>
+      </location>
+    </instance>
+  </instances>
+</designspace>


### PR DESCRIPTION
Fixes https://github.com/googlefonts/fontc/issues/1020

Some .designspace files contain axis `<labelname>` elements with an English string "en" which may be different from the default axis name attribute (there was a convention to have axis names all lowercase in the old MutatorMath days, which some tools have kept).

fonttools varLib prefers to use the "en" labelname when present over the axis.name. This PR is meant to match this.

Note this requires a change in norad which hasn't been released yet.

I don't plan to add support in here for non-English localised names proper. We will do that later at some point.