### PR TITLE
Update gftools to latest v0.9.92 in requirements.txt

### DIFF
--- a/resources/scripts/requirements.in
+++ b/resources/scripts/requirements.in
@@ -10,4 +10,4 @@ cdifflib
 glyphsLib
 # keep gftools pinned as well to ensure ttx_diff.py output is stable.
 # 0.9.74 is when experimental support for fontc was added to gftools.
-gftools==0.9.85
+gftools==0.9.92

--- a/resources/scripts/requirements.txt
+++ b/resources/scripts/requirements.txt
@@ -64,6 +64,8 @@ defcon[lxml,pens]==0.12.2
     #   glyphsets
     #   mutatormath
     #   ufoprocessor
+ffmpeg-python==0.2.0
+    # via gftools
 filelock==3.20.0
     # via youseedee
 font-v==2.1.0
@@ -115,13 +117,15 @@ fonttools[lxml,repacker,ufo,unicode,woff]==4.60.1
     #   ufoprocessor
     #   vharfbuzz
     #   vttlib
+future==1.0.0
+    # via ffmpeg-python
 gflanguages==0.7.7
     # via
     #   gftools
     #   glyphsets
 gfsubsets==2024.9.25
     # via gftools
-gftools==0.9.85
+gftools==0.9.92
     # via -r resources/scripts/requirements.in
 gitdb==4.0.12
     # via gitpython


### PR DESCRIPTION
We hadn't updated it since v0.9.85 which was released back in May 2025 apparently, I guess it's time to compare with the latest?

https://pypi.org/project/gftools/#history

JMM