### PR TITLE
bump fontbe, fea-rs and fontc patch versions

### DIFF
--- a/fea-rs/Cargo.toml
+++ b/fea-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fea-rs"
-version = "0.20.2"
+version = "0.20.3"
 license = "MIT/Apache-2.0"
 authors = ["Colin Rofls <colin@cmyr.net>"]
 description = "Tools for working with Adobe OpenType Feature files."

--- a/fontbe/Cargo.toml
+++ b/fontbe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fontbe"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "the backend for fontc, a font compiler."
@@ -13,7 +13,7 @@ categories = ["text-processing", "parsing", "graphics"]
 [dependencies]
 fontdrasil = { version = "0.2.2", path = "../fontdrasil" }
 fontir = { version = "0.3.0", path = "../fontir" }
-fea-rs = { version = "0.20.2", path = "../fea-rs", features = ["serde"] }
+fea-rs = { version = "0.20.3", path = "../fea-rs", features = ["serde"] }
 tinystr = {version = "0.8.0", features = ["serde"] }
 
 icu_properties.workspace = true

--- a/fontc/Cargo.toml
+++ b/fontc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fontc"
-version = "0.3.1"
+version = "0.3.2"
 build = "build.rs"
 edition = "2021"
 license = "MIT/Apache-2.0"
@@ -21,7 +21,7 @@ cli = ["clap"]
 
 [dependencies]
 fontdrasil = { version = "0.2.2", path = "../fontdrasil" }
-fontbe = { version = "0.2.2", path = "../fontbe" }
+fontbe = { version = "0.2.3", path = "../fontbe" }
 fontir = { version = "0.3.0", path = "../fontir" }
 glyphs2fontir = { version = "0.3.0", path = "../glyphs2fontir" }
 fontra2fontir = { version = "0.2.2", path = "../fontra2fontir" }

--- a/fontc_crater/Cargo.toml
+++ b/fontc_crater/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/googlefonts/fontc"
 readme = "README.md"
 
 [dependencies]
-fontc = { version = "0.3.1", path = "../fontc" }
+fontc = { version = "0.3.2", path = "../fontc" }
 
 google-fonts-sources = "0.10.0"
 maud = "0.27.0"

--- a/otl-normalizer/Cargo.toml
+++ b/otl-normalizer/Cargo.toml
@@ -17,5 +17,5 @@ write-fonts.workspace = true
 indexmap.workspace = true
 
 [dev-dependencies]
-fea-rs = { version = "0.20.2", path = "../fea-rs" }
+fea-rs = { version = "0.20.3", path = "../fea-rs" }
 


### PR DESCRIPTION
     Changes for fea-rs from fea-rs-v0.20.2 to 0.20.3
             0a98219 bump fontbe, fea-rs and fontc patch versions
             4e7e754 [marks] Ignore feature markers for ungenerated features
     Changes for fontbe from fontbe-v0.2.2 to 0.2.3
             0a98219 bump fontbe, fea-rs and fontc patch versions
             1b23498 Revert "Revert "[glyf] Only set USE_MY_METRICS flag for static fonts, not variable fonts""
             04bb264 Revert "[glyf] Only set USE_MY_METRICS flag for static fonts, not variable fonts"
             7a65f60 [glyf] Only set USE_MY_METRICS flag for static fonts, not variable fonts
     Changes for fontc from fontc-v0.3.1 to 0.3.2
             0a98219 bump fontbe, fea-rs and fontc patch versions
             1b23498 Revert "Revert "[glyf] Only set USE_MY_METRICS flag for static fonts, not variable fonts""
             04bb264 Revert "[glyf] Only set USE_MY_METRICS flag for static fonts, not variable fonts"
             75134a7 no need to parametrize with rstest in this case
             7a65f60 [glyf] Only set USE_MY_METRICS flag for static fonts, not variable fonts