### PR TITLE
bump minor versions of fontc and related crates

### DIFF
--- a/fea-rs/Cargo.toml
+++ b/fea-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fea-rs"
-version = "0.21.0"
+version = "0.22.0"
 license = "MIT/Apache-2.0"
 authors = ["Colin Rofls <colin@cmyr.net>"]
 description = "Tools for working with Adobe OpenType Feature files."

--- a/fontbe/Cargo.toml
+++ b/fontbe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fontbe"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 license = "MIT/Apache-2.0"
 description = "the backend for fontc, a font compiler."
@@ -12,8 +12,8 @@ categories = ["text-processing", "parsing", "graphics"]
 
 [dependencies]
 fontdrasil = { version = "0.3.0", path = "../fontdrasil" }
-fontir = { version = "0.4.0", path = "../fontir" }
-fea-rs = { version = "0.21.0", path = "../fea-rs", features = ["serde"] }
+fontir = { version = "0.5.0", path = "../fontir" }
+fea-rs = { version = "0.22.0", path = "../fea-rs", features = ["serde"] }
 tinystr = {version = "0.8.0", features = ["serde"] }
 
 icu_properties.workspace = true

--- a/fontc/Cargo.toml
+++ b/fontc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fontc"
-version = "0.4.0"
+version = "0.5.0"
 build = "build.rs"
 edition = "2024"
 license = "MIT/Apache-2.0"
@@ -21,11 +21,11 @@ cli = ["clap"]
 
 [dependencies]
 fontdrasil = { version = "0.3.0", path = "../fontdrasil" }
-fontbe = { version = "0.3.0", path = "../fontbe" }
-fontir = { version = "0.4.0", path = "../fontir" }
-glyphs2fontir = { version = "0.4.0", path = "../glyphs2fontir" }
-fontra2fontir = { version = "0.3.0", path = "../fontra2fontir" }
-ufo2fontir = { version = "0.3.0", path = "../ufo2fontir" }
+fontbe = { version = "0.4.0", path = "../fontbe" }
+fontir = { version = "0.5.0", path = "../fontir" }
+glyphs2fontir = { version = "0.5.0", path = "../glyphs2fontir" }
+fontra2fontir = { version = "0.4.0", path = "../fontra2fontir" }
+ufo2fontir = { version = "0.4.0", path = "../ufo2fontir" }
 
 bitflags.workspace = true
 

--- a/fontc_crater/Cargo.toml
+++ b/fontc_crater/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/googlefonts/fontc"
 readme = "README.md"
 
 [dependencies]
-fontc = { version = "0.4.0", path = "../fontc" }
+fontc = { version = "0.5.0", path = "../fontc" }
 
 google-fonts-sources = "0.10.3"
 maud = "0.27.0"

--- a/fontir/Cargo.toml
+++ b/fontir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fontir"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 license = "MIT/Apache-2.0"
 description = "Intermediate Representation used by fontc, a font compiler."

--- a/fontra2fontir/Cargo.toml
+++ b/fontra2fontir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fontra2fontir"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 license = "MIT/Apache-2.0"
 description = "Converts fontra.xyz/ files to font ir for compilation."
@@ -12,7 +12,7 @@ categories = ["text-processing", "parsing", "graphics"]
 
 [dependencies]
 fontdrasil = { version = "0.3.0", path = "../fontdrasil" }
-fontir = { version = "0.4.0", path = "../fontir" }
+fontir = { version = "0.5.0", path = "../fontir" }
 
 write-fonts.workspace = true
 

--- a/glyphs-reader/Cargo.toml
+++ b/glyphs-reader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glyphs-reader"
-version = "0.3.0"
+version = "0.4.0"
 license = "MIT/Apache-2.0"
 authors = ["Raph Levien <raph.levien@gmail.com>"]
 repository = "https://github.com/googlefonts/fontc"

--- a/glyphs2fontir/Cargo.toml
+++ b/glyphs2fontir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glyphs2fontir"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 license = "MIT/Apache-2.0"
 description = "Converts www.glyphsapp.com files to font ir for compilation."
@@ -12,8 +12,8 @@ categories = ["text-processing", "parsing", "graphics"]
 
 [dependencies]
 fontdrasil = { version = "0.3.0", path = "../fontdrasil" }
-fontir = { version = "0.4.0", path = "../fontir" }
-glyphs-reader = { version = "0.3.0", path = "../glyphs-reader" }
+fontir = { version = "0.5.0", path = "../fontir" }
+glyphs-reader = { version = "0.4.0", path = "../glyphs-reader" }
 
 smol_str.workspace = true
 log.workspace = true

--- a/otl-normalizer/Cargo.toml
+++ b/otl-normalizer/Cargo.toml
@@ -17,7 +17,7 @@ write-fonts.workspace = true
 indexmap.workspace = true
 
 [dev-dependencies]
