### PR TITLE
[fea-rs] Disable optimization for empty ConditionSets

### DIFF
--- a/fea-rs/src/compile/lookups.rs
+++ b/fea-rs/src/compile/lookups.rs
@@ -1155,8 +1155,14 @@ where
                 .variations
                 .into_iter()
                 .map(|(condset, features)| {
-                    // if this is an empty conditionset, leave the offset null
-                    let condset = (!condset.conditions.is_empty()).then_some(condset);
+                    // TODO: it would be more efficient to skip writing the
+                    // ConditionSet if it is empty, but for the time being we
+                    // are going to match fonttools.
+                    // See https://github.com/fonttools/fonttools/issues/3844
+                    //
+                    // (the old optimization is commented out below)
+                    //let condset = (!condset.conditions.is_empty()).then_some(condset);
+                    let condset = Some(condset);
                     FeatureVariationRecord::new(
                         condset,
                         FeatureTableSubstitution::new(

--- a/fea-rs/test-data/compile-tests/mini-latin/good/variable_condition_sort_order.ttx
+++ b/fea-rs/test-data/compile-tests/mini-latin/good/variable_condition_sort_order.ttx
@@ -45,6 +45,9 @@
       <Version value="0x00010000"/>
       <!-- FeatureVariationCount=4 -->
       <FeatureVariationRecord index="0">
+        <ConditionSet>
+          <!-- ConditionCount=0 -->
+        </ConditionSet>
         <FeatureTableSubstitution>
           <Version value="0x00010000"/>
           <!-- SubstitutionCount=1 -->

--- a/fea-rs/test-data/compile-tests/mini-latin/good/variable_feature_null_conditionset.ttx
+++ b/fea-rs/test-data/compile-tests/mini-latin/good/variable_feature_null_conditionset.ttx
@@ -53,6 +53,9 @@
       <Version value="0x00010000"/>
       <!-- FeatureVariationCount=1 -->
       <FeatureVariationRecord index="0">
+        <ConditionSet>
+          <!-- ConditionCount=0 -->
+        </ConditionSet>
         <FeatureTableSubstitution>
           <Version value="0x00010000"/>
           <!-- SubstitutionCount=1 -->


### PR DESCRIPTION
It is more efficient to write null offsets in this case, but fonttools does not perform this optimization and it is a minor optimization that applies to a small number of fonts, so it feels fine to disable for now.

This gives us a cheap +1 on crater.

see https://github.com/fonttools/fonttools/issues/3844 for discussion on adding this optimization in fonttools.


JMM
