### PR TITLE
Parse quoted floats

### DIFF
--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -4765,4 +4765,19 @@ etc;
 
         let _just_dont_crash_plz = user_to_design_from_axis_location(&myfont);
     }
+
+    #[test]
+    fn axis_location_string_value() {
+        let raw = Plist::Dictionary(BTreeMap::from([
+            ("Axis".into(), Plist::String("Weight".into())),
+            ("Location".into(), Plist::String("42".into())),
+        ]));
+        assert_eq!(
+            Some(AxisLocation {
+                axis_name: "Weight".into(),
+                location: 42.0.into(),
+            }),
+            raw.as_axis_location()
+        );
+    }
 }

--- a/glyphs-reader/src/plist.rs
+++ b/glyphs-reader/src/plist.rs
@@ -223,6 +223,7 @@ impl Plist {
     pub fn as_i64(&self) -> Option<i64> {
         match self {
             Plist::Integer(i) => Some(*i),
+            Plist::String(raw) => raw.parse().ok(),
             _ => None,
         }
     }
@@ -231,6 +232,7 @@ impl Plist {
         match self {
             Plist::Integer(i) => Some(*i as f64),
             Plist::Float(f) => Some((*f).into_inner()),
+            Plist::String(raw) => raw.parse().ok(),
             _ => None,
         }
     }
@@ -1161,9 +1163,18 @@ mod tests {
     }
 
     #[test]
-    fn parse_quoted_and_unquoted_ints_and_bools() {
+    fn parse_quoted_and_unquoted() {
         assert_eq!(
-            (Ok(1), Ok(1), Ok(true), Ok(true), Ok(false), Ok(false)),
+            (
+                Ok(1),
+                Ok(1),
+                Ok(true),
+                Ok(true),
+                Ok(false),
+                Ok(false),
+                Ok(1.0),
+                Ok(1.0)
+            ),
             (
                 Tokenizer::new("1").parse::<i64>(),
                 Tokenizer::new("\"1\"").parse::<i64>(),
@@ -1171,6 +1182,8 @@ mod tests {
                 Tokenizer::new("\"1\"").parse::<bool>(),
                 Tokenizer::new("0").parse::<bool>(),
                 Tokenizer::new("\"0\"").parse::<bool>(),
+                Tokenizer::new("1").parse::<f64>(),
+                Tokenizer::new("\"1\"").parse::<f64>(),
             )
         );
     }


### PR DESCRIPTION
Apparently some idiot (pretty sure it was me...) thought that despite randomly quoting bools and ints nobody would ever do that for a float.

Makes `python3 resources/scripts/ttx_diff.py 'https://github.com/SUSE/suse-font?7159afb255#sources/SUSE.glyphs'` identical because `"900"` now parses as an axis location value instead of magically vanishing out from under us.