### PR TITLE
Make all paths optional

### DIFF
--- a/fontbe/src/paths.rs
+++ b/fontbe/src/paths.rs
@@ -10,21 +10,15 @@ use crate::orchestration::WorkId;
 pub struct Paths {
     build_dir: PathBuf,
     glyph_dir: PathBuf,
-    debug_dir: PathBuf,
-    output_file: PathBuf,
 }
 
 impl Paths {
     pub fn new(build_dir: &Path) -> Paths {
         let glyph_dir = build_dir.join("glyphs");
-        let debug_dir = build_dir.join("debug");
         let build_dir = build_dir.to_path_buf();
-        let output_file = build_dir.join("font.ttf");
         Paths {
             build_dir,
             glyph_dir,
-            debug_dir,
-            output_file,
         }
     }
 
@@ -32,16 +26,8 @@ impl Paths {
         &self.build_dir
     }
 
-    pub fn debug_dir(&self) -> &Path {
-        &self.debug_dir
-    }
-
     pub fn glyph_dir(&self) -> &Path {
         &self.glyph_dir
-    }
-
-    pub fn output_file(&self) -> &Path {
-        &self.output_file
     }
 
     fn glyph_glyf_file(&self, name: &str) -> PathBuf {
@@ -97,7 +83,10 @@ impl Paths {
             WorkId::Vmtx => self.build_dir.join("vmtx.table"),
             WorkId::Vvar => self.build_dir.join("vvar.table"),
             WorkId::ExtraFeaTables => self.build_dir.join("extra_tables.bin"),
-            WorkId::Font => self.output_file.clone(),
+            // This will be written out when we're emimtting IR, because while it isn't
+            // *intermediate* work, it is work none the less. But the "official"
+            // output file is written by write_font_file.
+            WorkId::Font => self.build_dir.join("font.ttf"),
         }
     }
 }

--- a/fontc/src/args.rs
+++ b/fontc/src/args.rs
@@ -122,8 +122,8 @@ impl Args {
     pub fn flags(&self) -> Flags {
         let mut flags = Flags::default();
 
-        flags.set(Flags::EMIT_IR, self.emit_ir);
-        flags.set(Flags::EMIT_DEBUG, self.emit_debug);
+        flags.ir_dir = self.emit_ir.then(|| self.build_dir.clone()).flatten();
+        flags.debug_dir = self.emit_debug.then(|| self.build_dir.clone()).flatten();
         flags.set(Flags::PREFER_SIMPLE_GLYPHS, self.prefer_simple_glyphs);
         flags.set(Flags::FLATTEN_COMPONENTS, self.flatten_components);
         flags.set(Flags::ERASE_OPEN_CORNERS, self.erase_open_corners);

--- a/fontir/src/glyph.rs
+++ b/fontir/src/glyph.rs
@@ -929,8 +929,8 @@ mod tests {
         )
         .unwrap();
         let mut flags = Flags::default();
-        flags.set(Flags::EMIT_IR, false); // we don't want to write anything down
-        let ctx = Context::new_root(flags, None).copy_for_work(Access::All, Access::All);
+        flags.ir_dir = None; // we don't want to write anything down
+        let ctx = Context::new_root(flags).copy_for_work(Access::All, Access::All);
         ctx.static_metadata.set(meta);
         ctx
     }

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -1879,8 +1879,8 @@ mod tests {
     fn context_for(glyphs_file: &Path) -> (impl Source + use<>, Context) {
         let source = GlyphsIrSource::new(glyphs_file).unwrap();
         let mut flags = Flags::default();
-        flags.set(Flags::EMIT_IR, false); // we don't want to write anything down
-        (source, Context::new_root(flags, None))
+        flags.ir_dir = None; // we don't want to write anything down
+        (source, Context::new_root(flags))
     }
 
     #[test]

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -1951,13 +1951,13 @@ mod tests {
     }
 
     fn default_test_flags() -> Flags {
-        Flags::default() - Flags::EMIT_IR
+        Flags::default()
     }
 
     fn build_static_metadata(name: &str, flags: Flags) -> (impl Source + use<>, Context) {
         let _ = env_logger::builder().is_test(true).try_init();
         let source = load_designspace(name);
-        let context = Context::new_root(flags, None);
+        let context = Context::new_root(flags);
         let task_context = context.copy_for_work(
             Access::None,
             AccessBuilder::new()
@@ -2593,7 +2593,8 @@ mod tests {
 
     #[test]
     fn static_metadata_disable_postscript_names() {
-        let no_production_names = default_test_flags() - Flags::PRODUCTION_NAMES;
+        let mut no_production_names = default_test_flags();
+        no_production_names.set(Flags::PRODUCTION_NAMES, false);
         let (_, context) = build_static_metadata(
             "designspace_from_glyphs/WghtVar.designspace",
             no_production_names,


### PR DESCRIPTION
Another thing that's a bit of a downer for WASM is that fontc currently stores a lot of paths and does make-directory operations on those paths, even though sometimes we're not storing anything in those paths except the final font file. (and in the case of WASM, not even that!)

The first commit makes `PersistentStorage` objects an `Option<T>` instead of having a flag called `active`; that's relatively standalone. On top of that, we then make the `Paths` object optional except where `EMIT_IR | EMIT_DEBUG` is set.

The end result is you can run `generate_font` with `build_dir` set to `None`, and you don't have to do this kind of rubbish any more:

https://github.com/googlefonts/fontc/blob/f453ef017e664dcdfea115a75dbbded604044f36/fontir/src/glyph.rs#L937