### PR TITLE
Remove unused deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ serde_yaml = "0.9.14"
 serde_json = "1.0.113"
 bitflags = "2.0"
 chrono = { version = "0.4.24", features = ["serde"] }
-filetime = "0.2.18"
 indexmap = { version = "2.0", features = ["serde"] }
 kurbo = { version = "0.12.0", features = ["serde"] }
 ordered-float = { version = "4.1.0", features = ["serde"] }

--- a/fea-rs/Cargo.toml
+++ b/fea-rs/Cargo.toml
@@ -23,7 +23,6 @@ rayon = { workspace = true, optional = true }
 clap = { workspace = true, optional = true }
 write-fonts.workspace = true
 smol_str.workspace = true
-chrono.workspace = true
 indexmap.workspace = true
 thiserror.workspace = true
 ordered-float.workspace = true

--- a/fontbe/Cargo.toml
+++ b/fontbe/Cargo.toml
@@ -25,7 +25,6 @@ ordered-float.workspace = true
 indexmap.workspace = true
 
 log.workspace = true
-env_logger.workspace = true
 
 write-fonts.workspace = true
 
@@ -47,4 +46,5 @@ more-asserts.workspace = true
 temp-env.workspace = true
 rstest.workspace = true
 pretty_assertions.workspace = true
+env_logger.workspace = true
 otl-normalizer = { version = "0.0.1", path = "../otl-normalizer" }

--- a/fontc/Cargo.toml
+++ b/fontc/Cargo.toml
@@ -28,12 +28,9 @@ fontra2fontir = { version = "0.2.3", path = "../fontra2fontir" }
 ufo2fontir = { version = "0.2.3", path = "../ufo2fontir" }
 
 bitflags.workspace = true
-bincode.workspace = true
 
 serde.workspace = true
 serde_yaml.workspace = true
-
-filetime.workspace = true
 
 log.workspace = true
 env_logger.workspace = true

--- a/fontir/Cargo.toml
+++ b/fontir/Cargo.toml
@@ -16,8 +16,6 @@ fontdrasil = { version = "0.2.3", path = "../fontdrasil" }
 bitflags.workspace = true
 serde.workspace = true
 serde_yaml.workspace = true
-bincode.workspace = true
-filetime.workspace = true
 thiserror.workspace = true
 
 kurbo.workspace = true
@@ -46,3 +44,4 @@ parking_lot = { version = "0.12.3", features = ["nightly"] }
 diff.workspace = true
 tempfile.workspace = true
 pretty_assertions.workspace = true
+bincode.workspace = true

--- a/glyphs-reader/Cargo.toml
+++ b/glyphs-reader/Cargo.toml
@@ -30,7 +30,6 @@ regex.workspace = true
 chrono.workspace = true
 smol_str.workspace = true
 serde.workspace = true
-bincode.workspace = true
 
 [dev-dependencies]
 pretty_assertions.workspace = true


### PR DESCRIPTION
Namely chrono, filetime, and bincode. In some packages, these dependencies were not being used. In others, they are only being used in tests and can be moved to `dev-dependencies`.