### PR TITLE
Add a source that requires glyph-splitting for color

### DIFF
--- a/resources/testdata/glyphs3/COLRv1-manyshapes-per-glyph.glyphs
+++ b/resources/testdata/glyphs3/COLRv1-manyshapes-per-glyph.glyphs
@@ -1,0 +1,82 @@
+{
+.appVersion = "3343";
+.formatVersion = 3;
+familyName = "New Font";
+fontMaster = (
+{
+id = m01;
+name = Regular;
+}
+);
+glyphs = (
+{
+glyphname = A;
+layers = (
+{
+attr = {
+color = 1;
+};
+layerId = m01;
+shapes = (
+{
+attr = {
+gradient = {
+colors = (
+(
+(255,0,0,255),
+0
+),
+(
+(0,0,255,255),
+1
+)
+);
+end = (0.9,0.9);
+start = (0.1,0.1);
+};
+};
+closed = 1;
+nodes = (
+(263,0,l),
+(542,0,l),
+(542,500,l),
+(263,500,l)
+);
+},
+{
+attr = {
+gradient = {
+colors = (
+(
+(0,255,0,255),
+0
+),
+(
+(0,255,255,255),
+1
+)
+);
+end = (0.9,0.9);
+start = (0.1,0.1);
+};
+};
+closed = 1;
+nodes = (
+(63,0,l),
+(342,0,l),
+(342,300,l),
+(63,300,l)
+);
+}
+);
+width = 600;
+}
+);
+unicode = 65;
+}
+);
+
+unitsPerEm = 1000;
+versionMajor = 1;
+versionMinor = 0;
+}


### PR DESCRIPTION
In fontmake this produces A.color0, A.color1. fontc will need to learn this trick. For now just adding the test file.

JMM