### PR TITLE
[fea-rs] Account for promoted rules in aalt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ rayon = "1.6"
 icu_properties = "2.0.0-beta1"
 
 # fontations etc
-write-fonts = { version = "0.38.1", features = ["serde", "read"] }
+write-fonts = { version = "0.38.2", features = ["serde", "read"] }
 skrifa = "0.31.0"
 norad = { version = "0.15.0", default-features = false }
 

--- a/fea-rs/src/compile/features.rs
+++ b/fea-rs/src/compile/features.rs
@@ -10,7 +10,7 @@ use write_fonts::{
 
 use super::{
     language_system::{DefaultLanguageSystems, LanguageSystem},
-    lookups::{AllLookups, FeatureKey, LookupId, LookupIdMap},
+    lookups::{AllLookups, FeatureKey, IterAaltPairs, LookupId, LookupIdMap},
     tables::{NameBuilder, NameSpec},
     tags,
 };
@@ -162,12 +162,32 @@ impl AllFeatures {
         // now go through the lookups, ordered by appearance of feature in aalt
         for (_, lookup) in relevant_lookups.iter().flat_map(|x| x.iter()) {
             match lookup {
-                super::lookups::SubstitutionLookup::Single(lookup) => {
-                    aalt.extend(lookup.iter_subtables().flat_map(|sub| sub.iter_pairs()))
+                super::lookups::SubstitutionLookup::Single(lookup) => aalt.extend(
+                    lookup
+                        .iter_subtables()
+                        .flat_map(|sub| sub.iter_aalt_pairs()),
+                ),
+                super::lookups::SubstitutionLookup::Alternate(lookup) => aalt.extend(
+                    lookup
+                        .iter_subtables()
+                        .flat_map(|sub| sub.iter_aalt_pairs()),
+                ),
+                super::lookups::SubstitutionLookup::Multiple(lookup) => {
+                    aalt.extend(
+                        lookup
+                            .iter_subtables()
+                            .flat_map(|sub| sub.iter_aalt_pairs()),
+                    );
                 }
-                super::lookups::SubstitutionLookup::Alternate(lookup) => {
-                    aalt.extend(lookup.iter_subtables().flat_map(|sub| sub.iter_pairs()))
+
+                super::lookups::SubstitutionLookup::Ligature(lookup) => {
+                    aalt.extend(
+                        lookup
+                            .iter_subtables()
+                            .flat_map(|sub| sub.iter_aalt_pairs()),
+                    );
                 }
+
                 _ => (),
             }
         }

--- a/fea-rs/test-data/compile-tests/mini-latin/good/rule_promotion_and_aalt.fea
+++ b/fea-rs/test-data/compile-tests/mini-latin/good/rule_promotion_and_aalt.fea
@@ -1,0 +1,15 @@
+feature aalt {
+    feature calt;
+    feature halt;
+    sub a by c;
+} aalt;
+
+feature calt {
+    sub b by d; # this will get promoted to a ligature rule, but we still want it in aalt
+    sub f e by g;
+} calt;
+
+feature halt {
+    sub h by i; # this will be promoted to multisub, but we still want it in aalt
+    sub j by k l;
+} halt;

--- a/fea-rs/test-data/compile-tests/mini-latin/good/rule_promotion_and_aalt.ttx
+++ b/fea-rs/test-data/compile-tests/mini-latin/good/rule_promotion_and_aalt.ttx
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont>
+
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=3 -->
+            <FeatureIndex index="0" value="0"/>
+            <FeatureIndex index="1" value="1"/>
+            <FeatureIndex index="2" value="2"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=3 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="aalt"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="1">
+        <FeatureTag value="calt"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="1"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="2">
+        <FeatureTag value="halt"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="2"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=3 -->
+      <Lookup index="0">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0">
+          <Substitution in="a" out="c"/>
+          <Substitution in="b" out="d"/>
+          <Substitution in="h" out="i"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="1">
+        <LookupType value="4"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <LigatureSubst index="0">
+          <LigatureSet glyph="b">
+            <Ligature components="" glyph="d"/>
+          </LigatureSet>
+          <LigatureSet glyph="f">
+            <Ligature components="e" glyph="g"/>
+          </LigatureSet>
+        </LigatureSubst>
+      </Lookup>
+      <Lookup index="2">
+        <LookupType value="2"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <MultipleSubst index="0">
+          <Substitution in="h" out="i"/>
+          <Substitution in="j" out="k,l"/>
+        </MultipleSubst>
+      </Lookup>
+    </LookupList>
+  </GSUB>
+
+</ttFont>

--- a/fea-rs/test-data/fonttools-tests/spec8a.ttx
+++ b/fea-rs/test-data/fonttools-tests/spec8a.ttx
@@ -89,8 +89,6 @@
         <LookupFlag value="0"/>
         <!-- SubTableCount=1 -->
         <SingleSubst index="0">
-          <Substitution in="b" out="b.alt"/>
-          <Substitution in="c" out="c.mid"/>
           <Substitution in="e" out="e.mid"/>
         </SingleSubst>
       </Lookup>
@@ -103,6 +101,15 @@
             <Alternate glyph="a.alt1"/>
             <Alternate glyph="a.alt2"/>
             <Alternate glyph="a.alt3"/>
+            <Alternate glyph="A.sc"/>
+          </AlternateSet>
+          <AlternateSet glyph="b">
+            <Alternate glyph="b.alt"/>
+            <Alternate glyph="B.sc"/>
+          </AlternateSet>
+          <AlternateSet glyph="c">
+            <Alternate glyph="c.mid"/>
+            <Alternate glyph="C.sc"/>
           </AlternateSet>
           <AlternateSet glyph="d">
             <Alternate glyph="d.alt"/>


### PR DESCRIPTION
That is, if a single sub rule has been promoted to a ligature or multiple sub lookup, but it is in an aalt-participating feature, we should still include those rules in aalt.

See https://github.com/fonttools/fonttools/pull/3847 for the fonttools impl of this logic.


(this will be a minor regression until we update fonttools in ci, but I think that's okay)