### PR TITLE
[glyphs] Support include statements in glyphs sources

### DIFF
--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -3343,6 +3343,17 @@ mod tests {
     }
 
     #[test]
+    fn glyphs_fea_include_file() {
+        // ensure that we resolve inclue statements in glyphs sources
+        let _ = env_logger::builder().is_test(true).try_init();
+        let result = TestCompile::compile_source("glyphs_fea_include/glyphs_include.glyphs");
+        let gsub = result.font().gsub().unwrap();
+        let feature_list = gsub.feature_list().unwrap();
+        assert_eq!(feature_list.feature_records().len(), 1);
+        assert_eq!(feature_list.feature_records()[0].feature_tag(), "test");
+    }
+
+    #[test]
     fn compile_instance_postscript_names() {
         let result = TestCompile::compile_source("glyphs3/InstancePostscript.glyphs");
         let font = result.font();

--- a/glyphs2fontir/src/toir.rs
+++ b/glyphs2fontir/src/toir.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::{HashMap, HashSet},
+    path::PathBuf,
     str::FromStr,
 };
 
@@ -129,14 +130,17 @@ fn to_ir_path(glyph_name: GlyphName, src_path: &Path) -> Result<BezPath, PathCon
     Ok(path)
 }
 
-pub(crate) fn to_ir_features(features: &[FeatureSnippet]) -> Result<ir::FeaturesSource, Error> {
+pub(crate) fn to_ir_features(
+    features: &[FeatureSnippet],
+    include_dir: PathBuf,
+) -> Result<ir::FeaturesSource, Error> {
     // Based on https://github.com/googlefonts/glyphsLib/blob/24b4d340e4c82948ba121dcfe563c1450a8e69c9/Lib/glyphsLib/builder/features.py#L74
     // TODO: token expansion
     // TODO: implement notes
     let fea_snippets: Vec<_> = features.iter().filter_map(|f| f.str_if_enabled()).collect();
     Ok(ir::FeaturesSource::Memory {
         fea_content: fea_snippets.join("\n\n"),
-        include_dir: None,
+        include_dir: include_dir.into(),
     })
 }
 

--- a/resources/testdata/glyphs_fea_include/features/hello.fea
+++ b/resources/testdata/glyphs_fea_include/features/hello.fea
@@ -1,0 +1,3 @@
+feature test {
+    sub a by b;
+} test;

--- a/resources/testdata/glyphs_fea_include/glyphs_include.glyphs
+++ b/resources/testdata/glyphs_fea_include/glyphs_include.glyphs
@@ -1,0 +1,43 @@
+{
+.appVersion = "3343";
+.formatVersion = 3;
+date = "2025-06-11 15:07:51 +0000";
+familyName = "New Font";
+featurePrefixes = (
+{
+code = "include(features/hello.fea);";
+name = include;
+}
+);
+fontMaster = (
+{
+id = m01;
+name = Regular;
+}
+);
+glyphs = (
+{
+glyphname = a;
+layers = (
+{
+layerId = m01;
+width = 600;
+}
+);
+unicode = 97;
+},
+{
+glyphname = b;
+layers = (
+{
+layerId = m01;
+width = 600;
+}
+);
+unicode = 98;
+}
+);
+unitsPerEm = 1000;
+versionMajor = 1;
+versionMinor = 0;
+}


### PR DESCRIPTION
This requires tracking the directory where the file was stored, and passing this through to fea-rs, so it can lookup referenced files using that directory as a base.

This is currently the source of a number of fontc crashes (which it might not fully fix, but at least they evolve into a different sort of crash)