### PR TITLE
[fontbe] Expose FeatureVariationsProvider and FeaVariationInfo

### DIFF
--- a/fontbe/src/features.rs
+++ b/fontbe/src/features.rs
@@ -9,7 +9,7 @@ use std::{
     sync::Arc,
 };
 
-use feature_variations::FeatureVariationsProvider;
+pub use feature_variations::FeatureVariationsProvider;
 use log::{debug, error, trace, warn};
 use ordered_float::OrderedFloat;
 
@@ -50,7 +50,7 @@ use crate::{
     paths::Paths,
 };
 
-pub mod feature_variations;
+mod feature_variations;
 mod kern;
 mod marks;
 mod ot_tags;

--- a/fontbe/src/features/feature_variations.rs
+++ b/fontbe/src/features/feature_variations.rs
@@ -27,7 +27,7 @@ pub struct FeatureVariationsProvider {
 }
 
 impl FeatureVariationsProvider {
-    // https://github.com/fonttools/fonttools/blob/a1c189bda7c8d970143f92b542f5e26759945a37/Lib/fontTools/varLib/__init__.py#L799
+    // https://github.com/fonttools/fonttools/blob/a1c189bda/Lib/fontTools/varLib/__init__.py#L799
     pub fn new(
         ir_variations: &VariableFeature,
         static_metadata: &StaticMetadata,


### PR DESCRIPTION
~~Make fontbe’s `FeatureVariationsProvider` public and add a public `make_feature_variations_provider()` that builds a `FeatureVariationsProvider` without needing `StaticMetadata`.~~

Make `FeatureVariationsProvider` and `FeaVariationInfo` public. Also turn `make_gsub_feature_variations` into `FeatureVariationsProvider::new`.

This is to support building feature variations from rules in clients that don’t use the full fontc.