### PR TITLE
[glyphs] Sort bracket layers like glyphsLib

### DIFF
--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -545,6 +545,14 @@ impl Layer {
             .collect()
     }
 
+    fn axis_rules_sort_key(&self) -> Vec<(i64, i64)> {
+        self.attributes
+            .axis_rules
+            .iter()
+            .map(|ax| (ax.min.unwrap_or(i64::MIN), ax.max.unwrap_or(i64::MAX)))
+            .collect()
+    }
+
     pub(crate) fn get_anchor_pt(&self, anchor_name: &str) -> Option<Point> {
         self.anchors
             .iter()
@@ -3672,6 +3680,9 @@ impl Font {
                     new_layers.push(new_layer);
                 }
             }
+
+            // match glyphsLib sorting: https://github.com/googlefonts/glyphsLib/blob/d42d3b15/Lib/glyphsLib/builder/transformations/align_alternate_layers.py#L79
+            new_layers.sort_by_cached_key(|l| l.axis_rules_sort_key());
 
             self.glyphs
                 .get_mut(name)


### PR DESCRIPTION
This is a minor tweak to how we sort newly created bracket layers during alignment, to match the current logic in glyphsLib. It improves the score of one family on crater.

Candidly, I would like to avoid writing a test for this. The order only matters for determining—in the case where a glyph has multiple different bracket conditions—the order in which the names (`x.BRACKET.varAlt0N`) are assigned, and isn't a matter of correctness, and it doesn't seem worth the ~hour it would take to jig up a pretty contrived test file to cover this one case.