### PR TITLE
[otl-normalizer] disable generate_release_notes, fix cargo binstall

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -373,4 +373,4 @@ jobs:
             checksums.txt
             requirements.txt
           prerelease: ${{ steps.before_release.outputs.is_prerelease }}
-          generate_release_notes: true
+          generate_release_notes: ${{ needs.detect.outputs.tool == 'fontc' }}

--- a/otl-normalizer/Cargo.toml
+++ b/otl-normalizer/Cargo.toml
@@ -19,3 +19,20 @@ indexmap.workspace = true
 [dev-dependencies]
 fea-rs = { version = "0.20.3", path = "../fea-rs" }
 
+# Support for `cargo binstall otl-normalizer`.
+# The default Github download URL template used by cargo-binstall doesn't work
+# because our tag is named `otl-normalizer-v{version}` instead of just `v{version}`.
+# https://github.com/cargo-bins/cargo-binstall/blob/main/SUPPORT.md
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/{ name }-v{ version }/{ name }-{ target }{ archive-suffix }"
+# Our binary archives contain just the `otl-normalizer` executable, no sub-folders
+bin-dir = "{ bin }{ binary-ext }"
+# We use .tar.gz for Linux/Mac binary archives, .zip for Windows
+pkg-fmt = "tgz"
+
+[package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
+pkg-fmt = "zip"
+
+[package.metadata.binstall.overrides.i686-pc-windows-msvc]
+pkg-fmt = "zip"
+


### PR DESCRIPTION
- we don't want GH to autogenerate release notes when creating a release for otl-normalizer (or else it would include changes from the entire workspace), so skip that
- add some metadata to otl-normalizer/Cargo.toml so `cargo binstall` can discover the prebuilt packages uploaded to Github release, same as we do for `fontc/Cargo.toml`.

JMM