### PR TITLE
But what if a master had a palette?!

### DIFF
--- a/fontbe/src/colr.rs
+++ b/fontbe/src/colr.rs
@@ -293,11 +293,11 @@ fn new_colr0(
     palette: &ColorPalettes,
     glyph_order: &GlyphOrder,
     glyph_name: &GlyphName,
-    paint: &[&ir::PaintGlyph],
+    paints: &[&ir::PaintGlyph],
     layers: &mut Vec<Layer>,
 ) -> Result<BaseGlyph, Error> {
     let gid = glyph_order.glyph_id(glyph_name).expect("Prevalidated");
-    let candidate_layers = paint
+    let candidate_layers = paints
         .iter()
         .map(|p| {
             let ir::Paint::Solid(solid) = &p.paint else {
@@ -320,7 +320,7 @@ fn new_colr0(
         layers.extend(candidate_layers);
         pos
     };
-    Ok(BaseGlyph::new(gid, first_idx as u16, paint.len() as u16))
+    Ok(BaseGlyph::new(gid, first_idx as u16, paints.len() as u16))
 }
 
 impl Work<Context, AnyWorkId, Error> for ColrWork {

--- a/fontbe/src/error.rs
+++ b/fontbe/src/error.rs
@@ -103,6 +103,8 @@ pub enum Error {
     InconsistentPaletteLength(Vec<usize>),
     #[error("No metrics instance for '{0:?}'")]
     NoGlobalMetricsInstance(NormalizedLocation),
+    #[error("No palette entry for '{0:?}'")]
+    MissingPaletteEntry(Color),
 }
 
 #[derive(Debug)]

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -3695,6 +3695,50 @@ mod tests {
     }
 
     #[test]
+    fn cpal_prefer_master() {
+        let result = TestCompile::compile_source("glyphs3/COLRv0-palette-redefinition.glyphs");
+        let cpal = result.font().cpal().unwrap();
+        assert_eq!(
+            (
+                2,
+                2,
+                [
+                    ColorRecord {
+                        red: 20,
+                        green: 21,
+                        blue: 22,
+                        alpha: 23
+                    },
+                    ColorRecord {
+                        red: 24,
+                        green: 25,
+                        blue: 26,
+                        alpha: 27
+                    },
+                    ColorRecord {
+                        red: 28,
+                        green: 29,
+                        blue: 30,
+                        alpha: 31
+                    },
+                    ColorRecord {
+                        red: 32,
+                        green: 33,
+                        blue: 34,
+                        alpha: 35
+                    },
+                ]
+                .as_slice()
+            ),
+            (
+                cpal.num_palettes(),
+                cpal.num_palette_entries(),
+                cpal.color_records_array().unwrap().unwrap()
+            )
+        );
+    }
+
+    #[test]
     fn cpal_grayscale() {
         let result = TestCompile::compile_source("glyphs3/COLRv1-grayscale.glyphs");
         let cpal = result.font().cpal().unwrap();

--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -3293,11 +3293,16 @@ impl Font {
         Ok(font)
     }
 
-    pub fn default_palette(&self) -> Option<&[Color]> {
-        self.custom_parameters
+    pub fn color_palettes(&self) -> Option<&Vec<Vec<Color>>> {
+        self.default_master()
+            .custom_parameters
             .color_palettes
             .as_ref()
-            .map(|p| p[0].as_slice())
+            .or(self.custom_parameters.color_palettes.as_ref())
+    }
+
+    pub fn default_palette(&self) -> Option<&[Color]> {
+        self.color_palettes().map(|p| p[0].as_slice())
     }
 
     fn preprocess(&mut self) -> Result<(), Error> {

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -1604,14 +1604,8 @@ impl Work<Context, WorkId, Error> for ColorPaletteWork {
     }
 
     fn exec(&self, context: &Context) -> Result<(), Error> {
-        // Directly declared palette(s)
-        let mut palettes = if let Some(declared_palettes) = self
-            .font_info
-            .font
-            .custom_parameters
-            .color_palettes
-            .as_ref()
-        {
+        // Directly declared palette(s), preferring master to global
+        let mut palettes = if let Some(declared_palettes) = self.font_info.font.color_palettes() {
             declared_palettes
                 .iter()
                 .map(|raw_palette| {
@@ -1629,7 +1623,7 @@ impl Work<Context, WorkId, Error> for ColorPaletteWork {
             palettes.push(Vec::new());
         }
 
-        // Plus any colors declared directly on glyphs
+        // Plus any colors declared directly on COLRv1 glyphs
         // Glue them onto all palettes to keep size even, duplication will be resolved later
         let glyph_colors = self
             .font_info

--- a/resources/testdata/glyphs3/COLRv0-palette-redefinition.glyphs
+++ b/resources/testdata/glyphs3/COLRv0-palette-redefinition.glyphs
@@ -1,0 +1,86 @@
+{
+.appVersion = "3343";
+.formatVersion = 3;
+customParameters = (
+{
+name = "Color Palettes";
+value = (
+(
+(1, 2, 3, 4),
+(5, 6, 7, 8)
+),
+(
+(9, 10, 11, 12),
+(13, 14, 15, 16)
+)
+);
+}
+);
+familyName = "New Font";
+fontMaster = (
+{
+customParameters = (
+{
+name = "Color Palettes";
+value = (
+(
+(20, 21, 22, 23),
+(24, 25, 26, 27)
+),
+(
+(28, 29, 30, 31),
+(32, 33, 34, 35)
+)
+);
+}
+);
+id = m01;
+name = Regular;
+}
+);
+glyphs = (
+{
+glyphname = A;
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(63,0,l),
+(542,0,l),
+(542,500,l),
+(63,500,l)
+);
+}
+);
+width = 600;
+},
+{
+attr = {
+colorPalette = 1;
+};
+layerId = m02;
+associatedMasterId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(63,0,l),
+(542,0,l),
+(542,500,l),
+(63,500,l)
+);
+}
+);
+width = 600;
+}
+);
+unicode = 65;
+}
+);
+unitsPerEm = 1000;
+versionMajor = 1;
+versionMinor = 0;
+}


### PR DESCRIPTION
Coral Pixels evidently does this.

`python3 -m ttx_diff resources/testdata/glyphs3/COLRv0-palette-redefinition.glyphs` is now identical

`python3 -m ttx_diff 'https://github.com/tanukifont/Coral-Pixels?2817da74e3#sources/CoralPixels.glyphs'` is now identical for CPAL, 99.984% for COLR. Amusingly the glyph order is quite different, in a way that makes me think fontmake sorts (left fontc, right fontmake):

<img width="1135" height="96" alt="image" src="https://github.com/user-attachments/assets/1785547e-9b2b-4052-a700-11f3514848b9" />

Builds on #1757

