### PR TITLE
set up webhook to trigger Glyphs.app export plugin update upon fontc releases

### DIFF
--- a/.github/workflows/notify-plugin.yml
+++ b/.github/workflows/notify-plugin.yml
@@ -1,0 +1,53 @@
+name: Notify googlefonts/fontc-export-plugin of fontc release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  notify-plugin:
+    runs-on: ubuntu-latest
+    environment: fontc-plugin-notifications
+    # Only run for fontc releases (not other packages in the repo)
+    if: startsWith(github.event.release.tag_name, 'fontc-v')
+
+    steps:
+      - name: Extract version from tag
+        id: version
+        run: |
+          TAG_NAME="${{ github.event.release.tag_name }}"
+          # Remove 'fontc-v' prefix to get just the version number
+          VERSION="${TAG_NAME#fontc-v}"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Extracted version: $VERSION from tag: $TAG_NAME"
+
+      - name: Validate version format (X.Y.Z)
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          TAG_NAME="${{ github.event.release.tag_name }}"
+          if [ "$VERSION" = "$TAG_NAME" ]; then
+            echo "ERROR: Failed to extract version from tag: $TAG_NAME"
+            echo "Expected tag format: fontc-vX.Y.Z"
+            exit 1
+          fi
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "ERROR: Invalid version format: $VERSION"
+            echo "Expected format: X.Y.Z (e.g., 0.5.0)"
+            exit 1
+          fi
+          echo "Version validated: $VERSION"
+
+      # https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#create-a-repository-dispatch-event
+      - name: Send repository_dispatch to plugin repo
+        env:
+          GH_TOKEN: ${{ secrets.FONTC_GLYPHS_PLUGIN_REPO_TOKEN }}
+        run: |
+          gh api repos/googlefonts/fontc-export-plugin/dispatches \
+            --method POST \
+            --field event_type='fontc-release' \
+            --raw-field client_payload="{\"version\":\"${{ steps.version.outputs.version }}\"}"
+
+      - name: Log notification
+        run: |
+          echo "Successfully notified googlefonts/fontc-export-plugin repository"
+          echo "Version: ${{ steps.version.outputs.version }}"


### PR DESCRIPTION
Add a workflow that sends a [`repository_dispatch`](https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#create-a-repository-dispatch-event) event to googlefonts/fontc-export-plugin repo whenever a new fontc released is published.

This will automatically trigger the latter's auto-update workflow, which bumps the embedded fontc version and creates an automated PR: https://github.com/googlefonts/fontc-export-plugin/pull/8

Example (manually triggered):
https://github.com/googlefonts/fontc-export-plugin/pull/12