### PR TITLE
bump fontc and other crates in preparation for 0.3.0 release

### DIFF
--- a/fea-rs/Cargo.toml
+++ b/fea-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fea-rs"
-version = "0.20.0"
+version = "0.20.1"
 license = "MIT/Apache-2.0"
 authors = ["Colin Rofls <colin@cmyr.net>"]
 description = "Tools for working with Adobe OpenType Feature files."
@@ -12,7 +12,7 @@ edition = "2021"
 exclude = ["test-data"]
 
 [dependencies]
-fontdrasil = { version = "0.2.0", path = "../fontdrasil" }
+fontdrasil = { version = "0.2.1", path = "../fontdrasil" }
 ansi_term = "0.12.1"
 serde_json = {version = "1.0.87", optional = true }
 

--- a/fontbe/Cargo.toml
+++ b/fontbe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fontbe"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "the backend for fontc, a font compiler."
@@ -11,9 +11,9 @@ categories = ["text-processing", "parsing", "graphics"]
 [features]
 
 [dependencies]
-fontdrasil = { version = "0.2.0", path = "../fontdrasil" }
-fontir = { version = "0.2.0", path = "../fontir" }
-fea-rs = { version = "0.20.0", path = "../fea-rs", features = ["serde"] }
+fontdrasil = { version = "0.2.1", path = "../fontdrasil" }
+fontir = { version = "0.2.1", path = "../fontir" }
+fea-rs = { version = "0.20.1", path = "../fea-rs", features = ["serde"] }
 tinystr = {version = "0.8.0", features = ["serde"] }
 
 icu_properties.workspace = true

--- a/fontc/Cargo.toml
+++ b/fontc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fontc"
-version = "0.2.0"
+version = "0.3.0"
 build = "build.rs"
 edition = "2021"
 license = "MIT/Apache-2.0"
@@ -20,12 +20,12 @@ default = ["cli"]
 cli = ["clap"]
 
 [dependencies]
-fontdrasil = { version = "0.2.0", path = "../fontdrasil" }
-fontbe = { version = "0.2.0", path = "../fontbe" }
-fontir = { version = "0.2.0", path = "../fontir" }
-glyphs2fontir = { version = "0.2.0", path = "../glyphs2fontir" }
-fontra2fontir = { version = "0.2.0", path = "../fontra2fontir" }
-ufo2fontir = { version = "0.2.0", path = "../ufo2fontir" }
+fontdrasil = { version = "0.2.1", path = "../fontdrasil" }
+fontbe = { version = "0.2.1", path = "../fontbe" }
+fontir = { version = "0.2.1", path = "../fontir" }
+glyphs2fontir = { version = "0.2.1", path = "../glyphs2fontir" }
+fontra2fontir = { version = "0.2.1", path = "../fontra2fontir" }
+ufo2fontir = { version = "0.2.1", path = "../ufo2fontir" }
 
 bitflags.workspace = true
 bincode.workspace = true

--- a/fontc_crater/Cargo.toml
+++ b/fontc_crater/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/googlefonts/fontc"
 readme = "README.md"
 
 [dependencies]
-fontc = { version = "0.2.0", path = "../fontc" }
+fontc = { version = "0.3.0", path = "../fontc" }
 
 google-fonts-sources = "0.9.0"
 maud = "0.27.0"

--- a/fontdrasil/Cargo.toml
+++ b/fontdrasil/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fontdrasil"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Common types and utilites used by fontc, a font compiler."

--- a/fontir/Cargo.toml
+++ b/fontir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fontir"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Intermediate Representation used by fontc, a font compiler."
@@ -11,7 +11,7 @@ categories = ["text-processing", "parsing", "graphics"]
 [features]
 
 [dependencies]
-fontdrasil = { version = "0.2.0", path = "../fontdrasil" }
+fontdrasil = { version = "0.2.1", path = "../fontdrasil" }
 
 bitflags.workspace = true
 serde.workspace = true

--- a/fontra2fontir/Cargo.toml
+++ b/fontra2fontir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fontra2fontir"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Converts fontra.xyz/ files to font ir for compilation."
@@ -11,8 +11,8 @@ categories = ["text-processing", "parsing", "graphics"]
 [features]
 
 [dependencies]
-fontdrasil = { version = "0.2.0", path = "../fontdrasil" }
-fontir = { version = "0.2.0", path = "../fontir" }
+fontdrasil = { version = "0.2.1", path = "../fontdrasil" }
+fontir = { version = "0.2.1", path = "../fontir" }
 
 write-fonts.workspace = true
 

--- a/glyphs-reader/Cargo.toml
+++ b/glyphs-reader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glyphs-reader"
-version = "0.2.0"
+version = "0.2.1"
 license = "MIT/Apache-2.0"
 authors = ["Raph Levien <raph.levien@gmail.com>"]
 repository = "https://github.com/googlefonts/fontc"
@@ -13,7 +13,7 @@ readme = "README.md"
 
 [dependencies]
 ascii_plist_derive = { version = "0.1.0", path = "ascii_plist_derive" }
