### PR TITLE
ttx_diff: exclude query from the git clone url

### DIFF
--- a/resources/scripts/ttx_diff.py
+++ b/resources/scripts/ttx_diff.py
@@ -1163,7 +1163,7 @@ def resolve_source(source: str) -> Path:
         if not local_repo.parent.is_dir():
             local_repo.parent.mkdir(parents=True)
         if not local_repo.is_dir():
-            cmd = ("git", "clone", source_url._replace(fragment="").geturl())
+            cmd = ("git", "clone", source_url._replace(fragment="", query="").geturl())
             print("Running", " ".join(cmd), "in", local_repo.parent)
             subprocess.run(cmd, cwd=local_repo.parent, check=True)
         else:


### PR DESCRIPTION
If I copy and run one of fontc_crater's reproducer commands I get the following error when the url contains a query (? followed by the commit sha):

```
$ python resources/scripts/ttx_diff.py 'https://github.com/JulietaUla/Montserrat?cc8daf2e70#sources/Montserrat-Italic.glyphs'
https://github.com/JulietaUla/Montserrat?cc8daf2e70#sources/Montserrat-Italic.glyphs
Running git clone https://github.com/JulietaUla/Montserrat?cc8daf2e70 in /Users/clupo/.fontc_crater_cache/JulietaUla
Cloning into 'Montserrat?cc8daf2e70'...
fatal: https://github.com/JulietaUla/Montserrat?cc8daf2e70/info/refs not valid: is this a git repository?
Traceback (most recent call last):
  File "/Users/clupo/oss/fontc/resources/scripts/ttx_diff.py", line 1320, in <module>
    app.run(main)
    ~~~~~~~^^^^^^
  File "/Users/clupo/oss/fontc/.venv313/lib/python3.13/site-packages/absl/app.py", line 316, in run
    _run_main(main, args)
    ~~~~~~~~~^^^^^^^^^^^^
  File "/Users/clupo/oss/fontc/.venv313/lib/python3.13/site-packages/absl/app.py", line 261, in _run_main
    sys.exit(main(argv))
             ~~~~^^^^^^
  File "/Users/clupo/oss/fontc/resources/scripts/ttx_diff.py", line 1240, in main
    source = resolve_source(argv[1]).resolve()
             ~~~~~~~~~~~~~~^^^^^^^^^
  File "/Users/clupo/oss/fontc/resources/scripts/ttx_diff.py", line 1169, in resolve_source
    subprocess.run(cmd, cwd=local_repo.parent, check=True)
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.13/3.13.0_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/subprocess.py", line 577, in run
    raise CalledProcessError(retcode, process.args,
                             output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '('git', 'clone', 'https://github.com/JulietaUla/Montserrat?cc8daf2e70')' returned non-zero exit status 128.
```

This seems to fix it for me