### PR TITLE
[glyphs] Propagate component bracket layers

### DIFF
--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -1349,7 +1349,7 @@ mod tests {
     };
     use fontir::{
         error::Error,
-        ir::{AnchorKind, GlobalMetricsInstance, GlyphOrder, NameKey},
+        ir::{AnchorKind, GlobalMetricsInstance, Glyph, GlyphOrder, NameKey},
         orchestration::{Context, Flags, WorkId},
         paths::Paths,
         source::Source,
@@ -2415,6 +2415,15 @@ mod tests {
         );
     }
 
+    fn get_components(glyph: &Glyph) -> Vec<&str> {
+        glyph
+            .default_instance()
+            .components
+            .iter()
+            .map(|c| c.base.as_str())
+            .collect()
+    }
+
     #[test]
     fn bracket_glyph_components() {
         let (source, context) =
@@ -2422,25 +2431,24 @@ mod tests {
         build_glyphs(&source, &context).unwrap();
 
         let yen = context.get_glyph("yen");
-        assert_eq!(
-            yen.default_instance()
-                .components
-                .iter()
-                .map(|c| c.base.as_str())
-                .collect::<Vec<_>>(),
-            ["peso"]
-        );
+        assert_eq!(get_components(&yen), ["peso"]);
 
         let yen_bracket = context.get_glyph("yen.BRACKET.varAlt01");
-        assert_eq!(
-            yen_bracket
-                .default_instance()
-                .components
-                .iter()
-                .map(|c| c.base.as_str())
-                .collect::<Vec<_>>(),
-            ["peso.BRACKET.varAlt01"]
-        );
+        assert_eq!(get_components(&yen_bracket), ["peso.BRACKET.varAlt01"]);
+    }
+
+    // if a glyph does not have bracket layers but a component does, we make
+    // fake bracket layers on the glyph.
+    #[test]
+    fn non_bracket_glyph_with_bracket_component() {
+        let (source, context) =
+            build_global_metrics(glyphs3_dir().join("glyph-with-bracket-component.glyphs"));
+        build_glyphs(&source, &context).unwrap();
+        let yen = context.get_glyph("yen");
+        assert_eq!(get_components(&yen), ["peso"]);
+
+        let yen_bracket = context.get_glyph("yen.BRACKET.varAlt01");
+        assert_eq!(get_components(&yen_bracket), ["peso.BRACKET.varAlt01"]);
     }
 
     #[test]

--- a/resources/testdata/glyphs3/glyph-with-bracket-component.glyphs
+++ b/resources/testdata/glyphs3/glyph-with-bracket-component.glyphs
@@ -1,0 +1,147 @@
+{
+.appVersion = "3343";
+.formatVersion = 3;
+axes = (
+{
+name = Weight;
+tag = wght;
+}
+);
+familyName = "Libre Franklin";
+fontMaster = (
+{
+axesValues = (
+40
+);
+id = "91AB5BCA-6A50-42DA-B2F7-8181BF189245";
+name = Thin;
+},
+{
+axesValues = (
+200
+);
+iconName = Bold;
+id = "258ED206-D907-4350-8EBA-CBDDA1C16BF7";
+name = Bold;
+}
+);
+glyphs = (
+{
+glyphname = peso;
+layers = (
+{
+anchors = (
+{
+name = top;
+pos = (10,40);
+}
+);
+layerId = "91AB5BCA-6A50-42DA-B2F7-8181BF189245";
+shapes = (
+);
+width = 750;
+},
+{
+anchors = (
+{
+name = top;
+pos = (20,50);
+}
+);
+layerId = "258ED206-D907-4350-8EBA-CBDDA1C16BF7";
+shapes = (
+);
+width = 786;
+},
+{
+anchors = (
+{
+name = top;
+pos = (15,50);
+}
+);
+associatedMasterId = "258ED206-D907-4350-8EBA-CBDDA1C16BF7";
+attr = {
+axisRules = (
+{
+min = 150;
+}
+);
+};
+layerId = "1D3EBF91-071A-467B-8029-6ADF751ECC6B";
+name = "Bold [150]";
+shapes = (
+);
+width = 746;
+},
+{
+anchors = (
+{
+name = top;
+pos = (11,41);
+}
+);
+associatedMasterId = "91AB5BCA-6A50-42DA-B2F7-8181BF189245";
+attr = {
+axisRules = (
+{
+min = 150;
+}
+);
+};
+layerId = "E1B5A3D9-B3FF-40F6-8D6C-CD5C7D48B817";
+name = "Light [150]";
+shapes = (
+);
+width = 780;
+}
+);
+metricRight = P;
+unicode = 8369;
+},
+{
+glyphname = yen;
+layers = (
+{
+layerId = "91AB5BCA-6A50-42DA-B2F7-8181BF189245";
+shapes = (
+{
+ref = peso;
+}
+);
+width = 750;
+},
+{
+layerId = "258ED206-D907-4350-8EBA-CBDDA1C16BF7";
+shapes = (
+{
+ref = peso;
+}
+);
+width = 786;
+}
+);
+metricRight = P;
+unicode = 165;
+}
+);
+instances = (
+{
+axesValues = (
+40
+);
+name = Thin;
+weightClass = 100;
+},
+{
+axesValues = (
+200
+);
+name = Black;
+weightClass = 900;
+}
+);
+unitsPerEm = 1000;
+versionMajor = 3;
+versionMinor = 0;
+}


### PR DESCRIPTION
One of the larger remaining todos for bracket layers: if a glyph does not have bracket layers but it has components that do, we need to create dummy bracket layers in order for the components to be set correctly.