### PR TITLE
[fea-rs] Mask out high byte of lookupflag literals

### DIFF
--- a/fea-rs/src/compile/compile_ctx.rs
+++ b/fea-rs/src/compile/compile_ctx.rs
@@ -481,8 +481,10 @@ impl<'a, F: FeatureProvider, V: VariationInfo> CompilationCtx<'a, F, V> {
     fn set_lookup_flag(&mut self, node: typed::LookupFlag) {
         self.lookup_flags.clear();
         if let Some(number) = node.number() {
-            self.lookup_flags.flags =
-                LookupFlag::from_bits_truncate(number.parse_unsigned().unwrap());
+            let raw = number.parse_unsigned().unwrap() & 0xff;
+            // match fonttools in masking out the high parts:
+            //https://github.com/fonttools/fonttools/blame/e89d7db4f4/Lib/fontTools/feaLib/builder.py#L1198
+            self.lookup_flags.flags = LookupFlag::from_bits_truncate(raw);
             return;
         }
 

--- a/fea-rs/src/compile/validate.rs
+++ b/fea-rs/src/compile/validate.rs
@@ -1102,8 +1102,18 @@ impl<'a, V: VariationInfo> ValidationCtx<'a, V> {
 
     fn validate_lookupflag(&mut self, node: &typed::LookupFlag) {
         if let Some(number) = node.number() {
-            if number.text().parse::<u16>().is_err() {
-                self.error(number.range(), "value must be a positive 16 bit integer");
+            match number.text().parse::<u16>() {
+                Ok(val) => {
+                    if val > 0xff {
+                        self.warning(
+                        number.range(),
+                        "the high byte of lookupflag literals is not portable and will be ignored.",
+                    );
+                    }
+                }
+                Err(_) => {
+                    self.error(number.range(), "value must be a positive 16 bit integer");
+                }
             }
             return;
         }

--- a/fea-rs/test-data/compile-tests/mini-latin/good/lookupflag_oob_literal.fea
+++ b/fea-rs/test-data/compile-tests/mini-latin/good/lookupflag_oob_literal.fea
@@ -1,0 +1,7 @@
+feature hola {
+    # this literal is nonsensical; we will match fonttools and mask
+    # out the high byte.
+    # https://github.com/googlefonts/fontc/issues/1485
+    lookupflag 512;
+    pos a 10;
+} hola;

--- a/fea-rs/test-data/compile-tests/mini-latin/good/lookupflag_oob_literal.ttx
+++ b/fea-rs/test-data/compile-tests/mini-latin/good/lookupflag_oob_literal.ttx
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont>
+
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=1 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="hola"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=1 -->
+      <Lookup index="0">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SinglePos index="0" Format="1">
+          <Coverage>
+            <Glyph value="a"/>
+          </Coverage>
+          <ValueFormat value="4"/>
+          <Value XAdvance="10"/>
+        </SinglePos>
+      </Lookup>
+    </LookupList>
+  </GPOS>
+
+</ttFont>


### PR DESCRIPTION
The meaning of these bytes is implementation dependent, so passing them through introduces potentially unintended behaviour.

This will also print a warning if we encounter these literals in a source.

- closes #1485