### PR TITLE
[ttx_diff] make --help and --version work in absl-py

### DIFF
--- a/ttx_diff/src/ttx_diff/__main__.py
+++ b/ttx_diff/src/ttx_diff/__main__.py
@@ -1,6 +1,85 @@
-"""Allow running ttx-diff as `python -m ttx_diff`."""
+"""A tool for comparing font compiler outputs (fontc vs fontmake)."""
 
-from ttx_diff.cli import main
+from absl import app, flags
+
+from ttx_diff import core
+
+_COMPARE_DEFAULTS = "default"
+_COMPARE_GFTOOLS = "gftools"
+
+# Flag definitions (moved from core.py so they appear in --help)
+flags.DEFINE_boolean(
+    "version", False, "Show application version and exit.", short_name="V"
+)
+flags.DEFINE_string(
+    "config",
+    default=None,
+    help="config.yaml to be passed to gftools in gftools mode",
+)
+flags.DEFINE_string(
+    "fontc_path",
+    default=None,
+    help="Optional path to precompiled fontc binary",
+)
+flags.DEFINE_string(
+    "normalizer_path",
+    default=None,
+    help="Optional path to precompiled otl-normalizer binary",
+)
+flags.DEFINE_enum(
+    "compare",
+    "default",
+    [_COMPARE_DEFAULTS, _COMPARE_GFTOOLS],
+    "Compare results using either a default build or a build managed by gftools. Note that as of 5/21/2023 defaults still sets flags for fontmake to match fontc behavior.",
+)
+flags.DEFINE_enum(
+    "rebuild",
+    "both",
+    ["both", "fontc", "fontmake", "none"],
+    "Which compilers to rebuild with if the output appears to already exist. None is handy when playing with ttx_diff.py itself.",
+)
+flags.DEFINE_float(
+    "off_by_one_budget",
+    0.1,
+    "The percentage of point (glyf) or delta (gvar) values allowed to differ by one without counting as a diff",
+)
+flags.DEFINE_bool("json", False, "print results in machine-readable JSON format")
+flags.DEFINE_string("outdir", default=None, help="directory to store generated files")
+flags.DEFINE_bool(
+    "production_names",
+    True,
+    "rename glyphs to AGL-compliant names (uniXXXX, etc.) suitable for production. Disable to see the original glyph names.",
+)
+
+# fontmake - and so gftools' - static builds perform overlaps removal, but fontc
+# can't do that yet, and so we default to disabling the filter to make the diff
+# less noisy.
+# TODO: Change the default if/when fontc gains the ability to remove overlaps.
+# https://github.com/googlefonts/fontc/issues/975
+flags.DEFINE_bool(
+    "keep_overlaps",
+    True,
+    "Keep overlaps when building static fonts. Disable to compare with simplified outlines.",
+)
+flags.DEFINE_bool(
+    "keep_direction", False, "Preserve contour winding direction from source."
+)
+flags.DEFINE_string(
+    "fontc_font",
+    default=None,
+    help="Optional path to precompiled fontc font. Must be used with --fontmake_font.",
+)
+flags.DEFINE_string(
+    "fontmake_font",
+    default=None,
+    help="Optional path to precompiled fontmake font. Must be used with --fontc_font.",
+)
+
+
+def main():
+    """Entry point for running ttx-diff as a module."""
+    app.run(core.main)
+
 
 if __name__ == "__main__":
     main()

--- a/ttx_diff/src/ttx_diff/cli.py
+++ b/ttx_diff/src/ttx_diff/cli.py
@@ -1,13 +1,20 @@
-"""Command-line interface for ttx-diff."""
+"""Entry point wrapper for ttx-diff command-line tool.
 
-from absl import app
+This wrapper uses runpy to execute __main__.py as the main module,
+which ensures absl-py treats its flags as main module flags and displays
+them in --help output.
+"""
 
-from ttx_diff.core import main as core_main
+import runpy
+import sys
 
 
 def main():
-    """Entry point for the ttx-diff command-line tool."""
-    app.run(core_main)
+    """Entry point that executes ttx_diff.__main__ as the main module."""
+    # Remove this script from sys.argv so the target module gets clean args
+    sys.argv[0] = "ttx-diff"
+    # Execute __main__.py as if it were run with python -m ttx_diff
+    runpy.run_module("ttx_diff.__main__", run_name="__main__")
 
 
 if __name__ == "__main__":

--- a/ttx_diff/tests/test_cli.py
+++ b/ttx_diff/tests/test_cli.py
@@ -14,7 +14,7 @@ def test_version():
 def test_cli_missing_source():
     """Test CLI with non-existent source file."""
     result = subprocess.run(
-        [sys.executable, "-m", "ttx_diff.cli", "/nonexistent/file.glyphs"],
+        [sys.executable, "-m", "ttx_diff", "/nonexistent/file.glyphs"],
         capture_output=True,
         text=True,
     )


### PR DESCRIPTION
python -m ttx_diff --help wasn't showing any flags and telling users to use --helpfull (which unhelpfully shows all absl-related flags which the user could care less).

The problem is absl-py only shows flags from the "__main__" module in --help. So I moved them there to make it happy and `python -m ttx_diff --help` finally shows our flags.

But still, when running via the installed `ttx-diff` entry point, because the `__name__` of that one was not '__main__', absl woudn't recognize it as the main module and end up showing no flags.

So I resorted to runpy.run_module which executes the __main__.py module with run_name="__main__" mimicking `pyton -m module` behavior.

So now both `pythom -m ttx_diff --help` and `ttx-diff --help` display all flags consistently.

I also added a --version which absl-py doesn't provide out of the box.