### PR TITLE
Respect 'Original kern groups'

### DIFF
--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -270,11 +270,31 @@ impl KernSide {
 }
 
 impl KernGroup {
+    pub const UFO_KERN1_PREFIX: &str = "public.kern1.";
+    pub const UFO_KERN2_PREFIX: &str = "public.kern2.";
     /// Convert to the other side. Used when processing RTL kerns in glyphs.
     pub fn flip(self) -> Self {
         match self {
             KernGroup::Side1(name) => KernGroup::Side2(name),
             KernGroup::Side2(name) => KernGroup::Side1(name),
+        }
+    }
+
+    /// Construct from a string with the conventional prefixes used in UFO
+    pub fn from_ufo_group_name(name: &str) -> Option<KernGroup> {
+        name.strip_prefix(Self::UFO_KERN1_PREFIX)
+            .map(|name| Self::Side1(name.into()))
+            .or_else(|| {
+                name.strip_prefix(Self::UFO_KERN2_PREFIX)
+                    .map(|name| Self::Side2(name.into()))
+            })
+    }
+
+    /// the side number, as an integer
+    pub fn side_integer(&self) -> u8 {
+        match self {
+            KernGroup::Side1(_) => 1,
+            KernGroup::Side2(_) => 2,
         }
     }
 }

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -1010,6 +1010,32 @@ impl Work<Context, WorkId, Error> for KerningGroupWork {
         let font = &font_info.font;
 
         let mut groups = KerningGroups::default();
+        let mut recovered = HashSet::new();
+        for (group, glyphs) in &font.user_data.original_kerning_groups {
+            let Some(group) = KernGroup::from_ufo_group_name(group) else {
+                log::info!("unknown kern group '{group}'");
+                continue;
+            };
+
+            for glyph_name in glyphs {
+                //https://github.com/googlefonts/glyphsLib/blob/f90e4060/Lib/glyphsLib/builder/groups.py#L100
+                let condition = match font.glyphs.get(glyph_name) {
+                    None => true,
+                    Some(glyph) => match &group {
+                        KernGroup::Side1(name) => glyph.right_kern.as_ref() == Some(name),
+                        KernGroup::Side2(name) => glyph.left_kern.as_ref() == Some(name),
+                    },
+                };
+                if condition {
+                    groups
+                        .groups
+                        .entry(group.clone())
+                        .or_default()
+                        .insert(glyph_name.clone().into());
+                    recovered.insert((glyph_name, group.side_integer()));
+                }
+            }
+        }
 
         //https://github.com/googlefonts/glyphsLib/blob/682ff4b177/Lib/glyphsLib/builder/groups.py#L114
         let rtl_glyphs = get_glyphs_with_rtl_kerning(font);
@@ -1035,6 +1061,9 @@ impl Work<Context, WorkId, Error> for KerningGroupWork {
                 (right, left)
             };
             for group in [side1, side2].into_iter().flatten() {
+                if recovered.contains(&(name, group.side_integer())) {
+                    continue;
+                }
                 groups.groups.entry(group).or_default().extend(
                     bracket_names
                         .iter()
@@ -2663,6 +2692,20 @@ mod tests {
                 ("@side1.bet", "@side2.alef", 29)
             ])
         )
+    }
+
+    #[test]
+    fn respect_original_groups_lib_key() {
+        let _ = env_logger::builder().is_test(true).try_init();
+        let (_, ctx) = build_kerning(glyphs3_dir().join("FontcIssue1728.glyphs"));
+        let groups = ctx.kerning_groups.get();
+        assert!(
+            !groups
+                .groups
+                .get(&KernGroup::Side1("A".into()))
+                .unwrap()
+                .contains("AE")
+        );
     }
 
     #[test]

--- a/resources/testdata/glyphs3/FontcIssue1728.glyphs
+++ b/resources/testdata/glyphs3/FontcIssue1728.glyphs
@@ -1,0 +1,131 @@
+{
+.appVersion = "3436";
+.formatVersion = 3;
+familyName = FunkyKerns;
+fontMaster = (
+{
+id = "FF2DC345-5101-49B6-97F3-57A040F7C387";
+name = Regular;
+}
+);
+glyphs = (
+{
+glyphname = A;
+kernLeft = A;
+kernRight = A;
+layers = (
+{
+layerId = "FF2DC345-5101-49B6-97F3-57A040F7C387";
+}
+);
+unicode = 65;
+},
+{
+glyphname = AE;
+kernLeft = A;
+kernRight = E;
+layers = (
+{
+layerId = "FF2DC345-5101-49B6-97F3-57A040F7C387";
+}
+);
+unicode = 198;
+},
+{
+glyphname = E;
+kernRight = E;
+layers = (
+{
+layerId = "FF2DC345-5101-49B6-97F3-57A040F7C387";
+}
+);
+unicode = 69;
+},
+{
+glyphname = S;
+kernLeft = S;
+kernRight = S;
+layers = (
+{
+layerId = "FF2DC345-5101-49B6-97F3-57A040F7C387";
+}
+);
+unicode = 83;
+},
+{
+glyphname = V;
+kernLeft = V;
+kernRight = V;
+layers = (
+{
+layerId = "FF2DC345-5101-49B6-97F3-57A040F7C387";
+}
+);
+unicode = 86;
+},
+{
+glyphname = a;
+kernLeft = a;
+kernRight = a;
+layers = (
+{
+layerId = "FF2DC345-5101-49B6-97F3-57A040F7C387";
+}
+);
+unicode = 97;
+},
+{
+glyphname = c;
+kernLeft = o;
+kernRight = c;
+layers = (
+{
+layerId = "FF2DC345-5101-49B6-97F3-57A040F7C387";
+}
+);
+unicode = 99;
+}
+);
+kerningLTR = {
+"FF2DC345-5101-49B6-97F3-57A040F7C387" = {
+"@MMK_L_A" = {
+"@MMK_R_S" = -55;
+"@MMK_R_o" = -65;
+};
+"@MMK_L_E" = {
+"@MMK_R_a" = -40;
+"@MMK_R_o" = -40;
+};
+"@MMK_L_V" = {
+"@MMK_R_A" = -66;
+"@MMK_R_a" = -56;
+"@MMK_R_o" = -56;
+};
+};
+};
+kerningRTL = {
+"FF2DC345-5101-49B6-97F3-57A040F7C387" = {
+"@MMK_R_A" = {
+"@MMK_L_V" = -69;
+};
+};
+};
+unitsPerEm = 1000;
+userData = {
+com.schriftgestaltung.Glyphs.originalKerningGroups = {
+public.kern1.A = (A,);
+public.kern1.E = (AE,E,);
+public.kern1.S = (S,);
+public.kern1.a = (a,);
+public.kern1.c = (c,);
+public.kern2.A = (A,);
+public.kern2.AE = (AE,);
+public.kern2.I = (E,);
+public.kern2.S = (S,);
+public.kern2.a = (a,);
+public.kern2.o = (c,);
+};
+};
+versionMajor = 1;
+versionMinor = 100;
+}


### PR DESCRIPTION
See #1728.

This patch has some pros and cons:

**cons**:
- it is replicating behaviour that we know to be buggy (https://github.com/googlefonts/glyphsLib/pull/778#issue-1146079983, https://github.com/googlefonts/glyphsLib/blob/f90e4060b/Lib/glyphsLib/builder/groups.py#L109-L112)
- it adds a bunch of mysterious logic that doesn't really do anything useful
- the actual behaviour we're 'fixing' here is ultimately probably an error in one source file (an LTR kern being added to RTL by accident)
- I hate it

**pros**
- green number go up