### PR TITLE
Produce color layers for split glyphs

### DIFF
--- a/fontdrasil/src/types.rs
+++ b/fontdrasil/src/types.rs
@@ -56,6 +56,12 @@ impl From<SmolStr> for GlyphName {
     }
 }
 
+impl From<&SmolStr> for GlyphName {
+    fn from(value: &SmolStr) -> Self {
+        GlyphName(value.clone())
+    }
+}
+
 impl From<&GlyphName> for GlyphName {
     fn from(value: &GlyphName) -> Self {
         value.to_owned()

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -2019,6 +2019,7 @@ pub enum Paint {
     Solid(Box<PaintSolid>),
     LinearGradient(Box<PaintLinearGradient>),
     RadialGradient(Box<PaintRadialGradient>),
+    Layers(Box<Vec<Paint>>),
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]

--- a/resources/testdata/glyphs3/COLRv1-gradientsolid.glyphs
+++ b/resources/testdata/glyphs3/COLRv1-gradientsolid.glyphs
@@ -1,0 +1,68 @@
+{
+.appVersion = "3343";
+.formatVersion = 3;
+familyName = "New Font";
+fontMaster = (
+{
+id = m01;
+name = Regular;
+}
+);
+glyphs = (
+{
+glyphname = A;
+layers = (
+{
+attr = {
+color = 1;
+};
+layerId = m01;
+shapes = (
+{
+attr = {
+gradient = {
+colors = (
+(
+(64,255),
+0
+),
+(
+(0,255),
+1
+)
+);
+end = (0.9,0.9);
+start = (0.1,0.1);
+};
+};
+closed = 1;
+nodes = (
+(63,0,l),
+(242,0,l),
+(242,500,l),
+(63,500,l)
+);
+},
+{
+attr = {
+fillColor = (177,216,243,255);
+};
+closed = 1;
+nodes = (
+(256,0,l),
+(542,0,l),
+(542,500,l),
+(256,500,l)
+);
+}
+);
+width = 600;
+}
+);
+unicode = 65;
+}
+);
+unitsPerEm = 1000;
+versionMajor = 1;
+versionMinor = 0;
+}


### PR DESCRIPTION
`python3 -m ttx_diff resources/testdata/glyphs3/COLRv1-manyshapes-per-glyph.glyphs` is now 82% matching for COLR, the remaining diffs are individual coords in clip boxes and gradients