### PR TITLE
[name] Skip empty strings in NameBuilder

### DIFF
--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -820,6 +820,10 @@ impl NameBuilder {
     }
 
     pub fn add(&mut self, name_id: NameId, value: String) {
+        // skip empty strings: https://github.com/googlefonts/ufo2ft/blob/01d3faee/Lib/ufo2ft/outlineCompiler.py#L446
+        if value.is_empty() {
+            return;
+        }
         let key = NameKey::new(name_id, &value);
         self.names.insert(key, value);
         self.name_to_key.insert(name_id, key);

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -2670,6 +2670,14 @@ mod tests {
     }
 
     #[test]
+    fn ignore_empty_name() {
+        let font = Font::load(&glyphs3_dir().join("EmptyName.glyphs")).unwrap();
+
+        let names = names(&font, SelectionFlags::empty());
+        assert!(!names.contains_key(&NameKey::new_bmp_only(NameId::TRADEMARK)));
+    }
+
+    #[test]
     fn captures_global_metrics() {
         let (_, context) = build_global_metrics(glyphs3_dir().join("WghtVar.glyphs"));
         let static_metadata = &context.static_metadata.get();

--- a/resources/testdata/glyphs3/EmptyName.glyphs
+++ b/resources/testdata/glyphs3/EmptyName.glyphs
@@ -1,0 +1,23 @@
+{
+.formatVersion = 3;
+
+properties = (
+{
+key = trademarks;
+values = (
+{
+language = dflt;
+value = "";
+}
+);
+}
+);
+familyName = EmptyName;
+fontMaster = (
+{
+id = m01;
+name = Regular;
+}
+);
+unitsPerEm = 1000;
+}


### PR DESCRIPTION
This was easy to diagnose, easy to track down, and easy to fix 🥲.

Gives us a +small on crater.