### PR TITLE
also bump patch for the rest of fontc crates

### DIFF
--- a/fea-rs/Cargo.toml
+++ b/fea-rs/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 exclude = ["test-data"]
 
 [dependencies]
-fontdrasil = { version = "0.2.2", path = "../fontdrasil" }
+fontdrasil = { version = "0.2.3", path = "../fontdrasil" }
 ansi_term = "0.12.1"
 serde_json = {version = "1.0.87", optional = true }
 

--- a/fontbe/Cargo.toml
+++ b/fontbe/Cargo.toml
@@ -11,8 +11,8 @@ categories = ["text-processing", "parsing", "graphics"]
 [features]
 
 [dependencies]
-fontdrasil = { version = "0.2.2", path = "../fontdrasil" }
-fontir = { version = "0.3.0", path = "../fontir" }
+fontdrasil = { version = "0.2.3", path = "../fontdrasil" }
+fontir = { version = "0.3.1", path = "../fontir" }
 fea-rs = { version = "0.20.3", path = "../fea-rs", features = ["serde"] }
 tinystr = {version = "0.8.0", features = ["serde"] }
 

--- a/fontc/Cargo.toml
+++ b/fontc/Cargo.toml
@@ -20,12 +20,12 @@ default = ["cli"]
 cli = ["clap"]
 
 [dependencies]
-fontdrasil = { version = "0.2.2", path = "../fontdrasil" }
+fontdrasil = { version = "0.2.3", path = "../fontdrasil" }
 fontbe = { version = "0.2.3", path = "../fontbe" }
-fontir = { version = "0.3.0", path = "../fontir" }
-glyphs2fontir = { version = "0.3.0", path = "../glyphs2fontir" }
-fontra2fontir = { version = "0.2.2", path = "../fontra2fontir" }
-ufo2fontir = { version = "0.2.2", path = "../ufo2fontir" }
+fontir = { version = "0.3.1", path = "../fontir" }
+glyphs2fontir = { version = "0.3.1", path = "../glyphs2fontir" }
+fontra2fontir = { version = "0.2.3", path = "../fontra2fontir" }
+ufo2fontir = { version = "0.2.3", path = "../ufo2fontir" }
 
 bitflags.workspace = true
 bincode.workspace = true

--- a/fontdrasil/Cargo.toml
+++ b/fontdrasil/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fontdrasil"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Common types and utilites used by fontc, a font compiler."

--- a/fontir/Cargo.toml
+++ b/fontir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fontir"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Intermediate Representation used by fontc, a font compiler."
@@ -11,7 +11,7 @@ categories = ["text-processing", "parsing", "graphics"]
 [features]
 
 [dependencies]
-fontdrasil = { version = "0.2.2", path = "../fontdrasil" }
+fontdrasil = { version = "0.2.3", path = "../fontdrasil" }
 
 bitflags.workspace = true
 serde.workspace = true

--- a/fontra2fontir/Cargo.toml
+++ b/fontra2fontir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fontra2fontir"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Converts fontra.xyz/ files to font ir for compilation."
@@ -11,8 +11,8 @@ categories = ["text-processing", "parsing", "graphics"]
 [features]
 
 [dependencies]
-fontdrasil = { version = "0.2.2", path = "../fontdrasil" }
-fontir = { version = "0.3.0", path = "../fontir" }
+fontdrasil = { version = "0.2.3", path = "../fontdrasil" }
+fontir = { version = "0.3.1", path = "../fontir" }
 
 write-fonts.workspace = true
 

--- a/glyphs-reader/Cargo.toml
+++ b/glyphs-reader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glyphs-reader"
-version = "0.2.2"
+version = "0.2.3"
 license = "MIT/Apache-2.0"
 authors = ["Raph Levien <raph.levien@gmail.com>"]
 repository = "https://github.com/googlefonts/fontc"
@@ -13,7 +13,7 @@ readme = "README.md"
 
 [dependencies]
 ascii_plist_derive = { version = "0.1.0", path = "ascii_plist_derive" }
