### PR TITLE
[name] Refactor NameBuilder, skip names at the end

### DIFF
--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -287,9 +287,7 @@ fn names(font: &Font, flags: SelectionFlags) -> HashMap<NameKey, String> {
     }
 
     let vendor = font.vendor_id().unwrap_or(DEFAULT_VENDOR_ID);
-    builder.apply_default_fallbacks(vendor);
-
-    let mut names = builder.into_inner();
+    let mut names = builder.build(vendor);
 
     for (key, lang, value) in font.localized_names() {
         let Some(name_id) = try_name_id(key) else {

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -787,7 +787,6 @@ fn names(font_info: &norad::FontInfo) -> HashMap<NameKey, String> {
         .open_type_os2_vendor_id
         .as_deref()
         .unwrap_or(DEFAULT_VENDOR_ID);
-    builder.apply_default_fallbacks(vendor);
 
     // Name's that don't get individual fields
     if let Some(name_records) = font_info.open_type_name_records.as_ref() {
@@ -797,7 +796,7 @@ fn names(font_info: &norad::FontInfo) -> HashMap<NameKey, String> {
         }
     }
 
-    builder.into_inner()
+    builder.build(vendor)
 }
 
 /// <https://unifiedfontobject.org/versions/ufo3/fontinfo.plist/#opentype-head-table-fields>


### PR DESCRIPTION
_Followup on #1794; turns out we want to skip these at the end._

----

So in order to match ufo2ft, we want to avoid generating fallback names if a name was declared in the source, even if it was empty and we will skip it later.

This implements that by only clearing out the empty names at the end.

To make 'the end' slightly more clearly defined, this also includes a minor refactor to NameBuilder to combine 'apply_default_fallbacks' and 'into_inner' into a single 'build' method. This ensures that empty strings are always cleared at the end, and more cannot be added afterwards.