### PR TITLE
[glyphs] Support 'Name Table Entry' custom param

### DIFF
--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -302,6 +302,16 @@ fn names(font: &Font, flags: SelectionFlags) -> HashMap<NameKey, String> {
         names.insert(name_key, value.to_string());
     }
 
+    for entry in &font.custom_parameters.name_table_entries {
+        let key = NameKey {
+            name_id: NameId::new(entry.name_id),
+            platform_id: entry.platform_id,
+            encoding_id: entry.encoding_id,
+            lang_id: entry.lang_id,
+        };
+        names.insert(key, entry.value.clone());
+    }
+
     names
 }
 
@@ -2673,6 +2683,25 @@ mod tests {
 
         let names = names(&font, SelectionFlags::empty());
         assert!(!names.contains_key(&NameKey::new_bmp_only(NameId::TRADEMARK)));
+    }
+
+    #[test]
+    fn reads_name_table_entry_custom_param() {
+        let font = Font::load(&glyphs3_dir().join("NameTableEntry.glyphs")).unwrap();
+
+        let names = names(&font, SelectionFlags::empty());
+        let key_ch_tw = NameKey {
+            name_id: NameId::new(16),
+            platform_id: 3,
+            encoding_id: 1,
+            lang_id: 0x404,
+        };
+        assert_eq!(names.get(&key_ch_tw).map(|s| s.as_str()), Some("粉圓"));
+        let key_en_us = NameKey {
+            lang_id: 0x409,
+            ..key_ch_tw
+        };
+        assert_eq!(names.get(&key_en_us).map(|s| s.as_str()), Some("Derp"));
     }
 
     #[test]

--- a/resources/testdata/glyphs3/NameTableEntry.glyphs
+++ b/resources/testdata/glyphs3/NameTableEntry.glyphs
@@ -1,0 +1,22 @@
+{
+.formatVersion = 3;
+
+customParameters = (
+{
+name = "Name Table Entry";
+value = "16 3 1 0x404; 粉圓";
+},
+{
+name = "Name Table Entry";
+value = "16 3 1 1033; Derp";
+},
+);
+familyName = NameTableEntry;
+fontMaster = (
+{
+id = m01;
+name = Regular;
+}
+);
+unitsPerEm = 1000;
+}


### PR DESCRIPTION
This is a way of specifying additional entires for the name table, akin to the openTypeNameRecords field in a UFO's fontinfo.plist (which we already handle).

(this gives us a +1/2 on crater, JMM)