### PR TITLE
Bump fontations deps: write-fonts 0.47.0, skrifa 0.42.0, kurbo 0.13.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ serde_json = "1.0.113"
 bitflags = "2.0"
 chrono = { version = "0.4.24", features = ["serde"] }
 indexmap = { version = "2.0", features = ["serde"] }
-kurbo = { version = "0.12.0", features = ["serde"] }
+kurbo = { version = "0.13.0", features = ["serde"] }
 ordered-float = { version = "5.1.0", features = ["serde"] }
 smol_str = { version = "0.3.0", features = ["serde"] }
 regex = "1.7.1"
@@ -22,8 +22,8 @@ icu_properties = "=2.1"
 smallvec = {version = "1.15", features = ["const_new"]}
 
 # fontations etc
-write-fonts = { version = "0.44.1", features = ["serde", "read"] }
-skrifa = { version = "0.39.0", features = ["traversal"] }
+write-fonts = { version = "0.47.0", features = ["serde", "read"] }
+skrifa = { version = "0.42.0", features = ["traversal"] }
 norad = { version = "0.18.2", default-features = false }
 
 # dev dependencies

--- a/fea-rs/src/compile/compile_ctx.rs
+++ b/fea-rs/src/compile/compile_ctx.rs
@@ -24,7 +24,7 @@ use write_fonts::{
             ConditionFormat1, ConditionSet, FeatureVariations, LookupFlag,
             builders::{CaretValueBuilder as CaretValue, DeviceOrDeltas, Metric},
         },
-        variations::ivs_builder::{RemapVariationIndices, VariationStoreBuilder},
+        variations::{common_builder::RemapVarStore, ivs_builder::VariationStoreBuilder},
     },
     types::{F2Dot14, NameId, Tag},
 };

--- a/fea-rs/src/compile/tables/gdef.rs
+++ b/fea-rs/src/compile/tables/gdef.rs
@@ -21,7 +21,7 @@ use write_fonts::tables::{
         ClassDef,
         builders::{CaretValueBuilder, CoverageTableBuilder},
     },
-    variations::ivs_builder::RemapVariationIndices,
+    variations::common_builder::RemapVarStore,
 };
 
 use super::{VariationIndexRemapping, VariationStoreBuilder};

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -345,14 +345,14 @@ mod tests {
     use write_fonts::{
         dump_table,
         read::{
-            FontData, FontRead, FontReadWithArgs, FontRef, TableProvider, TableRef,
+            FontData, FontRead, FontReadWithArgs, FontRef, TableProvider,
             tables::{
                 cmap::{Cmap, CmapSubtable},
                 colr::{Colr, Paint, PaintGlyph},
                 cpal::ColorRecord,
                 gasp::GaspRangeBehavior,
                 glyf::{self, CompositeGlyph, CurvePoint, Glyf},
-                gpos::{AnchorTable, Gpos, MarkBasePosFormat1Marker, PositionLookup},
+                gpos::{AnchorTable, Gpos, MarkBasePosFormat1, PositionLookup},
                 gsub::{SingleSubst, SubstitutionLookup},
                 hmtx::Hmtx,
                 layout::FeatureParams,
@@ -3058,7 +3058,7 @@ mod tests {
         }
     }
 
-    fn mark_base_lookups<'a>(gpos: &'a Gpos) -> Vec<TableRef<'a, MarkBasePosFormat1Marker>> {
+    fn mark_base_lookups<'a>(gpos: &'a Gpos) -> Vec<MarkBasePosFormat1<'a>> {
         // If only we had more indirections
         gpos.lookup_list()
             .iter()
@@ -3086,11 +3086,13 @@ mod tests {
 
         let bases = mark_base_lookups
             .iter()
-            .flat_map(|mb| mb.base_coverage().unwrap().iter().collect::<Vec<_>>())
+            .flat_map(|mb: &MarkBasePosFormat1| {
+                mb.base_coverage().unwrap().iter().collect::<Vec<_>>()
+            })
             .zip(
                 mark_base_lookups
                     .iter()
-                    .flat_map(|mb| {
+                    .flat_map(|mb: &MarkBasePosFormat1| {
                         let base_array = mb.base_array().unwrap();
                         let data = base_array.offset_data();
                         base_array
@@ -3105,11 +3107,13 @@ mod tests {
 
         let marks = mark_base_lookups
             .iter()
-            .flat_map(|mb| mb.mark_coverage().unwrap().iter().collect::<Vec<_>>())
+            .flat_map(|mb: &MarkBasePosFormat1| {
+                mb.mark_coverage().unwrap().iter().collect::<Vec<_>>()
+            })
             .zip(
                 mark_base_lookups
                     .iter()
-                    .flat_map(|mb| {
+                    .flat_map(|mb: &MarkBasePosFormat1| {
                         let mark_array = mb.mark_array().unwrap();
                         let data = mark_array.offset_data();
                         mb.mark_array()


### PR DESCRIPTION
Update to latest published fontations crates and adapt to API changes:
- `RemapVariationIndices` trait renamed to `RemapVarStore`, moved from `ivs_builder` to `common_builder` module (googlefonts/fontations#1716)
- read-fonts removed `TableRef`/`MarkBasePosFormat1Marker` in favour of `MarkBasePosFormat1<'a>` directly; add explicit closure type annotations where type inference can no longer resolve them (googlefonts/fontations#1709)

JMM