### PR TITLE
[crater] Print per-target runtime

### DIFF
--- a/fontc_crater/src/ci.rs
+++ b/fontc_crater/src/ci.rs
@@ -7,12 +7,11 @@
 
 use std::{
     collections::{BTreeMap, HashSet},
-    fmt::Write,
     path::{Path, PathBuf},
     process::Command,
 };
 
-use chrono::{DateTime, TimeZone, Utc};
+use chrono::{DateTime, Utc};
 use google_fonts_sources::{Config, FontSource, SourceSet};
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use serde::de::DeserializeOwned;
@@ -154,7 +153,10 @@ fn run_crater_and_save_results(args: &CiArgs) -> Result<(), Error> {
         .collect();
     let finished = Utc::now();
 
-    let elapsed = format_elapsed_time(&began, &finished);
+    let elapsed = finished.signed_duration_since(began);
+    let elapsed = elapsed.to_std().unwrap_or_default();
+    let elapsed = super::human_readable_duration(elapsed);
+
     log::info!("completed {n_targets} targets in {elapsed}");
 
     let summary = super::ttx_diff_runner::Summary::new(&results);
@@ -345,21 +347,6 @@ fn should_build_in_gftools_mode(src_path: &Path, config: &Config) -> bool {
         .as_ref()
         .filter(|provider| *provider != "googlefonts")
         .is_none()
-}
-
-fn format_elapsed_time<Tmz: TimeZone>(start: &DateTime<Tmz>, end: &DateTime<Tmz>) -> String {
-    let delta = end.clone().signed_duration_since(start);
-    let mut out = String::new();
-    let hours = delta.num_hours();
-    let mins = delta.num_minutes() - hours * 60;
-    let secs = delta.num_seconds() - (hours * 60 + mins) * 60;
-    assert!(!hours.is_negative() | mins.is_negative() | secs.is_negative());
-    if delta.num_hours() > 0 {
-        write!(&mut out, "{hours}h").unwrap();
-    }
-    write!(&mut out, "{mins}m").unwrap();
-    write!(&mut out, "{secs}s").unwrap();
-    out
 }
 
 fn precompile_rust_binaries(temp_dir: &Path) -> (PathBuf, PathBuf) {

--- a/fontc_crater/src/ci/html.rs
+++ b/fontc_crater/src/ci/html.rs
@@ -299,7 +299,12 @@ fn make_table_body(runs: &[RunSummary]) -> Markup {
             td.other_err {  (run.stats.other_failure) " " (other_err_diff)  }
             }
         };
-        let elapsed = super::format_elapsed_time(&run.began, &run.finished);
+        let elapsed = run
+            .finished
+            .signed_duration_since(run.began)
+            .to_std()
+            .unwrap_or_default();
+        let elapsed = crate::human_readable_duration(elapsed);
         let class = (!default_visible).then_some("hidden_row");
         html! {
             tr class=[class] {


### PR DESCRIPTION
It's otherwise tricky to see what targets take the longest to run, which is something I'm curious about.