### PR TITLE
Handle components with overflowing 2x2 transform exceeding F2Dot14 limits

### DIFF
--- a/fontbe/src/glyphs.rs
+++ b/fontbe/src/glyphs.rs
@@ -93,6 +93,12 @@ fn create_component_ref_gid(
         round_xy_to_grid: true, // ufo2ft defaults to this, match it
         ..Default::default()
     };
+
+    // By this point, fontir should have decomposed any components with transforms
+    // outside the -2.0 to +2.0 range. For values between MAX_F2DOT14 and 2.0,
+    // F2Dot14::from_f32() will saturate to MAX_F2DOT14, matching fonttools behavior:
+    // https://github.com/googlefonts/fontc/issues/1638
+
     let component = Component::new(
         gid,
         Anchor::Offset {
@@ -1043,5 +1049,32 @@ mod tests {
             panic!("Must be an offset");
         };
         assert_eq!((0, 1), (x, y));
+    }
+
+    /// Minimum and maximum values that can fit in an F2Dot14: [-2.0, 1.99993896484375]
+    const MAX_F2DOT14: f32 = (0x7FFF as f32) / ((1 << 14) as f32);
+    const MIN_F2DOT14: f32 = -2.0;
+
+    #[test]
+    fn test_component_transform_saturation() {
+        // Test that component 2x2 transforms with values exceeding F2Dot14's range
+        // get saturated to min/max by font-types' F2Dot14::from_f32.
+        // We are interested in particular to values > MAX_F2DOT14 but <= 2.0 (e.g.
+        // 'xx' below), which fonttools TTGlyphPen clamps to MAX_F2DOT14.
+        // Components with transform values < -2.0 or > 2.0 are always decomposed
+        // in fontir so they should never reach here. I include them here to
+        // show what would happen if they did.
+        let transform = Affine::new([1.99995, -2.0001, 1.0, 2.5, 100.0, -200.0]);
+        let (c, _) = create_component_ref_gid(GlyphId16::new(42), &transform).unwrap();
+
+        // Both xx and yy are > MAX_F2DOT14 thus get clamped to MAX_F2DOT14
+        assert_eq!(c.transform.xx.to_f32(), MAX_F2DOT14);
+        assert_eq!(c.transform.yy.to_f32(), MAX_F2DOT14);
+        // yx < MIN_F2DOT14 and gets clamped to MIN_F2DOT14
+        assert_eq!(c.transform.yx.to_f32(), MIN_F2DOT14);
+        // xy is within the valid range
+        assert_eq!(c.transform.xy.to_f32(), 1.0);
+        // translation offsets are encoded as Fixed16.16 so stay the same
+        assert_eq!(c.anchor, Anchor::Offset { x: 100, y: -200 });
     }
 }

--- a/fontbe/src/glyphs.rs
+++ b/fontbe/src/glyphs.rs
@@ -1051,10 +1051,6 @@ mod tests {
         assert_eq!((0, 1), (x, y));
     }
 
-    /// Minimum and maximum values that can fit in an F2Dot14: [-2.0, 1.99993896484375]
-    const MAX_F2DOT14: f32 = (0x7FFF as f32) / ((1 << 14) as f32);
-    const MIN_F2DOT14: f32 = -2.0;
-
     #[test]
     fn test_component_transform_saturation() {
         // Test that component 2x2 transforms with values exceeding F2Dot14's range
@@ -1068,10 +1064,10 @@ mod tests {
         let (c, _) = create_component_ref_gid(GlyphId16::new(42), &transform).unwrap();
 
         // Both xx and yy are > MAX_F2DOT14 thus get clamped to MAX_F2DOT14
-        assert_eq!(c.transform.xx.to_f32(), MAX_F2DOT14);
-        assert_eq!(c.transform.yy.to_f32(), MAX_F2DOT14);
+        assert_eq!(c.transform.xx, F2Dot14::MAX);
+        assert_eq!(c.transform.yy, F2Dot14::MAX);
         // yx < MIN_F2DOT14 and gets clamped to MIN_F2DOT14
-        assert_eq!(c.transform.yx.to_f32(), MIN_F2DOT14);
+        assert_eq!(c.transform.yx, F2Dot14::MIN);
         // xy is within the valid range
         assert_eq!(c.transform.xy.to_f32(), 1.0);
         // translation offsets are encoded as Fixed16.16 so stay the same

--- a/fontir/Cargo.toml
+++ b/fontir/Cargo.toml
@@ -45,3 +45,4 @@ diff.workspace = true
 tempfile.workspace = true
 pretty_assertions.workspace = true
 bincode.workspace = true
+rstest.workspace = true

--- a/fontir/src/glyph.rs
+++ b/fontir/src/glyph.rs
@@ -614,6 +614,12 @@ impl Work<Context, WorkId, Error> for GlyphOrderWork {
                         component 2x2s vary across the designspace"
                 );
                 todo.push_back((GlyphOp::ConvertToContour, glyph.clone()));
+            } else if glyph.has_overflowing_component_transforms() {
+                log::debug!(
+                    "Decomposing '{glyph_name}' into a simple glyph: \
+                        component transforms overflow F2Dot14 [-2.0, 2.0] range"
+                );
+                todo.push_back((GlyphOp::ConvertToContour, glyph.clone()));
             } else if has_components_and_contours(glyph) {
                 if context.flags.contains(Flags::PREFER_SIMPLE_GLYPHS) {
                     todo.push_back((GlyphOp::ConvertToContour, glyph.clone()));

--- a/fontir/src/glyph.rs
+++ b/fontir/src/glyph.rs
@@ -676,6 +676,7 @@ mod tests {
 
     use fontdrasil::{orchestration::Access, types::GlyphName};
     use kurbo::{Affine, BezPath, Rect, Shape};
+    use rstest::rstest;
 
     use crate::{
         ir::{Component, Glyph, GlyphBuilder, GlyphInstance, GlyphOrder},
@@ -1398,5 +1399,32 @@ mod tests {
             (Affine::scale_non_uniform(-1., 1.) * simple_square_path()).reverse_subpaths();
 
         assert_eq!(contour, &expected);
+    }
+
+    #[rstest]
+    #[case::normal_scale(1.5, false)]
+    #[case::near_positive_edge(1.999999, false)]
+    #[case::near_negative_edge(-1.999999, false)]
+    #[case::exactly_minus_2(-2.0, false)]
+    #[case::exactly_2(2.0, false)]
+    #[case::positive_just_over_2(2.000001, true)]
+    #[case::negative_just_under_minus_2(-2.000001, true)]
+    #[case::positive_over_2(2.5, true)]
+    #[case::negative_under_minus_2(-2.5, true)]
+    fn glyph_has_overflowing_transforms(#[case] scale: f64, #[case] expected_overflow: bool) {
+        let mut instance = GlyphInstance::default();
+        instance.components.push(Component {
+            base: "base".into(),
+            transform: Affine::scale(scale),
+        });
+        let mut sources = HashMap::new();
+        sources.insert(NormalizedLocation::default(), instance);
+
+        let glyph = Glyph::new("test".into(), true, Default::default(), sources).unwrap();
+
+        assert_eq!(
+            glyph.has_overflowing_component_transforms(),
+            expected_overflow
+        );
     }
 }


### PR DESCRIPTION
Fixes https://github.com/googlefonts/fontc/issues/1638

Makes VendSans.glyphs among others "output is identical"

```
$ python3 resources/scripts/ttx_diff.py 'https://github.com/ktkm/Vend-Sans?2663f1c7da#sources/VendSans.glyphs'
```

(Will add some tests after lunch)