### PR TITLE
Support --flag=false to force-disable source-enabled flags

### DIFF
--- a/fontc/src/args.rs
+++ b/fontc/src/args.rs
@@ -3,7 +3,7 @@
 use std::path::PathBuf;
 
 use clap::{ArgAction, Parser};
-use fontc::{Input, Options};
+use fontc::{DisableFlags, Input, Options};
 use fontir::orchestration::Flags;
 
 use regex::Regex;
@@ -152,7 +152,7 @@ impl Args {
     /// - `None` = use source default
     /// - `Some(true)` = force enable (handled in `flags()`)
     /// - `Some(false)` = force disable (returned here)
-    pub fn flags_to_disable(&self) -> Flags {
+    pub fn flags_to_disable(&self) -> DisableFlags {
         let mut disable = Flags::empty();
         if self.flatten_components == Some(false) {
             disable.set(Flags::FLATTEN_COMPONENTS, true);
@@ -161,7 +161,7 @@ impl Args {
             disable.set(Flags::ERASE_OPEN_CORNERS, true);
         }
         // TODO: add PROPAGATE_ANCHORS flag when we have that implemented
-        disable
+        disable.into()
     }
 
     /// The input source to compile.

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -84,34 +84,58 @@ impl TryFrom<&Path> for Input {
     }
 }
 
+/// Flags to explicitly disable, overriding source defaults.
+///
+/// Defaults to empty (no flags disabled).
+#[derive(Debug, Clone, Copy)]
+pub struct DisableFlags(Flags);
+
+impl Default for DisableFlags {
+    fn default() -> Self {
+        DisableFlags(Flags::empty())
+    }
+}
+
+impl DisableFlags {
+    /// Returns an empty set of flags to disable.
+    pub fn empty() -> Self {
+        DisableFlags(Flags::empty())
+    }
+
+    /// Returns true if no flags are set to be disabled.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl From<Flags> for DisableFlags {
+    fn from(flags: Flags) -> Self {
+        DisableFlags(flags)
+    }
+}
+
+impl std::ops::Not for DisableFlags {
+    type Output = Flags;
+
+    fn not(self) -> Flags {
+        !self.0
+    }
+}
+
 /// Options for font compilation.
 ///
 /// Configures how the font is compiled (flags, output paths, etc.)
 /// but not *what* is compiled (that's the [`Input`] or [`Source`]).
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Options {
     pub flags: Flags,
     /// Flags to explicitly disable, overriding source defaults (tri-state).
-    pub flags_to_disable: Flags,
+    pub flags_to_disable: DisableFlags,
     pub skip_features: bool,
     pub output_file: Option<PathBuf>,
     pub timing_file: Option<PathBuf>,
     pub ir_dir: Option<PathBuf>,
     pub debug_dir: Option<PathBuf>,
-}
-
-impl Default for Options {
-    fn default() -> Self {
-        Self {
-            flags: Flags::default(),
-            flags_to_disable: Flags::empty(), // Must be empty, not default!
-            skip_features: false,
-            output_file: None,
-            timing_file: None,
-            ir_dir: None,
-            debug_dir: None,
-        }
-    }
 }
 
 /// Run the compiler with the provided input and options.


### PR DESCRIPTION
Some compilation flags such as ERASE_OPEN_CORNERS and FLATTEN_COMPONENTS (and the future PROPAGATE_ANCHORS #1704) are either enabled by default for specific source types or the source may contains compilation flags that enable them.
Currently the CLI can only enable these flags, but not force-disable them, because bitflags can only be true or false and source compilation flags are OR'ed intlo the CLI flags so they are enabled whenever either is set.

In this PR, I changed --flatten-components and --erase-open-corners to tri-state args whereby:
- when omitted, we use source default or source-level compilation flag (e.g. custom parameter or lib filter)
- if --flag or --flag=true: we enable them, irrespective of source
- if --flag=false: force disable

To accomplish this I added a new `flags_to_disable: Flags` field to  the `Option` struct and updated `merge_compilation_flags()` to apply the disable mask _after_ merging CLI and source compilation flags.

(I had a version of this commit in my WIP local work on anchor-propagation-in-fontir but figured that it'd be cleaner to push it seprately)