### PR TITLE
Disable overlap removal for gftools too

### DIFF
--- a/resources/scripts/ttx_diff.py
+++ b/resources/scripts/ttx_diff.py
@@ -321,8 +321,8 @@ def modified_gftools_config(
         with open(config_path, "r") as f:
             config = yaml.safe_load(f)
 
-        config["extraFontmakeArgs"] = config.get("extraFontmakeArgs", "") + " ".join(
-            extra_args
+        config["extraFontmakeArgs"] = " ".join(
+            config.get("extraFontmakeArgs", "").split(" ") + extra_args
         )
 
         with NamedTemporaryFile(


### PR DESCRIPTION
Since #979, we have been disabling overlap removal for fontmake's static builds, but this was only applying in the `default` mode. This PR ensures it applies it in the `gftools` mode too, to make it clear which differences are due to gftools' influence alone.

In particular, some Soft Type fonts that only differed in their gftools builds now build identically :rocket: 

## Others bits

This PR also:

- Makes overlap removal configurable with a flag, as we will re-enable it in all static cases later (#717)
- Fixes space-separation when concatenating extra arguments, which was needed to pass in the new arg and – if we cross our fingers – may fix existing crashes on crater too