### PR TITLE
ttx_diff: make repository root check more robust

### DIFF
--- a/resources/scripts/ttx_diff.py
+++ b/resources/scripts/ttx_diff.py
@@ -1251,8 +1251,11 @@ def main(argv):
     source = resolve_source(argv[1]).resolve()
 
     root = Path(".").resolve()
-    if root.name != "fontc":
-        sys.exit("Expected to be at the root of fontc")
+    if not (root / "fontc" / "Cargo.toml").is_file():
+        sys.exit(
+            "This script must be run from the root of the fontc repository; "
+            "could not find 'fontc/Cargo.toml'."
+        )
 
     fontc_bin_path = get_crate_path(FLAGS.fontc_path, root, "fontc")
     otl_bin_path = get_crate_path(FLAGS.normalizer_path, root, "otl-normalizer")


### PR DESCRIPTION
The script previously checked if the current directory was named "fontc" to ensure it was running from the repository root.

This check is too restrictive and fails when using `git worktree` (for checking out a branch into separate directories) or if the repository itself was cloned with a different name than "fontc".

Replace the directory name check with a verification for the existence of `fontc/Cargo.toml`. This is a more reliable way to confirm the script is being executed from the correct location without depending on the name of the root folder.

JMM