### PR TITLE
Build directly declared (typically for COLRv0) palettes

### DIFF
--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -3751,6 +3751,50 @@ mod tests {
     }
 
     #[test]
+    fn cpal_from_declared_palettes() {
+        let result = TestCompile::compile_source("glyphs3/COLRv0-simple.glyphs");
+        let cpal = result.font().cpal().unwrap();
+        assert_eq!(
+            (
+                2,
+                2,
+                [
+                    ColorRecord {
+                        red: 1,
+                        green: 2,
+                        blue: 3,
+                        alpha: 4
+                    },
+                    ColorRecord {
+                        red: 5,
+                        green: 6,
+                        blue: 7,
+                        alpha: 8
+                    },
+                    ColorRecord {
+                        red: 9,
+                        green: 10,
+                        blue: 11,
+                        alpha: 12
+                    },
+                    ColorRecord {
+                        red: 13,
+                        green: 14,
+                        blue: 15,
+                        alpha: 16
+                    },
+                ]
+                .as_slice()
+            ),
+            (
+                cpal.num_palettes(),
+                cpal.num_palette_entries(),
+                cpal.color_records_array().unwrap().unwrap()
+            )
+        );
+    }
+
+    #[test]
     fn color_me_not() {
         let compile = TestCompile::compile_source("glyphs3/WghtVar.glyphs");
         assert!(compile.font().cpal().is_err());

--- a/resources/testdata/glyphs3/COLRv0-simple.glyphs
+++ b/resources/testdata/glyphs3/COLRv0-simple.glyphs
@@ -1,0 +1,71 @@
+{
+.appVersion = "3343";
+.formatVersion = 3;
+customParameters = (
+{
+name = "Color Palettes";
+value = (
+(
+(1, 2, 3, 4),
+(5, 6, 7, 8)
+),
+(
+(9, 10, 11, 12),
+(13, 14, 15, 16)
+)
+);
+}
+);
+familyName = "New Font";
+fontMaster = (
+{
+id = m01;
+name = Regular;
+}
+);
+glyphs = (
+{
+glyphname = A;
+layers = (
+{
+attr = {
+colorPalette = 1;
+};
+layerId = m01;
+shapes = (
+{
+attr = {
+gradient = {
+colors = (
+(
+(255,0,0,255),
+0
+),
+(
+(0,0,255,255),
+1
+)
+);
+end = (0.9,0.9);
+start = (0.1,0.1);
+};
+};
+closed = 1;
+nodes = (
+(63,0,l),
+(542,0,l),
+(542,500,l),
+(63,500,l)
+);
+}
+);
+width = 600;
+}
+);
+unicode = 65;
+}
+);
+unitsPerEm = 1000;
+versionMajor = 1;
+versionMinor = 0;
+}


### PR DESCRIPTION
`CPAL` now identical in `python3 -m ttx_diff 'https://github.com/fridamedrano/Kalnia-Glaze?3338853e09#sources/KalniaGlaze.glyphs'` (alas only fontmake produced COLR tho, coming soon!)