### PR TITLE
Fix bug where non-color glyphs contributed to CPAL

### DIFF
--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -3749,6 +3749,13 @@ mod tests {
     }
 
     #[test]
+    fn color_only_if_explicitly_color() {
+        let compile = TestCompile::compile_source("glyphs3/COLRv1-solidnoncolor.glyphs");
+        assert!(compile.font().cpal().is_err());
+        assert!(compile.font().colr().is_err());
+    }
+
+    #[test]
     fn colr_grayscale() {
         let result = TestCompile::compile_source("glyphs3/COLRv1-grayscale.glyphs");
         result.font().colr().unwrap(); // for now just check the table exists

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -1588,6 +1588,7 @@ impl Work<Context, WorkId, Error> for ColorPaletteWork {
             .flat_map(|g| {
                 g.layers
                     .iter()
+                    .filter(|l| l.attributes.color)
                     .flat_map(|l| l.shapes.iter())
                     .flat_map(|s| s.attributes().colors())
             })

--- a/resources/testdata/glyphs3/COLRv1-solidnoncolor.glyphs
+++ b/resources/testdata/glyphs3/COLRv1-solidnoncolor.glyphs
@@ -1,0 +1,41 @@
+{
+.appVersion = "3343";
+.formatVersion = 3;
+familyName = "New Font";
+fontMaster = (
+{
+id = m01;
+name = Regular;
+}
+);
+glyphs = (
+{
+glyphname = A;
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+attr = {
+fillColor = (177,216,243,255);
+};
+closed = 1;
+nodes = (
+(63,0,l),
+(542,0,l),
+(542,500,l),
+(63,500,l)
+);
+}
+);
+width = 600;
+}
+);
+unicode = 65;
+}
+);
+
+unitsPerEm = 1000;
+versionMajor = 1;
+versionMinor = 0;
+}


### PR DESCRIPTION
Makes `python3 -m ttx_diff 'https://github.com/vercel/geist-font?b193ef7401#sources/Geist.glyphspackage'` identical again, hopefully correcting the -10 I scored yesterday :)

JMM