### PR TITLE
[ttx_diff] Normalize name table indentation

### DIFF
--- a/resources/scripts/ttx_diff.py
+++ b/resources/scripts/ttx_diff.py
@@ -458,6 +458,9 @@ def normalize_name_ids(ttx: etree.ElementTree):
     for record in records:
         name.append(record)
 
+    # items keep their indentation when we reorder them, so reindent everything
+    etree.indent(name)
+
 
 def find_table(ttx, tag):
     return select_one(ttx, f"/ttFont/{tag}")


### PR DESCRIPTION
Some of the modifications we make to the name table can change the indentation. With this patch we normalize indentation after the last modification to this table.

JMM