### PR TITLE
Adjust threshold based on local testing

### DIFF
--- a/fontbe/src/features/kern.rs
+++ b/fontbe/src/features/kern.rs
@@ -47,7 +47,7 @@ use super::{DFLT_LANG, DFLT_SCRIPT, PendingLookup, properties::CharMap};
 
 /// On Linux it took ~0.01 ms per loop, try to get enough to make fan out worthwhile
 /// based on empirical testing
-const KERNS_PER_BLOCK: usize = 2048;
+const KERNS_PER_BLOCK: usize = 256;
 const KERN: Tag = Tag::new(b"kern");
 // we don't currently compile this feature, but we will, and it is referenced
 // in places because our impl is based on fonttools.


### PR DESCRIPTION
Break apart kern-frag more finely. JMM if convinced.

Threads before:

<img width="1437" height="1119" alt="image" src="https://github.com/user-attachments/assets/fa62d699-3ec9-4073-89df-940bd969efd4" />

Threads after:

<img width="1440" height="1103" alt="image" src="https://github.com/user-attachments/assets/e2b9f601-6b43-4e33-95d5-b97cfd602233" />

Note that when kern-frag runs it's basically the only thing running, breaking it appart more finely (when theres a lot of work) speeds things up:

```shell
$ hyperfine \
  --parameter-list branch main,$(git rev-parse --abbrev-ref HEAD) \
  --setup "git checkout {branch} && cargo build --release" \
   --warmup 5 --runs 20 \
   --prepare 'rm -rf build/' \
   "target/release/fontc --source ../googlesans-flex/sources/GoogleSansFlex.designspace --flatten-components --decompose-transformed-components"

Summary
  target/release/fontc --source ../googlesans-flex/sources/GoogleSansFlex.designspace --flatten-components --decompose-transformed-components (branch = thresh) ran
    1.10 ± 0.03 times faster than target/release/fontc --source ../googlesans-flex/sources/GoogleSansFlex.designspace --flatten-components --decompose-transformed-components (branch = main)
```

It looks to me like this threshold was probably set at a time when kerning fragments did less work.