### PR TITLE
also need to bump fontdrasil as it exposes SmolStr in public API

### DIFF
--- a/fea-rs/Cargo.toml
+++ b/fea-rs/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2024"
 exclude = ["test-data"]
 
 [dependencies]
-fontdrasil = { version = "0.3.0", path = "../fontdrasil" }
+fontdrasil = { version = "0.4.0", path = "../fontdrasil" }
 ansi_term = "0.12.1"
 serde_json = {version = "1.0.87", optional = true }
 

--- a/fontbe/Cargo.toml
+++ b/fontbe/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["text-processing", "parsing", "graphics"]
 [features]
 
 [dependencies]
-fontdrasil = { version = "0.3.0", path = "../fontdrasil" }
+fontdrasil = { version = "0.4.0", path = "../fontdrasil" }
 fontir = { version = "0.5.0", path = "../fontir" }
 fea-rs = { version = "0.22.0", path = "../fea-rs", features = ["serde"] }
 tinystr = {version = "0.8.0", features = ["serde"] }
@@ -47,4 +47,4 @@ temp-env.workspace = true
 rstest.workspace = true
 pretty_assertions.workspace = true
 env_logger.workspace = true
-otl-normalizer = { version = "0.2.0", path = "../otl-normalizer" }
+otl-normalizer = { version = "0.3.0", path = "../otl-normalizer" }

--- a/fontc/Cargo.toml
+++ b/fontc/Cargo.toml
@@ -20,7 +20,7 @@ default = ["cli"]
 cli = ["clap"]
 
 [dependencies]
-fontdrasil = { version = "0.3.0", path = "../fontdrasil" }
+fontdrasil = { version = "0.4.0", path = "../fontdrasil" }
 fontbe = { version = "0.4.0", path = "../fontbe" }
 fontir = { version = "0.5.0", path = "../fontir" }
 glyphs2fontir = { version = "0.5.0", path = "../glyphs2fontir" }

--- a/fontdrasil/Cargo.toml
+++ b/fontdrasil/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fontdrasil"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 license = "MIT/Apache-2.0"
 description = "Common types and utilites used by fontc, a font compiler."

--- a/fontir/Cargo.toml
+++ b/fontir/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["text-processing", "parsing", "graphics"]
 [features]
 
 [dependencies]
-fontdrasil = { version = "0.3.0", path = "../fontdrasil" }
+fontdrasil = { version = "0.4.0", path = "../fontdrasil" }
 
 bitflags.workspace = true
 serde.workspace = true

--- a/fontra2fontir/Cargo.toml
+++ b/fontra2fontir/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["text-processing", "parsing", "graphics"]
 [features]
 
 [dependencies]
-fontdrasil = { version = "0.3.0", path = "../fontdrasil" }
+fontdrasil = { version = "0.4.0", path = "../fontdrasil" }
 fontir = { version = "0.5.0", path = "../fontir" }
 
 write-fonts.workspace = true

--- a/glyphs-reader/Cargo.toml
+++ b/glyphs-reader/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 
 [dependencies]
 ascii_plist_derive = { version = "0.2.0", path = "ascii_plist_derive" }
-fontdrasil = { version = "0.3.0", path = "../fontdrasil" }
+fontdrasil = { version = "0.4.0", path = "../fontdrasil" }
 quick-xml = "0.38"
 ordered-float.workspace = true
 kurbo.workspace = true

--- a/glyphs2fontir/Cargo.toml
+++ b/glyphs2fontir/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["text-processing", "parsing", "graphics"]
 [features]
 
 [dependencies]
-fontdrasil = { version = "0.3.0", path = "../fontdrasil" }
+fontdrasil = { version = "0.4.0", path = "../fontdrasil" }
 fontir = { version = "0.5.0", path = "../fontir" }
 glyphs-reader = { version = "0.4.0", path = "../glyphs-reader" }
 

--- a/otl-normalizer/Cargo.toml
+++ b/otl-normalizer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "otl-normalizer"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 license = "MIT/Apache-2.0"
 description = "a normalized text representation of OpenType layout subtables"
@@ -9,7 +9,7 @@ readme = "README.md"
 
 
 [dependencies]
-fontdrasil = { version = "0.3.0", path = "../fontdrasil" }
+fontdrasil = { version = "0.4.0", path = "../fontdrasil" }
 clap.workspace = true
 thiserror.workspace = true
 smol_str.workspace = true

--- a/ufo2fontir/Cargo.toml
+++ b/ufo2fontir/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["text-processing", "parsing", "graphics"]
 [features]
 
 [dependencies]
-fontdrasil = { version = "0.3.0", path = "../fontdrasil" }
+fontdrasil = { version = "0.4.0", path = "../fontdrasil" }
 fontir = { version = "0.5.0", path = "../fontir" }
 
 kurbo.workspace = true


### PR DESCRIPTION
even though fontdrasil did NOT change since the published 0.3.0, we have bumped smol_str version from 0.2.0 -> 0.3.0 in d026a4f46ec8980c55c540fb720bec809fba7d15 a couple weeks ago, at the workspace level so all crates are affected.

Since fontdrasil exposes SmolStr in its public API (e.g. glyph_name_to_unicode), I can't publish e.g. glyphs-reader because the fontdrasil on crates.io specifies a different incompatible smol_str (0.2 instead of 0.3) and the verify step fails.

I also bump otl-normalizer which depends on fontdrasil so everyone is happy, even though no code changes there either.