### PR TITLE
Fixup sub/superscript metric fallback logic

### DIFF
--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -1632,6 +1632,20 @@ mod tests {
     }
 
     #[test]
+    fn os2_superscript_reuses_explicit_subscript() {
+        // if a font has explicitly stated a value for the subscriptXSize and related
+        // metrics, but not the superscript equivalents, we should reuse the
+        // subscript values.
+
+        let result = TestCompile::compile_source("glyphs2/SuperscriptCustomParamFallback.glyphs");
+        let font = result.font();
+        let os2 = font.os2().unwrap();
+        assert_eq!(os2.y_superscript_x_size(), 701);
+        assert_eq!(os2.y_superscript_y_size(), 659);
+        assert_eq!(os2.y_superscript_y_offset(), 350); // default: ppem * 0.35
+    }
+
+    #[test]
     fn glyphs_app_ir_categories() {
         let result = TestCompile::compile_source("glyphs3/Oswald-glyph-categories.glyphs");
         let staticmeta = result.fe_context.static_metadata.get();

--- a/fontdrasil/src/coords.rs
+++ b/fontdrasil/src/coords.rs
@@ -120,6 +120,12 @@ pub type UserLocation = Location<UserSpace>;
 /// A location in [`NormalizedSpace`].
 pub type NormalizedLocation = Location<NormalizedSpace>;
 
+impl<T: Clone> From<&Location<T>> for Location<T> {
+    fn from(value: &Location<T>) -> Self {
+        value.clone()
+    }
+}
+
 // a little helper to generate methods on coord/location for specific conversions
 macro_rules! convert_convenience_methods {
     ($space:ident, $fn_name:ident) => {

--- a/resources/testdata/glyphs2/SuperscriptCustomParamFallback.glyphs
+++ b/resources/testdata/glyphs2/SuperscriptCustomParamFallback.glyphs
@@ -1,0 +1,31 @@
+{
+familyName = SuperDuperScript;
+fontMaster = (
+{
+id = master01;
+name = Regular;
+customParameters = (
+{
+name = subscriptXSize;
+value = 701;
+},
+{
+name = subscriptYSize;
+value = 659;
+},
+);
+}
+);
+glyphs = (
+{
+glyphname = space;
+layers = (
+{
+layerId = master01;
+}
+);
+unicode = 32;
+}
+);
+unitsPerEm = 1000;
+}


### PR DESCRIPTION
If there are explicit values in a font for the 'Os2Subscript___' metrics, we want to reuse those for the corresponding superscript metrics.

This means that we need to query metrics in this routine, which ran into borrowck issues due to the long-lived closure that had a mutable ref to self. To work around that, I've replaced that closure with a macro.

