### PR TITLE
[glyphs] Parse openTypeHeadFlags custom param

### DIFF
--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -125,6 +125,7 @@ pub struct CustomParameters {
     pub codepage_range_bits: Option<BTreeSet<u32>>,
     pub panose: Option<Vec<i64>>,
 
+    pub head_flags: Option<Vec<i64>>,
     pub lowest_rec_ppem: Option<i64>,
     pub hhea_caret_slope_run: Option<i64>,
     pub hhea_caret_slope_rise: Option<i64>,
@@ -1197,10 +1198,13 @@ impl RawCustomParameters {
                 "Link Metrics With Master" => {
                     add_and_report_issues!(link_metrics_with_master, Plist::as_str, into)
                 }
+                "openTypeHeadFlags" => {
+                    add_and_report_issues!(head_flags, Plist::as_vec_of_ints)
+                }
                 // these might need to be handled? they're in the same list as
                 // the items above:
                 // https://github.com/googlefonts/glyphsLib/blob/74c63244fdb/Lib/glyphsLib/builder/custom_params.py#L429
-                "openTypeOS2FamilyClass" | "openTypeHeadFlags" => {
+                "openTypeOS2FamilyClass" => {
                     log_once_warn!("unhandled custom param '{name}'")
                 }
 

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -37,6 +37,7 @@ use write_fonts::{
     tables::{
         gasp::{GaspRange, GaspRangeBehavior},
         gdef::GlyphClassDef,
+        head,
         os2::SelectionFlags,
     },
     types::{NameId, Tag},
@@ -526,6 +527,15 @@ impl Work<Context, WorkId, Error> for StaticMetadataWork {
         static_metadata.misc.version_minor = font.version_minor;
         if let Some(lowest_rec_ppm) = font.custom_parameters.lowest_rec_ppem {
             static_metadata.misc.lowest_rec_ppm = lowest_rec_ppm as _;
+        }
+
+        if let Some(bit_indices) = &font.custom_parameters.head_flags {
+            static_metadata.misc.head_flags = head::Flags::from_bits_truncate(
+                bit_indices
+                    .iter()
+                    .map(|i| 1 << i)
+                    .fold(0u16, |acc, e| acc | e),
+            );
         }
 
         static_metadata.misc.created = font
@@ -3209,6 +3219,12 @@ mod tests {
         let (_, context) = build_static_metadata(glyphs3_dir().join("UnusualCustomParams.glyphs"));
         let meta = context.static_metadata.get();
         assert_eq!(meta.misc.lowest_rec_ppm, 7);
+        assert_eq!(
+            meta.misc.head_flags,
+            head::Flags::BASELINE_AT_Y_0
+                | head::Flags::LSB_AT_X_0
+                | head::Flags::FORCE_INTEGER_PPEM
+        );
 
         // some of these end up as metrics:
         let (_, context) = build_global_metrics(glyphs3_dir().join("UnusualCustomParams.glyphs"));

--- a/resources/testdata/glyphs3/UnusualCustomParams.glyphs
+++ b/resources/testdata/glyphs3/UnusualCustomParams.glyphs
@@ -5,7 +5,9 @@ customParameters = (
 {
 name = openTypeHeadFlags;
 value = (
-0
+0,
+1,
+3
 );
 },
 {


### PR DESCRIPTION
This was causing a few diffs, particularly in the RedHat brand fonts.