### PR TITLE
[fea-rs] Remap any name IDs in GPOS feature params

### DIFF
--- a/fea-rs/src/compile/output.rs
+++ b/fea-rs/src/compile/output.rs
@@ -104,26 +104,30 @@ impl Compilation {
                 .collect();
         }
 
-        if let Some(gsub) = self.gsub.as_mut() {
-            gsub.feature_list
-                .as_mut()
-                .feature_records
-                .iter_mut()
-                .for_each(|rec| match rec.feature.as_mut().feature_params.as_mut() {
-                    Some(FeatureParams::StylisticSet(params)) => {
-                        params.ui_name_id = adjust_id(params.ui_name_id);
-                    }
-                    Some(FeatureParams::CharacterVariant(params)) => {
-                        params.feat_ui_label_name_id = adjust_id(params.feat_ui_label_name_id);
-                        params.feat_ui_tooltip_text_name_id =
-                            adjust_id(params.feat_ui_tooltip_text_name_id);
-                        params.sample_text_name_id = adjust_id(params.sample_text_name_id);
-                        params.first_param_ui_label_name_id =
-                            adjust_id(params.first_param_ui_label_name_id);
-                    }
-                    _ => (),
-                });
-        }
+        self.gsub
+            .as_mut()
+            .into_iter()
+            .flat_map(|t| t.feature_list.feature_records.iter_mut())
+            .chain(
+                self.gpos
+                    .as_mut()
+                    .into_iter()
+                    .flat_map(|t| t.feature_list.feature_records.iter_mut()),
+            )
+            .for_each(|rec| match rec.feature.as_mut().feature_params.as_mut() {
+                Some(FeatureParams::StylisticSet(params)) => {
+                    params.ui_name_id = adjust_id(params.ui_name_id);
+                }
+                Some(FeatureParams::CharacterVariant(params)) => {
+                    params.feat_ui_label_name_id = adjust_id(params.feat_ui_label_name_id);
+                    params.feat_ui_tooltip_text_name_id =
+                        adjust_id(params.feat_ui_tooltip_text_name_id);
+                    params.sample_text_name_id = adjust_id(params.sample_text_name_id);
+                    params.first_param_ui_label_name_id =
+                        adjust_id(params.first_param_ui_label_name_id);
+                }
+                _ => (),
+            });
         if let Some(stat) = self.stat.as_mut() {
             stat.elided_fallback_name_id = stat
                 .elided_fallback_name_id

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -3617,6 +3617,37 @@ mod tests {
     }
 
     #[test]
+    fn remap_nameids_for_gpos_featureparam() {
+        let result = TestCompile::compile_source("glyphs3/GposWithFeatureParamName.glyphs");
+        let font = result.font();
+        let gpos = font.gpos().unwrap();
+        let name = font.name().unwrap();
+        let features = gpos.feature_list().unwrap();
+        assert_eq!(features.feature_count(), 1);
+        let feat = features
+            .feature_records()
+            .first()
+            .unwrap()
+            .feature(features.offset_data())
+            .unwrap();
+        let FeatureParams::StylisticSet(params) = feat.feature_params().unwrap().unwrap() else {
+            panic!("not a stylistic set");
+        };
+
+        let name_id = params.ui_name_id();
+
+        let matching_ids = name
+            .name_record()
+            .iter()
+            .filter(|rec| rec.name_id() == name_id)
+            .collect::<Vec<_>>();
+        assert_eq!(matching_ids.len(), 1);
+
+        let name = matching_ids[0].string(name.string_data()).unwrap();
+        assert_eq!(name.to_string(), "An extremely stylish set");
+    }
+
+    #[test]
     fn use_base_table_from_fea() {
         let _ = env_logger::builder().is_test(true).try_init();
         let result = TestCompile::compile_source("CustomBaseTableInFea.ufo");

--- a/resources/testdata/glyphs3/GposWithFeatureParamName.glyphs
+++ b/resources/testdata/glyphs3/GposWithFeatureParamName.glyphs
@@ -1,0 +1,51 @@
+{
+.appVersion = "3260";
+.formatVersion = 3;
+familyName = GposWithFeatureParamName;
+customParameters = (
+{
+name = "Name Table Entry";
+value = "256 3 1 0x409; this should collide with first assigned name value";
+},
+);
+
+features = (
+{
+code = "pos a b 420;";
+labels = (
+{
+language = dflt;
+value = "An extremely stylish set";
+}
+);
+tag = ss01;
+},
+);
+fontMaster = (
+{
+id = master01;
+name = Regular;
+}
+);
+glyphs = (
+{
+glyphname = a;
+layers = (
+{
+layerId = master01;
+}
+);
+unicode = 97;
+},
+{
+glyphname = b;
+layers = (
+{
+layerId = master01;
+}
+);
+unicode = 98;
+}
+);
+unitsPerEm = 1000;
+}


### PR DESCRIPTION
These _mostly_ just occur in GSUB, but it is not impossible for them to exist in GPOS as well, so :shrug:


gives us a +small on crater

JMM