### PR TITLE
Bump norad to 0.18.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ smallvec = {version = "1.15", features = ["const_new"]}
 # fontations etc
 write-fonts = { version = "0.44.1", features = ["serde", "read"] }
 skrifa = { version = "0.39.0", features = ["traversal"] }
-norad = { version = "0.18.0", default-features = false }
+norad = { version = "0.18.2", default-features = false }
 
 # dev dependencies
 criterion = "0.7"


### PR DESCRIPTION
This relaxes glyph parsing somewhat, which should allow us to compile a couple of additional sources.

JMM