### PR TITLE
[glyphs-reader] Don't truncate Axis Location values as in latest glyphsLib

### DIFF
--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -631,11 +631,9 @@ impl PlistParamsExt for Plist {
         let plist = self.as_dict()?;
         let name = plist.get("Axis").and_then(Plist::as_str)?;
         let location = plist.get("Location").and_then(Plist::as_f64)?;
-        // trunc to match the int() call in Python
-        // <https://github.com/googlefonts/glyphsLib/blob/8caf679cfe4ea774d0d27088c89d382c5b6e0185/Lib/glyphsLib/builder/axes.py#L433-L443>
         Some(AxisLocation {
             axis_name: name.into(),
-            location: location.trunc().into(),
+            location: location.into(),
         })
     }
 
@@ -4689,14 +4687,14 @@ etc;
     }
 
     #[test]
-    fn truncates_axis_location() {
+    fn does_not_truncate_axis_location() {
         let font = Font::load(&glyphs3_dir().join("WghtVar_AxisLocationFloat.glyphs")).unwrap();
         let mapping = &font.axis_mappings.0.get("Weight").unwrap().0;
 
-        // The user location 400.75 was truncated
+        // The user location 400.75 must *NOT* be truncated
         assert_eq!(
             mapping.as_slice(),
-            &[(OrderedFloat(400f64), OrderedFloat(0f64)),]
+            &[(OrderedFloat(400.75), OrderedFloat(0f64)),]
         )
     }
 }


### PR DESCRIPTION
Reverts #1588

Requires https://github.com/googlefonts/glyphsLib/releases/tag/v6.11.5

JMM