### PR TITLE
[crater] Cleaner format for showing targets

### DIFF
--- a/fontc_crater/src/target.rs
+++ b/fontc_crater/src/target.rs
@@ -15,7 +15,7 @@ pub(crate) struct Target {
     /// path to the source dir for this target (relative to the git cache root)
     source_dir: PathBuf,
     /// Filename of config file, in the source directory.
-    config: Option<PathBuf>,
+    pub(crate) config: Option<PathBuf>,
     /// Path to source file, relative to the source_dir
     source: PathBuf,
     pub(crate) build: BuildType,


### PR DESCRIPTION
- Instead of showing the path to the target file, just show the filename
- Show the config file for gftools builds if it is not named 'config'


This is a minor tweak, so the main page now looks like:

<img width="1055" alt="Screenshot 2025-06-12 at 3 39 41 PM" src="https://github.com/user-attachments/assets/2051ce99-d334-48c2-8c88-ff7a4e291bd7" />


I'm working on updating the repro command to include the commit but it's more annoying than expected because how we store the information about what target we're running against is an accumulation of hacks, and does not itself include the SHA.