### PR TITLE
Make interpolate_from_deltas a method

### DIFF
--- a/fontdrasil/src/variations.rs
+++ b/fontdrasil/src/variations.rs
@@ -356,6 +356,7 @@ impl VariationModel {
     /// type parameter for the return value so that e.g. absolute Points are returned
     /// when the deltas are Vec2?
     pub fn interpolate_from_deltas<V>(
+        &self,
         location: &NormalizedLocation,
         deltasets: &[(VariationRegion, Vec<V>)],
     ) -> Vec<V>
@@ -1429,10 +1430,7 @@ mod tests {
 
         let loc = NormalizedLocation::for_pos(&[("wght", -0.5)]);
         let expected = vec![7.5];
-        assert_eq!(
-            expected,
-            VariationModel::interpolate_from_deltas(&loc, &deltas)
-        );
+        assert_eq!(expected, model.interpolate_from_deltas(&loc, &deltas));
     }
 
     #[derive(Debug, Default, Copy, Clone, PartialEq)]
@@ -1521,8 +1519,8 @@ mod tests {
                     .all(|(_, deltas)| { deltas.iter().all(|d| d.fract() == 0.0) })
             );
 
-            let expected: Vec<f64> = VariationModel::interpolate_from_deltas(&loc, &deltas_float);
-            let actual: Vec<f64> = VariationModel::interpolate_from_deltas(&loc, &deltas_round);
+            let expected: Vec<f64> = model.interpolate_from_deltas(&loc, &deltas_float);
+            let actual: Vec<f64> = model.interpolate_from_deltas(&loc, &deltas_round);
 
             let err = (actual[0] - expected[0]).abs();
             assert!(err <= 0.5, "i: {i}, err: {err}");
@@ -1530,7 +1528,7 @@ mod tests {
             // when the influence of many masters overlap a particular location
             // interpolating from late-rounded deltas may lead to an accummulation
             // of rounding errors that exceed the max tolerance
-            let bad = VariationModel::interpolate_from_deltas(&loc, &deltas_late_round);
+            let bad = model.interpolate_from_deltas(&loc, &deltas_late_round);
             let err_bad = (bad[0] - expected[0]).abs();
             if err_bad > 0.5 {
                 num_bad_errors += 1;
@@ -1608,9 +1606,7 @@ mod tests {
                 .iter()
                 .map(|(loc, _)| (
                     loc.clone(),
-                    VariationModel::interpolate_from_deltas(loc, &deltas)
-                        .iter()
-                        .sum()
+                    model.interpolate_from_deltas(loc, &deltas).iter().sum()
                 ))
                 .collect::<Vec<_>>()
         );

--- a/fontir/src/glyph.rs
+++ b/fontir/src/glyph.rs
@@ -468,7 +468,7 @@ fn instantiate_instance(
     let deltas = model
         .deltas_with_rounding(&point_seqs, RoundingBehaviour::None)
         .map_err(|e| BadGlyph::new(&glyph.name, e))?;
-    let points = VariationModel::interpolate_from_deltas(loc, &deltas);
+    let points = model.interpolate_from_deltas(loc, &deltas);
     Ok(glyph
         .default_instance()
         .new_with_interpolated_values(&points))

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -625,7 +625,10 @@ impl GlobalMetrics {
     pub fn get(&self, metric: GlobalMetric, pos: &NormalizedLocation) -> OrderedFloat<f64> {
         let deltas = self.deltas(metric);
 
-        VariationModel::interpolate_from_deltas(pos, deltas)
+        VariationModel::empty()
+            // the 'self' param of this method is only used to get extrapolation
+            // information, and we are not extrapolating here.
+            .interpolate_from_deltas(pos, deltas)
             .iter()
             .map(|float| OrderedFloat::<f64>::from(*float))
             .sum()

--- a/glyphs-reader/src/smart_components.rs
+++ b/glyphs-reader/src/smart_components.rs
@@ -138,7 +138,7 @@ pub(crate) fn instantiate_for_layer(
         })
         .collect::<Result<HashMap<_, _>, BadSmartComponent>>()?;
     let deltas = model.deltas(&point_seqs).unwrap();
-    let points = VariationModel::interpolate_from_deltas(&location, &deltas);
+    let points = model.interpolate_from_deltas(&location, &deltas);
     let mut shapes = shapes_with_new_points(relevant_layers[0], &points);
     shapes.iter_mut().for_each(|shape| {
         shape.apply_affine(component.transform);


### PR DESCRIPTION
This matches fonttools, and will let us support extrapolation in the variation model. (Extrapolation requires passing extra arguments to get_scalar, and we can store those arguments in the VariationModel.)


(this is otherwise no functional change, it just sets me up for the next patch)