### PR TITLE
[glyphs2fontir] Build vertical tables when vhea params are defined

### DIFF
--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -3838,4 +3838,11 @@ mod tests {
             "Intermediate layer should use its own width (750), NOT the linked master's width (600)"
         );
     }
+
+    #[test]
+    fn vhea_params_trigger_build_vertical() {
+        // https://github.com/googlefonts/fontc/issues/1859
+        let (_, context) = build_static_metadata(glyphs3_dir().join("VheaParams.glyphs"));
+        assert!(context.static_metadata.get().build_vertical);
+    }
 }

--- a/resources/testdata/glyphs3/VheaParams.glyphs
+++ b/resources/testdata/glyphs3/VheaParams.glyphs
@@ -1,0 +1,37 @@
+{
+.appVersion = "3219";
+.formatVersion = 3;
+customParameters = (
+{
+name = vheaVertAscender;
+value = 500;
+},
+{
+name = vheaVertDescender;
+value = -500;
+},
+{
+name = vheaVertLineGap;
+value = 0;
+}
+);
+familyName = VheaParams;
+fontMaster = (
+{
+id = m01;
+name = Regular;
+}
+);
+glyphs = (
+{
+glyphname = space;
+layers = (
+{
+layerId = m01;
+width = 200;
+}
+);
+}
+);
+unitsPerEm = 1000;
+}


### PR DESCRIPTION
Build vhea/vmtx tables when all three vhea custom parameters are defined, even if no glyphs have `vertWidth`/`vertOrigin`
Matches ufo2ft behavior which requires all three vhea params (ascender, descender, lineGap)

Fixes https://github.com/googlefonts/fontc/issues/1859