### PR TITLE
[normalizer] Normalize cursive pos

### DIFF
--- a/otl-normalizer/src/gpos/cursive.rs
+++ b/otl-normalizer/src/gpos/cursive.rs
@@ -1,0 +1,75 @@
+use std::collections::HashSet;
+
+use write_fonts::read::{tables::gpos::CursivePosFormat1, ReadError};
+
+use crate::{
+    common::PrintNames,
+    gpos::{GlyphId16, ResolvedAnchor},
+    variations::DeltaComputer,
+};
+
+#[derive(Clone, Debug)]
+pub(crate) struct CursivePosRule {
+    pub glyph: GlyphId16,
+    entry: Option<ResolvedAnchor>,
+    exit: Option<ResolvedAnchor>,
+}
+
+impl PrintNames for CursivePosRule {
+    fn fmt_names(
+        &self,
+        f: &mut std::fmt::Formatter<'_>,
+        names: &crate::NameMap,
+    ) -> std::fmt::Result {
+        let name = names.get(self.glyph);
+        writeln!(f, "{name}")?;
+        write!(f, "  entry: ")?;
+        match self.entry.as_ref() {
+            Some(anchor) => writeln!(f, "{anchor}"),
+            None => writeln!(f, "<NULL>"),
+        }?;
+        write!(f, "  exit: ")?;
+        match self.exit.as_ref() {
+            Some(anchor) => write!(f, "{anchor}"),
+            None => write!(f, "<NULL>"),
+        }
+    }
+}
+
+pub(super) fn get_cursive_rules(
+    subtables: &[CursivePosFormat1],
+    delta_computer: Option<&DeltaComputer>,
+) -> Result<Vec<CursivePosRule>, ReadError> {
+    let mut seen = HashSet::new();
+    let mut result = Vec::new();
+
+    for sub in subtables {
+        let coverage = sub.coverage().unwrap();
+        let entry_exits = sub.entry_exit_record();
+        let data = sub.offset_data();
+        for (gid, entry_exit) in coverage.iter().zip(entry_exits) {
+            if !seen.insert(gid) {
+                continue;
+            }
+
+            let entry = entry_exit
+                .entry_anchor(data)
+                .transpose()?
+                .map(|a| ResolvedAnchor::new(&a, delta_computer))
+                .transpose()?;
+            let exit = entry_exit
+                .exit_anchor(data)
+                .transpose()?
+                .map(|a| ResolvedAnchor::new(&a, delta_computer))
+                .transpose()?;
+
+            result.push(CursivePosRule {
+                glyph: gid,
+                entry,
+                exit,
+            });
+        }
+    }
+
+    Ok(result)
+}

--- a/resources/scripts/ttx_diff.py
+++ b/resources/scripts/ttx_diff.py
@@ -702,10 +702,10 @@ def sort_gdef_mark_filter_sets(ttx: etree.ElementTree):
     etree.indent(markglyphs, level=3)
 
 
-LOOKUPS_TO_SKIP = set([2, 4, 5, 6])  # pairpos, markbase, marklig, markmark
+LOOKUPS_TO_SKIP = set([2, 3, 4, 5, 6])  # pairpos, cursive, markbase, marklig, markmark
 
 
-def remove_mark_and_kern_lookups(ttx):
+def remove_mark_and_kern_and_curs_lookups(ttx):
     gpos = ttx.find("GPOS")
     if gpos is None:
         return
@@ -940,7 +940,7 @@ def reduce_diff_noise(fontc: etree.ElementTree, fontmake: etree.ElementTree):
         erase_checksum(ttx)
 
         stat_like_fontmake(ttx)
-        remove_mark_and_kern_lookups(ttx)
+        remove_mark_and_kern_and_curs_lookups(ttx)
 
         point_orders = normalize_glyf_contours(ttx)
         normalize_gvar_contours(ttx, point_orders)


### PR DESCRIPTION
This is simple as there's only one subtable type and it reueses structures we already had from other work.

This does give us at least a +1, but it also has made clear that we have a bug in our cursive lookup generation, where it seems like we're handling RTL differently from fontmake.