### PR TITLE
Compile anything which implements Source

### DIFF
--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -144,7 +144,7 @@ pub fn generate_font(
 }
 
 fn _generate_font(
-    source: &Input,
+    input: &Input,
     build_dir: &Path,
     output_file: Option<&PathBuf>,
     flags: Flags,
@@ -155,6 +155,13 @@ fn _generate_font(
         .create_timer(AnyWorkId::InternalTiming("Init config"), 0)
         .run();
     let (ir_paths, be_paths) = init_paths(output_file, build_dir, flags)?;
+    timer.add(time.complete());
+    let time = timer
+        .create_timer(AnyWorkId::InternalTiming("create_source"), 0)
+        .run();
+
+    let source = input.create_source()?;
+
     timer.add(time.complete());
     let workload = Workload::new(source, timer, skip_features)?;
     let fe_root = FeContext::new_root(flags, ir_paths);
@@ -348,8 +355,8 @@ mod tests {
 
             let fe_context = FeContext::new_root(flags, ir_paths);
             let be_context = BeContext::new_root(flags, be_paths, &fe_context.read_only());
-            let source = args.source().unwrap();
-            let workload = Workload::new(&source, timer, args.skip_features).unwrap();
+            let input = args.source().unwrap().create_source().unwrap();
+            let workload = Workload::new(input, timer, args.skip_features).unwrap();
 
             TestCompile {
                 _temp_dir: temp_dir,

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -90,10 +90,17 @@ impl TryFrom<&Path> for Input {
 ///
 /// This is the main entry point for the fontc command line utility.
 #[cfg(feature = "cli")]
-pub fn run(args: Args, timer: JobTimer) -> Result<(), Error> {
-    let source = args.source()?;
+pub fn run(args: Args, mut timer: JobTimer) -> Result<(), Error> {
+    let input = args.source()?;
+    let time = timer
+        .create_timer(AnyWorkId::InternalTiming("create_source"), 0)
+        .run();
+    let source = input.create_source()?;
+
+    timer.add(time.complete());
+
     let (be_root, mut timing) = _generate_font(
-        &source,
+        source,
         &args.build_dir,
         args.output_file.as_ref(),
         args.flags(),
@@ -126,7 +133,7 @@ pub fn run(args: Args, timer: JobTimer) -> Result<(), Error> {
 ///
 /// This is the library entry point to fontc.
 pub fn generate_font(
-    source: &Input,
+    source: Box<dyn Source>,
     build_dir: &Path,
     output_file: Option<&PathBuf>,
     flags: Flags,
@@ -144,7 +151,7 @@ pub fn generate_font(
 }
 
 fn _generate_font(
-    input: &Input,
+    source: Box<dyn Source>,
     build_dir: &Path,
     output_file: Option<&PathBuf>,
     flags: Flags,
@@ -155,13 +162,6 @@ fn _generate_font(
         .create_timer(AnyWorkId::InternalTiming("Init config"), 0)
         .run();
     let (ir_paths, be_paths) = init_paths(output_file, build_dir, flags)?;
-    timer.add(time.complete());
-    let time = timer
-        .create_timer(AnyWorkId::InternalTiming("create_source"), 0)
-        .run();
-
-    let source = input.create_source()?;
-
     timer.add(time.complete());
     let workload = Workload::new(source, timer, skip_features)?;
     let fe_root = FeContext::new_root(flags, ir_paths);

--- a/fontc/src/workload.rs
+++ b/fontc/src/workload.rs
@@ -52,7 +52,7 @@ use log::{debug, trace, warn};
 use crate::{
     timing::{JobTime, JobTimer},
     work::{AnyAccess, AnyContext, AnyWork},
-    Error, Input,
+    Error,
 };
 
 /// A set of interdependent jobs to execute.
@@ -117,14 +117,11 @@ fn priority(id: &AnyWorkId) -> u32 {
 
 impl Workload {
     // Pass in timer to enable t0 to be as early as possible
-    pub fn new(input: &Input, mut timer: JobTimer, skip_features: bool) -> Result<Self, Error> {
-        let time = timer
-            .create_timer(AnyWorkId::InternalTiming("create_source"), 0)
-            .run();
-
-        let source = input.create_source()?;
-
-        timer.add(time.complete());
+    pub fn new(
+        source: Box<dyn Source>,
+        timer: JobTimer,
+        skip_features: bool,
+    ) -> Result<Self, Error> {
         let time = timer
             .create_timer(AnyWorkId::InternalTiming("Create workload"), 0)
             .run();


### PR DESCRIPTION
Current, the input to the compiler API is `Input` - which admittedly makes sense, given the name. But it means that inputs are restricted to the set of source types enumerated in the `Input` enum. If we have people implementing their own source types (which we do!) then it makes sense for allow compilation of *any* object which `impl Source`. This pushes the creation of a `Source` from an `Input` higher up the pipeline, so that any `Box<dyn Source>` can be compiled.

Also improves the lifetime story of `Workload` to avoid messing with `'static` - `Workload`s only need hang around as long as the `Source`s that they are compiling.