### PR TITLE
[fea-rs] Better match fonttools handling of script stmt

### DIFF
--- a/fea-rs/src/compile/compile_ctx.rs
+++ b/fea-rs/src/compile/compile_ctx.rs
@@ -446,7 +446,17 @@ impl<'a, F: FeatureProvider, V: VariationInfo> CompilationCtx<'a, F, V> {
 
     fn set_script(&mut self, stmt: typed::Script) {
         let script = stmt.tag().to_raw();
-        if Some(script) == self.script {
+
+        // fonttools logic here is kind of particular, so let's match it literally
+        //https://github.com/fonttools/fonttools/blob/5ae2943a43/Lib/fontTools/feaLib/builder.py#L1239
+        if self
+            .active_feature
+            .as_ref()
+            .unwrap()
+            .current_system()
+            .map(|langsys| (langsys.script, langsys.language))
+            == Some((script, tags::LANG_DFLT))
+        {
             return;
         }
 

--- a/fea-rs/src/compile/features.rs
+++ b/fea-rs/src/compile/features.rs
@@ -347,6 +347,10 @@ impl ActiveFeature {
         }
     }
 
+    pub(crate) fn current_system(&self) -> Option<LanguageSystem> {
+        self.current_lang_sys
+    }
+
     /// Change the active language system.
     ///
     /// This method is called when encountering 'script' and 'language' statements

--- a/fea-rs/test-data/compile-tests/mini-latin/good/lookupflag_scope.fea
+++ b/fea-rs/test-data/compile-tests/mini-latin/good/lookupflag_scope.fea
@@ -1,0 +1,34 @@
+languagesystem DFLT dflt;
+languagesystem latn ENG;
+languagesystem latn NLD;
+
+feature test {
+    script latn;
+    language ENG;
+
+    lookupflag IgnoreMarks;
+    sub a by b;
+
+    # we need to clear the lookupflags when we encounter this statement.
+    script latn;
+    language NLD;
+    sub x by z;
+} test;
+
+
+feature derp {
+    lookup W {
+        lookupflag IgnoreMarks;
+        # this script statement clears the preceding IgnoreMarks flag.
+        script latn;
+        sub one by two;
+    } W;
+
+    lookup X {
+        lookupflag IgnoreMarks;
+        # but both fonttools and afdko ignore _this_ script statement,
+        # and this lookup ends up with IgnoreMarks set.
+        script latn;
+        sub three by four;
+    } X;
+} derp;

--- a/fea-rs/test-data/compile-tests/mini-latin/good/lookupflag_scope.ttx
+++ b/fea-rs/test-data/compile-tests/mini-latin/good/lookupflag_scope.ttx
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont>
+
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="latn"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=2 -->
+          <LangSysRecord index="0">
+            <LangSysTag value="ENG "/>
+            <LangSys>
+              <ReqFeatureIndex value="65535"/>
+              <!-- FeatureCount=1 -->
+              <FeatureIndex index="0" value="1"/>
+            </LangSys>
+          </LangSysRecord>
+          <LangSysRecord index="1">
+            <LangSysTag value="NLD "/>
+            <LangSys>
+              <ReqFeatureIndex value="65535"/>
+              <!-- FeatureCount=1 -->
+              <FeatureIndex index="0" value="2"/>
+            </LangSys>
+          </LangSysRecord>
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=3 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="derp"/>
+        <Feature>
+          <!-- LookupCount=2 -->
+          <LookupListIndex index="0" value="2"/>
+          <LookupListIndex index="1" value="3"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="1">
+        <FeatureTag value="test"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="2">
+        <FeatureTag value="test"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="1"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=4 -->
+      <Lookup index="0">
+        <LookupType value="1"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0">
+          <Substitution in="a" out="b"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="1">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0">
+          <Substitution in="x" out="z"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="2">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0">
+          <Substitution in="one" out="two"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="3">
+        <LookupType value="1"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0">
+          <Substitution in="three" out="four"/>
+        </SingleSubst>
+      </Lookup>
+    </LookupList>
+  </GSUB>
+
+</ttFont>


### PR DESCRIPTION
This is kind of interesting; I'm not really sure that fonttools is correct, but it matches afdko and this is a corner case that is unlikely to matter in a real source.

According to the spec, any lookupflags should be cleared whenever we encounter a script statement.

fonttools follows this, _unless_ the current language system is already (script, dflt), where 'script' is the script set by the new statement.

We _kind of_ matched this, previously, except that we did not take the language into account; we would skip clearing the flags if the new script was the same as the old one.

The fonttools logic here is definitely better. That said, the behaviour is unintuitive in some cases, for instance:

```fea
feature derp {
    lookup W {
        lookupflag IgnoreMarks;
        # this script statement clears the preceding IgnoreMarks flag.
        script latn;
        sub one by two;
    } W;

    lookup X {
        lookupflag IgnoreMarks;
        # but both fonttools and afdko ignore _this_ script statement,
        # and this lookup ends up with IgnoreMarks set.
        script latn;
        sub three by four;
    } X;
} derp;
```

Per the spec, it seems like _neither_ lookup should have `IgnoreMarks` set, but in practice both fonttools & afdko set it for the second lookup, so we will match that.