### PR TITLE
Truncate axis location values like glyphsLib

### DIFF
--- a/resources/testdata/glyphs3/WghtVar_AxisLocationFloat.glyphs
+++ b/resources/testdata/glyphs3/WghtVar_AxisLocationFloat.glyphs
@@ -1,0 +1,44 @@
+{
+.appVersion = "3414";
+.formatVersion = 3;
+axes = (
+{
+name = Weight;
+tag = wght;
+}
+);
+familyName = WghtVar;
+fontMaster = (
+{
+axesValues = (
+0
+);
+customParameters = (
+{
+name = "Axis Location";
+value = (
+{
+Axis = Weight;
+Location = 400.75;
+}
+);
+}
+);
+id = m01;
+name = Regular;
+}
+);
+glyphs = (
+{
+glyphname = space;
+layers = (
+{
+layerId = m01;
+width = 200;
+}
+);
+unicode = 32;
+}
+);
+unitsPerEm = 1000;
+}


### PR DESCRIPTION
`python3 resources/scripts/ttx_diff.py 'https://github.com/usted/Albert-Sans?f7f4608223#sources/AlbertSans-Italic.glyphs' --compare gftools --config ~/.fontc_crater_cache/usted/Albert-Sans/sources/config.yaml` is identical with this change.

JMM.