### PR TITLE
[crater] Strip sha from printed target representation

### DIFF
--- a/fontc_crater/src/target.rs
+++ b/fontc_crater/src/target.rs
@@ -180,16 +180,23 @@ impl Display for BuildType {
 
 impl Display for Target {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let config_path = if self.is_virtual {
+        let mut config_path = if self.is_virtual {
             self.repo_dir.join("$VIRTUAL").join(&self.config)
         } else {
             self.repo_dir.join(&self.config)
-        };
+        }
+        .display()
+        .to_string();
+
+        // our directories always have _SHA appended, so strip that.
+        let suffix = format!("_{}", self.sha);
+        if let Some(idx) = config_path.match_indices(suffix.as_str()).next() {
+            config_path.replace_range(idx.0..idx.0 + suffix.len(), "");
+        }
 
         write!(
             f,
-            "{} {}?{} ({})",
-            config_path.display(),
+            "{config_path} {}?{} ({})",
             self.source.display(),
             self.sha,
             self.build


### PR DESCRIPTION
We append the sha to the repo directory in the case that there are collisions, but we don't need to include that in the html output since the sha is already always included there.


this is no functional change, but will add a noisey update on crater where ~100 targets get renamed; I want to PR it on its own so that it doesn't clutter a later patch that makes more meaningful changes.

JMM