### PR TITLE
This is very noisy

### DIFF
--- a/ttx_diff/src/ttx_diff/core.py
+++ b/ttx_diff/src/ttx_diff/core.py
@@ -769,7 +769,6 @@ def allow_some_off_by_ones(fontc, fontmake, container, name_attr, coord_holder):
         name = fontmake_container.attrib[name_attr]
         fontc_container = fontc_items.get(name)
         if fontc_container is None:
-            eprint(f"no item where {name_attr}='{name}' in {container}")
             continue
 
         fontc_els = [el for el in fontc_container.iter() if el.tag == coord_tag]


### PR DESCRIPTION
This is producing endless streams of prints that are not helpful, ex

```
no item where name='zcaron.color2' in glyf/TTGlyph
no item where name='zcaron.color3' in glyf/TTGlyph
no item where name='zcaron.color4' in glyf/TTGlyph
no item where name='zcaron.color5' in glyf/TTGlyph
no item where name='zcaron.color6' in glyf/TTGlyph
no item where name='zcaron.color7' in glyf/TTGlyph
no item where name='zcaron.color8' in glyf/TTGlyph
...MANY more...
```

JMM