### PR TITLE
Library cleanliness

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -130,8 +130,8 @@ jobs:
       - name: cargo check fontbe
         run: cargo check --manifest-path=fontbe/Cargo.toml --no-default-features
 
-      - name: cargo check fontc
-        run: cargo check --manifest-path=fontc/Cargo.toml --no-default-features
+      - name: cargo check fontc --lib
+        run: cargo check --manifest-path=fontc/Cargo.toml --no-default-features --lib
 
   check-ots:
     name: resources/scripts/ots_test.sh

--- a/fontc/Cargo.toml
+++ b/fontc/Cargo.toml
@@ -10,6 +10,13 @@ readme = "README.md"
 categories = ["text-processing", "parsing", "graphics"]
 default-run = "fontc"
 
+[[bin]]
+name = "fontc"
+path = "src/main.rs"
+
+[features]
+default = ["cli"]
+cli = ["clap"]
 
 [dependencies]
 fontdrasil = { version = "0.2.0", path = "../fontdrasil" }
@@ -35,11 +42,12 @@ indexmap.workspace = true
 regex.workspace = true
 
 write-fonts.workspace = true
-clap.workspace = true
 rayon.workspace = true
 
 # just for fontc!
 crossbeam-channel = "0.5.6"
+
+clap = { workspace = true, optional = true }
 
 [dev-dependencies]
 diff.workspace = true

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -81,12 +81,7 @@ pub fn run(args: Args, mut timer: JobTimer) -> Result<(), Error> {
     )?;
     timer.add(time.complete());
 
-    let workload = Workload::new(
-        args.source(),
-        args.input_binary.as_ref(),
-        JobTimer::default(),
-        args.skip_features,
-    )?;
+    let workload = Workload::new(args.source(), None, JobTimer::default(), args.skip_features)?;
 
     let fe_root = FeContext::new_root(args.flags(), ir_paths);
     let be_root = BeContext::new_root(args.flags(), be_paths, &fe_root);
@@ -334,13 +329,8 @@ mod tests {
                 raw_font: Vec::new(),
             };
 
-            let mut workload = Workload::new(
-                args.source(),
-                args.input_binary.as_ref(),
-                timer,
-                args.skip_features,
-            )
-            .unwrap();
+            let mut workload =
+                Workload::new(args.source(), None, timer, args.skip_features).unwrap();
             let completed = workload.run_for_test(&result.fe_context, &result.be_context);
 
             result.work_executed = completed;

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -33,6 +33,10 @@ use fontir::paths::Paths as IrPaths;
 
 use log::debug;
 
+/// The input source for the font compiler.
+///
+/// This allows us to load a font source in a variety of formats, and also
+/// from a variety of sources (on disk or in memory).
 pub enum Input {
     DesignSpacePath(PathBuf),
     GlyphsPath(PathBuf),
@@ -83,10 +87,10 @@ impl TryFrom<&Path> for Input {
     }
 }
 
-#[cfg(feature = "cli")]
 /// Run the compiler with the provided arguments
 ///
 /// This is the main entry point for the fontc command line utility.
