### PR TITLE
Match fontmake name nuance

### DIFF
--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -940,14 +940,17 @@ impl RawName {
         // See <https://github.com/googlefonts/fontc/issues/1011>
         // In order of preference: dflt, default, ENG, whatever is first
         // <https://github.com/googlefonts/glyphsLib/blob/1cb4fc5ae2cf385df95d2b7768e7ab4eb60a5ac3/Lib/glyphsLib/classes.py#L3155-L3161>
+        // If the same name is defined repeatedly, e.g. dflt has 2 values, pick the last occurrence.
+
+        let scale: i32 = 1000;
         self.values
             .iter()
             .enumerate()
             // (score [lower better], index)
             .map(|(i, raw)| match raw.language.as_str() {
-                "dflt" => (-3, raw.value.as_str()),
-                "default" => (-2, raw.value.as_str()),
-                "ENG" => (-1, raw.value.as_str()),
+                "dflt" => (-scale * 3 - i as i32, raw.value.as_str()),
+                "default" => (-scale * 2 - i as i32, raw.value.as_str()),
+                "ENG" => (-scale - i as i32, raw.value.as_str()),
                 _ => (i as i32, raw.value.as_str()),
             })
             .min()

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -194,6 +194,7 @@ fn try_name_id(name: &str) -> Option<NameId> {
 fn names(font: &Font, flags: SelectionFlags) -> HashMap<NameKey, String> {
     let mut builder = NameBuilder::default();
     builder.set_version(font.version_major, font.version_minor);
+
     for (name, value) in font.names.iter() {
         if let Some(name_id) = try_name_id(name) {
             builder.add(name_id, value.clone());
@@ -2629,6 +2630,23 @@ mod tests {
                 SelectionFlags::ITALIC
             )
         );
+    }
+
+    #[test]
+    fn prefers_last_if_defined_repeatedly() {
+        let (_, context) =
+            build_static_metadata(glyphs3_dir().join("CustomParamRedefinition.glyphs"));
+        let static_metadata = context.static_metadata.get();
+        let name = |id: NameId| {
+            static_metadata
+                .names
+                .get(&NameKey::new_bmp_only(id))
+                .map(|s| s.as_str())
+                .unwrap_or_default()
+        };
+
+        // Correct value taken from fontmake side of ttx_diff
+        assert_eq!((name(NameId::DESIGNER),), ("Third Definition",));
     }
 
     #[test]

--- a/resources/testdata/glyphs3/CustomParamRedefinition.glyphs
+++ b/resources/testdata/glyphs3/CustomParamRedefinition.glyphs
@@ -1,0 +1,32 @@
+{
+.formatVersion = 3;
+
+properties = (
+{
+key = designers;
+values = (
+{
+language = dflt;
+value = "First Definition";
+},
+{
+language = dflt;
+value = "Second Definition";
+},
+{
+language = dflt;
+value = "Third Definition";
+}
+);
+}
+);
+
+familyName = FP;
+fontMaster = (
+{
+id = m01;
+name = Regular;
+}
+);
+unitsPerEm = 1000;
+}


### PR DESCRIPTION
Makes `python3 resources/scripts/ttx_diff.py 'https://github.com/ktkm/Vend-Sans?2663f1c7da#sources/VendSans-Italic.glyphs'` identical

JMM
