### PR TITLE
[fea-rs] Compile format 2 contextual lookups

### DIFF
--- a/fea-rs/test-data/compile-tests/mini-latin/good/gsub_context_format2.fea
+++ b/fea-rs/test-data/compile-tests/mini-latin/good/gsub_context_format2.fea
@@ -1,0 +1,23 @@
+languagesystem DFLT dflt;
+
+lookup swapperoo {
+    sub a by A;
+    sub b by B;
+    sub c by C;
+    sub d by D;
+    sub e by E;
+    sub f by F;
+    sub g by G;
+} swapperoo;
+
+# manually constructed such that format 2 is best
+lookup rups {
+    sub [a b]' lookup swapperoo [c d]' lookup swapperoo;
+    sub [a b]' lookup swapperoo [e f g]' lookup swapperoo;
+    sub [a b]' lookup swapperoo [h i]' lookup swapperoo;
+    sub [one two three]' lookup swapperoo [h i]' lookup swapperoo;
+} rups;
+
+feature derp {
+    lookup rups;
+} derp;

--- a/fea-rs/test-data/compile-tests/mini-latin/good/gsub_context_format2.ttx
+++ b/fea-rs/test-data/compile-tests/mini-latin/good/gsub_context_format2.ttx
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont>
+
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="DFLT"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=1 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="derp"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="1"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=2 -->
+      <Lookup index="0">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0">
+          <Substitution in="a" out="A"/>
+          <Substitution in="b" out="B"/>
+          <Substitution in="c" out="C"/>
+          <Substitution in="d" out="D"/>
+          <Substitution in="e" out="E"/>
+          <Substitution in="f" out="F"/>
+          <Substitution in="g" out="G"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="1">
+        <LookupType value="5"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <ContextSubst index="0" Format="2">
+          <Coverage>
+            <Glyph value="one"/>
+            <Glyph value="two"/>
+            <Glyph value="three"/>
+            <Glyph value="a"/>
+            <Glyph value="b"/>
+          </Coverage>
+          <ClassDef>
+            <ClassDef glyph="a" class="3"/>
+            <ClassDef glyph="b" class="3"/>
+            <ClassDef glyph="c" class="4"/>
+            <ClassDef glyph="d" class="4"/>
+            <ClassDef glyph="e" class="2"/>
+            <ClassDef glyph="f" class="2"/>
+            <ClassDef glyph="g" class="2"/>
+            <ClassDef glyph="h" class="5"/>
+            <ClassDef glyph="i" class="5"/>
+            <ClassDef glyph="one" class="1"/>
+            <ClassDef glyph="three" class="1"/>
+            <ClassDef glyph="two" class="1"/>
+          </ClassDef>
+          <!-- SubClassSetCount=6 -->
+          <SubClassSet index="0" empty="1"/>
+          <SubClassSet index="1">
+            <!-- SubClassRuleCount=1 -->
+            <SubClassRule index="0">
+              <!-- GlyphCount=2 -->
+              <!-- SubstCount=2 -->
+              <Class index="0" value="5"/>
+              <SubstLookupRecord index="0">
+                <SequenceIndex value="0"/>
+                <LookupListIndex value="0"/>
+              </SubstLookupRecord>
+              <SubstLookupRecord index="1">
+                <SequenceIndex value="1"/>
+                <LookupListIndex value="0"/>
+              </SubstLookupRecord>
+            </SubClassRule>
+          </SubClassSet>
+          <SubClassSet index="2" empty="1"/>
+          <SubClassSet index="3">
+            <!-- SubClassRuleCount=3 -->
+            <SubClassRule index="0">
+              <!-- GlyphCount=2 -->
+              <!-- SubstCount=2 -->
+              <Class index="0" value="4"/>
+              <SubstLookupRecord index="0">
+                <SequenceIndex value="0"/>
+                <LookupListIndex value="0"/>
+              </SubstLookupRecord>
+              <SubstLookupRecord index="1">
+                <SequenceIndex value="1"/>
+                <LookupListIndex value="0"/>
+              </SubstLookupRecord>
+            </SubClassRule>
+            <SubClassRule index="1">
+              <!-- GlyphCount=2 -->
+              <!-- SubstCount=2 -->
+              <Class index="0" value="2"/>
+              <SubstLookupRecord index="0">
+                <SequenceIndex value="0"/>
+                <LookupListIndex value="0"/>
+              </SubstLookupRecord>
+              <SubstLookupRecord index="1">
+                <SequenceIndex value="1"/>
+                <LookupListIndex value="0"/>
+              </SubstLookupRecord>
+            </SubClassRule>
+            <SubClassRule index="2">
+              <!-- GlyphCount=2 -->
+              <!-- SubstCount=2 -->
+              <Class index="0" value="5"/>
+              <SubstLookupRecord index="0">
+                <SequenceIndex value="0"/>
+                <LookupListIndex value="0"/>
+              </SubstLookupRecord>
+              <SubstLookupRecord index="1">
+                <SequenceIndex value="1"/>
+                <LookupListIndex value="0"/>
+              </SubstLookupRecord>
+            </SubClassRule>
+          </SubClassSet>
+          <SubClassSet index="4" empty="1"/>
+          <SubClassSet index="5" empty="1"/>
+        </ContextSubst>
+      </Lookup>
+    </LookupList>
+  </GSUB>
+
+</ttFont>


### PR DESCRIPTION
I had initially struggled to come up with an input where format 2 outperformed format 3, but of course they are out there.

This also updates ttx_diff to normalize these; we were already doing this for chain contexts.


- closes #1863
- should be worth at least a +8 on crater