### PR TITLE
Deduplicate duplicate anchors instead of rejecting them

### DIFF
--- a/fontir/src/error.rs
+++ b/fontir/src/error.rs
@@ -159,8 +159,6 @@ pub struct BadAnchor {
 /// Reasons an anchor can be malformed
 #[derive(Clone, Debug, PartialEq)]
 pub enum BadAnchorReason {
-    /// Multiple definitions at a given location
-    Ambiguous(NormalizedLocation),
     NoDefault,
     // top_0 looks like a ligature base, but 0 is an invalid index
     ZeroIndex,
@@ -189,7 +187,6 @@ impl Display for BadAnchorReason {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             BadAnchorReason::NoDefault => write!(f, "no value at default location"),
-            BadAnchorReason::Ambiguous(loc) => write!(f, "multiple definitions at {loc:?}"),
             BadAnchorReason::ZeroIndex => write!(f, "ligature indexes must begin with '1'"),
             BadAnchorReason::NumberedMarkAnchor => write!(f, "mark anchors cannot be numbered"),
             BadAnchorReason::NilMarkGroup => write!(f, "mark anchor key is nil"),

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -1349,17 +1349,20 @@ impl AnchorBuilder {
         loc: NormalizedLocation,
         pos: Point,
     ) -> Result<(), BadGlyph> {
+        // Match ufo2ft last-one-wins behavior for duplicate anchors.
+        // https://github.com/googlefonts/fontc/issues/1927
         if self
             .anchors
             .entry(anchor_name.clone())
             .or_default()
-            .insert(loc.clone(), pos)
+            .insert(loc, pos)
             .is_some()
         {
-            return Err(BadGlyph::new(
-                self.glyph_name.clone(),
-                BadAnchor::new(anchor_name, BadAnchorReason::Ambiguous(loc)),
-            ));
+            log::warn!(
+                "duplicate anchor '{}' in glyph '{}'",
+                anchor_name,
+                self.glyph_name
+            );
         }
         Ok(())
     }


### PR DESCRIPTION
Fixes #1927

Match ufo2ft's last-one-wins behavior for duplicate anchors: when a glyph has multiple anchors with the same name at the same location, keep the last value and log a warning instead of erroring out.

Removed the now-unused `BadAnchorReason::Ambiguous` variant.
