### PR TITLE
[glyphs] Ensure brackets have axis rules for each axis

### DIFF
--- a/resources/testdata/glyphs2/AxisRules.glyphs
+++ b/resources/testdata/glyphs2/AxisRules.glyphs
@@ -1,0 +1,41 @@
+{
+.appVersion = "3260";
+familyName = FunnyAxisThing;
+customParameters = (
+{
+name = Axes;
+value = (
+{
+Name = Weight;
+Tag = wght;
+},
+{
+Name = Width;
+Tag = wdth;
+}
+);
+},
+);
+fontMaster = (
+{
+id = master01;
+name = Regular;
+}
+);
+glyphs = (
+{
+glyphname = space;
+layers = (
+{
+
+associatedMasterId = master01;
+layerId = bracket01;
+width = 600;
+name = "]141]";
+}
+);
+unicode = 32;
+}
+);
+unitsPerEm = 1000;
+}


### PR DESCRIPTION
In glyphs2, a bracket layer can only reference a value on a single axis (from experimentation, it seems to only work with the first axis) and so in the case where multiple axes are defined, we need to add empty axis rules for the additional axes.

This fixes one crater diff.