### PR TITLE
Add paintcompiler to requirements.in

### DIFF
--- a/resources/scripts/requirements.in
+++ b/resources/scripts/requirements.in
@@ -8,3 +8,7 @@ fontmake[repacker]==3.11.0
 # keep gftools pinned as well to ensure ttx-diff output is stable.
 # 0.9.74 is when experimental support for fontc was added to gftools.
 gftools==0.9.93
+# Some COLR fonts like Kalnia-Glaze require an (undeclared) optional dependency
+# of gftools builder, which is run as a post-process step, see:
+# https://github.com/googlefonts/gftools/issues/1159
+paintcompiler

--- a/resources/scripts/requirements.txt
+++ b/resources/scripts/requirements.txt
@@ -112,6 +112,7 @@ fonttools[lxml,repacker,ufo,unicode,woff]==4.60.1
     #   glyphslib
     #   mutatormath
     #   nanoemoji
+    #   paintcompiler
     #   statmake
     #   ttx-diff
     #   ufo2ft
@@ -169,7 +170,7 @@ mutatormath==3.0.1
     # via ufoprocessor
 nanoemoji==0.15.9
     # via gftools
-networkx==3.5
+networkx==3.6
     # via gftools
 ninja==1.13.0
     # via
@@ -188,6 +189,8 @@ orjson==3.11.4
     #   ufolib2
 packaging==25.0
     # via gftools
+paintcompiler==0.3.4
+    # via -r resources/scripts/requirements.in
 picosvg==0.22.3
     # via nanoemoji
 pillow==12.0.0


### PR DESCRIPTION
Some COLR fonts like Kalnia-Glaze require an (undeclared) optional dependency of gftools builder, which is run as a post-process step, see: https://github.com/googlefonts/gftools/issues/1159

without this, we get an unhelpful message on crater, under **both failures:**

<img width="742" height="166" alt="Screenshot 2025-11-24 at 16 38 12" src="https://github.com/user-attachments/assets/c821b543-14b0-40f4-8317-d701bc519f1f" />

After I add this, I can at least compile Kalnia-Glaze in ttx-diff gftools mode. There may be more fonts that make use of this which I am not aware of.

JMM