### PR TITLE
[fea-rs] Check lookupflags before promoting mixed rules

### DIFF
--- a/fea-rs/src/compile/compile_ctx.rs
+++ b/fea-rs/src/compile/compile_ctx.rs
@@ -695,7 +695,9 @@ impl<'a, F: FeatureProvider, V: VariationInfo> CompilationCtx<'a, F, V> {
         // we combine mixed single/multi-sub rules into a multi-sub lookup.
         // if this is the first multi-sub rule after a sequence of single-sub rules,
         // we need to promote the current single-sub lookup before continuing.
-        self.lookups.promote_single_sub_to_multi_if_necessary();
+        if self.lookups.has_same_flags(self.lookup_flags) {
+            self.lookups.promote_single_sub_to_multi_if_necessary();
+        }
         let lookup = self.ensure_current_lookup_type(Kind::GsubType2);
         lookup.add_gsub_type_2(target_id, replacement);
     }
@@ -714,7 +716,9 @@ impl<'a, F: FeatureProvider, V: VariationInfo> CompilationCtx<'a, F, V> {
             .collect::<Vec<_>>();
         let replacement = self.resolve_glyph(&node.replacement());
         // we combine mixed single & ligature sub rules into a ligature-sub lookup.
-        self.lookups.promote_single_sub_to_liga_if_necessary();
+        if self.lookups.has_same_flags(self.lookup_flags) {
+            self.lookups.promote_single_sub_to_liga_if_necessary();
+        }
         let lookup = self.ensure_current_lookup_type(Kind::GsubType4);
 
         for target in sequence_enumerator(&target) {

--- a/fea-rs/test-data/compile-tests/mini-latin/good/mixed_single_and_liga_with_lookupflags.fea
+++ b/fea-rs/test-data/compile-tests/mini-latin/good/mixed_single_and_liga_with_lookupflags.fea
@@ -1,0 +1,8 @@
+# breaking down a funny lookup situation from a real font
+feature clig {
+    sub a by b;
+    lookupflag 4;
+    sub e l f by z;
+} clig;
+
+

--- a/fea-rs/test-data/compile-tests/mini-latin/good/mixed_single_and_liga_with_lookupflags.ttx
+++ b/fea-rs/test-data/compile-tests/mini-latin/good/mixed_single_and_liga_with_lookupflags.ttx
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont>
+
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=1 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="clig"/>
+        <Feature>
+          <!-- LookupCount=2 -->
+          <LookupListIndex index="0" value="0"/>
+          <LookupListIndex index="1" value="1"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=2 -->
+      <Lookup index="0">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0">
+          <Substitution in="a" out="b"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="1">
+        <LookupType value="4"/>
+        <LookupFlag value="4"/><!-- ignoreLigatures -->
+        <!-- SubTableCount=1 -->
+        <LigatureSubst index="0">
+          <LigatureSet glyph="e">
+            <Ligature components="l,f" glyph="z"/>
+          </LigatureSet>
+        </LigatureSubst>
+      </Lookup>
+    </LookupList>
+  </GSUB>
+
+</ttFont>


### PR DESCRIPTION
this was an oversight that was also missing in fonttools, but it has been fixed there as of https://github.com/fonttools/fonttools/pull/3849.