### PR TITLE
Cv FeatureParam tables use 'null'

### DIFF
--- a/fea-rs/src/compile/features.rs
+++ b/fea-rs/src/compile/features.rs
@@ -5,7 +5,7 @@ use std::collections::{BTreeMap, HashMap, HashSet, hash_map};
 use smol_str::SmolStr;
 use write_fonts::{
     tables::layout::{ConditionSet, FeatureParams, SizeParams, StylisticSetParams},
-    types::{GlyphId16, Tag, Uint24},
+    types::{GlyphId16, NameId, Tag, Uint24},
 };
 
 use super::{
@@ -557,6 +557,15 @@ impl CvParams {
         names: &mut NameBuilder,
     ) -> write_fonts::tables::layout::CharacterVariantParams {
         let mut out = write_fonts::tables::layout::CharacterVariantParams::default();
+
+        // funnyness: name id 0 is assigned a meaning, but in this particular case
+        // it seems that the spec wants us to also use it to indicate 'no value':
+        // TODO: fix this when https://github.com/googlefonts/fontations/pull/1704 lands
+        const NULL: NameId = NameId::new(0);
+        out.feat_ui_label_name_id = NULL;
+        out.feat_ui_tooltip_text_name_id = NULL;
+        out.first_param_ui_label_name_id = NULL;
+        out.sample_text_name_id = NULL;
         if !self.feat_ui_label_name.is_empty() {
             out.feat_ui_label_name_id = names.add_anon_group(&self.feat_ui_label_name);
         }

--- a/fea-rs/test-data/compile-tests/mini-latin/good/cvparam_null.fea
+++ b/fea-rs/test-data/compile-tests/mini-latin/good/cvparam_null.fea
@@ -1,0 +1,6 @@
+feature cv02 {
+    # the missing fields are allowed, and the compiler should generate a FeatureParameters
+    # table where the missing name ids are `0`
+    cvParameters { FeatUILabelNameID { name "Tall W"; }; };
+    sub a by b;
+} cv02;

--- a/fea-rs/test-data/compile-tests/mini-latin/good/cvparam_null.ttx
+++ b/fea-rs/test-data/compile-tests/mini-latin/good/cvparam_null.ttx
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont>
+
+  <name>
+    <namerecord nameID="256" platformID="3" platEncID="1" langID="0x409">
+      Tall W
+    </namerecord>
+  </name>
+
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=1 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="cv02"/>
+        <Feature>
+          <FeatureParamsCharacterVariants Format="0">
+            <Format value="0"/>
+            <FeatUILabelNameID value="256"/>  <!-- Tall W -->
+            <FeatUITooltipTextNameID value="0"/>
+            <SampleTextNameID value="0"/>
+            <NumNamedParameters value="0"/>
+            <FirstParamUILabelNameID value="0"/>
+            <!-- CharCount=0 -->
+          </FeatureParamsCharacterVariants>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=1 -->
+      <Lookup index="0">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0">
+          <Substitution in="a" out="b"/>
+        </SingleSubst>
+      </Lookup>
+    </LookupList>
+  </GSUB>
+
+</ttFont>


### PR DESCRIPTION
A funny corner of the spec: this table wants us to use '0' to indicate the absense of a name ID, even though '0' _is_ a valid name ID.


Also opened https://github.com/googlefonts/fontations/pull/1704 so this can be handled in write-fonts.


JMM