### PR TITLE
Make `Anchor` public in glyphs-reader

### DIFF
--- a/glyphs-reader/src/lib.rs
+++ b/glyphs-reader/src/lib.rs
@@ -9,7 +9,7 @@ mod plist;
 mod propagate_anchors;
 
 pub use font::{
-    Axis, Component, CustomParameters, FeatureSnippet, Font, FontMaster, Glyph, InstanceType,
-    Layer, Node, NodeType, Path, Shape,
+    Anchor, Axis, Component, CustomParameters, FeatureSnippet, Font, FontMaster, Glyph,
+    InstanceType, Layer, Node, NodeType, Path, Shape,
 };
 pub use plist::Plist;


### PR DESCRIPTION
`Glyph::anchors` is a public field, but the `Anchor` type itself was not actually exported (despite it and all its fields being public) so it wasn't really that useful.