### PR TITLE
Move variations module into fontdrasil

### DIFF
--- a/fontbe/src/error.rs
+++ b/fontbe/src/error.rs
@@ -1,11 +1,12 @@
 use std::{fmt::Display, io, path::PathBuf};
 
 use fea_rs::compile::error::CompilerError;
-use fontdrasil::{coords::NormalizedLocation, types::GlyphName};
-use fontir::{
-    error::VariationModelError, ir::KernPair, orchestration::WorkId as FeWorkId,
-    variations::DeltaError,
+use fontdrasil::{
+    coords::NormalizedLocation,
+    types::GlyphName,
+    variations::{DeltaError, VariationModelError},
 };
+use fontir::{ir::KernPair, orchestration::WorkId as FeWorkId};
 use smol_str::SmolStr;
 use thiserror::Error;
 use write_fonts::{

--- a/fontbe/src/features.rs
+++ b/fontbe/src/features.rs
@@ -26,13 +26,13 @@ use fea_rs::{
 use fontir::{
     ir::{FeaturesSource, GlyphOrder, StaticMetadata},
     orchestration::{Flags, WorkId as FeWorkId},
-    variations::{DeltaError, VariationModel},
 };
 
 use fontdrasil::{
     coords::NormalizedLocation,
     orchestration::{Access, AccessBuilder, Work},
     types::Axis,
+    variations::{DeltaError, VariationModel},
 };
 use properties::UnicodeShortName;
 use write_fonts::{

--- a/fontbe/src/features/marks.rs
+++ b/fontbe/src/features/marks.rs
@@ -9,6 +9,7 @@ use fea_rs::{
 use fontdrasil::{
     orchestration::{Access, AccessBuilder, Work},
     types::GlyphName,
+    variations::DeltaError,
 };
 
 use ordered_float::OrderedFloat;
@@ -36,7 +37,6 @@ use crate::{
 use fontir::{
     ir::{self, Anchor, AnchorKind, GlyphAnchors, GlyphOrder, StaticMetadata},
     orchestration::WorkId as FeWorkId,
-    variations::DeltaError,
 };
 
 use super::{

--- a/fontbe/src/glyphs.rs
+++ b/fontbe/src/glyphs.rs
@@ -12,11 +12,11 @@ use fontdrasil::{
     coords::NormalizedLocation,
     orchestration::{Access, AccessBuilder, Work},
     types::GlyphName,
+    variations::{VariationModel, VariationRegion},
 };
 use fontir::{
     ir::{self, GlobalMetrics, GlyphOrder},
     orchestration::{Flags, WorkId as FeWorkId},
-    variations::{VariationModel, VariationRegion},
 };
 use kurbo::{cubics_to_quadratic_splines, Affine, BezPath, CubicBez, PathEl, Point, Rect, Vec2};
 use log::{log_enabled, trace, warn};

--- a/fontbe/src/metric_variations.rs
+++ b/fontbe/src/metric_variations.rs
@@ -5,12 +5,15 @@
 use std::any::type_name;
 use std::collections::{BTreeSet, HashMap};
 
-use fontdrasil::types::Axes;
-use fontdrasil::{coords::NormalizedLocation, types::GlyphName};
-use fontir::ir::{GlobalMetrics, GlobalMetricsInstance, GlyphInstance};
-use fontir::{ir::Glyph, variations::VariationModel};
-use write_fonts::dump_table;
-use write_fonts::{tables::variations::VariationRegion, validate::Validate, FontWrite, OtRound};
+use fontdrasil::{
+    coords::NormalizedLocation,
+    types::{Axes, GlyphName},
+    variations::VariationModel,
+};
+use fontir::ir::{GlobalMetrics, GlobalMetricsInstance, Glyph, GlyphInstance};
+use write_fonts::{
+    dump_table, tables::variations::VariationRegion, validate::Validate, FontWrite, OtRound,
+};
 
 use crate::error::Error;
 

--- a/fontbe/src/mvar.rs
+++ b/fontbe/src/mvar.rs
@@ -2,21 +2,18 @@
 
 use std::collections::BTreeMap;
 
-use fontdrasil::orchestration::AccessBuilder;
-
 use fontdrasil::{
-    orchestration::{Access, Work},
+    orchestration::{Access, AccessBuilder, Work},
     types::Axes,
+    variations::{ModelDeltas, VariationModel},
 };
-use fontir::variations::ModelDeltas;
-use fontir::{orchestration::WorkId as FeWorkId, variations::VariationModel};
-use write_fonts::types::MajorMinor;
+use fontir::orchestration::WorkId as FeWorkId;
 use write_fonts::{
     tables::{
         mvar::{Mvar, ValueRecord},
         variations::{ivs_builder::VariationStoreBuilder, VariationRegion},
     },
-    types::Tag,
+    types::{MajorMinor, Tag},
     OtRound,
 };
 

--- a/fontbe/src/orchestration.rs
+++ b/fontbe/src/orchestration.rs
@@ -17,6 +17,7 @@ use fontdrasil::{
     coords::NormalizedLocation,
     orchestration::{Access, AccessControlList, Identifier, IdentifierDiscriminant, Work},
     types::GlyphName,
+    variations::VariationRegion,
 };
 use fontir::{
     ir::{self, GlyphOrder, KernGroup},
@@ -24,7 +25,6 @@ use fontir::{
         Context as FeContext, ContextItem, ContextMap, Flags, IdAware, Persistable,
         PersistentStorage, WorkId as FeWorkIdentifier,
     },
-    variations::VariationRegion,
 };
 
 use ordered_float::OrderedFloat;
@@ -1088,8 +1088,10 @@ where
 
 #[cfg(test)]
 mod tests {
-    use fontdrasil::coords::NormalizedCoord;
-    use fontir::variations::{Tent, VariationRegion};
+    use fontdrasil::{
+        coords::NormalizedCoord,
+        variations::{Tent, VariationRegion},
+    };
 
     use super::*;
 

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -270,11 +270,11 @@ mod tests {
         orchestration::Access,
         paths::string_to_filename,
         types::{GlyphName, WidthClass},
+        variations::{Tent, VariationRegion},
     };
     use fontir::{
         ir::{self, GlobalMetric, GlyphOrder, KernGroup, KernPair, KernSide},
         orchestration::{Context as FeContext, Persistable, WorkId as FeWorkIdentifier},
-        variations::{Tent, VariationRegion},
     };
     use kurbo::{Point, Rect};
     use log::info;

--- a/fontdrasil/Cargo.toml
+++ b/fontdrasil/Cargo.toml
@@ -17,7 +17,10 @@ serde.workspace = true
 write-fonts.workspace = true
 log.workspace = true
 env_logger.workspace = true
+thiserror.workspace = true
+kurbo.workspace = true
 
 [dev-dependencies]
 diff.workspace = true
 tempfile.workspace = true
+pretty_assertions.workspace = true

--- a/fontdrasil/src/lib.rs
+++ b/fontdrasil/src/lib.rs
@@ -7,3 +7,4 @@ pub mod paths;
 mod piecewise_linear_map;
 pub mod types;
 pub mod util;
+pub mod variations;

--- a/fontdrasil/src/variations.rs
+++ b/fontdrasil/src/variations.rs
@@ -6,7 +6,7 @@ use std::{
     ops::{Add, Mul, Sub},
 };
 
-use fontdrasil::{
+use crate::{
     coords::{NormalizedCoord, NormalizedLocation},
     types::{Axes, Axis},
 };
@@ -19,7 +19,16 @@ use write_fonts::{
     types::{F2Dot14, Tag},
 };
 
-use crate::error::VariationModelError;
+#[derive(Debug, Error)]
+pub enum VariationModelError {
+    #[error("{axis_names:?} in {location:?} have no assigned order")]
+    AxesWithoutAssignedOrder {
+        axis_names: Vec<Tag>,
+        location: NormalizedLocation,
+    },
+    #[error("{0} is an axis of variation defined only at a single point")]
+    PointAxis(Tag),
+}
 
 /// Different ways of rounding values.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -872,12 +881,13 @@ fn delta_weights(
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use std::{
         collections::{HashMap, HashSet},
         str::FromStr,
     };
 
-    use fontdrasil::{
+    use crate::{
         coords::{CoordConverter, DesignCoord, NormalizedLocation, UserCoord},
         types::Axis,
     };
@@ -885,10 +895,6 @@ mod tests {
     use ordered_float::OrderedFloat;
 
     use pretty_assertions::assert_eq;
-
-    use crate::variations::ONE;
-
-    use super::*;
 
     fn default_master_weight() -> Vec<(usize, OrderedFloat<f64>)> {
         // no locations are contributing deltas

--- a/fontir/src/error.rs
+++ b/fontir/src/error.rs
@@ -3,13 +3,14 @@ use std::{fmt::Display, io, path::PathBuf};
 use fontdrasil::{
     coords::{DesignCoord, NormalizedCoord, NormalizedLocation, UserCoord, UserLocation},
     types::GlyphName,
+    variations::{DeltaError, VariationModelError},
 };
 use kurbo::Point;
 use smol_str::SmolStr;
 use thiserror::Error;
 use write_fonts::types::{InvalidTag, Tag};
 
-use crate::{ir::GlobalMetric, variations::DeltaError};
+use crate::ir::GlobalMetric;
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -179,17 +180,6 @@ pub enum PathConversionError {
     /// The source data could not be parsed or interpreted
     #[error("{0}")]
     Parse(String),
-}
-
-#[derive(Debug, Error)]
-pub enum VariationModelError {
-    #[error("{axis_names:?} in {location:?} have no assigned order")]
-    AxesWithoutAssignedOrder {
-        axis_names: Vec<Tag>,
-        location: NormalizedLocation,
-    },
-    #[error("{0} is an axis of variation defined only at a single point")]
-    PointAxis(Tag),
 }
 
 impl Display for BadAnchorReason {

--- a/fontir/src/glyph.rs
+++ b/fontir/src/glyph.rs
@@ -13,6 +13,7 @@ use fontdrasil::{
     coords::NormalizedLocation,
     orchestration::{Access, AccessBuilder, Work},
     types::GlyphName,
+    variations::{RoundingBehaviour, VariationModel},
 };
 use kurbo::{Affine, BezPath};
 use log::{debug, log_enabled, trace};
@@ -23,7 +24,6 @@ use crate::{
     error::{BadGlyph, Error},
     ir::{Component, GlobalMetric, Glyph, GlyphBuilder, GlyphInstance, GlyphOrder, StaticMetadata},
     orchestration::{Context, Flags, IrWork, WorkId},
-    variations::VariationModel,
 };
 
 pub fn create_glyph_order_work() -> Box<IrWork> {
@@ -467,7 +467,7 @@ fn instantiate_instance(
     // the fractional bits can be very important).
     // This matches fonttools, see https://github.com/googlefonts/ufo2ft/blob/01d3faee/Lib/ufo2ft/_compilers/baseCompiler.py#L266
     let deltas = model
-        .deltas_with_rounding(&point_seqs, crate::variations::RoundingBehaviour::None)
+        .deltas_with_rounding(&point_seqs, RoundingBehaviour::None)
         .map_err(|e| BadGlyph::new(&glyph.name, e))?;
     let points = VariationModel::interpolate_from_deltas(loc, &deltas);
     Ok(glyph

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -20,12 +20,12 @@ use write_fonts::{
 use fontdrasil::{
     coords::NormalizedLocation,
     types::{Axes, GlyphName},
+    variations::{ModelDeltas, VariationModel},
 };
 
 use crate::{
     error::{BadAnchor, BadAnchorReason, BadGlyph, BadGlyphKind, Error},
     orchestration::{IdAware, Persistable, WorkId},
-    variations::{ModelDeltas, VariationModel},
 };
 
 // just public so we publish the docs

--- a/fontir/src/ir/static_metadata.rs
+++ b/fontir/src/ir/static_metadata.rs
@@ -18,9 +18,10 @@ use write_fonts::{
 use fontdrasil::{
     coords::{DesignCoord, NormalizedCoord, NormalizedLocation, UserLocation},
     types::{Axes, Axis, GlyphName},
+    variations::{VariationModel, VariationModelError},
 };
 
-use crate::{error::VariationModelError, orchestration::Persistable, variations::VariationModel};
+use crate::orchestration::Persistable;
 
 /// Glyph names mapped to postscript names
 pub type PostscriptNames = HashMap<GlyphName, GlyphName>;

--- a/fontir/src/lib.rs
+++ b/fontir/src/lib.rs
@@ -7,4 +7,3 @@ pub mod ir;
 pub mod orchestration;
 pub mod paths;
 pub mod source;
-pub mod variations;

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -1859,6 +1859,7 @@ mod tests {
         coords::{DesignCoord, DesignLocation, NormalizedCoord, NormalizedLocation, UserCoord},
         orchestration::{Access, AccessBuilder},
         types::GlyphName,
+        variations::Tent,
     };
     use fontir::{
         ir::{
@@ -1868,7 +1869,6 @@ mod tests {
         orchestration::{Context, Flags, WorkId},
         paths::Paths,
         source::Source,
-        variations::Tent,
     };
     use norad::designspace;
 


### PR DESCRIPTION
This will let me use it from glyphs-reader, where I'm trying to instantiate smart components.

(It might also be useful for interpolating anchors?)