### PR TITLE
[crater] Display identical %

### DIFF
--- a/fontc_crater/resources/style.css
+++ b/fontc_crater/resources/style.css
@@ -33,7 +33,7 @@ td {
   font-size: 0.8em;
 }
 
-.elapsed {
+.deemphasized {
   color: #888;
   font-size: 0.8em;
 }
@@ -42,19 +42,17 @@ td.rev {
   font-family: monospace;
 }
 
+/*the timestamp is big, give it room*/
 #results_head th:nth-child(1) {
-  width: 17%
+  width: 19%
 }
 
-#results_head th:nth-child(4) {
-  width: 8%
-}
-
-#results_head th:nth-child(5) {
+/*and some columns dont need as much space, so make them smaller */
+#results_head th:nth-child(6) {
   width: 9%
 }
 
-#results_head th:nth-child(7) {
+#results_head th:nth-child(8) {
   width: 9%
 }
 

--- a/fontc_crater/src/ci/html.rs
+++ b/fontc_crater/src/ci/html.rs
@@ -84,8 +84,9 @@ fn make_html(
                 tr #results_head {
                     th.date scope="col" { "date" }
                     th.rev scope="col" { "rev" }
-                    th.total scope="col" { "targets" }
                     th.identical scope="col" { "identical" }
+                    th.total scope="col" { "targets" }
+                    th.identical_perc scope="col" { "identical %" }
                     th.fontc_err scope="col" { "fontc 💥" }
                     th.fontmake_err scope="col" { "fontmake 💥" }
                     th.both_err scope="col" { "both 💥" }
@@ -306,12 +307,17 @@ fn make_table_body(runs: &[RunSummary]) -> Markup {
             .unwrap_or_default();
         let elapsed = crate::human_readable_duration(elapsed);
         let class = (!default_visible).then_some("hidden_row");
+        let pct = 100.0 * run.stats.identical as f32 / run.stats.total_targets as f32;
+        let pct = format!("{pct:.1}%");
+
         html! {
             tr class=[class] {
-                td.date { (run.began.format("%Y-%m-%d %H%M")) span.elapsed { " (" (elapsed) ")"} }
+                td.date { (run.began.format("%Y-%m-%d %H%M")) span.deemphasized { " (" (elapsed) ")"} }
                 td.rev { a href=(diff_url) { (short_rev) } }
-                td.total {  ( run.stats.total_targets) " " (total_diff) }
                 td.identical {  (run.stats.identical) " " (identical_diff)  }
+                td.total {  ( run.stats.total_targets) " " (total_diff) }
+                td.identical_perc {  (pct) }
+
                 (err_cells)
 
                 td.diff_perc {  (diff_fmt) " " (diff_perc_diff) }


### PR DESCRIPTION
An alternative to #1673 

It's a bit annoying to do this in a way that makes the columns generally line up (this is why the `+/- N` bit is now at the end, since it varies in width) but I think this version scans more easily.

<img width="1253" height="277" alt="Screenshot 2025-10-02 at 11 05 27 AM" src="https://github.com/user-attachments/assets/702dbde6-b283-4b0c-ae5e-d495363cf1ba" />
