### PR TITLE
Better match glyphs feature variation logic

### DIFF
--- a/fontdrasil/src/coords.rs
+++ b/fontdrasil/src/coords.rs
@@ -158,6 +158,10 @@ impl Coord<NormalizedSpace> {
         coord: OrderedFloat(1.0),
         space: PhantomData,
     };
+
+    pub fn to_f2dot14(self) -> F2Dot14 {
+        F2Dot14::from_f32(self.to_f64() as _)
+    }
 }
 
 /// Converts between Design, User, and Normalized coordinates.

--- a/glyphs-reader/src/lib.rs
+++ b/glyphs-reader/src/lib.rs
@@ -10,8 +10,8 @@ mod propagate_anchors;
 mod smart_components;
 
 pub use font::{
-    Anchor, Axis, Color, ColorStop, Component, CustomParameters, FeatureSnippet, Font, FontMaster,
-    Glyph, InstanceType, Layer, Node, NodeType, Path, Shape, ShapeAttributes,
+    Anchor, Axis, AxisRule, Color, ColorStop, Component, CustomParameters, FeatureSnippet, Font,
+    FontMaster, Glyph, InstanceType, Layer, Node, NodeType, Path, Shape, ShapeAttributes,
     glyphs_to_opentype_lang_id,
 };
 pub use plist::Plist;


### PR DESCRIPTION
Specifically make sure that we are always creating designspace rules for all relevant axes, even if the condition matches the whole axis; we will then filter out unnecessary axes later, just before generating the final data.

As far as I can tell this is functionally equivalent, but it was causing us to generate slightly different code from fonttools, and those diffs were hard to interpret.