### PR TITLE
Preserve original anchor names through propagation

### DIFF
--- a/fontbe/src/features/marks.rs
+++ b/fontbe/src/features/marks.rs
@@ -1148,7 +1148,11 @@ mod tests {
                 })
                 .collect();
             let kind = AnchorKind::new(anchor_name).unwrap();
-            self.anchors.push(Anchor { kind, positions });
+            self.anchors.push(Anchor {
+                kind,
+                original_name: anchor_name.into(),
+                positions,
+            });
             self
         }
     }

--- a/fontir/src/propagate_anchors.rs
+++ b/fontir/src/propagate_anchors.rs
@@ -84,7 +84,7 @@ pub fn propagate_all_anchors(context: &Context) -> Result<(), Error> {
                         .iter()
                         .filter_map(|anchor| {
                             anchor.positions.get(location).map(|pos| RawAnchor {
-                                name: anchor.kind.to_name(),
+                                name: anchor.original_name.clone(),
                                 pos: *pos,
                             })
                         })
@@ -917,7 +917,7 @@ mod tests {
                 let mut names: Vec<String> = ga
                     .anchors
                     .iter()
-                    .map(|a| a.kind.to_name().to_string())
+                    .map(|a| a.original_name.to_string())
                     .collect();
                 names.sort();
                 names


### PR DESCRIPTION
After #1832 (propagate anchors in IR), fonts with non-standard caret anchor naming lost caret positions. For example, [ComforterBrush-Pro.glyphs](https://github.com/googlefonts/comforter-brush) defines two caret anchors on "ffi":

- `caret_1` at x=242
- `caret_1_` at x=588

`AnchorKind::new("caret_1_")` parses the suffix "1_", fails `parse::<usize>()`, and falls back to `Caret(1)`, i.e. the same variant as `caret_1`. When `to_name()` method converts both back to strings during anchor propagation, both become "caret_1" and one overwrites the other in the IndexMap.

Before #1832 this didn't matter because `fontbe` consumed `Vec<Anchor>` directly without round-tripping through names. After the merge, propagation serializes anchors via `AnchorKind::to_name()` at 

https://github.com/googlefonts/fontc/blob/ade0a9bc/fontir/src/propagate_anchors.rs#L87

... introducing the lossy conversion.

(fontmake/ufo2ft doesn't have this problem because it never parses caret indices, it just checks `name.startswith("caret_")` and collects positions.. apparently nobody cares about caret indices except me)

The fix is to add `original_name: SmolStr` field to `fontir::ir::Anchor` to preserve the original source name and use that instead of anchor.kind.to_name() when feeding anchors into propagation.

The existing `to_name()` is kept as a public method but documented as lossy.

The first commit adds the regression test that asserts both caret_1 and caret_1_ survive propagation (deliberately fails without the fix). It is followed by the actual fix.
