### PR TITLE
Fix typos in Bhaiksuki and N'ko script tags, following ufo2ft

### DIFF
--- a/fontbe/src/features/ot_tags.rs
+++ b/fontbe/src/features/ot_tags.rs
@@ -71,6 +71,7 @@ pub(crate) static USE_SCRIPTS: &[&str] = &[
     "Ahom", // Ahom
     "Bali", // Balinese
     "Batk", // Batak
+    "Bhks", // Bhaiksuki
     "Brah", // Brahmi
     "Bugi", // Buginese
     "Buhd", // Buhid
@@ -112,8 +113,7 @@ pub(crate) static USE_SCRIPTS: &[&str] = &[
     "Nagm", // Nag Mundari
     "Nand", // Nandinagari
     "Newa", // Newa
-    "Nhks", // Bhaiksuki
-    "Nko ", // Nko
+    "Nkoo", // Nko
     "Ougr", // Old Uyghur
     "Phag", // Phags Pa
     "Phlp", // Psalter Pahlavi


### PR DESCRIPTION
This PR mirrors the equivalent fix for issue googlefonts/ufo2ft#896 in commits googlefonts/ufo2ft@b06c85c5 and googlefonts/ufo2ft@0b5e1598.

As a lone difference it avoids retaining the incorrect name for N'Ko, as my understanding is that unlike ufo2ft all use-cases are in-repo and so there is no outwards backwards compatibility to preserve.

This gives a few crater wins for the respective Noto fonts for each writing system.

cc @anthrotype