### PR TITLE
fix non-determinism in FeatureParamsCharacterVariants nameIDs

### DIFF
--- a/fea-rs/src/compile/features.rs
+++ b/fea-rs/src/compile/features.rs
@@ -32,7 +32,7 @@ pub(crate) struct AllFeatures {
     pub(crate) size: Option<SizeFeature>,
     pub(crate) aalt: Option<AaltFeature>,
     pub(crate) stylistic_sets: BTreeMap<Tag, Vec<NameSpec>>,
-    pub(crate) character_variants: HashMap<Tag, CvParams>,
+    pub(crate) character_variants: BTreeMap<Tag, CvParams>,
 }
 
 /// Tracking state within a feature block


### PR DESCRIPTION
Part of fixing #1568

We were iterating over HashMap's items while incrementally assigning new nameIDs for the Feature Parameters Character Variants, but the iteration order changes each time, so best to use a BTreeMap in this case

https://github.com/googlefonts/fontc/blob/00c61129fee5f42b1d9a92633429fed3404e28f5/fea-rs/src/compile/features.rs#L256-L259

After applying this patch, running the following command multiple times produces the same GSUB table:

```
python3 resources/scripts/ttx_diff.py 'https://github.com/calcom/font?b833fb1129#sources/Cal-Sans.glyphs'
```

JMM