### PR TITLE
[glyphs] Match glyphsLib for component anchor propagation

### DIFF
--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -2993,20 +2993,26 @@ impl Font {
         if font.custom_parameters.propagate_anchors.unwrap_or(true) {
             font.propagate_all_anchors();
         }
+
+        // ensure that glyphs with components that have bracket layers
+        // also have bracket layers.
+        font.align_bracket_layers();
+
         Ok(font)
     }
 
     pub fn load(glyphs_file: &path::Path) -> Result<Font, Error> {
         let mut font = Self::load_raw(glyphs_file)?;
 
-        // ensure that glyphs with components that have bracket layers
-        // also have bracket layers.
-        font.align_bracket_layers();
-
         // propagate anchors by default unless explicitly set to false
         if font.custom_parameters.propagate_anchors.unwrap_or(true) {
             font.propagate_all_anchors();
         }
+
+        // ensure that glyphs with components that have bracket layers
+        // also have bracket layers.
+        font.align_bracket_layers();
+
         Ok(font)
     }
 


### PR DESCRIPTION
I think glyphsLib is wrong on this count but it will be useful to match for the time being, and then we can easily revert this if we decide to change glyphsLib.

See https://github.com/googlefonts/glyphsLib/issues/1090