### PR TITLE
bump otl-normalizer to 0.1.1

### DIFF
--- a/fontbe/Cargo.toml
+++ b/fontbe/Cargo.toml
@@ -47,4 +47,4 @@ temp-env.workspace = true
 rstest.workspace = true
 pretty_assertions.workspace = true
 env_logger.workspace = true
-otl-normalizer = { version = "0.1.0", path = "../otl-normalizer" }
+otl-normalizer = { version = "0.1.1", path = "../otl-normalizer" }

--- a/otl-normalizer/Cargo.toml
+++ b/otl-normalizer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "otl-normalizer"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 license = "MIT/Apache-2.0"
 description = "a normalized text representation of OpenType layout subtables"


### PR DESCRIPTION
no much changes besides some metadata in Cargo.toml to accommdate cargo binstall. I also need to bump the version to test the upload from Github to PyPI which failed the last time 'cause I didn't set up Trusted Publishing properly.

ignore me.