-fontdrasil = { version = "0.2.2", path = "../fontdrasil" }
+fontdrasil = { version = "0.2.3", path = "../fontdrasil" }
 quick-xml = "0.37"
 ordered-float.workspace = true
 kurbo.workspace = true

--- a/glyphs2fontir/Cargo.toml
+++ b/glyphs2fontir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glyphs2fontir"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Converts www.glyphsapp.com files to font ir for compilation."
@@ -11,9 +11,9 @@ categories = ["text-processing", "parsing", "graphics"]
 [features]
 
 [dependencies]
-fontdrasil = { version = "0.2.2", path = "../fontdrasil" }
-fontir = { version = "0.3.0", path = "../fontir" }
-glyphs-reader = { version = "0.2.2", path = "../glyphs-reader" }
+fontdrasil = { version = "0.2.3", path = "../fontdrasil" }
+fontir = { version = "0.3.1", path = "../fontir" }
+glyphs-reader = { version = "0.2.3", path = "../glyphs-reader" }
 
 smol_str.workspace = true
 log.workspace = true

--- a/otl-normalizer/Cargo.toml
+++ b/otl-normalizer/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 
 
 [dependencies]
-fontdrasil = { version = "0.2.2", path = "../fontdrasil" }
+fontdrasil = { version = "0.2.3", path = "../fontdrasil" }
 clap.workspace = true
 thiserror.workspace = true
 smol_str.workspace = true

--- a/ufo2fontir/Cargo.toml
+++ b/ufo2fontir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ufo2fontir"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Converts UFO or UFO+designspace to font ir for compilation."
@@ -11,8 +11,8 @@ categories = ["text-processing", "parsing", "graphics"]
 [features]
 
 [dependencies]
-fontdrasil = { version = "0.2.2", path = "../fontdrasil" }
-fontir = { version = "0.3.0", path = "../fontir" }
+fontdrasil = { version = "0.2.3", path = "../fontdrasil" }
+fontir = { version = "0.3.1", path = "../fontir" }
 
 kurbo.workspace = true
 serde.workspace = true


### PR DESCRIPTION
... they also use write-fonts, and if we don't bump and publish these as well, we may get errors about types coming multiple versions of shared crates.

E.g. I tried to publish fea-rs but got the following error:

```
   Compiling fea-rs v0.20.3 (/private/tmp/fontc/target/package/fea-rs-0.20.3)
error[E0308]: mismatched types
    --> src/compile/compile_ctx.rs:1275:28
     |
1275 |                 pos.insert(tag, coord);
     |                     ------ ^^^ expected `font_types::tag::Tag`, found `write_fonts::font_types::Tag`
     |                     |
     |                     arguments to this method are incorrect
     |
note: two different versions of crate `font_types` are being used; two types coming from two different versions of the same crate are different types even if they look the same
    --> /Users/clupo/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/font-types-0.10.0/src/tag.rs:23:1
     |
23   | pub struct Tag([u8; 4]);
     | ^^^^^^^^^^^^^^ this is the found type `write_fonts::font_types::Tag`
     |
    ::: /Users/clupo/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/font-types-0.9.0/src/tag.rs:23:1
     |
23   | pub struct Tag([u8; 4]);
     | ^^^^^^^^^^^^^^ this is the expected type `font_types::tag::Tag`
     |
    ::: src/common.rs:5:5
     |
5    | use fontdrasil::types::GlyphName;
     |     ---------- one version of crate `font_types` used here, as a dependency of crate `write_fonts`
6    | use write_fonts::tables::gpos::builders::AnchorBuilder;
     |     ----------- one version of crate `font_types` used here, as a dependency of crate `write_fonts`
     = help: you can use `cargo tree` to explore your dependency tree
note: method defined here
    --> /Users/clupo/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/fontdrasil-0.2.2/src/coords.rs:318:12
     |
318  |     pub fn insert(&mut self, tag: Tag, pos: Coord<Space>) -> &mut Location<...
     |            ^^^^^^

For more information about this error, try `rustc --explain E0308`.
error: could not compile `fea-rs` (lib) due to 1 previous error
error: failed to verify package tarball
```

Apparently the old fontdrasil from crates uses an old write-fonts which in turns uses an old font-types, etc.