### PR TITLE
 [glyphs-reader] Add log-once mechanism to avoid repetitive warnings

### DIFF
--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -32,11 +32,13 @@ static LOGGED_WARNINGS: LazyLock<Mutex<HashSet<String>>> =
 /// Log a warning message only once per process lifetime
 macro_rules! log_once_warn {
     ($($arg:tt)*) => {{
-        let msg = format!($($arg)*);
-        let mut logged = LOGGED_WARNINGS.lock().unwrap();
-        if !logged.contains(&msg) {
-            log::warn!("{}", msg);
-            logged.insert(msg);
+        if log::log_enabled!(log::Level::Warn) {
+            let msg = format!($($arg)*);
+            let mut logged = LOGGED_WARNINGS.lock().unwrap();
+            if !logged.contains(&msg) {
+                log::warn!("{}", msg);
+                logged.insert(msg);
+            }
         }
     }};
 }


### PR DESCRIPTION
Implements `log_once_warn!` macro to deduplicate warnings like  "unknown custom parameter 'xHeight'" that previously could appear multiple times when parsing .glyphs font with several masters/instances.

Fixes #1680

```
$ cargo run -- /Users/clupo/.fontc_crater_cache/notofonts/bengali/sources/NotoSansBengali.glyphspackage --log warn
   Compiling glyphs-reader v0.2.3 (/Users/clupo/oss/fontc/glyphs-reader)
   Compiling glyphs2fontir v0.3.1 (/Users/clupo/oss/fontc/glyphs2fontir)
   Compiling fontc v0.3.2 (/Users/clupo/oss/fontc/fontc)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.66s
     Running `target/debug/fontc /Users/clupo/.fontc_crater_cache/notofonts/bengali/sources/NotoSansBengali.glyphspackage --log warn`
[2025-10-07T11:05:58.780560Z ThreadId(1) glyphs_reader::font WARN] unknown custom parameter 'openTypeOS2VendorID'
[2025-10-07T11:05:58.780989Z ThreadId(1) glyphs_reader::font WARN] unknown custom parameter 'Enforce Compatibility Check'
[2025-10-07T11:05:58.780998Z ThreadId(1) glyphs_reader::font WARN] unknown custom parameter 'DisableAllAutomaticBehaviour'
[2025-10-07T11:05:58.781004Z ThreadId(1) glyphs_reader::font WARN] unknown custom parameter 'Write lastChange'
[2025-10-07T11:05:58.781012Z ThreadId(1) glyphs_reader::font WARN] unknown custom parameter 'Axis Mappings'
[2025-10-07T11:05:58.781018Z ThreadId(1) glyphs_reader::font WARN] unknown custom parameter 'Variable Font Origin'
[2025-10-07T11:05:58.781774Z ThreadId(1) glyphs_reader::font WARN] unknown custom parameter 'xHeight'
[2025-10-07T11:05:58.781942Z ThreadId(1) glyphs_reader::font WARN] unknown custom parameter 'Reencode Glyphs'
[2025-10-07T11:05:58.809449Z ThreadId(1) glyphs_reader::font WARN] unknown custom parameter 'Master Icon Glyph Name'
[2025-10-07T11:05:58.809562Z ThreadId(1) glyphs_reader::font WARN] unknown custom parameter 'Replace Feature'
```