### PR TITLE
VariationModel only needs to know the axis order

### DIFF
--- a/fontbe/src/features.rs
+++ b/fontbe/src/features.rs
@@ -207,13 +207,10 @@ pub(crate) fn resolve_variable_metric<'a>(
     let var_model: Cow<'_, VariationModel> = if locations == global_locations {
         Cow::Borrowed(&static_metadata.variation_model)
     } else {
-        Cow::Owned(
-            VariationModel::new(
-                locations.into_iter().cloned().collect(),
-                static_metadata.axes.clone(),
-            )
-            .unwrap(),
-        )
+        Cow::Owned(VariationModel::new(
+            locations.into_iter().cloned().collect(),
+            static_metadata.axes.axis_order(),
+        ))
     };
 
     let raw_deltas: Vec<_> = var_model
@@ -335,13 +332,10 @@ impl VariationInfo for FeaVariationInfo<'_> {
         let var_model: Cow<'_, VariationModel> = if locations == global_locations {
             Cow::Borrowed(&self.static_metadata.variation_model)
         } else {
-            Cow::Owned(
-                VariationModel::new(
-                    locations.into_iter().cloned().collect(),
-                    self.static_metadata.axes.clone(),
-                )
-                .unwrap(),
-            )
+            Cow::Owned(VariationModel::new(
+                locations.into_iter().cloned().collect(),
+                self.static_metadata.axes.axis_order(),
+            ))
         };
 
         // Only 1 value per region for our input

