### PR TITLE
[crater] Support annotations

### DIFF
--- a/fontc_crater/resources/style.css
+++ b/fontc_crater/resources/style.css
@@ -98,3 +98,40 @@ td.rev {
 .hidden_row {
   display: none;
 }
+
+/* Modal overlay - covers entire screen */
+.modal-overlay {
+  display: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 1000;
+}
+
+/* Modal content box */
+.modal {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: white;
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+  max-width: 800px;
+  width: 90%;
+  /*text-align: center;*/
+}
+
+.modal pre {
+  background: #ddd;
+}
+
+/* Show modal when active */
+.modal-overlay.show {
+  display: block;
+}
+


### PR DESCRIPTION
This allows users to add 'annotations' to targets, which can be used to explain known problems and link to issues.

Annotations are added by manually editing an `annotations.json` file stored alongside the output.

Annotations are maximally dumb: they are associated with a target and will be visible for as long as that target produces a diff, unless they are manually removed.


(This seems more and more useful as we get into the long tail, and is particularly motivated by the fact that I'm currently focused on investigating diffs and opening issues.)

annotations are displayed like:

<img width="953" height="235" alt="Screenshot 2025-08-11 at 2 48 33 PM" src="https://github.com/user-attachments/assets/bac5cbe3-74a1-43b4-8810-9434e413a670" />

and if no annotations exist, a little button will give you the following:

<img width="876" height="310" alt="Screenshot 2025-08-11 at 2 44 44 PM" src="https://github.com/user-attachments/assets/56fecafb-48f9-49df-a276-8df4e865ad9a" />
