### PR TITLE
Handle git revs in crater/ttx_diff

### DIFF
--- a/fontc_crater/src/ci.rs
+++ b/fontc_crater/src/ci.rs
@@ -271,9 +271,12 @@ fn make_targets(cache_dir: &Path, repos: &[FontSource]) -> ResolvedTargets {
             let src_path = src_path
                 .strip_prefix(cache_dir)
                 .expect("source is always in cache dir");
-            result
-                .targets
-                .extend(targets_for_source(src_path, relative_config_path, &config))
+            result.targets.extend(targets_for_source(
+                repo,
+                src_path,
+                relative_config_path,
+                &config,
+            ))
         }
     }
 
@@ -296,13 +299,16 @@ fn preflight_all_repos(cache_dir: &Path, sources: &[FontSource]) {
 }
 
 fn targets_for_source(
+    source: &FontSource,
     src_path: &Path,
     config_path: &Path,
     config: &Config,
 ) -> impl Iterator<Item = Target> {
+    let sha = source.git_rev();
     let default = Some(Target::new(
         src_path.to_owned(),
         config_path.to_owned(),
+        sha.to_owned(),
         BuildType::Default,
     ));
 
@@ -310,6 +316,7 @@ fn targets_for_source(
         Target::new(
             src_path.to_owned(),
             config_path.to_owned(),
+            sha.to_owned(),
             BuildType::GfTools,
         )
     });

--- a/resources/scripts/ttx_diff.py
+++ b/resources/scripts/ttx_diff.py
@@ -1149,6 +1149,7 @@ def resolve_source(source: str) -> Path:
         repo_path = source_url.fragment
         org_name = source_url.path.split("/")[-2]
         repo_name = source_url.path.split("/")[-1]
+        sha = source_url.query
         local_repo = (
             Path.home() / ".fontc_crater_cache" / org_name / repo_name
         ).resolve()
@@ -1160,6 +1161,9 @@ def resolve_source(source: str) -> Path:
             subprocess.run(cmd, cwd=local_repo.parent, check=True)
         else:
             print(f"Reusing existing {local_repo}")
+
+        if len(sha) > 0:
+            log_and_run(("git", "checkout", sha), cwd=local_repo, check=True)
         source = local_repo / repo_path
     else:
         source = Path(source)


### PR DESCRIPTION
- when creating a reproduction command for ttx_diff, we will now pass the relevant SHA as a url query
- in a repro command for a target with a disambiguated checkout (i.e. that includes a _SHA suffix) we will strip that suffix from the command (but include the appropriate SHA as a query, above)
- in ttx_diff we will checkout the rev that is passed as a query.

annoyingly, this involved a change to the data representation of a 'target', which means that crater will act as if every result in the run that includes this change is new; after that one run everything should go back to normal.