### PR TITLE
Use the physical number of CPU instead of logical

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ env_logger = "0.11.0"
 parking_lot = "0.12.1"
 clap = { version = "4.0.32", features = ["derive"] }
 rayon = "1.6"
+num_cpus = { version = ">=1.17.0" }
 icu_properties = "=2.0"
 smallvec = {version = "1.15", features = ["const_new"]}
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Two main reasons:
 1. A key part of Google Fonts technical strategy is to get off both Python and C++, consolidating on Rust
    * Rust enables us to write fast code that integrates well with our serving stack
    * See https://github.com/googlefonts/oxidize
-  
+
 So, Rust compiler time!
 
 ![image](https://github.com/googlefonts/fontc/assets/6466432/669778a7-5efa-43f8-8380-2f71bfc49f3f)
@@ -202,7 +202,7 @@ $ rm -rf build/ perf.data flamegraph.svg && cargo flamegraph -p fontc -- ../Oswa
 
 # On macOS you might have to pass `--root` to cargo flamegraph, e.g. cargo flamegraph --root ...as above...
 
-# If you are losing samples you might want to dial down the rayon threadcount
+# If you are losing samples you might want to dial down the threadcount
 # You'll see a perf error similar to:
 Warning:
 Processed 5114 events and lost 159 chunks!
@@ -213,7 +213,7 @@ Warning:
 Processed 5116 samples and lost 35.01%!
 
 # Fix is to lower the threadcount:
-$ export RAYON_NUM_THREADS=16
+$ <cmd...> --num-threads=16
 ```
 
 ### Focused flames

--- a/fontc/Cargo.toml
+++ b/fontc/Cargo.toml
@@ -18,6 +18,7 @@ required-features = ["cli"]
 [features]
 default = ["cli", "rayon"]
 cli = ["clap"]
+rayon = ["dep:rayon", "num_cpus"]
 
 [dependencies]
 fontdrasil = { version = "0.4.0", path = "../fontdrasil" }
@@ -41,6 +42,7 @@ regex.workspace = true
 
 write-fonts.workspace = true
 rayon = { workspace = true, optional = true }
+num_cpus = { version = ">=1.17.0", optional = true }
 
 # just for fontc!
 crossbeam-channel = "0.5.6"

--- a/fontc/src/args.rs
+++ b/fontc/src/args.rs
@@ -1,6 +1,6 @@
 //! Command line arguments
 
-use std::path::PathBuf;
+use std::{num::NonZeroUsize, path::PathBuf};
 
 use clap::{ArgAction, Parser};
 use fontc::{Input, Options};
@@ -110,6 +110,10 @@ pub struct Args {
     /// See <https://docs.rs/env_logger/latest/env_logger/#enabling-logging> for format.
     #[arg(long)]
     pub log: Option<String>,
+
+    /// The number of threads to use for processing or 0 to use the number of physical CPU cores.
+    #[arg(long, default_value = "0")]
+    pub num_threads: usize,
 }
 
 /// A wrapper around a validated regex string
@@ -195,6 +199,7 @@ impl TryInto<Options> for Args {
         let timing_file = self.emit_timing.then(|| self.build_dir.join("threads.svg"));
         let debug_dir = self.emit_debug.then(|| self.build_dir.join("debug/"));
         let ir_dir = self.emit_ir.then(|| self.build_dir.clone());
+        let num_threads = NonZeroUsize::new(self.num_threads);
         Ok(Options {
             flags,
             skip_features: self.skip_features,
@@ -204,6 +209,7 @@ impl TryInto<Options> for Args {
             timing_file,
             debug_dir,
             ir_dir,
+            num_threads,
         })
     }
 }

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -20,6 +20,7 @@ use fontbe::orchestration::AnyWorkId;
 use std::{
     ffi::OsStr,
     fs,
+    num::NonZeroUsize,
     path::{Path, PathBuf},
 };
 
@@ -96,6 +97,7 @@ pub struct Options {
     pub timing_file: Option<PathBuf>,
     pub ir_dir: Option<PathBuf>,
     pub debug_dir: Option<PathBuf>,
+    pub num_threads: Option<NonZeroUsize>,
 }
 
 /// Run the compiler with the provided input and options.
@@ -179,7 +181,7 @@ fn generate_font_internal(
         options.debug_dir.clone(),
         &fe_root,
     );
-    let timer = workload.exec(&fe_root, &be_root)?;
+    let timer = workload.exec(options.num_threads, &fe_root, &be_root)?;
     Ok((fe_root, be_root, timer))
 }
 


### PR DESCRIPTION
TLDR: 13% improvement on AMD/Intel CPUs.

Rayon uses the number of logical cores by default. On most AMD and Intel CPUs, the number of logical cores is double the physical due to [SMT](https://en.wikipedia.org/wiki/Simultaneous_multithreading). However, scheduling more cores seems to add more overhead than benefit.

`num_cpus` is used to get the number of physical cores. This is already a transitive dependency through:

```mermaid
graph LR
    ufo2fontir --> norad --> close_already --> threadpool --> num_cpus
```

# Results

Tested on:
- GoogleSans Flex
-  `AMD Ryzen Threadripper PRO 3945WX 12-Cores`
    - 12 physical cores
    - 24 logical cores

## Command

```
time poop "/tmp/fontc-before ../googlesans-flex/sources/GoogleSansFlex.designspace --flatten-components --decompose-transformed-components" "/tmp/fontc-after  ../googlesans-flex/sources/GoogleSansFlex.designspace --flatten-components --decompose-transformed-components"
```

## Stats

Measurement | Benchmark 1 (Before) Mean | Benchmark 2 (After) Mean | Delta (Improvement)
-- | -- | -- | --
Wall Time | 14.3s $\pm$ 140ms | 12.3s $\pm$ 154ms | ⚡-13.7% $\pm$ 2.3%
CPU Cycles | 568G $\pm$ 640M | 349G $\pm$ 871M | ⚡-38.5% $\pm$ 0.3%
Branch Misses | 2.21G $\pm$ 12.6M | 1.36G $\pm$ 2.44M | ⚡-38.4% $\pm$ 0.9%
Peak RSS (Memory) | 2.03GB $\pm$ 93.2MB | 2.03GB $\pm$ 103MB | -0.2% $\pm$ 11.0%
Instructions | 1.12T $\pm$ 30.6M | 1.12T $\pm$ 45.1M | +0.0% $\pm$ 0.0%
