### PR TITLE
[ttx_diff.py] only normalize contour order when contours perfectly match between fontc vs fontmake

### DIFF
--- a/resources/scripts/ttx_diff.py
+++ b/resources/scripts/ttx_diff.py
@@ -521,42 +521,92 @@ def stat_like_fontmake(ttx):
 
 
 # https://github.com/googlefonts/fontc/issues/1107
-def normalize_glyf_contours(ttx: etree.ElementTree) -> dict[str, list[int]]:
-    # store new order of prior point indices for each glyph
-    point_orders: dict[str, list[int]] = {}
+def normalize_glyf_contours(
+    fontc_ttx: etree.ElementTree, fontmake_ttx: etree.ElementTree
+) -> tuple[dict[str, list[int]], dict[str, list[int]]]:
+    """Reorders contours when they are identical between fontc and fontmake.
 
-    for glyph in ttx.xpath("//glyf/TTGlyph"):
-        contours = glyph.xpath("./contour")
-        if len(contours) < 2:
+    If contours differ (e.g., different starting points), leaves
+    them in their original order to avoid misleading diffs.
+
+    Returns a tuple of two dicts, one for fontc and one for fontmake, containing
+    the new order of prior point indices for each glyph, later used for sorting
+    gvar contours.
+    """
+    fontc_point_orders: dict[str, list[int]] = {}
+    fontmake_point_orders: dict[str, list[int]] = {}
+
+    # Get glyphs from both TTX trees
+    fontc_glyphs = {g.attrib["name"]: g for g in fontc_ttx.xpath("//glyf/TTGlyph")}
+    fontmake_glyphs = {
+        g.attrib["name"]: g for g in fontmake_ttx.xpath("//glyf/TTGlyph")
+    }
+
+    # Only process glyphs that exist in both outputs
+    for glyph_name in fontc_glyphs.keys() & fontmake_glyphs.keys():
+        fontc_glyph = fontc_glyphs[glyph_name]
+        fontmake_glyph = fontmake_glyphs[glyph_name]
+
+        fontc_contours = fontc_glyph.xpath("./contour")
+        fontmake_contours = fontmake_glyph.xpath("./contour")
+
+        # Skip glyphs with mismatched contour counts
+        if len(fontc_contours) != len(fontmake_contours):
             continue
 
-        # annotate each contour with the range of point indices it covers
-        with_range: list[tuple[range, etree.ElementTree]] = []
-        points_seen = 0
-        for contour in contours:
-            points_here = len(contour.xpath("./pt"))
-            with_range.append((range(points_seen, points_seen + points_here), contour))
-            points_seen += points_here
-        annotated = sorted(with_range, key=lambda a: to_xml_string(a[1]))
+        # Compare contours as sets to see if they're identical (ignoring order)
+        fontc_strings = {to_xml_string(c) for c in fontc_contours}
+        fontmake_strings = {to_xml_string(c) for c in fontmake_contours}
 
-        # sort by string representation, and skip if nothing has changed
-        normalized = [contour for _, contour in annotated]
-        if normalized == contours:
-            continue
-        # normalized contours should be inserted before any other TTGlyph's
-        # subelements (e.g. instructions)
-        for contour in contours:
-            glyph.remove(contour)
-        non_contours = list(glyph)
-        for el in non_contours:
-            glyph.remove(el)
-        glyph.extend(normalized + non_contours)
+        if fontc_strings == fontmake_strings:
+            # Contours are identical, just in different order - normalize both
+            _normalize_single_glyph(fontc_glyph, fontc_contours, fontc_point_orders)
+            _normalize_single_glyph(
+                fontmake_glyph, fontmake_contours, fontmake_point_orders
+            )
+        # If sets don't match, skip normalization - leave original order
 
-        # store new indices order
-        name = glyph.attrib["name"]
-        point_orders[name] = [idx for indices, _ in annotated for idx in indices]
+    return fontc_point_orders, fontmake_point_orders
 
