### PR TITLE
Build separate glibc and musl Linux wheels for better performance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,8 +131,51 @@ jobs:
             *.tar.gz
             *.zip
 
-  build_linux:
-    name: Build ${{ matrix.platform.target }}
+  build_linux_glibc:
+    name: Build ${{ matrix.platform.target }} (glibc)
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - target: "x86_64-unknown-linux-gnu"
+            manylinux: "2014"
+          - target: "aarch64-unknown-linux-gnu"
+            manylinux: "2014"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build Wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.platform.target }}
+          manylinux: ${{ matrix.platform.manylinux }}
+          args: --release -o dist
+
+      - name: Install x86_64 wheel
+        if: startsWith(matrix.platform.target, 'x86_64')
+        run: |
+          pip install --no-index --find-links dist/ --force-reinstall fontc
+          which fontc
+          fontc --version
+
+      - name: Archive binary
+        run: tar czvf target/release/fontc-${{ matrix.platform.target }}.tar.gz -C target/${{ matrix.platform.target }}/release fontc
+
+      - name: Upload wheel artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.platform.target }}
+          path: dist
+
+      - name: Upload binary artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: binaries-${{ matrix.platform.target }}
+          path: target/release/fontc-${{ matrix.platform.target }}.tar.gz
+
+  build_linux_musl:
+    name: Build ${{ matrix.platform.target }} (musl)
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -140,10 +183,10 @@ jobs:
         platform:
           - target: "x86_64-unknown-linux-musl"
             image_tag: "x86_64-musl"
-            compatibility: "manylinux2010 musllinux_1_1"
+            compatibility: "musllinux_1_1"
           - target: "aarch64-unknown-linux-musl"
             image_tag: "aarch64-musl"
-            compatibility: "manylinux2014 musllinux_1_1"
+            compatibility: "musllinux_1_1"
     container:
       image: docker://ghcr.io/rust-cross/rust-musl-cross:${{ matrix.platform.image_tag }}
     steps:
@@ -184,7 +227,7 @@ jobs:
   release-pypi:
     name: Publish to PyPI
     if: startsWith(github.ref, 'refs/tags/fontc-v')
-    needs: [build, build_linux]
+    needs: [build, build_linux_glibc, build_linux_musl]
     runs-on: ubuntu-latest
     permissions:
       # IMPORTANT: this permission is mandatory for trusted publishing
@@ -210,7 +253,7 @@ jobs:
     name: Publish to GitHub releases
     runs-on: ubuntu-latest
     if: "startsWith(github.ref, 'refs/tags/fontc-v')"
-    needs: [build, build_linux]
+    needs: [build, build_linux_glibc, build_linux_musl]
     steps:
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
Fixes #1707

Previously only musl-based wheels were built for Linux, causing performance regression on glibc systems (Ubuntu) due to musl's slower memory allocator.