### PR TITLE
[pyproject.toml] fix dynamic version warning when running `uv venv`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,9 +24,12 @@ exclude = [
 [project]
 # 'name' key is required for [project]
 name = "fontc"
-# comment out 'version' to use the same as Cargo.toml, only override if needed
+# We want to use the same 'version' as Cargo.toml; only override if needed
 # (e.g. for a post-release to fix some packaging issues with a previous release)
 # version = "0.0.1.post1"
+# Since 'version' is required filed in [project], we must also set it as
+# 'dynamic' otherwise tools such as `uv venv` issue a warning message
+dynamic = ["version"]
 # Ensure we use the workspace's top-level README.md for the sdist/wheel metadata
 # not the fontc crate's specific README.md
 readme = "README.md"


### PR DESCRIPTION
pyproject.toml is used to set up maturin to build the fontc wheel that we publish to PyPI.
We omit the version field from `[project]` because we want the same version as fontc's Cargo.toml to be used so they are in sycn. Maturin merges Cargo.toml metadata with pyproject.toml, with the latter overriding the former.

Now, version is a required field in pyproject.toml and tools such as `uv venv` would issue a warning when that's absent.

We can still omit it but we have to declare that version field as "dynamic" (i.e. to be defined at build time)

JMM