### PR TITLE
[crater] Update google-fonts-sources

### DIFF
--- a/fontc_crater/Cargo.toml
+++ b/fontc_crater/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 [dependencies]
 fontc = { version = "0.3.2", path = "../fontc" }
 
-google-fonts-sources = "0.10.0"
+google-fonts-sources = "0.10.2"
 maud = "0.27.0"
 tidier = "0.5.3"
 

--- a/fontc_crater/src/ci.rs
+++ b/fontc_crater/src/ci.rs
@@ -100,6 +100,7 @@ fn run_crater_and_save_results(args: &CiArgs) -> Result<(), Error> {
     let input_file_sha = super::get_input_sha(&args.to_run);
 
     let cache_dir = args.cache_dir();
+    inputs.update_fonts_repo(&cache_dir)?;
     log::info!("using cache dir {}", cache_dir.display());
     let results_cache = ResultsCache::in_dir(&cache_dir);
 
@@ -266,8 +267,8 @@ fn make_targets(cache_dir: &Path, repos: &[FontSource]) -> ResolvedTargets {
             .insert(repo_dir.clone(), repo.repo_url.clone());
 
         let sources_dir = if repo.config_is_external() {
-            // virtual config always assumes it is in a directory named 'sources'
-            repo.repo_path(cache_dir).join("sources")
+            // virtual config always assumes it is in directory root
+            repo.repo_path(cache_dir)
         } else {
             // otherwise the config file is always in the source directory
             config_path.parent().unwrap().to_owned()

--- a/fontc_crater/src/target.rs
+++ b/fontc_crater/src/target.rs
@@ -9,8 +9,6 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 
-static VIRTUAL_CONFIG_DIR: &str = "sources";
-
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(crate) struct Target {
     /// path to the source repo, relative to the cache dir root
@@ -74,7 +72,7 @@ impl Target {
     /// Otherwise, it is the parent directory of the config file.
     fn source_dir(&self) -> PathBuf {
         if self.is_virtual {
-            self.repo_dir.join(VIRTUAL_CONFIG_DIR)
+            self.repo_dir.clone()
         } else {
             self.repo_dir.join(self.config.parent().unwrap())
         }


### PR DESCRIPTION
- we now assume that an external config is always in the repo root
- we now include the SHA of the google/fonts repo in the targets.json, and ensure that this matches when doing a crater run.


this fixes a bunch of missing sources.