### PR TITLE
[otl-normalizer] Filter GDEF ligcaret regions to only those referenced by caret data

### DIFF
--- a/otl-normalizer/src/gdef.rs
+++ b/otl-normalizer/src/gdef.rs
@@ -1,22 +1,47 @@
 //! Normalizing the ligature caret table
 
-use std::{fmt::Display, io};
+use std::{collections::BTreeSet, fmt::Display, io};
 
 use fontdrasil::types::GlyphName;
 use write_fonts::read::{
     ReadError,
     tables::gdef::{CaretValue, Gdef, LigGlyph},
+    tables::layout::DeviceOrVariationIndex,
 };
 
 use crate::{Error, NameMap, common::DeviceOrDeltas, variations::DeltaComputer};
 
+/// Collect the IVS outer (subtable) indices referenced by lig caret data.
+fn collect_caret_subtables(table: &Gdef) -> Result<BTreeSet<u16>, Error> {
+    let mut outers = BTreeSet::new();
+    let Some(lig_carets) = table.lig_caret_list().transpose().unwrap() else {
+        return Ok(outers);
+    };
+    for lig_glyph in lig_carets.lig_glyphs().iter() {
+        let lig_glyph = lig_glyph?;
+        for caret in lig_glyph.caret_values().iter() {
+            if let CaretValue::Format3(table_ref) = caret?
+                && let DeviceOrVariationIndex::VariationIndex(idx) = table_ref.device()?
+            {
+                outers.insert(idx.delta_set_outer_index());
+            }
+        }
+    }
+    Ok(outers)
+}
+
 /// Print normalized GDEF ligature carets
 pub fn print(f: &mut dyn io::Write, table: &Gdef, names: &NameMap) -> Result<(), Error> {
-    let var_store = table
-        .item_var_store()
-        .map(|ivs| ivs.and_then(DeltaComputer::new))
-        .transpose()
-        .unwrap();
+    let var_store = if table.item_var_store().is_some() {
+        let used_subtables = collect_caret_subtables(table)?;
+        table
+            .item_var_store()
+            .map(|ivs| ivs.and_then(|ivs| DeltaComputer::new(ivs, Some(&used_subtables))))
+            .transpose()
+            .unwrap()
+    } else {
+        None
+    };
 
     // so this is relatively simple; we're just looking at the ligature caret list.
     // - realistically, we only care if this has variations? but I think it's simpler

--- a/otl-normalizer/src/gpos.rs
+++ b/otl-normalizer/src/gpos.rs
@@ -44,7 +44,9 @@ pub fn print(
     let var_store = gdef
         .as_ref()
         .and_then(|gdef| gdef.item_var_store())
-        .map(|ivs| ivs.and_then(DeltaComputer::new))
+        // TODO: pre-scan GPOS data to collect used subtable indices and filter regions,
+        // like gdef::collect_caret_subtables does for ligature carets.
+        .map(|ivs| ivs.and_then(|ivs| DeltaComputer::new(ivs, None)))
         .transpose()
         .unwrap();
     let mark_glyph_sets = gdef

--- a/otl-normalizer/src/variations.rs
+++ b/otl-normalizer/src/variations.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeSet;
+
 use write_fonts::read::{
     ReadError,
     tables::{layout::VariationIndex, variations::ItemVariationStore},
@@ -12,19 +14,42 @@ pub(crate) struct DeltaComputer<'a> {
 }
 
 impl<'a> DeltaComputer<'a> {
-    pub(crate) fn new(ivs: ItemVariationStore<'a>) -> Result<Self, ReadError> {
-        let mut locations = vec![];
+    pub(crate) fn new(
+        ivs: ItemVariationStore<'a>,
+        used_subtables: Option<&BTreeSet<u16>>,
+    ) -> Result<Self, ReadError> {
         let region_list = ivs.variation_region_list()?;
-        for region in region_list.variation_regions().iter() {
-            let region = region?;
-            locations.push(
-                region
+
+        // Collect the set of global region indices actually referenced by the
+        // requested IVS subtables.  When None we keep all regions.
+        let used_regions: Option<BTreeSet<usize>> = used_subtables
+            .map(|outers| {
+                let mut set = BTreeSet::new();
+                for &outer in outers {
+                    if let Some(data) = ivs.item_variation_data().get(outer as usize) {
+                        for idx in data?.region_indexes() {
+                            set.insert(idx.get() as usize);
+                        }
+                    }
+                }
+                Ok(set)
+            })
+            .transpose()?;
+
+        let mut locations: MasterLocations = region_list
+            .variation_regions()
+            .iter()
+            .enumerate()
+            .filter(|(idx, _)| used_regions.as_ref().is_none_or(|set| set.contains(idx)))
+            .map(|(_, region)| {
+                let region = region?;
+                Ok(region
                     .region_axes()
                     .iter()
                     .map(|axis| axis.peak_coord())
-                    .collect(),
-            );
-        }
+                    .collect())
+            })
+            .collect::<Result<_, ReadError>>()?;
         locations.sort();
         Ok(DeltaComputer { ivs, locations })
     }
@@ -39,5 +64,79 @@ impl<'a> DeltaComputer<'a> {
             .iter()
             .map(|loc| self.ivs.compute_delta(delta_ix, loc).map(|d| d + coord))
             .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use write_fonts::{
+        dump_table,
+        read::{FontData, FontRead},
+        tables::variations::{
+            ItemVariationData, ItemVariationStore as WriteIvs, RegionAxisCoordinates,
+            VariationRegion, VariationRegionList,
+        },
+        types::F2Dot14,
+    };
+
+    fn region_1axis(peak: f32) -> VariationRegion {
+        VariationRegion::new(vec![RegionAxisCoordinates {
+            start_coord: F2Dot14::from_f32(0.0),
+            peak_coord: F2Dot14::from_f32(peak),
+            end_coord: F2Dot14::from_f32(1.0),
+        }])
+    }
+
+    /// Build an IVS with two subtables referencing different subsets of
+    /// a 3-region global VariationRegionList:
+    ///   - subtable 0 references regions 0 and 1 (peaks 0.5, 1.0)
+    ///   - subtable 1 references region 2 only (peak 0.75)
+    fn build_multi_subtable_ivs() -> Vec<u8> {
+        let regions = VariationRegionList::new(
+            1,
+            vec![region_1axis(0.5), region_1axis(1.0), region_1axis(0.75)],
+        );
+        // subtable 0: 1 item, 2 regions (indices 0, 1), deltas [10, 20]
+        let sub0 = ItemVariationData::new(1, 0, vec![0, 1], vec![10, 20]);
+        // subtable 1: 1 item, 1 region (index 2), delta [30]
+        let sub1 = ItemVariationData::new(1, 0, vec![2], vec![30]);
+        let store = WriteIvs::new(regions, vec![Some(sub0), Some(sub1)]);
+        dump_table(&store).unwrap()
+    }
+
+    #[test]
+    fn no_filter_includes_all_regions() {
+        let bytes = build_multi_subtable_ivs();
+        let ivs = ItemVariationStore::read(FontData::new(&bytes)).unwrap();
+        let computer = DeltaComputer::new(ivs, None).unwrap();
+        assert_eq!(computer.locations.len(), 3);
+    }
+
+    #[test]
+    fn filter_to_subtable_0_excludes_unrelated_regions() {
+        let bytes = build_multi_subtable_ivs();
+        let ivs = ItemVariationStore::read(FontData::new(&bytes)).unwrap();
+        let used = BTreeSet::from([0u16]);
+        let computer = DeltaComputer::new(ivs, Some(&used)).unwrap();
+        assert_eq!(computer.locations.len(), 2);
+    }
+
+    #[test]
+    fn filter_to_subtable_1_excludes_unrelated_regions() {
+        let bytes = build_multi_subtable_ivs();
+        let ivs = ItemVariationStore::read(FontData::new(&bytes)).unwrap();
+        let used = BTreeSet::from([1u16]);
+        let computer = DeltaComputer::new(ivs, Some(&used)).unwrap();
+        assert_eq!(computer.locations.len(), 1);
+    }
+
+    #[test]
+    fn filter_union_of_subtables_includes_all() {
+        let bytes = build_multi_subtable_ivs();
+        let ivs = ItemVariationStore::read(FontData::new(&bytes)).unwrap();
+        let used = BTreeSet::from([0u16, 1u16]);
+        let computer = DeltaComputer::new(ivs, Some(&used)).unwrap();
+        assert_eq!(computer.locations.len(), 3);
     }
 }


### PR DESCRIPTION
When comparing variable fonts from different compilers, otl-normalizer evaluates deltas at every region peak in the global `VariationRegionList`. If the two fonts have different global region counts (e.g. 20 vs 21 regions), the output shows spurious column-count differences even when the actual data is identical.

This was observed with MontaguSlab, where a fonttools rounding bug (fonttools/fonttools#4053) caused one extra region in fontmake's global list, inflating the ligcaret.txt's diff to 64% despite the ligature caret data being identical across compilers (only some GPOS mark anchors would differ and reference the extra region).

Now `DeltaComputer::new()` accepts an optional set of IVS subtable (outer) indices to filter regions. For GDEF, `gdef::print()` pre-scans lig caret data to collect which subtables are actually referenced, so only those regions appear in the output.
For GPOS it passes `None` (no filtering) for now, marked as potential TODO. Pre-scanning GPOS is significantly more involved since value records and anchors are spread across many lookup types, whereas GDEF ligature carets are a single flat list.

MontaguSlab ligcaret would go from 63.55% diff to `Identical` with fonttools 4.61.1 (before the fonttools fix that landed in 4.62.0). I speculate there might be other fonts in the crater that will benefit from this, though I can't say which/how many.