### PR TITLE
open/save a bunch of .glyphs testdata file with newer Glyphs.app

### DIFF
--- a/resources/testdata/glyphs2/OpszWghtVar_AxisMappings.glyphs
+++ b/resources/testdata/glyphs2/OpszWghtVar_AxisMappings.glyphs
@@ -1,23 +1,6 @@
 {
-.appVersion = "3148";
+.appVersion = "3414";
 customParameters = (
-{
-name = Axes;
-value = (
-{
-Name = Weight;
-Tag = wght;
-},
-{
-Name = "Optical Size";
-Tag = opsz;
-}
-);
-},
-{
-name = "Variable Font Origin";
-value = "medium-12pt";
-},
 {
 name = "Axis Mappings";
 value = {
@@ -35,6 +18,23 @@ wght = {
 700 = 73;
 };
 };
+},
+{
+name = Axes;
+value = (
+{
+Name = Weight;
+Tag = wght;
+},
+{
+Name = "Optical Size";
+Tag = opsz;
+}
+);
+},
+{
+name = "Variable Font Origin";
+value = "medium-12pt";
 }
 );
 familyName = WghtVar;
@@ -43,7 +43,7 @@ fontMaster = (
 ascender = 800;
 capHeight = 0;
 descender = -200;
-id = thin-12pt;
+id = "thin-12pt";
 weightValue = 40;
 widthValue = 12;
 xHeight = 0;
@@ -52,7 +52,7 @@ xHeight = 0;
 ascender = 800;
 capHeight = 0;
 descender = -200;
-id = thin-72pt;
+id = "thin-72pt";
 weightValue = 40;
 widthValue = 72;
 xHeight = 0;
@@ -61,7 +61,7 @@ xHeight = 0;
 ascender = 800;
 capHeight = 0;
 descender = -200;
-id = medium-12pt;
+id = "medium-12pt";
 weightValue = 62;
 widthValue = 12;
 xHeight = 0;
@@ -70,7 +70,7 @@ xHeight = 0;
 ascender = 800;
 capHeight = 0;
 descender = -200;
-id = medium-72pt;
+id = "medium-72pt";
 weightValue = 62;
 widthValue = 72;
 xHeight = 0;
@@ -101,11 +101,11 @@ glyphs = (
 glyphname = space;
 layers = (
 {
-layerId = thin-12pt;
+layerId = "thin-12pt";
 width = 200;
 },
 {
-layerId = medium-12pt;
+layerId = "medium-12pt";
 width = 250;
 },
 {
@@ -113,7 +113,7 @@ layerId = "bold-12pt";
 width = 550;
 },
 {
-layerId = thin-72pt;
+layerId = "thin-72pt";
 width = 250;
 },
 {
@@ -131,7 +131,7 @@ unicode = 0020;
 glyphname = hyphen;
 layers = (
 {
-layerId = thin-12pt;
+layerId = "thin-12pt";
 paths = (
 {
 closed = 1;
@@ -146,7 +146,7 @@ nodes = (
 width = 400;
 },
 {
-layerId = medium-12pt;
+layerId = "medium-12pt";
 paths = (
 {
 closed = 1;
@@ -176,7 +176,7 @@ nodes = (
 width = 600;
 },
 {
-layerId = thin-72pt;
+layerId = "thin-72pt";
 paths = (
 {
 closed = 1;
@@ -191,7 +191,7 @@ nodes = (
 width = 400;
 },
 {
-layerId = medium-72pt;
+layerId = "medium-72pt";
 paths = (
 {
 closed = 1;

--- a/resources/testdata/glyphs3/WghtVar_AxisLocation.glyphs
+++ b/resources/testdata/glyphs3/WghtVar_AxisLocation.glyphs
@@ -1,5 +1,5 @@
 {
-.appVersion = "3148";
+.appVersion = "3414";
 .formatVersion = 3;
 axes = (
 {
@@ -10,9 +10,9 @@ tag = wght;
 familyName = WghtVar;
 fontMaster = (
 {
-axesValues = (0);
-id = m01;
-name = Regular;
+axesValues = (
+0
+);
 customParameters = (
 {
 name = "Axis Location";
@@ -24,12 +24,13 @@ Location = 400;
 );
 }
 );
+id = m01;
+name = Regular;
 },
 {
-axesValues = (8);
-iconName = Medium;
-id = "medium-master";
-name = Medium;
+axesValues = (
+8
+);
 customParameters = (
 {
 name = "Axis Location";
@@ -41,12 +42,14 @@ Location = 500;
 );
 }
 );
+iconName = Medium;
+id = "medium-master";
+name = Medium;
 },
 {
-axesValues = (10);
-iconName = Bold;
-id = "bold-master";
-name = Bold;
+axesValues = (
+10
+);
 customParameters = (
 {
 name = "Axis Location";
@@ -58,6 +61,9 @@ Location = 700;
 );
 }
 );
+iconName = Bold;
+id = "bold-master";
+name = Bold;
 }
 );
 glyphs = (


### PR DESCRIPTION
... using a more recent .appVersion to workaround this bug:

https://github.com/googlefonts/glyphsLib/issues/993#issuecomment-2962404528

I need this for #1528 but would like to reduce the diff noise there

JMM