+#[cfg(feature = "cli")]
 pub fn run(args: Args, timer: JobTimer) -> Result<(), Error> {
     let source = args.source()?;
     let (be_root, mut timing) = _generate_font(

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -104,7 +104,7 @@ pub fn run(args: Args, mut timer: JobTimer) -> Result<(), Error> {
     write_font_file(&args, &be_root)
 }
 
-/// Run and return a binary
+/// Run and return an OpenType font
 ///
 /// This is the library entry point to fontc.
 pub fn generate_binary(args: Args) -> Result<Vec<u8>, Error> {

--- a/fontc/src/timing.rs
+++ b/fontc/src/timing.rs
@@ -11,6 +11,8 @@ use dummy_instant::Instant;
 #[cfg(not(target_family = "wasm"))]
 use std::time::Instant;
 
+/// WASM does not have access to the system time, so we use a dummy
+/// implementation of `Instant` and `Duration` that does nothing.
 #[cfg(target_family = "wasm")]
 mod dummy_instant {
     use std::ops::Sub;

--- a/fontc/src/workload.rs
+++ b/fontc/src/workload.rs
@@ -51,7 +51,7 @@ use log::{debug, trace, warn};
 
 use crate::{
     create_in_memory_source, create_source,
-    timing::{JobTime, JobTimer},
+    timing::{Clock, JobTime, JobTimer},
     work::{AnyAccess, AnyContext, AnyWork},
     Error, InMemorySource,
 };
@@ -121,7 +121,7 @@ impl Workload {
     pub fn new(
         source: &Path,
         input_binary: Option<&InMemorySource>,
-        mut timer: JobTimer,
+        mut timer: JobTimer<C>,
         skip_features: bool,
     ) -> Result<Self, Error> {
         let time = timer
@@ -580,7 +580,7 @@ impl Workload {
 
             // To avoid allocation every poll for work
             let mut launchable = Vec::with_capacity(512.min(self.job_count));
-            let mut successes = Vec::with_capacity(64);
+            let mut successes: Vec<(AnyWorkId, JobTime)> = Vec::with_capacity(64);
             let mut nth_wave = 0;
 
             while self.success.len() < self.job_count {

--- a/fontir/Cargo.toml
+++ b/fontir/Cargo.toml
@@ -34,8 +34,13 @@ smol_str.workspace = true
 
 [target.'cfg(not(platform_family = "wasm"))'.dependencies]
 parking_lot.workspace = true
+# From parking_lot README: "parking_lot will work mostly fine on stable...
+# Just make sure not to enable -C target-feature=+atomics on stable as that
+# will allow wasm to run with multiple threads." But we need multiple threads
+# for rayon, and we need atomics too. Also from the README: "The
+# wasm32-unknown-unknown target is only fully supported on nightly."
 [target.'cfg(platform_family = "wasm")'.dependencies]
-parking_lot = { version = "0.12.3", features=["nightly"] }
+parking_lot = { version = "0.12.3", features = ["nightly"] }
 
 [dev-dependencies]
 diff.workspace = true

--- a/fontir/Cargo.toml
+++ b/fontir/Cargo.toml
@@ -32,14 +32,14 @@ write-fonts.workspace = true  # for pens
 chrono.workspace = true
 smol_str.workspace = true
 
-[target.'cfg(not(platform_family = "wasm"))'.dependencies]
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
 parking_lot.workspace = true
 # From parking_lot README: "parking_lot will work mostly fine on stable...
 # Just make sure not to enable -C target-feature=+atomics on stable as that
 # will allow wasm to run with multiple threads." But we need multiple threads
 # for rayon, and we need atomics too. Also from the README: "The
 # wasm32-unknown-unknown target is only fully supported on nightly."
-[target.'cfg(platform_family = "wasm")'.dependencies]
+[target.'cfg(target_family="wasm")'.dependencies]
 parking_lot = { version = "0.12.3", features = ["nightly"] }
 
 [dev-dependencies]

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -862,9 +862,9 @@ impl Work<Context, WorkId, Error> for FeatureWork {
             &font.features,
             self.font_file_path.as_ref().map(|path| {
                 path.canonicalize()
-                    .unwrap()
+                    .expect("path cannot be canonicalized")
                     .parent()
-                    .unwrap() // the path must be in a directory
+                    .expect("the path must be in a directory")
                     .to_path_buf()
             }),
         )?);


### PR DESCRIPTION
Following Rod's comments on #1478, this cleans up the library interface to fontc by:

* Reducing WASM cfg ifdefs by choosing once between real and fake clocks for timing
* Separating out CLI-specific functions such argument parsing and moving the Clap dependency to the binary
* Merging "on disk" and "in memory" sources into a single `Input` type
* Sharing common code between the library and binary entry points

The clocks stuff turned out to be a little gnarly because of the use of `Instant` in the timing structs. I broke it down into fairly small atomic commits for ease of reviewing.