### PR TITLE
Update docs

### DIFF
--- a/fontbe/README.md
+++ b/fontbe/README.md
@@ -1,5 +1,7 @@
 # fontbe
 
+[![Crates.io](https://img.shields.io/crates/v/fontbe.svg)](https://crates.io/crates/fontbe)
+[![Docs.rs](https://docs.rs/fontbe/badge.svg)](https://docs.rs/fontbe)
 [![MIT/Apache 2.0](https://img.shields.io/badge/license-MIT%2FApache-blue.svg)](#license)
 
 fontbe: Font BackEnd.

--- a/fontc/README.md
+++ b/fontc/README.md
@@ -1,11 +1,15 @@
 # fontc
 
+[![Crates.io](https://img.shields.io/crates/v/fontc.svg)](https://crates.io/crates/fontc)
+[![Docs.rs](https://docs.rs/fontc/badge.svg)](https://docs.rs/fontc)
 [![MIT/Apache 2.0](https://img.shields.io/badge/license-MIT%2FApache-blue.svg)](#license)
 
 fontc: Font Compiler
 
-This crate provides the command line entrypoint into our font compiler.
+This crate provides the command line entrypoint into our font compiler. It also
+exposes a programmatic library entrypoint (`pub fn generate_font`) for
+integrating `fontc` natively as a Rust library.
 
-It's primary task is to accept arguments from the user, create a task graph, and execute it.
+Its primary task is to accept arguments from the user, create a `Workload`, and execute it using the orchestration system.
 
 This crate can reference all other crates in the workspace.

--- a/fontc_crater/README.md
+++ b/fontc_crater/README.md
@@ -1,5 +1,9 @@
 # `fontc_crater`
 
+[![Crates.io](https://img.shields.io/crates/v/fontc_crater.svg)](https://crates.io/crates/fontc_crater)
+[![Docs.rs](https://docs.rs/fontc_crater/badge.svg)](https://docs.rs/fontc_crater)
+[![MIT/Apache 2.0](https://img.shields.io/badge/license-MIT%2FApache-blue.svg)](#license)
+
 The `fontc_crater` crate (named after [rust-lang/crater]) is a tool for
 performing compilation and related actions across a large number of source
 fonts.
@@ -12,6 +16,8 @@ an existing checkout of this repository, which saves time.
 
 Once sources are identified, they are checked out into a cache directory, where
 they can be reused between runs.
+
+The tool processes and generates JSON outputs for tracking successful and failed font compilations across targets, in addition to an optional HTML report.
 
 ## CI
 

--- a/fontdrasil/README.md
+++ b/fontdrasil/README.md
@@ -1,5 +1,7 @@
 # fontdrasil
 
+[![Crates.io](https://img.shields.io/crates/v/fontdrasil.svg)](https://crates.io/crates/fontdrasil)
+[![Docs.rs](https://docs.rs/fontdrasil/badge.svg)](https://docs.rs/fontdrasil)
 [![MIT/Apache 2.0](https://img.shields.io/badge/license-MIT%2FApache-blue.svg)](#license)
 
 fontdrasil: Common types and functionality shared between all layers of fontc.

--- a/fontir/README.md
+++ b/fontir/README.md
@@ -1,5 +1,7 @@
 # fontir
 
+[![Crates.io](https://img.shields.io/crates/v/fontir.svg)](https://crates.io/crates/fontir)
+[![Docs.rs](https://docs.rs/fontir/badge.svg)](https://docs.rs/fontir)
 [![MIT/Apache 2.0](https://img.shields.io/badge/license-MIT%2FApache-blue.svg)](#license)
 
 fontir: Font Intermediate Representation
@@ -7,4 +9,4 @@ fontir: Font Intermediate Representation
 This crate defines the intermediate representation (IR) of a font used by fontc and common operations
 on that IR.
 
-It should be referenced by fontc and any frontend (_format_2fontir) crates.
+It should be referenced by fontc, any frontend (_format_2fontir) crates, and the backend crate, `fontbe`, which heavily references `fontir` to read the Intermediate Representation and compile it into binary tables.

--- a/fontra2fontir/README.md
+++ b/fontra2fontir/README.md
@@ -1,5 +1,9 @@
 # fontra2fontir
 
+[![Crates.io](https://img.shields.io/crates/v/fontra2fontir.svg)](https://crates.io/crates/fontra2fontir)
+[![Docs.rs](https://docs.rs/fontra2fontir/badge.svg)](https://docs.rs/fontra2fontir)
+[![MIT/Apache 2.0](https://img.shields.io/badge/license-MIT%2FApache-blue.svg)](#license)
+
 This crate is a frontend for compilation of [Fontra](https://fontra.xyz/) json sources. It converts from .fontra to the fontc
 internal representation.
 

--- a/glyphs-reader/README.md
+++ b/glyphs-reader/README.md
@@ -1,6 +1,10 @@
 # glyphs-reader
 
-This crate reads Glyphs 2 and Glyphs 3 files.
+[![Crates.io](https://img.shields.io/crates/v/glyphs-reader.svg)](https://crates.io/crates/glyphs-reader)
+[![Docs.rs](https://docs.rs/glyphs-reader/badge.svg)](https://docs.rs/glyphs-reader)
+[![MIT/Apache 2.0](https://img.shields.io/badge/license-MIT%2FApache-blue.svg)](#license)
+
+This crate is a lightweight library for reading Glyphs 2 and Glyphs 3 font files, with support for writing the underlying Property List (`Plist`) format.
 
 It is part of [`fontc`], a font compiler.
 

--- a/glyphs2fontir/README.md
+++ b/glyphs2fontir/README.md
@@ -1,6 +1,10 @@
 # glyphs2fontir
 
-This crate is a frontend for compilation of Glyphs app sources. It converts from .glyphs to the fontc
+[![Crates.io](https://img.shields.io/crates/v/glyphs2fontir.svg)](https://crates.io/crates/glyphs2fontir)
+[![Docs.rs](https://docs.rs/glyphs2fontir/badge.svg)](https://docs.rs/glyphs2fontir)
+[![MIT/Apache 2.0](https://img.shields.io/badge/license-MIT%2FApache-blue.svg)](#license)
+
+This crate is a frontend for compilation of Glyphs app sources. It converts from .glyphs and .glyphspackage directory structures to the fontc
 internal representation.
 
 It should be referenced only by fontc.

--- a/otl-normalizer/README.md
+++ b/otl-normalizer/README.md
@@ -1,7 +1,14 @@
 # otl-normalizer
 
+[![Crates.io](https://img.shields.io/crates/v/otl-normalizer.svg)](https://crates.io/crates/otl-normalizer)
+[![Docs.rs](https://docs.rs/otl-normalizer/badge.svg)](https://docs.rs/otl-normalizer)
+[![MIT/Apache 2.0](https://img.shields.io/badge/license-MIT%2FApache-blue.svg)](#license)
+
 This crate converts OpenType layout subtables to a normalized representation,
 suitable for comparison in a text diff.
+
+This currently supports a subset of GPOS (kerning and marks) and normalizes the
+GDEF ligature caret table. GSUB is stubbed out not supported.
 
 It is part of the [`fontc`] project, and is used to test font compilation as
 well as to compare the output of different compiler toolchains.

--- a/ttx_diff/README.md
+++ b/ttx_diff/README.md
@@ -2,6 +2,7 @@
 
 [![PyPI](https://img.shields.io/pypi/v/ttx-diff)](https://pypi.org/project/ttx-diff/)
 [![Python Version](https://img.shields.io/pypi/pyversions/ttx-diff)](https://pypi.org/project/ttx-diff/)
+[![MIT/Apache 2.0](https://img.shields.io/badge/license-MIT%2FApache-blue.svg)](#license)
 
 A tool for comparing font compiler outputs between fontc (Rust) and fontmake (Python).
 
@@ -11,7 +12,11 @@ A tool for comparing font compiler outputs between fontc (Rust) and fontmake (Py
 - **fontc**: The Rust-based font compiler from Google Fonts
 - **fontmake**: The Python-based font compiler
 
-The tool converts each binary font to TTX (XML) format, normalizes expected differences, and provides a detailed comparison summary.
+The tool converts each binary font to TTX (XML) format, normalizes expected
+differences, and provides a detailed comparison summary.
+
+Note that `ttx_diff` is a pure Python package (located in `src/ttx_diff/`)
+rather than a typical Rust crate within this workspace.
 
 ## Installation
 

--- a/ufo2fontir/README.md
+++ b/ufo2fontir/README.md
@@ -1,6 +1,10 @@
 # ufo2fontir
 
-This crate is a frontend for compilation of .designspace sources. It converts from .designspace to the fontc
+[![Crates.io](https://img.shields.io/crates/v/ufo2fontir.svg)](https://crates.io/crates/ufo2fontir)
+[![Docs.rs](https://docs.rs/ufo2fontir/badge.svg)](https://docs.rs/ufo2fontir)
+[![MIT/Apache 2.0](https://img.shields.io/badge/license-MIT%2FApache-blue.svg)](#license)
+
+This crate is a frontend for compilation of .ufo (Unified Font Object) and .designspace sources. It converts natively from .ufo and .designspace to the fontc
 internal representation.
 
 It should be referenced only by fontc.


### PR DESCRIPTION
- Added crates.io, docs.rs and license badges
- fontir: Clarifies that fontbe is a primary consumer of the Intermediate Representation.
- fontc_crater: Adds details about JSON and HTML report generation for tracking compilation results.
- glyphs-reader: Notes support for reading Glyphs 2/3 and writing the underlying Plist format.
- glyphs2fontir: Confirms support for both .glyphs and .glyphspackage formats.
- otl-normalizer: Details current support for GPOS/GDEF normalization and the status of GSUB.
- ttx_diff: Clarifies that this is a pure Python package located in src/ttx_diff/.
- ufo2fontir: Explicitly mentions native support for both .ufo and .designspace sources.
