### PR TITLE
pin cattrs<25.1 in requirements.txt to workaround bug

### DIFF
--- a/resources/scripts/requirements.in
+++ b/resources/scripts/requirements.in
@@ -11,3 +11,9 @@ glyphsLib
 # keep gftools pinned as well to ensure ttx_diff.py output is stable.
 # 0.9.74 is when experimental support for fontc was added to gftools.
 gftools==0.9.85
+# keep cattrs pinned to previous version until a fix is released for
+# https://github.com/python-attrs/cattrs/issues/654
+# This affects static font builds from gftools builder which uses the fontmake
+# option --ufo-structure=json (a ufoLib2 feature which relies on cattrs
+# for [de]serialization from/to json)
+cattrs==24.1.3

--- a/resources/scripts/requirements.txt
+++ b/resources/scripts/requirements.txt
@@ -38,8 +38,9 @@ bump2version==1.0.1
     # via bumpfontversion
 bumpfontversion==0.4.1
     # via gftools
-cattrs==25.1.0
+cattrs==24.1.3
     # via
+    #   -r requirements.in
     #   statmake
     #   ufolib2
 cdifflib==1.2.9
@@ -267,7 +268,6 @@ ttfautohint-py==0.5.1
 typing-extensions==4.14.0
     # via
     #   beautifulsoup4
-    #   cattrs
     #   pygithub
 ufo2ft[cffsubr,compreffor]==3.4.6
     # via


### PR DESCRIPTION
... affecting UFO json [de]serialization in ufoLib2 (as used by gftools builder when compiling static instances with fontmake)

We shall remove this once my fix gets published upstream.