### PR TITLE
Update google-fonts-sources to 0.11

### DIFF
--- a/fontc_crater/Cargo.toml
+++ b/fontc_crater/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 [dependencies]
 fontc = { version = "0.6.0", path = "../fontc" }
 
-google-fonts-sources = "0.10.3"
+google-fonts-sources = "0.11"
 maud = "0.27.0"
 tidier = "0.5.3"
 


### PR DESCRIPTION
This brings in a change that should fix us failing to find a number of sources when those sources live on orphan branches.