### PR TITLE
fix notify-plugin workflow to use workflow_run instead of release event

### DIFF
--- a/.github/workflows/notify-plugin.yml
+++ b/.github/workflows/notify-plugin.yml
@@ -1,21 +1,28 @@
 name: Notify googlefonts/fontc-export-plugin of fontc release
 
+# Trigger when the release.yml workflow completes successfully.
+# https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflow_run
 on:
-  release:
-    types: [published]
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
 
 jobs:
   notify-plugin:
     runs-on: ubuntu-latest
     environment: fontc-plugin-notifications
-    # Only run for fontc releases (not other packages in the repo)
-    if: startsWith(github.event.release.tag_name, 'fontc-v')
+    # Only run if Release succeeded AND was triggered by a fontc tag.
+    # The `head_branch` property contains the tag name in case of a tag-triggered workflow.
+    # https://docs.github.com/en/webhooks/webhook-events-and-payloads#workflow_run
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      startsWith(github.event.workflow_run.head_branch, 'fontc-v')
 
     steps:
       - name: Extract version from tag
         id: version
         run: |
-          TAG_NAME="${{ github.event.release.tag_name }}"
+          TAG_NAME="${{ github.event.workflow_run.head_branch }}"
           # Remove 'fontc-v' prefix to get just the version number
           VERSION="${TAG_NAME#fontc-v}"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
@@ -24,7 +31,7 @@ jobs:
       - name: Validate version format (X.Y.Z)
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          TAG_NAME="${{ github.event.release.tag_name }}"
+          TAG_NAME="${{ github.event.workflow_run.head_branch }}"
           if [ "$VERSION" = "$TAG_NAME" ]; then
             echo "ERROR: Failed to extract version from tag: $TAG_NAME"
             echo "Expected tag format: fontc-vX.Y.Z"


### PR DESCRIPTION
Releases created by `softprops/action-gh-release` action (which we use in our release.yml workflow to create a GH release when a tag is pushed) do not trigger `release: [published]` events.
This is [because GitHub prevents GITHUB_TOKEN actions from triggering other workflows](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow) to avoid recursive loops.
So when I released fontc-v0.6.0 yesterday, the fontc-export-plugin repo was not notified automatically as I thought it would be...

To trigger a `release: [published]` event we would have to _manually_ create a Github Release, but we prefer instead to push a git tag and let the CI do the rest.

The correct way to do this is to use a `workflow_run` event to trigger the notify-plugin workflow when the release workflow completes successfully, as documented below:

https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflow_run

JMM