### PR TITLE
Patch tidy-sys to fix build failure on aarch64-apple-darwin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,3 +52,7 @@ members = [
     "otl-normalizer",
     "fontc_crater",
 ]
+
+# https://github.com/insomnimus/tidy-sys/issues/2
+[patch.crates-io]
+tidy-sys = { git = "https://github.com/googlefonts/tidy-sys.git", branch = "update-bindgen" }


### PR DESCRIPTION
tidy-sys 0.8.4 from crates.io fails to compile with Rust 1.94.1 on aarch64-apple-darwin due to a bindgen 0.70.1 bug that generates opaque structs with incorrect size assertions.

Use a patched fork until the fix is released upstream.

https://github.com/insomnimus/tidy-sys/issues/2