### PR TITLE
Update to use new-style crater sources

### DIFF
--- a/fontc_crater/Cargo.toml
+++ b/fontc_crater/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 [dependencies]
 fontc = { version = "0.2.0", path = "../fontc" }
 
-google-fonts-sources = "0.7.1"
+google-fonts-sources = "0.9.0"
 maud = "0.27.0"
 tidier = "0.5.3"
 

--- a/fontc_crater/src/ci.rs
+++ b/fontc_crater/src/ci.rs
@@ -6,14 +6,14 @@
 //! generate a fuller report that includes comparison with past runs.
 
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, HashSet},
     fmt::Write,
     path::{Path, PathBuf},
     process::Command,
 };
 
 use chrono::{DateTime, TimeZone, Utc};
-use google_fonts_sources::{Config, RepoInfo};
+use google_fonts_sources::{Config, FontSource, SourceSet};
 use serde::de::DeserializeOwned;
 
 use crate::{
@@ -87,7 +87,7 @@ fn run_crater_and_save_results(args: &CiArgs) -> Result<(), Error> {
 
     log_if_auth_or_not();
     // do this now so we error if the input file doesn't exist
-    let inputs: Vec<RepoInfo> = super::try_read_json(&args.to_run)?;
+    let inputs: SourceSet = super::try_read_json(&args.to_run)?;
 
     let summary_file = args.out_dir.join(SUMMARY_FILE);
     let mut prev_runs: Vec<RunSummary> = load_json_if_exists_else_default(&summary_file)?;
@@ -129,7 +129,7 @@ fn run_crater_and_save_results(args: &CiArgs) -> Result<(), Error> {
         mut targets,
         source_repos,
         failures,
-    } = make_targets(&cache_dir, &inputs);
+    } = make_targets(&cache_dir, &inputs.sources);
 
     if !args.gftools {
         targets.retain(|t| t.build == BuildType::Default);
@@ -215,50 +215,48 @@ struct ResolvedTargets {
     failures: BTreeMap<String, String>,
 }
 
-fn make_targets(cache_dir: &Path, repos: &[RepoInfo]) -> ResolvedTargets {
+fn make_targets(cache_dir: &Path, repos: &[FontSource]) -> ResolvedTargets {
     let mut result = ResolvedTargets::default();
-    'repo: for repo in repos {
-        let iter = match repo.iter_configs(cache_dir) {
-            Ok(iter) => iter,
+    for repo in repos {
+        let config_path = match repo.config_path(cache_dir) {
+            Ok(config) => config,
             Err(e) => {
                 result.failures.insert(repo.repo_url.clone(), e.to_string());
                 continue;
             }
         };
-        for config_path in iter {
-            let config = match Config::load(&config_path) {
-                Ok(x) => x,
-                Err(e) => {
-                    result.failures.insert(repo.repo_url.clone(), e.to_string());
-                    continue 'repo;
-                }
-            };
-            let relative_config_path = config_path
-                .strip_prefix(cache_dir)
-                .expect("config always in cache dir");
-            let sources_dir = config_path
-                .parent()
-                .expect("config path always in sources dir");
-            // config is always in sources, sources is always in org/repo
-            let repo_dir = relative_config_path.parent().unwrap().parent().unwrap();
-            result
-                .source_repos
-                .insert(repo_dir.to_owned(), repo.repo_url.clone());
-            for source in &config.sources {
-                let src_path = sources_dir.join(source);
-                if !src_path.exists() {
-                    result
-                        .failures
-                        .insert(repo.repo_url.clone(), format!("missing source '{source}'"));
-                    continue 'repo;
-                }
-                let src_path = src_path
-                    .strip_prefix(cache_dir)
-                    .expect("source is always in cache dir");
-                result
-                    .targets
-                    .extend(targets_for_source(src_path, relative_config_path, &config))
+        let config = match Config::load(&config_path) {
+            Ok(x) => x,
+            Err(e) => {
+                result.failures.insert(repo.repo_url.clone(), e.to_string());
+                continue;
             }
+        };
+        let relative_config_path = config_path
+            .strip_prefix(cache_dir)
+            .expect("config always in cache dir");
+        let sources_dir = config_path
+            .parent()
+            .expect("config path always in sources dir");
+        // config is always in sources, sources is always in org/repo
+        let repo_dir = relative_config_path.parent().unwrap().parent().unwrap();
+        result
+            .source_repos
+            .insert(repo_dir.to_owned(), repo.repo_url.clone());
+        for source in &config.sources {
+            let src_path = sources_dir.join(source);
+            if !src_path.exists() {
+                result
+                    .failures
+                    .insert(repo.repo_url.clone(), format!("missing source '{source}'"));
+                continue;
+            }
+            let src_path = src_path
+                .strip_prefix(cache_dir)
+                .expect("source is always in cache dir");
+            result
+                .targets
+                .extend(targets_for_source(src_path, relative_config_path, &config))
         }
     }
     result


### PR DESCRIPTION
This is a breaking change from the previous way of representing sources
which was 'repo focused', where a repo could contain multiple sources.
Now we are focused on a 'source', where it's possible that different
sources share a single repo (but have their own config files.)

This will need to be merged alongside an update to the targets.json
file in the crater repo. (https://github.com/googlefonts/fontc_crater/pull/22)