### PR TITLE
[fea] Allow '.null' as glyph name

### DIFF
--- a/fea-rs/src/compile/validate.rs
+++ b/fea-rs/src/compile/validate.rs
@@ -1224,6 +1224,14 @@ impl<'a, V: VariationInfo> ValidationCtx<'a, V> {
         if self.glyph_map.get(name.text()).is_none() {
             self.error(name.range(), "glyph not in font");
         }
+        if name.text() == ".null" {
+            self.warning(
+                name.range(),
+                ".null is not a valid glyph name, and may \
+                not be supported on all compilers. You should use the name 'null', and \
+                escape it with a backslash ('\\null') in FEA.",
+            );
+        }
     }
 
     fn validate_cid(&mut self, cid: &typed::Cid) {

--- a/fea-rs/src/parse/grammar/glyph.rs
+++ b/fea-rs/src/parse/grammar/glyph.rs
@@ -204,7 +204,9 @@ fn validate_glyph_name(name: &[u8]) -> NameType {
     let (first, rest) = name.split_first().expect("glyph names are not empty");
     match first {
         b'_' | b'a'..=b'z' | b'A'..=b'Z' => validate_glyph_body(rest),
-        b'.' if name == b".notdef" => NameType::Valid,
+        // .null is technically not allowed per the spec but exists in many
+        // existing sources.
+        b'.' if name == b".notdef" || name == b".null" => NameType::Valid,
         _ => NameType::Invalid(0),
     }
 }

--- a/fea-rs/test-data/parse-tests/good/notdef_and_null.PARSE_TREE
+++ b/fea-rs/test-data/parse-tests/good/notdef_and_null.PARSE_TREE
@@ -1,0 +1,14 @@
+FILE@[0; 28)
+    GlyphClassDefNode@[0; 27)
+      @GlyphClass@0 "@parseme"
+      WS@8 " "
+      =@9 "="
+      WS@10 " "
+        GlyphClass@[11; 26)
+          [@11 "["
+          GlyphName@12 ".notdef"
+          WS@19 " "
+          GlyphName@20 ".null"
+          ]@25 "]"
+      ;@26 ";"
+  WS@27 "\n"

--- a/fea-rs/test-data/parse-tests/good/notdef_and_null.fea
+++ b/fea-rs/test-data/parse-tests/good/notdef_and_null.fea
@@ -1,0 +1,1 @@
+@parseme = [.notdef .null];


### PR DESCRIPTION
The spec is very clear that '.' is not valid in a glyph name with the sole exception of '.notdef', and that if you are using 'null' as a glyphname you should escape it with a backslash.

Ultimately, though, a bunch of fonts _do_ use '.null' as a glyph name, and it feels pointless to try and update all of these sources.

As a compromise we will now accept these glyph names, but print a warning, as our last concession to principle.