### PR TITLE
Make debug dir relative to build dir

### DIFF
--- a/fontc/src/args.rs
+++ b/fontc/src/args.rs
@@ -193,7 +193,7 @@ impl TryInto<Options> for Args {
     fn try_into(self) -> Result<Options, Self::Error> {
         let flags = self.flags();
         let timing_file = self.emit_timing.then(|| self.build_dir.join("threads.svg"));
-        let debug_dir = self.emit_debug.then(|| self.build_dir.clone());
+        let debug_dir = self.emit_debug.then(|| self.build_dir.join("debug/"));
         let ir_dir = self.emit_ir.then(|| self.build_dir.clone());
         Ok(Options {
             flags,


### PR DESCRIPTION
Followon to #1800 

Proof:

```shell
# Default dirs
$ (cd /tmp/build_here && ~/oss/fontc/target/release/fontc --emit-debug ~/oss/fontc/resources/testdata/glyphs3/WghtVar.glyphs)

[2025-12-04T22:51:56.823298Z ThreadId(1) fontc DEBUG] Running with options Options {
    flags: Flags(
        PREFER_SIMPLE_GLYPHS | PRODUCTION_NAMES,
    ),
    skip_features: false,
    output_file: Some(
        "build/font.ttf",
    ),
    timing_file: None,
    ir_dir: None,
    debug_dir: Some(
        "build/debug/",
    ),
}

# Specified build dir
$ (cd /tmp/build_here && ~/oss/fontc/target/release/fontc --emit-debug ~/oss/fontc/resources/testdata/glyphs3/WghtVar.glyphs --build-dir .)

[2025-12-04T22:54:44.591677Z ThreadId(1) fontc DEBUG] Running with options Options {
    flags: Flags(
        PREFER_SIMPLE_GLYPHS | PRODUCTION_NAMES,
    ),
    skip_features: false,
    output_file: Some(
        "./font.ttf",
    ),
    timing_file: None,
    ir_dir: None,
    debug_dir: Some(
        "./debug/",
    ),
}
```

JMM