### PR TITLE
[ttx_diff] Faster off-by-one budget picking

### DIFF
--- a/ttx_diff/src/ttx_diff/core.py
+++ b/ttx_diff/src/ttx_diff/core.py
@@ -736,17 +736,19 @@ def allow_fontc_only_variations_postscript_prefix(fontc, fontmake):
 
 
 def allow_some_off_by_ones(fontc, fontmake, container, name_attr, coord_holder):
-    fontmake_num_coords = len(fontmake.xpath(f"//{container}/{coord_holder}"))
+    fontmake_containers = fontmake.xpath(f"//{container}")
+    coord_tag = coord_holder.rpartition("/")[-1]
+    fontmake_num_coords = sum(
+        sum(1 for _ in c.iter(coord_tag)) for c in fontmake_containers
+    )
     off_by_one_budget = int(FLAGS.off_by_one_budget / 100.0 * fontmake_num_coords)
     spent = 0
     if off_by_one_budget == 0:
         return
 
-    coord_tag = coord_holder.rpartition("/")[-1]
     # put all the containers into a dict to make querying more efficient:
-
     fontc_items = {x.attrib[name_attr]: x for x in fontc.xpath(f"//{container}")}
-    for fontmake_container in fontmake.xpath(f"//{container}"):
+    for fontmake_container in fontmake_containers:
         name = fontmake_container.attrib[name_attr]
         fontc_container = fontc_items.get(name)
         if fontc_container is None:


### PR DESCRIPTION
In cases where there are a large number of total glyph points (fonts where glyphs have lots of points, or there are just a lot of glyphs) generating the list of all coordinates in order to then call `len` was proving to be the main place we were spending our time.

Instead of counting _all_ points, we now just count the points in the first ten non-empty glyphs and assume that they are representative.

This brings the compare time for rubik pixels from ~8 minutes to ~2 minutes, and shows a similar speedup for a bunch of other fonts, particularly CJK.