### PR TITLE
ttx_diff: use more specific xpath to select nameID=25

### DIFF
--- a/resources/scripts/ttx_diff.py
+++ b/resources/scripts/ttx_diff.py
@@ -610,7 +610,7 @@ def erase_type_from_stranded_points(ttx):
 
 # only fontc emits name 25 currently, don't treat that as an error
 def allow_fontc_only_variations_postscript_prefix(fontc, fontmake):
-    xpath_to_name_25 = "//namerecord[@nameID='25']"
+    xpath_to_name_25 = "/ttFont/name/namerecord[@nameID='25']"
     fontc_name25 = fontc.xpath(xpath_to_name_25)
     fontmake_name25 = fontmake.xpath(xpath_to_name_25)
     if fontc_name25 and not fontmake_name25:


### PR DESCRIPTION
I am not entirely sure why, but after #1590 running ttx_diff.py on Kablammo.glyphs gives a weird "lxml.etree.XPathEvalError: unknown error".  Notice the +2 in red under https://googlefonts.github.io/fontc_crater/#other-failures

Maybe the xml file is to big and the xpath expression too broad? i am not entirely sure. But making the xpath expression more selective and explicit seems to fix the error.

JMM