-fontdrasil = { version = "0.2.0", path = "../fontdrasil" }
+fontdrasil = { version = "0.2.1", path = "../fontdrasil" }
 quick-xml = "0.37"
 ordered-float.workspace = true
 kurbo.workspace = true

--- a/glyphs2fontir/Cargo.toml
+++ b/glyphs2fontir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glyphs2fontir"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Converts www.glyphsapp.com files to font ir for compilation."
@@ -11,9 +11,9 @@ categories = ["text-processing", "parsing", "graphics"]
 [features]
 
 [dependencies]
-fontdrasil = { version = "0.2.0", path = "../fontdrasil" }
-fontir = { version = "0.2.0", path = "../fontir" }
-glyphs-reader = { version = "0.2.0", path = "../glyphs-reader" }
+fontdrasil = { version = "0.2.1", path = "../fontdrasil" }
+fontir = { version = "0.2.1", path = "../fontir" }
+glyphs-reader = { version = "0.2.1", path = "../glyphs-reader" }
 
 smol_str.workspace = true
 log.workspace = true

--- a/otl-normalizer/Cargo.toml
+++ b/otl-normalizer/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 
 
 [dependencies]
-fontdrasil = { version = "0.2.0", path = "../fontdrasil" }
+fontdrasil = { version = "0.2.1", path = "../fontdrasil" }
 clap.workspace = true
 thiserror.workspace = true
 smol_str.workspace = true
@@ -17,5 +17,5 @@ write-fonts.workspace = true
 indexmap.workspace = true
 
 [dev-dependencies]
-fea-rs = { version = "0.20.0", path = "../fea-rs" }
+fea-rs = { version = "0.20.1", path = "../fea-rs" }
 

--- a/ufo2fontir/Cargo.toml
+++ b/ufo2fontir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ufo2fontir"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Converts UFO or UFO+designspace to font ir for compilation."
@@ -11,8 +11,8 @@ categories = ["text-processing", "parsing", "graphics"]
 [features]
 
 [dependencies]
-fontdrasil = { version = "0.2.0", path = "../fontdrasil" }
-fontir = { version = "0.2.0", path = "../fontir" }
+fontdrasil = { version = "0.2.1", path = "../fontdrasil" }
+fontir = { version = "0.2.1", path = "../fontir" }
 
 kurbo.workspace = true
 serde.workspace = true