--- a/fontbe/src/glyphs.rs
+++ b/fontbe/src/glyphs.rs
@@ -464,8 +464,8 @@ impl Work<Context, AnyWorkId, Error> for GlyphWork {
             )?
         } else {
             let locations: HashSet<_> = ir_glyph.sources().keys().cloned().collect();
-            let sub_model = VariationModel::new(locations, static_metadata.axes.clone())
-                .map_err(|e| Error::VariationModelError(self.glyph_name.clone(), e))?;
+            let sub_model = VariationModel::new(locations, static_metadata.axes.axis_order());
+
             compute_deltas(
                 &self.glyph_name,
                 &sub_model,

--- a/fontbe/src/hvar.rs
+++ b/fontbe/src/hvar.rs
@@ -48,7 +48,7 @@ impl Work<Context, AnyWorkId, Error> for HvarWork {
         }
         let var_model = &static_metadata.variation_model;
         let glyph_order = context.ir.glyph_order.get();
-        let axis_count = var_model.axes().count().try_into().unwrap();
+        let axis_count = var_model.axis_order().len().try_into().unwrap();
         let glyphs: Vec<_> = glyph_order
             .names()
             .map(|name| context.ir.glyphs.get(&FeWorkId::Glyph(name.clone())))
@@ -57,7 +57,7 @@ impl Work<Context, AnyWorkId, Error> for HvarWork {
         let metrics = context.ir.global_metrics.get();
 
         let mut glyph_width_deltas = AdvanceDeltas::new(
-            var_model.clone(),
+            &static_metadata,
             glyph_locations,
             &metrics,
             DeltaDirection::Horizontal,

--- a/fontbe/src/mvar.rs
+++ b/fontbe/src/mvar.rs
@@ -5,7 +5,7 @@ use std::collections::BTreeMap;
 use fontdrasil::{
     orchestration::{Access, AccessBuilder, Work},
     types::Axes,
-    variations::{ModelDeltas, VariationModel},
+    variations::ModelDeltas,
 };
 use fontir::orchestration::WorkId as FeWorkId;
 use write_fonts::{
@@ -38,8 +38,7 @@ struct MvarBuilder {
 }
 
 impl MvarBuilder {
-    fn new(global_model: VariationModel) -> Self {
-        let axes = global_model.axes().cloned().collect();
+    fn new(axes: Axes) -> Self {
         MvarBuilder {
             axes,
             deltas: BTreeMap::new(),
@@ -118,9 +117,7 @@ impl Work<Context, AnyWorkId, Error> for MvarWork {
         // https://github.com/fonttools/fonttools/blob/2dc887c/Lib/fontTools/varLib/__init__.py#L661-L736
         let static_metadata = context.ir.static_metadata.get();
         let metrics = context.ir.global_metrics.get();
-        let var_model = &static_metadata.variation_model;
-
-        let mut mvar_builder = MvarBuilder::new(var_model.clone());
+        let mut mvar_builder = MvarBuilder::new(static_metadata.axes.clone());
         for (metric, deltas) in metrics.iter() {
             // some of the GlobalMetric variants are not MVAR-relevant, e.g.
             // hhea ascender/descender/lineGap so we just skip those
@@ -154,10 +151,9 @@ mod tests {
     use super::*;
     use crate::test_util;
 
-    fn new_mvar_builder(locations: Vec<&NormalizedLocation>, axes: Vec<Axis>) -> MvarBuilder {
-        let locations = locations.into_iter().cloned().collect();
-        let model = VariationModel::new(locations, axes.into()).unwrap();
-        MvarBuilder::new(model)
+    fn new_mvar_builder(axes: Vec<Axis>) -> MvarBuilder {
+        let axes = Axes::new(axes);
+        MvarBuilder::new(axes)
     }
 
     fn build_metrics(
@@ -195,7 +191,7 @@ mod tests {
         let regular = NormalizedLocation::for_pos(&[("wght", 0.0)]);
         let bold = NormalizedLocation::for_pos(&[("wght", 1.0)]);
         let axes = vec![test_util::axis("wght", 400.0, 400.0, 700.0)];
-        let mut builder = new_mvar_builder(vec![&regular, &bold], axes.clone());
+        let mut builder = new_mvar_builder(axes.clone());
 
         let metrics = build_metrics(
             &[(GlobalMetric::XHeight, &[(&regular, 500.0), (&bold, 550.0)])],
@@ -235,7 +231,7 @@ mod tests {
         let regular = NormalizedLocation::for_pos(&[("wght", 0.0)]);
         let bold = NormalizedLocation::for_pos(&[("wght", 1.0)]);
         let axes = vec![test_util::axis("wght", 400.0, 400.0, 700.0)];
-        let mut builder = new_mvar_builder(vec![&regular, &bold], axes.clone());
+        let mut builder = new_mvar_builder(axes.clone());
 
         let metrics = build_metrics(
             &[
@@ -278,7 +274,7 @@ mod tests {
         let medium = NormalizedLocation::for_pos(&[("wght", 0.5)]);
         let bold = NormalizedLocation::for_pos(&[("wght", 1.0)]);
         let axes = vec![test_util::axis("wght", 400.0, 400.0, 700.0)];
-        let mut builder = new_mvar_builder(vec![&regular, &medium, &bold], axes.clone());
+        let mut builder = new_mvar_builder(axes.clone());
 
         let metrics = build_metrics(
             &[

--- a/fontbe/src/vvar.rs
+++ b/fontbe/src/vvar.rs
@@ -54,7 +54,7 @@ impl Work<Context, AnyWorkId, Error> for VvarWork {
         }
         let var_model = &static_metadata.variation_model;
         let glyph_order = context.ir.glyph_order.get();
-        let axis_count = var_model.axes().count().try_into().unwrap();
+        let axis_count = var_model.axis_order().len().try_into().unwrap();
         let glyphs: Vec<_> = glyph_order
             .names()
             .map(|name| context.ir.glyphs.get(&FeWorkId::Glyph(name.clone())))
@@ -63,7 +63,7 @@ impl Work<Context, AnyWorkId, Error> for VvarWork {
         let metrics = context.ir.global_metrics.get();
 
         let mut glyph_deltas = AdvanceDeltas::new(
-            var_model.clone(),
+            &static_metadata,
             glyph_locations,
             &metrics,
             DeltaDirection::Vertical,

--- a/fontdrasil/src/types.rs
+++ b/fontdrasil/src/types.rs
@@ -10,7 +10,7 @@ use std::{
 use serde::{Deserialize, Serialize};
 use smol_str::SmolStr;
 
-use write_fonts::types::Tag;
+pub use write_fonts::types::Tag;
 
 use crate::coords::{CoordConverter, UserCoord};
 
@@ -208,6 +208,10 @@ impl Axes {
     pub fn new(axes: Vec<Axis>) -> Self {
         let by_tag = axes.iter().enumerate().map(|(i, ax)| (ax.tag, i)).collect();
         Self { axes, by_tag }
+    }
+
+    pub fn axis_order(&self) -> Vec<Tag> {
+        self.axes.iter().map(|ax| ax.tag).collect()
     }
 
     #[doc(hidden)]

--- a/fontir/src/glyph.rs
+++ b/fontir/src/glyph.rs
@@ -492,10 +492,10 @@ fn variation_model_for_glyph<'a>(
     // otherwise we need a special model for this glyph.
     // This code is duplicated in various places (hvar, e.g.)
     // and maybe we can share it? or cache these models more globally?
-    Cow::Owned(
-        VariationModel::new(glyph.sources().keys().cloned().collect(), meta.axes.clone())
-            .expect("point axes not present in meta.axes"),
-    )
+    Cow::Owned(VariationModel::new(
+        glyph.sources().keys().cloned().collect(),
+        meta.axes.iter().map(|ax| ax.tag).collect(),
+    ))
 }
 
 fn move_contours_to_new_component(

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -588,8 +588,8 @@ impl GlobalMetricsBuilder {
             .0
             .into_iter()
             .map(|(tag, values)| -> Result<_, Error> {
-                let model = VariationModel::new(values.keys().cloned().collect(), axes.clone())
-                    .map_err(|e| Error::MetricVariationError(tag, e))?;
+                let model =
+                    VariationModel::new(values.keys().cloned().collect(), axes.axis_order());
 
                 let sources = values
                     .into_iter()

--- a/fontir/src/ir/static_metadata.rs
+++ b/fontir/src/ir/static_metadata.rs
@@ -432,7 +432,7 @@ impl StaticMetadata {
                 .map(|(string, key)| (key, string)),
         );
 
-        let variation_model = VariationModel::new(global_locations, variable_axes.clone())?;
+        let variation_model = VariationModel::new(global_locations, variable_axes.axis_order());
 
         let default_location = axes
             .iter()
@@ -570,9 +570,8 @@ mod tests {
                     vec![(WGHT, NormalizedCoord::new(0.0))].into(),
                     vec![(WGHT, NormalizedCoord::new(1.0))].into(),
                 ]),
-                vec![axis.clone()].into(),
-            )
-            .unwrap(),
+                vec![axis.tag],
+            ),
             default_location: vec![(WGHT, NormalizedCoord::new(0.0))].into(),
             names: HashMap::from([
                 (


### PR DESCRIPTION
Instead of needing to fully own a copy of the `Axes` struct.

- this will simplify using the variation model for the mini design spaces used by smart components
- this means there is only one copy of 'Axes', which lives in StaticMetadata
- overall this makes it easier to construct a VariationModel.