### PR TITLE
Rough in static COLRv0

### DIFF
--- a/fontbe/src/colr.rs
+++ b/fontbe/src/colr.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     error::{Error, GlyphProblem},
-    orchestration::{AnyWorkId, BeWork, Context, WorkId},
+    orchestration::{AnyWorkId, BeWork, Context, Glyph, WorkId},
 };
 use fontdrasil::{
     orchestration::{Access, AccessBuilder, Work},
@@ -15,13 +15,13 @@ use fontir::{
 use write_fonts::{
     tables::{
         colr::{
-            BaseGlyphList, BaseGlyphPaint, Clip, ClipBox, ClipList, ColorLine, ColorStop, Colr,
-            Extend, LayerList, Paint, PaintColrLayers, PaintGlyph, PaintLinearGradient,
-            PaintRadialGradient, PaintSolid,
+            BaseGlyph, BaseGlyphList, BaseGlyphPaint, Clip, ClipBox, ClipList, ColorLine,
+            ColorStop, Colr, Extend, Layer, LayerList, Paint, PaintColrLayers, PaintGlyph,
+            PaintLinearGradient, PaintRadialGradient, PaintSolid,
         },
         glyf::Bbox,
     },
-    types::F2Dot14,
+    types::{F2Dot14, GlyphId16},
 };
 
 static OPAQUE: F2Dot14 = F2Dot14::ONE;
@@ -240,6 +240,89 @@ fn to_colr_paint(
     }
 }
 
+fn add_or_extend_clip(clips: &mut Vec<Clip>, quantization: i16, gid: GlyphId16, glyph: &Glyph) {
+    let bbox = glyph.data.bbox().unwrap_or_default();
+    // Quantize the bbox to maximize clipbox reuse
+    let next_clip = quantize_bbox(&bbox, quantization);
+    let next_clip = ClipBox::format_1(
+        next_clip.x_min.into(),
+        next_clip.y_min.into(),
+        next_clip.x_max.into(),
+        next_clip.y_max.into(),
+    );
+    if let Some(curr) = clips.last_mut()
+        && curr.end_glyph_id.to_u32() + 1 == gid.to_u32()
+        && *curr.clip_box == next_clip
+    {
+        // wow wow wow, a run!
+        curr.end_glyph_id = gid;
+        return; // DONE
+    }
+
+    // Evidently we didn't make a run
+    clips.push(Clip::new(gid, gid, next_clip));
+}
+
+fn is_paint_glyph_solid(paint: &ir::Paint) -> bool {
+    if let ir::Paint::Glyph(paint_glyph) = paint
+        && let ir::Paint::Solid(_) = &paint_glyph.paint
+    {
+        true
+    } else {
+        false
+    }
+}
+
+fn colr_v0_compatible(paint: &ir::Paint) -> bool {
+    if is_paint_glyph_solid(paint) {
+        return true;
+    }
+    if let ir::Paint::Layers(layers) = paint
+        && layers.iter().all(is_paint_glyph_solid)
+    {
+        return true;
+    }
+    false
+}
+
+/// Invariants:
+///
+/// * All glyph names are valid
+/// * All paint are PaintGlyph whose nested paint is PaintSolid (e.g. are COLRv0 compatible)
+fn new_colr0(
+    palette: &ColorPalettes,
+    glyph_order: &GlyphOrder,
+    glyph_name: &GlyphName,
+    paint: &[&ir::PaintGlyph],
+    layers: &mut Vec<Layer>,
+) -> Result<BaseGlyph, Error> {
+    let gid = glyph_order.glyph_id(glyph_name).expect("Prevalidated");
+    let candidate_layers = paint
+        .iter()
+        .map(|p| {
+            let ir::Paint::Solid(solid) = &p.paint else {
+                unreachable!("We prevalidated, what is {p:?}?!");
+            };
+            let palette_idx = palette.index_of(solid.color).expect("Prevalidated");
+            Layer::new(
+                glyph_order.glyph_id(&p.name).expect("Prevalidated"),
+                palette_idx as u16,
+            )
+        })
+        .collect::<Vec<_>>();
+    let first_idx = if let Some(pos) = layers
+        .windows(candidate_layers.len())
+        .position(|window| candidate_layers.as_slice() == window)
+    {
+        pos
+    } else {
+        let pos = layers.len();
+        layers.extend(candidate_layers);
+        pos
+    };
+    Ok(BaseGlyph::new(gid, first_idx as u16, paint.len() as u16))
+}
+
 impl Work<Context, AnyWorkId, Error> for ColrWork {
     fn id(&self) -> AnyWorkId {
         WorkId::Colr.into()
@@ -264,67 +347,98 @@ impl Work<Context, AnyWorkId, Error> for ColrWork {
         let glyph_order = context.ir.glyph_order.get();
         let static_metadata = context.ir.static_metadata.get();
         let quantization = colr_clip_box_quantization(static_metadata.units_per_em);
-        let mut colr = Colr::new(0, None, None, 0);
-        let mut base_glyphs = Vec::with_capacity(paint_graph.base_glyphs.len());
-        let mut layer_list = LayerList::default();
-        for (glyph_name, paint) in paint_graph.base_glyphs.iter() {
-            // Fetch the glyph's bounding box for gradient coordinate scaling
-            let glyph = context
-                .glyphs
-                .get(&WorkId::GlyfFragment(glyph_name.clone()).into());
-            let bbox = glyph.data.bbox().unwrap_or_default();
 
-            base_glyphs.push(BaseGlyphPaint::new(
-                glyph_order
-                    .glyph_id(glyph_name)
-                    .ok_or_else(|| Error::MissingGlyphId(glyph_name.clone()))?,
-                to_colr_paint(
-                    context,
-                    &glyph_order,
-                    &palette,
-                    glyph_name,
-                    &bbox,
-                    &mut layer_list,
-                    paint,
-                )?,
-            ));
-        }
+        let mut colr_v0_glyphs = Vec::new();
+        let mut colr_v0_layers = Vec::new();
+        let mut colr_v1_glyphs = Vec::with_capacity(paint_graph.base_glyphs.len());
+        let mut colr_v1_layers = LayerList::default();
+        let mut clips = Vec::new();
 
-        colr.base_glyph_list =
-            BaseGlyphList::new(paint_graph.base_glyphs.len() as u32, base_glyphs).into();
-        if !layer_list.paints.is_empty() {
-            layer_list.num_layers = layer_list.paints.len() as u32;
-            colr.layer_list = layer_list.into();
-        }
+        for glyph_name in glyph_order.names() {
+            let Some(paint) = paint_graph.base_glyphs.get(glyph_name) else {
+                continue;
+            };
+            if colr_v0_compatible(paint) {
+                // This can be a COLRv0 glyph!
+                if let ir::Paint::Glyph(paint_glyph) = paint {
+                    colr_v0_glyphs.push(new_colr0(
+                        &palette,
+                        &glyph_order,
+                        glyph_name,
+                        &[paint_glyph],
+                        &mut colr_v0_layers,
+                    )?);
+                } else if let ir::Paint::Layers(layers) = paint {
+                    let mut paint_glyphs: Vec<&ir::PaintGlyph> = Vec::with_capacity(layers.len());
+                    for paint in layers.iter() {
+                        let ir::Paint::Glyph(paint_glyph) = paint else {
+                            unreachable!("We *just* checked for this! What is {paint:#?}");
+                        };
+                        paint_glyphs.push(paint_glyph);
+                    }
+                    colr_v0_glyphs.push(new_colr0(
+                        &palette,
+                        &glyph_order,
+                        glyph_name,
+                        &paint_glyphs,
+                        &mut colr_v0_layers,
+                    )?);
+                } else {
+                    unreachable!("We *just* checked for this! What is {paint:#?}");
+                };
+            } else {
+                // This is too complicated and fiddly to be a COLRv0, use v1
+                // Fetch the glyph's bounding box for gradient coordinate scaling
+                let glyph = context
+                    .glyphs
+                    .get(&WorkId::GlyfFragment(glyph_name.clone()).into());
+                let bbox = glyph.data.bbox().unwrap_or_default();
 
-        let mut clips = Vec::<Clip>::new();
-        for glyph_name in paint_graph.base_glyphs.iter().map(|(g, _)| g) {
-            let next_gid = glyph_order.glyph_id(glyph_name).expect("Validated earlier");
-            let next_glyph = context
-                .glyphs
-                .get(&WorkId::GlyfFragment(glyph_name.clone()).into());
-            let bbox = next_glyph.data.bbox().unwrap_or_default();
-            // Quantize the bbox to maximize clipbox reuse
-            let next_clip = quantize_bbox(&bbox, quantization);
-            let next_clip = ClipBox::format_1(
-                next_clip.x_min.into(),
-                next_clip.y_min.into(),
-                next_clip.x_max.into(),
-                next_clip.y_max.into(),
-            );
-            if let Some(curr) = clips.last_mut()
-                && curr.end_glyph_id.to_u32() + 1 == next_gid.to_u32()
-                && *curr.clip_box == next_clip
-            {
-                // wow wow wow, a run!
-                curr.end_glyph_id = next_gid;
-                continue; // DONE
+                colr_v1_glyphs.push(BaseGlyphPaint::new(
+                    glyph_order
+                        .glyph_id(glyph_name)
+                        .ok_or_else(|| Error::MissingGlyphId(glyph_name.clone()))?,
+                    to_colr_paint(
+                        context,
+                        &glyph_order,
+                        &palette,
+                        glyph_name,
+                        &bbox,
+                        &mut colr_v1_layers,
+                        paint,
+                    )?,
+                ));
+                add_or_extend_clip(
+                    &mut clips,
+                    quantization,
+                    glyph_order.glyph_id(glyph_name).expect("Prevalidated"),
+                    &glyph,
+                );
             }
-
-            // Evidently we didn't make a run
-            clips.push(Clip::new(next_gid, next_gid, next_clip));
         }
-        colr.clip_list = ClipList::new(1, clips.len() as u32, clips).into();
+
+        // Create the COLR table
+        let num_v0_glyphs = colr_v0_glyphs.len() as u16;
+        let num_colr_v0_layers = colr_v0_layers.len() as u16;
+        let base_glyph_records = (!colr_v0_glyphs.is_empty()).then_some(colr_v0_glyphs);
+        let layer_records = (!colr_v0_layers.is_empty()).then_some(colr_v0_layers);
+        let mut colr = Colr::new(
+            num_v0_glyphs,
+            base_glyph_records,
+            layer_records,
+            num_colr_v0_layers,
+        );
+        if !colr_v1_glyphs.is_empty() {
+            colr.base_glyph_list =
+                BaseGlyphList::new(colr_v1_glyphs.len() as u32, colr_v1_glyphs).into();
+        }
+        if !colr_v1_layers.paints.is_empty() {
+            colr_v1_layers.num_layers = colr_v1_layers.paints.len() as u32;
+            colr.layer_list = colr_v1_layers.into();
+        }
+        if !clips.is_empty() {
+            colr.clip_list = ClipList::new(1, clips.len() as u32, clips).into();
+        }
 
         // All done, claim victory!
         context.colr.set(colr);

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -412,6 +412,14 @@ mod tests {
                 .map(|v| v.to_u16() as u32)
         }
 
+        fn get_glyph_name(&self, gid: GlyphId16) -> Option<GlyphName> {
+            self.fe_context
+                .glyph_order
+                .get()
+                .glyph_name(gid.to_u32() as usize)
+                .cloned()
+        }
+
         fn contains_glyph(&self, name: &str) -> bool {
             self.get_glyph_index(name).is_some()
         }
@@ -3752,7 +3760,7 @@ mod tests {
 
     #[test]
     fn cpal_from_declared_palettes() {
-        let result = TestCompile::compile_source("glyphs3/COLRv0-simple.glyphs");
+        let result = TestCompile::compile_source("glyphs3/COLRv0-1layer.glyphs");
         let cpal = result.font().cpal().unwrap();
         assert_eq!(
             (
@@ -3812,6 +3820,52 @@ mod tests {
     fn colr_grayscale() {
         let result = TestCompile::compile_source("glyphs3/COLRv1-grayscale.glyphs");
         result.font().colr().unwrap(); // for now just check the table exists
+    }
+
+    #[test]
+    fn colrv0_sorted_structures() {
+        let result = TestCompile::compile_source("glyphs3/COLRv0-reordered.glyphs");
+        let colr = result.font().colr().unwrap();
+
+        for pair in colr.base_glyph_records().unwrap().unwrap().windows(2) {
+            assert!(
+                pair[0].glyph_id().to_u32() < pair[1].glyph_id().to_u32(),
+                "Not sorted: {pair:#?}"
+            );
+        }
+    }
+
+    #[test]
+    fn colrv1_sorted_structures() {
+        let result = TestCompile::compile_source("glyphs3/COLRv1-reordered.glyphs");
+        let colr = result.font().colr().unwrap();
+
+        for pair in colr
+            .base_glyph_list()
+            .unwrap()
+            .unwrap()
+            .base_glyph_paint_records()
+            .windows(2)
+        {
+            assert!(
+                pair[0].glyph_id().to_u32() < pair[1].glyph_id().to_u32(),
+                "Not sorted: {pair:#?}"
+            );
+        }
+
+        let clips = colr.clip_list().unwrap().unwrap().clips();
+        for clip in clips {
+            assert!(
+                clip.start_glyph_id().to_u32() <= clip.end_glyph_id().to_u32(),
+                "Bad start/end: {clip:#?}"
+            );
+        }
+        for pair in clips.windows(2) {
+            assert!(
+                pair[0].end_glyph_id() < pair[1].start_glyph_id(),
+                "Not sorted: {pair:#?}"
+            );
+        }
     }
 
     fn root_paint<'a>(compile: &TestCompile, colr: &Colr<'a>, glyph_name: &str) -> Paint<'a> {
@@ -3955,7 +4009,7 @@ mod tests {
 
     #[test]
     fn colr_cliprun() {
-        let result = TestCompile::compile_source("glyphs3/COLRv1-solid.glyphs");
+        let result = TestCompile::compile_source("glyphs3/COLRv1-cliprun.glyphs");
         let colr = result.font().colr().unwrap();
         assert_eq!(
             vec![(1, 2)],
@@ -4064,6 +4118,60 @@ mod tests {
                 [Paint::LinearGradient(_), Paint::LinearGradient(_),]
             ),
             "{layers:#?}"
+        );
+    }
+
+    fn assert_colr0(compile: &TestCompile, expected: Vec<(String, Vec<(String, u16)>)>) {
+        let colr = compile.font().colr().unwrap();
+        let layers = colr
+            .layer_records()
+            .expect("A layer list")
+            .expect("A valid layer list");
+        assert_eq!(0, colr.version());
+        assert_eq!(
+            expected,
+            colr.base_glyph_records()
+                .expect("v0 records")
+                .expect("Valid v0 records")
+                .iter()
+                .map(|g| (
+                    compile
+                        .get_glyph_name(g.glyph_id())
+                        .expect("Valid gids")
+                        .to_string(),
+                    (g.first_layer_index()..(g.first_layer_index() + g.num_layers()))
+                        .map(|i| layers[i as usize])
+                        .map(|l| (
+                            compile
+                                .get_glyph_name(l.glyph_id())
+                                .expect("Valid gids")
+                                .to_string(),
+                            l.palette_index()
+                        ))
+                        .collect::<Vec<_>>()
+                ))
+                .collect::<Vec<_>>()
+        )
+    }
+
+    #[test]
+    fn colr0_1layer() {
+        let result = TestCompile::compile_source("glyphs3/COLRv0-1layer.glyphs");
+        assert_colr0(
+            &result,
+            vec![("A".to_string(), vec![("A.color0".to_string(), 1)])],
+        );
+    }
+
+    #[test]
+    fn colr0_2layers() {
+        let result = TestCompile::compile_source("glyphs3/COLRv0-2layers.glyphs");
+        assert_colr0(
+            &result,
+            vec![(
+                "A".to_string(),
+                vec![("A.color0".to_string(), 1), ("A.color1".to_string(), 0)],
+            )],
         );
     }
 

--- a/glyphs2fontir/src/toir.rs
+++ b/glyphs2fontir/src/toir.rs
@@ -6,7 +6,7 @@ use std::{
 
 use indexmap::IndexMap;
 use kurbo::{BezPath, Point};
-use log::trace;
+use log::{debug, trace};
 use ordered_float::OrderedFloat;
 
 use smol_str::SmolStr;
@@ -346,7 +346,7 @@ impl TryFrom<Font> for FontInfo {
 }
 
 #[derive(Debug, PartialEq, Eq, Hash)]
-enum PaintKey {
+enum Colrv1RunType {
     NonColor,
     Solid(glyphs_reader::Color),
     Linear(Vec<glyphs_reader::ColorStop>),
@@ -354,27 +354,173 @@ enum PaintKey {
     Unknown(ShapeAttributes),
 }
 
-impl PaintKey {
+#[derive(Debug)]
+struct Colrv1Run {
+    run_type: Colrv1RunType,
+    start: usize,
+    end: usize,
+}
+
+impl Colrv1Run {
+    fn color(&self) -> bool {
+        !matches!(self.run_type, Colrv1RunType::NonColor)
+    }
+}
+
+impl Colrv1RunType {
     fn key_for(layer: &Layer, shape: &Shape) -> Self {
+        // COLRv1?
         if !layer.attributes.color {
-            return PaintKey::NonColor;
+            return Colrv1RunType::NonColor;
         }
         let attr = shape.attributes();
         if let Some(gradient) = &attr.gradient {
             if gradient.style == "circle" {
-                return PaintKey::Radial(gradient.colors.clone());
+                return Colrv1RunType::Radial(gradient.colors.clone());
             }
-            return PaintKey::Linear(gradient.colors.clone());
+            return Colrv1RunType::Linear(gradient.colors.clone());
         }
         if let Some(fill) = attr.fill_color {
-            return PaintKey::Solid(fill);
+            return Colrv1RunType::Solid(fill);
         }
-        PaintKey::Unknown(attr.clone())
+        Colrv1RunType::Unknown(attr.clone())
+    }
+}
+
+fn new_color_glyph(original: &Glyph, nth: &mut usize) -> Glyph {
+    let new_glyph_name: SmolStr = format!("{}.color{nth}", original.name).into();
+    let new_production_name = original
+        .production_name
+        .as_ref()
+        .map(|production_name| format!("{}.color{nth}", production_name).into());
+    let new_glyph = Glyph {
+        name: new_glyph_name.clone(),
+        production_name: new_production_name,
+        export: original.export,
+        ..Default::default()
+    };
+    *nth += 1;
+    new_glyph
+}
+
+fn split_colrv0_glyph(
+    original: &Glyph,
+    default_master_layer: &Layer,
+    color_glyphs: &mut IndexMap<SmolStr, Vec<SmolStr>>,
+    additions: &mut Vec<(SmolStr, Glyph)>,
+) -> Result<(), Error> {
+    let glyph_name = &original.name;
+
+    // COLRv0 runs are just consecutive shapes by palette index
+    // The original glyph becomes uncolored,
+    // each color run becomes a new glyph named [original].color[i]
+    let mut nth = 0;
+    for layer in original.layers.iter() {
+        if layer.shapes.is_empty()
+            || layer.attributes.color_palette.is_none()
+            || layer.associated_master_id.as_deref() != Some(default_master_layer.layer_id.as_str())
+        {
+            continue;
+        }
+
+        // Every layer associated with the master that has a palette index becomes a new color glyph
+        let mut new_glyph = new_color_glyph(original, &mut nth);
+        let mut layer = layer.clone();
+        layer.layer_id = layer.associated_master_id.take().unwrap();
+        new_glyph.layers.push(layer);
+
+        debug!("Add COLRv0 {}", new_glyph.name);
+
+        color_glyphs
+            .entry(glyph_name.clone())
+            .or_default()
+            .push(new_glyph.name.clone());
+        additions.push((new_glyph.name.clone(), new_glyph));
+    }
+    Ok(())
+}
+
+fn split_colrv1_glyph(
+    glyph: &Glyph,
+    default_master_layer: &Layer,
+    color_glyphs: &mut IndexMap<SmolStr, Vec<SmolStr>>,
+    additions: &mut Vec<(SmolStr, Glyph)>,
+) -> Result<(), Error> {
+    let glyph_name = &glyph.name;
+
+    // Split into runs of the same paint
+    let mut runs = VecDeque::<Colrv1Run>::new();
+    for (idx, shape) in default_master_layer.shapes.iter().enumerate() {
+        let run_type = Colrv1RunType::key_for(default_master_layer, shape);
+        if let Some(curr) = runs.back_mut()
+            && curr.run_type == run_type
+        {
+            // Extend the current run
+            curr.end = idx + 1;
+        } else {
+            // New run
+            runs.push_back(Colrv1Run {
+                run_type,
+                start: idx,
+                end: idx + 1,
+            });
+        }
     }
 
-    fn color(&self) -> bool {
-        !matches!(self, Self::NonColor)
+    // Only one run we're done
+    if runs.len() <= 1 {
+        return Ok(());
     }
+
+    // There are multiple runs, we must split this glyph apart
+    // The original will remain but uncolored
+
+    // Each color run becomes a new glyph named [original].color[i]
+    let mut nth = 0;
+    for run in runs {
+        let new_glyph_name: SmolStr = format!("{glyph_name}.color{nth}").into();
+        let mut new_glyph = new_color_glyph(glyph, &mut nth);
+
+        // For each layer, chop the head that matches this paint group off glyph and attach it here
+        for old_layer in glyph.layers.iter() {
+            let mut new_layer = old_layer.clone();
+            new_layer.attributes.color = run.color();
+            new_layer.shapes = old_layer.shapes[run.start..run.end].to_vec();
+            trace!(
+                "{glyph_name} {} takes {} shapes for {run:?}",
+                old_layer.layer_id,
+                new_layer.shapes.len()
+            );
+            new_glyph.layers.push(new_layer);
+        }
+
+        let mut layer_sizes = new_glyph
+            .layers
+            .iter()
+            .map(|l| l.shapes.len())
+            .collect::<Vec<_>>();
+        layer_sizes.sort();
+        layer_sizes.dedup();
+        if layer_sizes.len() != 1 {
+            return Err(Error::BadGlyph(BadGlyph::new(
+                new_glyph_name,
+                BadGlyphKind::FrontendSpecific(format!("Inconsistent layer sizes {layer_sizes:?}")),
+            )));
+        }
+        if layer_sizes.first() == Some(&0) {
+            return Err(Error::BadGlyph(BadGlyph::new(
+                new_glyph_name,
+                BadGlyphKind::FrontendSpecific("All layers are empty?!".to_string()),
+            )));
+        }
+
+        color_glyphs
+            .entry(glyph_name.clone())
+            .or_default()
+            .push(new_glyph_name.clone());
+        additions.push((new_glyph_name, new_glyph));
+    }
+    Ok(())
 }
 
 fn split_color_glyphs(font: Font) -> Result<(Font, IndexMap<SmolStr, Vec<SmolStr>>), Error> {
@@ -383,14 +529,8 @@ fn split_color_glyphs(font: Font) -> Result<(Font, IndexMap<SmolStr, Vec<SmolStr
     let mut color_glyphs: IndexMap<SmolStr, Vec<SmolStr>> = Default::default();
     let default_master_id = font.default_master().id.clone();
 
-    let mut additions = Vec::new();
-    for (glyph_name, glyph) in font.glyphs.iter_mut() {
-        // Normal path: nop, not a color glyph
-        if glyph.layers.iter().all(|l| !l.attributes.color) {
-            continue;
-        }
-        // Remember the name!
-        color_glyphs.entry(glyph_name.clone()).or_default();
+    let mut additions: Vec<(SmolStr, Glyph)> = Vec::new();
+    for glyph in font.glyphs.values_mut() {
         let Some(default_master_layer) = glyph
             .layers
             .iter()
@@ -399,66 +539,32 @@ fn split_color_glyphs(font: Font) -> Result<(Font, IndexMap<SmolStr, Vec<SmolStr
             continue;
         };
 
-        // Split into runs of the same paint type
-        let mut paint_groups = default_master_layer
-            .shapes
-            .iter()
-            .map(|s| PaintKey::key_for(default_master_layer, s))
-            .collect::<Vec<_>>();
-        paint_groups.dedup();
-        let mut paint_groups: VecDeque<_> = paint_groups.into();
-
-        // If there is only one run we're done
-        if paint_groups.len() <= 1 {
+        // If 1..N layers with palette indices are associated this is COLRv0
+        // See <https://github.com/googlefonts/glyphsLib/blob/99328059ec4799956ecef3d47ebcc13ae70dacff/Lib/glyphsLib/builder/glyph.py#L289-L292>
+        if glyph.layers.iter().any(|l| {
+            l.attributes.color_palette.is_some()
+                && l.associated_master_id.as_deref() == Some(default_master_layer.layer_id.as_str())
+        }) {
+            split_colrv0_glyph(
+                glyph,
+                default_master_layer,
+                &mut color_glyphs,
+                &mut additions,
+            )?;
+        } else if default_master_layer.is_color() {
+            split_colrv1_glyph(
+                glyph,
+                default_master_layer,
+                &mut color_glyphs,
+                &mut additions,
+            )?;
+        } else {
+            // Not color
             continue;
         }
 
-        // There are multiple runs, we must split this glyph apart
-        // The original will remain but uncolored
-
-        // Each color run becomes a new glyph named [original].color[i]
-        let mut glyph = glyph.clone();
-        let mut nth = 0;
-        while let Some(paint_group) = paint_groups.pop_front() {
-            let new_glyph_name: SmolStr = format!("{glyph_name}.color{nth}").into();
-            let mut new_glyph = Glyph {
-                name: new_glyph_name.clone(),
-                export: glyph.export,
-                ..Default::default()
-            };
-
-            // For each layer, chop the head that matches this paint group off glyph and attach it here
-            for old_layer in glyph.layers.iter_mut() {
-                let mut new_layer = old_layer.clone();
-                new_layer.attributes.color = paint_group.color();
-                if let Some(split_at) = old_layer
-                    .shapes
-                    .iter()
-                    .position(|s| PaintKey::key_for(&new_layer, s) != paint_group)
-                {
-                    // Only some of the shapes fit the current run take them
-                    // Amusingly this results in the opposite arrangement than we want so swap
-                    new_layer.shapes = old_layer.shapes.split_off(split_at);
-                    std::mem::swap(&mut new_layer.shapes, &mut old_layer.shapes);
-                } else {
-                    // All the shapes fit the current run
-                    old_layer.shapes.clear();
-                }
-                trace!(
-                    "{glyph_name} {} takes {} shapes for {paint_group:?}",
-                    old_layer.layer_id,
-                    new_layer.shapes.len()
-                );
-                new_glyph.layers.push(new_layer);
-            }
-
-            color_glyphs
-                .entry(glyph_name.clone())
-                .or_default()
-                .push(new_glyph_name.clone());
-            additions.push((new_glyph_name, new_glyph));
-            nth += 1;
-        }
+        // Remember the name so it gets added to COLR
+        color_glyphs.entry(glyph.name.clone()).or_default();
     }
 
     font.glyph_order
@@ -490,8 +596,34 @@ pub(crate) fn to_ir_color_stops(stops: &[glyphs_reader::ColorStop]) -> Vec<Color
         .collect()
 }
 
-pub(crate) fn to_ir_paint(glyph_name: impl Into<GlyphName>, shape: &Shape) -> Result<Paint, Error> {
-    let attr = shape.attributes();
+pub(crate) fn to_ir_paint(
+    palette: Option<&[glyphs_reader::Color]>,
+    glyph_name: impl Into<GlyphName>,
+    layer: &Layer,
+    attr: &ShapeAttributes,
+) -> Result<Paint, Error> {
+    if let Some(palette_idx) = layer.attributes.color_palette {
+        let Some(palette) = palette else {
+            return Err(Error::BadGlyph(BadGlyph::new(
+                glyph_name,
+                BadGlyphKind::FrontendSpecific("Uses palette but there isn't one".to_string()),
+            )));
+        };
+        let Some(color) = palette.get(palette_idx as usize) else {
+            return Err(Error::BadGlyph(BadGlyph::new(
+                glyph_name,
+                BadGlyphKind::FrontendSpecific(format!(
+                    "Out of bounds palette index {palette_idx}"
+                )),
+            )));
+        };
+        return Ok(Paint::Solid(
+            PaintSolid {
+                color: to_ir_color(*color),
+            }
+            .into(),
+        ));
+    }
     if let Some(color) = attr.fill_color {
         return Ok(Paint::Solid(
             PaintSolid {
@@ -545,7 +677,10 @@ pub(crate) fn to_ir_paint(glyph_name: impl Into<GlyphName>, shape: &Shape) -> Re
 
     Err(Error::BadGlyph(BadGlyph::new(
         glyph_name,
-        BadGlyphKind::FrontendSpecific(format!("Unable to produce paint for {attr:?}")),
+        BadGlyphKind::FrontendSpecific(format!(
+            "Unable to produce paint for {:?}, {attr:?}",
+            layer.attributes
+        )),
     )))
 }
 

--- a/resources/testdata/glyphs3/COLRv0-1layer.glyphs
+++ b/resources/testdata/glyphs3/COLRv0-1layer.glyphs
@@ -28,28 +28,28 @@ glyphs = (
 glyphname = A;
 layers = (
 {
-attr = {
-colorPalette = 1;
-};
 layerId = m01;
 shapes = (
 {
-attr = {
-gradient = {
-colors = (
-(
-(255,0,0,255),
-0
-),
-(
-(0,0,255,255),
-1
-)
+closed = 1;
+nodes = (
+(63,0,l),
+(542,0,l),
+(542,500,l),
+(63,500,l)
 );
-end = (0.9,0.9);
-start = (0.1,0.1);
+}
+);
+width = 600;
+},
+{
+attr = {
+colorPalette = 1;
 };
-};
+layerId = m02;
+associatedMasterId = m01;
+shapes = (
+{
 closed = 1;
 nodes = (
 (63,0,l),

--- a/resources/testdata/glyphs3/COLRv0-2layers.glyphs
+++ b/resources/testdata/glyphs3/COLRv0-2layers.glyphs
@@ -1,0 +1,90 @@
+{
+.appVersion = "3343";
+.formatVersion = 3;
+customParameters = (
+{
+name = "Color Palettes";
+value = (
+(
+(1, 2, 3, 4),
+(5, 6, 7, 8)
+),
+(
+(9, 10, 11, 12),
+(13, 14, 15, 16)
+)
+);
+}
+);
+familyName = "New Font";
+fontMaster = (
+{
+id = m01;
+name = Regular;
+}
+);
+glyphs = (
+{
+glyphname = A;
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(63,0,l),
+(542,0,l),
+(542,500,l),
+(63,500,l)
+);
+}
+);
+width = 600;
+},
+{
+attr = {
+colorPalette = 1;
+};
+layerId = m02;
+associatedMasterId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(63,0,l),
+(542,0,l),
+(542,500,l),
+(63,500,l)
+);
+}
+);
+width = 600;
+},
+{
+attr = {
+colorPalette = 0;
+};
+layerId = m03;
+associatedMasterId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(63,0,l),
+(542,0,l),
+(542,500,l),
+(63,500,l)
+);
+}
+);
+width = 600;
+}
+);
+unicode = 65;
+}
+);
+unitsPerEm = 1000;
+versionMajor = 1;
+versionMinor = 0;
+}

--- a/resources/testdata/glyphs3/COLRv0-reordered.glyphs
+++ b/resources/testdata/glyphs3/COLRv0-reordered.glyphs
@@ -1,0 +1,79 @@
+{
+.appVersion = "3343";
+.formatVersion = 3;
+
+customParameters = (
+{
+name = glyphOrder;
+value = (B, A);
+}
+);
+
+familyName = "New Font";
+fontMaster = (
+{
+id = m01;
+name = Regular;
+}
+);
+glyphs = (
+{
+glyphname = A;
+layers = (
+{
+attr = {
+color = 1;
+};
+layerId = m01;
+shapes = (
+{
+attr = {
+fillColor = (177,216,243,255);
+};
+closed = 1;
+nodes = (
+(63,0,l),
+(542,0,l),
+(542,500,l),
+(63,500,l)
+);
+}
+);
+width = 600;
+}
+);
+unicode = 65;
+},
+{
+glyphname = B;
+layers = (
+{
+attr = {
+color = 1;
+};
+layerId = m01;
+shapes = (
+{
+attr = {
+fillColor = (42,43,44,255);
+};
+closed = 1;
+nodes = (
+(63,0,l),
+(542,0,l),
+(542,500,l),
+(63,500,l)
+);
+}
+);
+width = 600;
+}
+);
+unicode = 66;
+}
+);
+
+unitsPerEm = 1000;
+versionMajor = 1;
+versionMinor = 0;
+}

--- a/resources/testdata/glyphs3/COLRv1-cliprun.glyphs
+++ b/resources/testdata/glyphs3/COLRv1-cliprun.glyphs
@@ -1,0 +1,97 @@
+{
+.appVersion = "3343";
+.formatVersion = 3;
+familyName = "New Font";
+fontMaster = (
+{
+id = m01;
+name = Regular;
+}
+);
+glyphs = (
+{
+glyphname = A;
+layers = (
+{
+attr = {
+color = 1;
+};
+layerId = m01;
+shapes = (
+{
+attr = {
+gradient = {
+colors = (
+(
+(255,0,0,255),
+0
+),
+(
+(0,0,255,255),
+1
+)
+);
+end = (0.9,0.9);
+start = (0.1,0.1);
+};
+};
+closed = 1;
+nodes = (
+(63,0,l),
+(542,0,l),
+(542,500,l),
+(63,500,l)
+);
+}
+);
+width = 600;
+}
+);
+unicode = 65;
+},
+{
+glyphname = B;
+layers = (
+{
+attr = {
+color = 1;
+};
+layerId = m01;
+shapes = (
+{
+attr = {
+gradient = {
+colors = (
+(
+(255,0,0,255),
+0
+),
+(
+(0,0,255,255),
+1
+)
+);
+end = (0.9,0.9);
+start = (0.1,0.1);
+};
+};
+closed = 1;
+nodes = (
+(63,0,l),
+(542,0,l),
+(542,500,l),
+(63,500,l)
+);
+}
+);
+width = 600;
+}
+);
+unicode = 66;
+}
+);
+
+unitsPerEm = 1000;
+versionMajor = 1;
+versionMinor = 0;
+}

--- a/resources/testdata/glyphs3/COLRv1-reordered.glyphs
+++ b/resources/testdata/glyphs3/COLRv1-reordered.glyphs
@@ -1,0 +1,105 @@
+{
+.appVersion = "3343";
+.formatVersion = 3;
+
+customParameters = (
+{
+name = glyphOrder;
+value = (B, A);
+}
+);
+
+familyName = "New Font";
+fontMaster = (
+{
+id = m01;
+name = Regular;
+}
+);
+glyphs = (
+{
+glyphname = A;
+layers = (
+{
+attr = {
+color = 1;
+};
+layerId = m01;
+shapes = (
+{
+attr = {
+gradient = {
+colors = (
+(
+(255,255,0,255),
+0
+),
+(
+(255,0,255,255),
+1
+)
+);
+end = (0.9,0.9);
+start = (0.1,0.1);
+};
+};
+closed = 1;
+nodes = (
+(63,0,l),
+(542,0,l),
+(542,500,l),
+(63,500,l)
+);
+}
+);
+width = 600;
+}
+);
+unicode = 65;
+},
+{
+glyphname = B;
+layers = (
+{
+attr = {
+color = 1;
+};
+layerId = m01;
+shapes = (
+{
+attr = {
+gradient = {
+colors = (
+(
+(255,0,0,255),
+0
+),
+(
+(0,0,255,255),
+1
+)
+);
+end = (0.9,0.9);
+start = (0.1,0.1);
+};
+};
+closed = 1;
+nodes = (
+(63,0,l),
+(542,0,l),
+(542,500,l),
+(63,500,l)
+);
+}
+);
+width = 600;
+}
+);
+unicode = 66;
+}
+);
+
+unitsPerEm = 1000;
+versionMajor = 1;
+versionMinor = 0;
+}


### PR DESCRIPTION
`python3 -m ttx_diff 'https://github.com/fridamedrano/Kalnia-Glaze?3338853e09#sources/KalniaGlaze.glyphs'` now has matching CPAL and COLR instead of only fontmake produced for both.