-fea-rs = { version = "0.21.0", path = "../fea-rs" }
+fea-rs = { version = "0.22.0", path = "../fea-rs" }
 
 # Support for `cargo binstall otl-normalizer`.
 # The default Github download URL template used by cargo-binstall doesn't work

--- a/ufo2fontir/Cargo.toml
+++ b/ufo2fontir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ufo2fontir"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 license = "MIT/Apache-2.0"
 description = "Converts UFO or UFO+designspace to font ir for compilation."
@@ -12,7 +12,7 @@ categories = ["text-processing", "parsing", "graphics"]
 
 [dependencies]
 fontdrasil = { version = "0.3.0", path = "../fontdrasil" }
-fontir = { version = "0.4.0", path = "../fontir" }
+fontir = { version = "0.5.0", path = "../fontir" }
 
 kurbo.workspace = true
 serde.workspace = true


### PR DESCRIPTION
in preparation for a fontc release

```
     Changes for fea-rs from fea-rs-v0.21.0 to 0.22.0
             9a62536 bump minor versions for glyphs-reader, fontir, glyphs2fontir, fea-rs, fontbe and fontc
             b7907ee [fea-rs] Simplify GlyphMap construction
             98a67b1 [fea-rs] Sort BaseLangSysRecords by tag
             b2e8bb3 [fea-rs] Refactor base table compilation
             6c9eef7 [fea-rs] Compile BASE MinMax statements
             48fc5d3 [fea-rs] Validate BASE table blocks
             87748d9 [fea-rs] Parse BASE MinMax statements
     Changes for fontir from fontir-v0.4.0 to 0.5.0
             9a62536 bump minor versions for glyphs-reader, fontir, glyphs2fontir, fea-rs, fontbe and fontc
             5634f3d [fontir] make gradient fields optional in IR
     Changes for fontbe from fontbe-v0.3.0 to 0.4.0
             9a62536 bump minor versions for glyphs-reader, fontir, glyphs2fontir, fea-rs, fontbe and fontc
             f412922 [kern] Port more tests from ufo2ft
             8ee79e9 [colr] round gradient geometry at the end using OtRound
             0f30c4d [colr] fix FirstLayerIndex always 0
             5a958e6 Prefer master palette
             242e189 Produce COLRv0 where possible
             32c77d6 Add ClipBox quantization to maximize reuse
             c53e3e9 Implement gradient coordinate scaling and bbox-dependent calculations
     Changes for glyphs-reader from glyphs-reader-v0.3.0 to 0.4.0
             9a62536 bump minor versions for glyphs-reader, fontir, glyphs2fontir, fea-rs, fontbe and fontc
             a590bfa Add test for COLRv0 glyphs with empty palette layers
             5a958e6 Prefer master palette
             242e189 Produce COLRv0 where possible
             eaad7aa Build directly declared (typically for COLRv0) palettes
             d026a4f [chore] Update a few more deps
     Changes for glyphs2fontir from glyphs2fontir-v0.4.0 to 0.5.0
             9a62536 bump minor versions for glyphs-reader, fontir, glyphs2fontir, fea-rs, fontbe and fontc
             f03a7da [colr] include gradient start/end points in the Colrv1RunType
             1281ccc Fix panic with COLRv0/v1 glyphs that have empty color layers
             756bab0 Add test for COLRv1 glyphs with empty color layers
             a590bfa Add test for COLRv0 glyphs with empty palette layers
             5a958e6 Prefer master palette
             242e189 Produce COLRv0 where possible
             eaad7aa Build directly declared (typically for COLRv0) palettes
             5634f3d [fontir] make gradient fields optional in IR
     Changes for fontra2fontir from fontra2fontir-v0.3.0 to 0.4.0
             9a62536 bump minor versions for glyphs-reader, fontir, glyphs2fontir, fea-rs, fontbe and fontc
     Changes for ufo2fontir from ufo2fontir-v0.3.0 to 0.4.0
             9a62536 bump minor versions for glyphs-reader, fontir, glyphs2fontir, fea-rs, fontbe and fontc
     Changes for fontc from fontc-v0.4.0 to 0.5.0
             9a62536 bump minor versions for glyphs-reader, fontir, glyphs2fontir, fea-rs, fontbe and fontc
             6d13d70 test expected gradient geometry in COLRv1-manyshapes-per-glyph.glyphs
             f03a7da [colr] include gradient start/end points in the Colrv1RunType
             5a958e6 Prefer master palette
             242e189 Produce COLRv0 where possible
             3b3921f group asserted values together
             53beb83 test colr gradients' scaled geometry and actual clip boxes in integration tests
             eaad7aa Build directly declared (typically for COLRv0) palettes

```