### PR DESCRIPTION
```
     Changes for fontdrasil from fontdrasil-v0.2.0 to 0.2.1
             e789909 Simplify the debug repr of Coords
             2ff7939 [clippy] Push the rock back up the hill
             851376e [fontdrasil/ufo2fontir] Prefer axis (English) `<labelname>` over axis.name like fonttools does
     Changes for fea-rs from fea-rs-v0.20.0 to 0.20.1
             2ff7939 [clippy] Push the rock back up the hill
             c3896ea [fea] Handle nested contextual lookups in aalt
             e7e9494 [fea-rs] Account for promoted rules in aalt
             0c74763 [fea-rs] Check lookupflags before promoting mixed rules
             e18b0ee [fea-rs] Mask out high byte of lookupflag literals
             a455043 [fea-rs] Allow featureNames and cvParams in GPOS
             da49909 fix up all occurrences of Axis with empty localized_names map
             1acd3a1 [fea-rs] Use correct magic number in head table
     Changes for fontir from fontir-v0.2.0 to 0.2.1
             2ff7939 [clippy] Push the rock back up the hill
             e501254 Whoa, spelled that wrong
             31a26fa Document use of parking_lot nightly
             5ad057f [glyphs] Prune default axes if unused
             08e8d2d Use nightly features on wasm
             ea0301f only allow default named instance to reuse nameID 2/17, use >= 256 for anything else
             0d356ba [glyphs] Expand kerning to bracket glyphs
             7aed8cb [fontir] GlyphOrder Eq should consider... order
             863a86a New variation model test exhibiting computation of a final value
             da49909 fix up all occurrences of Axis with empty localized_names map
             2787252 Fixup a bug in overlay_feature_variations
             fe12f70 Ensure normalized coords are clamped during overlay
             14a84e1 [glyphs] Add another bracket layer test case
             0aaf96f [glyphs] More preciesly match glyphsLib bracket logic
             6e8f9b5 Move some feature variations logic to fontir
             ee54fd0 Decompose no-export glyphs earlier
             5b33415 Improve flattening nested no-export components
     Changes for fontbe from fontbe-v0.2.0 to 0.2.1
             2ff7939 [clippy] Push the rock back up the hill
             08e8d2d Use nightly features on wasm
             dfde807 [fontbe] Remove workaround for stale ICU data
             ea0301f only allow default named instance to reuse nameID 2/17, use >= 256 for anything else
             596bb0f Fix typos in Bhaiksuki and N'ko script tags, as in ufo2ft
             da49909 fix up all occurrences of Axis with empty localized_names map
             f432450 [fontbe] Clean up old timing code
             14a84e1 [glyphs] Add another bracket layer test case
             0aaf96f [glyphs] More preciesly match glyphsLib bracket logic
             6e8f9b5 Move some feature variations logic to fontir
     Changes for glyphs-reader from glyphs-reader-v0.2.0 to 0.2.1
             c02dd01 [glyphs] Handle custom 'weightClass' param on instances
             2ff7939 [clippy] Push the rock back up the hill
             855b790 [glyphs] Fix bug in anchor propagation
             898cbdb [glyphs] Add Conjunct Subcategory
             8b1faec [glyphs] Add a few more glyph subcategories
             508cfad [glyphs] Match glyphsLib for component anchor propagation
             2954153 Allow loading Glyphs files from in-memory string
             bda531f [glyphs] Propagate anchors to bracket layers
             8312735 [glyphs] Track layers using ids during propagation
             2a16b75 Update glyphsLib link
             c513224 Convert Glyphs v2 postscriptFontName custom parameter to v3 property
             d43ba06 Use also postscriptFontName for fvar instances
             456dbac [glyphs-reader] support Axis Location custom param from instances
             9248296 [glyphs-reader] allow axis mappings to define duplicate output values
             bf4ba87 add duplicate value to Axis Mappings test to expose bug
             f9ed87d [glyphs] Propagate component bracket layers
     Changes for glyphs2fontir from glyphs2fontir-v0.2.0 to 0.2.1
             2ff7939 [clippy] Push the rock back up the hill
             9779bac Banish a couple of unwraps
             5ad057f [glyphs] Prune default axes if unused
             d6964ee [glyphs] Compute GDEF categories for bracket glyphs
             2954153 Allow loading Glyphs files from in-memory string
             a0d13cc Accept 'meta Table' custom parameter from multiple places
             456dbac [glyphs-reader] support Axis Location custom param from instances
             bf4ba87 add duplicate value to Axis Mappings test to expose bug
             1442f38 [glyphs] Support include statements in glyphs sources
             e2e9c8c Revert "Determine GDEF categories for bracket glyphs too"
             8c5c071 [glyphs] Process bracket rules in glyph-order-order
             fac3327 [glyphs] Use axis defaults when generating ConditionSet
             0d356ba [glyphs] Expand kerning to bracket glyphs
             cd27297 Revert "[glyphs] Use axis defaults when generating ConditionSet"
             23a03ea [glyphs] Use axis defaults when generating ConditionSet
             e44b0e5 [glyphs] Add bracket glyphs in lexicographic order
             f9ed87d [glyphs] Propagate component bracket layers
             72b7ff8 Test that bracket glyphs have the same category as their originator
             7b1e18b Determine GDEF categories for bracket glyphs too
             8c34ba4 remove TODO
             da49909 fix up all occurrences of Axis with empty localized_names map
             14a84e1 [glyphs] Add another bracket layer test case
             0aaf96f [glyphs] More preciesly match glyphsLib bracket logic
             4f84d04 [glyphs] Feature variations go under rvrn by default
     Changes for fontra2fontir from fontra2fontir-v0.2.0 to 0.2.1
             2ff7939 [clippy] Push the rock back up the hill
             da49909 fix up all occurrences of Axis with empty localized_names map
     Changes for ufo2fontir from ufo2fontir-v0.2.0 to 0.2.1
             2ff7939 [clippy] Push the rock back up the hill
             fb4e98d [ufo2fontir] keep nice glyph names when no public.postscriptNames was provided
             851376e [fontdrasil/ufo2fontir] Prefer axis (English) `<labelname>` over axis.name like fonttools does
     Changes for fontc from fontc-v0.2.0 to 0.3.0
             9ee3fb3 Fix broken build with --no-default-features
             2ff7939 [clippy] Push the rock back up the hill
             304e1b0 Add doc comment
             f1cc7b9 Address other feedback
             3b74e67 Tidy library interface, make main’s run function and the lib entry point use shared code
             54a02b6 Use an Input enum to specify source, and drop input_binary
             0c876de Pass either a real or a fake clock to workload
             3c5dc62 emit_debug and emit_ir are in the flags, so use the flags
             fedf88b Push Args further out, gate behind cli feature
             1a085e1 Ordinary users do not input a binary
             597bffc Pull Args up out of workload
             320047f Clarify lib function doc
             d6964ee [glyphs] Compute GDEF categories for bracket glyphs
             f1644eb Ifdef out some timing stuff
             22c6fbc Don't use explicit thread pool on wasm
             facf3c7 Front-end API for in-memory compilation
             a4d202c Support in-memory source as an Args option
             c513224 Convert Glyphs v2 postscriptFontName custom parameter to v3 property
             d43ba06 Use also postscriptFontName for fvar instances
             1442f38 [glyphs] Support include statements in glyphs sources
             ea0301f only allow default named instance to reuse nameID 2/17, use >= 256 for anything else
             4665e66 add designspace with axis english <labelname> != axis.name
             38b6739 Make JobTime an enum
             4f8ce82 Simplify timing
             4f84d04 [glyphs] Feature variations go under rvrn by default
             5b33415 Improve flattening nested no-export components
```