### PR TITLE
bump ufo2ft to 3.6.5 in requirements.txt

### DIFF
--- a/resources/scripts/requirements.txt
+++ b/resources/scripts/requirements.txt
@@ -216,7 +216,7 @@ pyyaml==6.0.2
     # via
     #   gftools
     #   glyphsets
-regex==2025.9.1
+regex==2025.9.18
     # via nanoemoji
 requests==2.32.5
     # via
@@ -261,7 +261,7 @@ typing-extensions==4.15.0
     #   beautifulsoup4
     #   cattrs
     #   pygithub
-ufo2ft[cffsubr,compreffor]==3.6.4
+ufo2ft[cffsubr,compreffor]==3.6.5
     # via
     #   fontmake
     #   nanoemoji


### PR DESCRIPTION
https://github.com/googlefonts/ufo2ft/releases/tag/v3.6.5

Gives us at least one +1 with Ruthie.glyphs.

```diff
--- /Users/clupo/oss/fontc/build/default/fontc.glyf.ttx	2025-09-19 14:00:14
+++ /Users/clupo/oss/fontc/build/default/fontmake.glyf.ttx	2025-09-19 14:00:14
@@ -2482,8 +2482,7 @@
       </contour>
       <contour>
         <pt x="293" y="377" on="1"/>
-        <pt x="293" y="376" on="0"/>
-        <pt x="278" y="381" on="0"/>
+        <pt x="293" y="374" on="0"/>
         <pt x="268" y="385" on="1"/>
         <pt x="247" y="394" on="0"/>
         <pt x="242" y="399" on="1"/>
```

The diff was caused by the fact that the decomposition of a component with F2Dot14-overflowing transform was happening at different stages of the build pipeline in fontc vs ufo2ft/fonttools.

I made ufo2ft match fontc, because it makes more sense to decompose all glyphs that need decomposition before the other transformations (e.g. removeOverlaps may find that the decomposed contours overlap and need merging, or cu2qu applies the same tolerance to all outlines, etc.)