-    return point_orders
+
+def _normalize_single_glyph(
+    glyph: etree.Element,
+    contours: list[etree.Element],
+    point_orders: dict[str, list[int]],
+):
+    """Helper function to normalize contour order within a single glyph.
+
+    Contours are sorted alphabetically by xml string representation.
+
+    The `point_orders` dict is used to store the new order of prior point
+    indices for this glyph.
+    """
+    # annotate each contour with the range of point indices it covers
+    with_range: list[tuple[range, etree.Element]] = []
+    points_seen = 0
+    for contour in contours:
+        points_here = len(contour.xpath("./pt"))
+        with_range.append((range(points_seen, points_seen + points_here), contour))
+        points_seen += points_here
+    annotated = sorted(with_range, key=lambda a: to_xml_string(a[1]))
+
+    # sort by string representation, and skip if nothing has changed
+    normalized = [contour for _, contour in annotated]
+    if normalized == contours:
+        return
+
+    # normalized contours should be inserted before any other TTGlyph's
+    # subelements (e.g. instructions)
+    for contour in contours:
+        glyph.remove(contour)
+    non_contours = list(glyph)
+    for el in non_contours:
+        glyph.remove(el)
+    glyph.extend(normalized + non_contours)
+
+    # store new indices order
+    name = glyph.attrib["name"]
+    point_orders[name] = [idx for indices, _ in annotated for idx in indices]
 
 
 def normalize_gvar_contours(ttx: etree.ElementTree, point_orders: dict[str, list[int]]):
@@ -956,9 +1006,6 @@ def reduce_diff_noise(fontc: etree.ElementTree, fontmake: etree.ElementTree):
         stat_like_fontmake(ttx)
         remove_mark_and_kern_and_curs_lookups(ttx)
 
-        point_orders = normalize_glyf_contours(ttx)
-        normalize_gvar_contours(ttx, point_orders)
-
         erase_type_from_stranded_points(ttx)
         remove_gdef_lig_caret_and_var_store(ttx)
         sort_gdef_mark_filter_sets(ttx)
@@ -966,6 +1013,11 @@ def reduce_diff_noise(fontc: etree.ElementTree, fontmake: etree.ElementTree):
         # sort names within the name table (do this at the end, so ids are correct
         # for earlier steps)
         normalize_name_ids(ttx)
+
+    # Normalize glyf contour order but only when contours are identical
+    fontc_point_orders, fontmake_point_orders = normalize_glyf_contours(fontc, fontmake)
+    normalize_gvar_contours(fontc, fontc_point_orders)
+    normalize_gvar_contours(fontmake, fontmake_point_orders)
 
     allow_fontc_only_variations_postscript_prefix(fontc, fontmake)
 


### PR DESCRIPTION
Fixes part of https://github.com/googlefonts/fontc/issues/1653

Previously, ttx_diff.py would normalize contour order within each compiler's output independently, which could create misleading diffs when the contours actually differed (e.g., different starting points).

This change compares contours between fontc and fontmake first, and only normalizes the order of whole contours when the set of contors serialized as xml strings is identical. When contours differ, they are left in their original order to make the actual differences more apparent.

The ttx diff for Sirivennela-Regular.ufo now looks more sane and makes the different starting points more evident:

```diff
--- /Users/clupo/oss/fontc/build/default/fontc.glyf.ttx	2025-09-25 11:14:20
+++ /Users/clupo/oss/fontc/build/default/fontmake.glyf.ttx	2025-09-25 11:14:20
@@ -3206,6 +3206,7 @@

     <TTGlyph name="ellipsis" xMin="12" yMin="0" xMax="388" yMax="66">
       <contour>
+        <pt x="342" y="0" on="0"/>
         <pt x="322" y="20" on="0"/>
         <pt x="322" y="46" on="0"/>
         <pt x="342" y="66" on="0"/>
@@ -3213,9 +3214,9 @@
         <pt x="388" y="46" on="0"/>
         <pt x="388" y="20" on="0"/>
         <pt x="368" y="0" on="0"/>
-        <pt x="342" y="0" on="0"/>
       </contour>
       <contour>
+        <pt x="188" y="0" on="0"/>
         <pt x="169" y="20" on="0"/>
         <pt x="169" y="46" on="0"/>
         <pt x="188" y="66" on="0"/>
@@ -3223,9 +3224,9 @@
         <pt x="235" y="46" on="0"/>
         <pt x="235" y="20" on="0"/>
         <pt x="216" y="0" on="0"/>
-        <pt x="188" y="0" on="0"/>
       </contour>
       <contour>
+        <pt x="32" y="0" on="0"/>
         <pt x="12" y="20" on="0"/>
         <pt x="12" y="46" on="0"/>
         <pt x="32" y="66" on="0"/>
@@ -3233,7 +3234,6 @@
         <pt x="78" y="46" on="0"/>
         <pt x="78" y="20" on="0"/>
         <pt x="58" y="0" on="0"/>
-        <pt x="32" y="0" on="0"/>
       </contour>
       <instructions/>
     </TTGlyph>
```

I also exposed the `--keep-direction` flag to ttx_diff.py, so it gets forwarded to fontc and fontmake. I used underscore instead of hyphen because absl.flags wants that.

JMM