### PR TITLE
[fontbe] Round component pts before generating deltas

### DIFF
--- a/fontbe/src/glyphs.rs
+++ b/fontbe/src/glyphs.rs
@@ -213,7 +213,7 @@ fn add_phantom_points(advance: u16, points: &mut Vec<Point>) {
     points.push(Point::new(0.0, 0.0));
 }
 
-/// See <https://github.com/fonttools/fonttools/blob/86291b6ef62ad4bdb48495a4b915a597a9652dcf/Lib/fontTools/ttLib/tables/_g_l_y_f.py#L369>
+/// See <https://github.com/fonttools/fonttools/blob/86291b6ef6/Lib/fontTools/ttLib/tables/_g_l_y_f.py#L369>
 fn point_seqs_for_simple_glyph(
     ir_glyph: &ir::Glyph,
     instances: HashMap<NormalizedLocation, SimpleGlyph>,
@@ -235,18 +235,21 @@ fn point_seqs_for_simple_glyph(
         .collect()
 }
 
-/// See <https://github.com/fonttools/fonttools/blob/86291b6ef62ad4bdb48495a4b915a597a9652dcf/Lib/fontTools/ttLib/tables/_g_l_y_f.py#L369>
+/// <https://github.com/fonttools/fonttools/blob/86291b6ef6/Lib/fontTools/ttLib/tables/_g_l_y_f.py#L369>
 fn point_seqs_for_composite_glyph(ir_glyph: &ir::Glyph) -> HashMap<NormalizedLocation, Vec<Point>> {
     ir_glyph
         .sources()
         .iter()
         .map(|(loc, inst)| {
             // We need 1 point per component for it's X/Y, plus phantoms
-            // See https://github.com/fonttools/fonttools/blob/1c283756a5e39d69459eea80ed12792adc4922dd/Lib/fontTools/ttLib/tables/_g_v_a_r.py#L243
+            // See https://github.com/fonttools/fonttools/blob/1c283756a5/Lib/fontTools/ttLib/tables/_g_v_a_r.py#L243
             let mut points = Vec::new();
             for component in inst.components.iter() {
                 let [.., dx, dy] = component.transform.as_coeffs();
-                points.push((dx, dy).into());
+                // ensure we round now, before iup or gvar generation:
+                // https://github.com/fonttools/fonttools/blob/5ae2943a43/Lib/fontTools/pens/ttGlyphPen.py#L110
+                let point = Point::new(dx.ot_round(), dy.ot_round());
+                points.push(point);
             }
             add_phantom_points(inst.width.ot_round(), &mut points);
 
@@ -264,7 +267,7 @@ fn compute_deltas(
     contour_ends: &Vec<usize>,
 ) -> Result<Deltas, Error> {
     // FontTools hard-codes 0.5
-    //https://github.com/fonttools/fonttools/blob/65bc6105f7aec3478427525d23ddf2e3c8c4b21e/Lib/fontTools/varLib/__init__.py#L239
+    //https://github.com/fonttools/fonttools/blob/65bc6105f7/Lib/fontTools/varLib/__init__.py#L239
     let tolerance = 0.5;
 
     // Contour (aka Simple) and Composite both need gvar

--- a/resources/testdata/glyphs3/ComponentPointRounding.glyphs
+++ b/resources/testdata/glyphs3/ComponentPointRounding.glyphs
@@ -1,0 +1,129 @@
+{
+.appVersion = "3343";
+.formatVersion = 3;
+axes = (
+{
+name = Weight;
+tag = wght;
+}
+);
+familyName = TestFont;
+fontMaster = (
+{
+axesValues = (
+400
+);
+id = "C7381861-8087-459F-9A66-D6EC096294DF";
+name = Regular;
+},
+{
+axesValues = (
+800
+);
+iconName = Bold;
+id = "80F95D5A-7464-498F-9BB9-FC89FE1B12C4";
+name = ExtraBold;
+}
+);
+glyphs = (
+{
+glyphname = Zecyr;
+layers = (
+{
+layerId = "80F95D5A-7464-498F-9BB9-FC89FE1B12C4";
+shapes = (
+{
+closed = 1;
+nodes = (
+(10,10,l),
+(70,10,l),
+(70,70,l),
+(10,70,l)
+);
+}
+);
+width = 578;
+},
+{
+layerId = "C7381861-8087-459F-9A66-D6EC096294DF";
+shapes = (
+{
+closed = 1;
+nodes = (
+(10,10,l),
+(50,10,l),
+(50,50,l),
+(10,50,l)
+);
+}
+);
+width = 578;
+}
+);
+unicode = 1047;
+},
+{
+glyphname = Reversedzecyr;
+layers = (
+{
+layerId = "80F95D5A-7464-498F-9BB9-FC89FE1B12C4";
+shapes = (
+{
+alignment = -1;
+pos = (576,0);
+ref = Zecyr;
+}
+);
+width = 578;
+},
+{
+layerId = "C7381861-8087-459F-9A66-D6EC096294DF";
+shapes = (
+{
+alignment = -1;
+pos = (572.5,0);
+ref = Zecyr;
+}
+);
+width = 578;
+}
+);
+unicode = 1296;
+}
+);
+instances = (
+{
+axesValues = (
+400
+);
+instanceInterpolations = {
+"C7381861-8087-459F-9A66-D6EC096294DF" = 1;
+};
+name = Regular;
+},
+{
+axesValues = (
+600
+);
+instanceInterpolations = {
+"80F95D5A-7464-498F-9BB9-FC89FE1B12C4" = 0.5;
+"C7381861-8087-459F-9A66-D6EC096294DF" = 0.5;
+};
+name = SemiBold;
+weightClass = 600;
+},
+{
+axesValues = (
+800
+);
+instanceInterpolations = {
+"80F95D5A-7464-498F-9BB9-FC89FE1B12C4" = 1;
+};
+name = ExtraBold;
+weightClass = 800;
+}
+);
+unitsPerEm = 1000;
+versionMajor = 2;
+versionMinor = 120;
+}


### PR DESCRIPTION
This matches fontmake (and also our own simple glyphs) where rounding occurs before the final variation data is generated.


gives us another +small identical.

JMM