### PR TITLE
[fontir] 'Fix' overflow in overlay_feature_variations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ parking_lot = "0.12.1"
 clap = { version = "4.0.32", features = ["derive"] }
 rayon = "1.6"
 icu_properties = "=2.0"
+smallvec = {version = "1.15", features = ["const_new"]}
 
 # fontations etc
 write-fonts = { version = "0.44.1", features = ["serde", "read"] }

--- a/fontir/Cargo.toml
+++ b/fontir/Cargo.toml
@@ -17,6 +17,7 @@ bitflags.workspace = true
 serde.workspace = true
 serde_yaml.workspace = true
 thiserror.workspace = true
+smallvec.workspace = true
 
 kurbo.workspace = true
 ordered-float.workspace = true


### PR DESCRIPTION
This was ported directly from the python,  and the python uses an
(arbitrary precision) python integer to track the rank. We were using a
u64 here, and there exists at least one font (playfair) where there end
up being more than 64 unique regions for feature variations.

This new solution tries to balance performance and correctness: we can
handle up to 511 unique regions, will panic in debug if this is
exceeded, and will log if we exceed in release.

I am not 100% confident in this approach, or in 511 as a reasonable
maximum, but it's a starting point.