### PR TITLE
[glyf] Only set USE_MY_METRICS flag for static fonts, not variable fonts

### DIFF
--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -3791,37 +3791,39 @@ mod tests {
         )
     }
 
-    #[rstest]
-    #[case::static_font("glyphs3/StaticComposite.glyphs")]
-    #[case::variable_font("glyphs3/WghtVarComposite.glyphs")]
-    fn use_my_metrics_behavior_by_font_type(#[case] font_file: &str) {
+    fn has_use_my_metrics_flag(font_file: &str, composite_glyph_name: &str) -> bool {
         let result = TestCompile::compile_source(font_file);
-        let static_metadata = result.fe_context.static_metadata.get();
-        let is_variable = !static_metadata.axes.is_empty();
-
         let glyph_data = result.glyphs();
         let glyphs = glyph_data.read();
 
-        let gid = result.get_glyph_index("equal").unwrap();
+        let gid = result.get_glyph_index(composite_glyph_name).unwrap();
         let Some(glyf::Glyph::Composite(glyph)) = &glyphs[gid as usize] else {
-            panic!("Expected 'equal' to be a composite glyph");
+            panic!(
+                "Expected '{}' to be a composite glyph",
+                composite_glyph_name
+            );
         };
 
-        let has_use_my_metrics = glyph.components().any(|comp| {
+        let has_flag = glyph.components().any(|comp| {
             comp.flags
                 .contains(write_fonts::read::tables::glyf::CompositeGlyphFlags::USE_MY_METRICS)
         });
+        has_flag
+    }
 
-        if is_variable {
-            assert!(
-                !has_use_my_metrics,
-                "Variable composite glyph should NOT have USE_MY_METRICS set on any component"
-            );
-        } else {
-            assert!(
-                has_use_my_metrics,
-                "Static composite glyph should have USE_MY_METRICS set on at least one component"
-            );
-        }
+    #[test]
+    fn static_font_sets_use_my_metrics() {
+        assert!(
+            has_use_my_metrics_flag("glyphs3/StaticComposite.glyphs", "equal"),
+            "Static composite glyph should have USE_MY_METRICS set on at least one component"
+        );
+    }
+
+    #[test]
+    fn variable_font_does_not_set_use_my_metrics() {
+        assert!(
+            !has_use_my_metrics_flag("glyphs3/WghtVarComposite.glyphs", "equal"),
+            "Variable composite glyph should NOT have USE_MY_METRICS set on any component"
+        );
     }
 }

--- a/resources/testdata/glyphs3/StaticComposite.glyphs
+++ b/resources/testdata/glyphs3/StaticComposite.glyphs
@@ -1,0 +1,104 @@
+{
+.appVersion = "3419";
+.formatVersion = 3;
+axes = (
+{
+name = Weight;
+tag = wght;
+}
+);
+familyName = "Static Composite";
+fontMaster = (
+{
+axesValues = (
+400
+);
+id = m01;
+metricValues = (
+{
+over = 16;
+pos = 737;
+},
+{
+over = -16;
+},
+{
+over = -16;
+pos = -42;
+},
+{
+pos = 702;
+},
+{
+pos = 501;
+}
+);
+name = Regular;
+}
+);
+glyphs = (
+{
+glyphname = hyphen;
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(131,250,l,{
+name = hr00;
+}),
+(470,250,l),
+(470,330,l),
+(131,330,l)
+);
+}
+);
+width = 600;
+}
+);
+unicode = 45;
+},
+{
+glyphname = equal;
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+pos = (0,50);
+ref = hyphen;
+},
+{
+pos = (0,-50);
+ref = hyphen;
+}
+);
+width = 600;
+}
+);
+unicode = 61;
+}
+);
+metrics = (
+{
+type = ascender;
+},
+{
+type = baseline;
+},
+{
+type = descender;
+},
+{
+type = "cap height";
+},
+{
+type = "x-height";
+}
+);
+unitsPerEm = 1000;
+versionMajor = 42;
+versionMinor = 42;
+}

--- a/resources/testdata/glyphs3/WghtVarComposite.glyphs
+++ b/resources/testdata/glyphs3/WghtVarComposite.glyphs
@@ -1,0 +1,157 @@
+{
+.appVersion = "3419";
+.formatVersion = 3;
+axes = (
+{
+name = Weight;
+tag = wght;
+}
+);
+familyName = "WghtVar Composite";
+fontMaster = (
+{
+axesValues = (
+400
+);
+id = m01;
+metricValues = (
+{
+over = 16;
+pos = 737;
+},
+{
+over = -16;
+},
+{
+over = -16;
+pos = -42;
+},
+{
+pos = 702;
+},
+{
+pos = 501;
+}
+);
+name = Regular;
+},
+{
+axesValues = (
+700
+);
+iconName = Bold;
+id = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+metricValues = (
+{
+pos = 800;
+},
+{
+},
+{
+pos = -200;
+},
+{
+pos = 700;
+},
+{
+pos = 500;
+}
+);
+name = Bold;
+}
+);
+glyphs = (
+{
+glyphname = hyphen;
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(131,250,l,{
+name = hr00;
+}),
+(470,250,l),
+(470,330,l),
+(131,330,l)
+);
+}
+);
+width = 600;
+},
+{
+layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+shapes = (
+{
+closed = 1;
+nodes = (
+(92,224,l),
+(508,224,l),
+(508,356,l),
+(92,356,l)
+);
+}
+);
+width = 600;
+}
+);
+unicode = 45;
+},
+{
+glyphname = equal;
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+pos = (0,50);
+ref = hyphen;
+},
+{
+pos = (0,-50);
+ref = hyphen;
+}
+);
+width = 600;
+},
+{
+layerId = "E09E0C54-128D-4FEA-B209-1B70BEFE300B";
+shapes = (
+{
+pos = (0,70);
+ref = hyphen;
+},
+{
+pos = (0,-100);
+ref = hyphen;
+}
+);
+width = 600;
+}
+);
+unicode = 61;
+}
+);
+metrics = (
+{
+type = ascender;
+},
+{
+type = baseline;
+},
+{
+type = descender;
+},
+{
+type = "cap height";
+},
+{
+type = "x-height";
+}
+);
+unitsPerEm = 1000;
+versionMajor = 42;
+versionMinor = 42;
+}


### PR DESCRIPTION
The USE_MY_METRICS flag is primarily useful for hinted fonts where composite glyphs should reuse the hinted metrics of one of their components.

Since fontc doesn't support hinting, and the flag can be dangerous in variable fonts where composite and component metrics may differ across masters, we now only set the flag for static fonts to match fontmake's legacy behavior.

We plan to change fontmake to do the same for variable fonts as well.

Fixes https://github.com/googlefonts/fontc/issues/1614