### PR TITLE
[glyphs] Fix subtlety in gdef categories for spacing marks

### DIFF
--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -1702,6 +1702,19 @@ mod tests {
         assert_eq!(categories.get("U1C82"), Some(&GlyphClassDef::Base));
     }
 
+    // A "Mark, Spacing" glyph (tilde, U+02DC) composed of a "Mark, Nonspacing" component
+    // (tildecomb) should not be classified as GDEF Base. Without the fix, anchor propagation
+    // copied tildecomb's `top` anchor into tilde, causing recompute_gdef_categories to infer
+    // it as Base. With the fix, any Mark-category glyph that already has anchors skips
+    // component propagation (matching glyphsLib), leaving tilde unclassified.
+    #[test]
+    fn mark_spacing_glyph_not_classified_as_base() {
+        let result = TestCompile::compile_source("glyphs3/MarkSpacingGdef.glyphs");
+        let categories = &result.fe_context.gdef_categories.get().categories;
+        assert_eq!(categories.get("tildecomb"), Some(&GlyphClassDef::Mark));
+        assert_eq!(categories.get("tilde"), None);
+    }
+
     #[test]
     fn glyphs_app_bracket_glyph_categories() {
         let result = TestCompile::compile_source("glyphs3/PropagateAnchorsTest.glyphs");

--- a/fontir/src/glyph.rs
+++ b/fontir/src/glyph.rs
@@ -2279,6 +2279,7 @@ mod tests {
                 categories: Default::default(),
                 prefer_gdef_categories_in_fea: false,
                 infer_from_anchors: true,
+                mark_category_glyphs: Default::default(),
             });
         ctx.gdef_categories.set(GdefCategories::default());
 

--- a/fontir/src/ir/static_metadata.rs
+++ b/fontir/src/ir/static_metadata.rs
@@ -155,6 +155,16 @@ pub struct PreliminaryGdefCategories {
     /// of anchors (similarly to how glyphsLib does) or used as-is as defined in
     /// the source (as standard in DS+UFO workflows).
     pub infer_from_anchors: bool,
+    /// All glyphs whose source category is Mark (any subCategory)
+    ///
+    /// Used during anchor propagation. Glyphs.app skips component anchor
+    /// propagation for any Mark-category glyph that already has anchors,
+    /// regardless of subCategory. This differs from `categories` which only
+    /// contains GDEF Mark (Nonspacing/SpacingCombining); glyphs like "tilde"
+    /// (Mark, Spacing) are not GDEF marks but still need to opt out of
+    /// component propagation.
+    #[serde(default)]
+    pub mark_category_glyphs: BTreeSet<GlyphName>,
 }
 
 /// Final GDEF categories after anchor propagation has been applied.

--- a/fontir/src/propagate_anchors.rs
+++ b/fontir/src/propagate_anchors.rs
@@ -64,10 +64,16 @@ pub fn propagate_all_anchors(context: &Context) -> Result<(), Error> {
         let glyph = context.glyphs.get(&WorkId::Glyph(glyph_name.clone()));
 
         for (location, instance) in glyph.sources() {
-            let is_mark = gdef_categories
-                .categories
-                .get(&glyph_name)
-                .is_some_and(|c| matches!(c, GlyphClassDef::Mark));
+            // Use mark_category_glyphs (all Mark-category glyphs, any subCategory) rather
+            // than the GDEF Mark class (Nonspacing/SpacingCombining only). Glyphs.app skips
+            // component anchor propagation for any Mark-category glyph that has anchors,
+            // regardless of whether it's a GDEF mark. For example, "tilde" is Mark, Spacing
+            // (not a GDEF mark) but should still have its anchors returned as-is.
+            let is_mark = gdef_categories.mark_category_glyphs.contains(&glyph_name)
+                || gdef_categories
+                    .categories
+                    .get(&glyph_name)
+                    .is_some_and(|c| matches!(c, GlyphClassDef::Mark));
 
             let is_ligature = gdef_categories
                 .categories

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -761,6 +761,15 @@ fn get_bracket_info(layer: &Layer, axes: &Axes) -> ConditionSet {
 
 /// Compute GDEF glyph categories using only category and subcategory, no anchor inspection.
 fn make_preliminary_glyph_categories(font: &Font, axes: &Axes) -> PreliminaryGdefCategories {
+    let mark_category_glyphs = font
+        .glyphs
+        .values()
+        .filter(|glyph| glyph.category == Some(Category::Mark))
+        .flat_map(|glyph| {
+            std::iter::once(glyph.name.clone().into())
+                .chain(bracket_glyph_names(glyph, axes).map(|(name, _)| name))
+        })
+        .collect();
     let categories = font
         .glyphs
         .values()
@@ -783,6 +792,7 @@ fn make_preliminary_glyph_categories(font: &Font, axes: &Axes) -> PreliminaryGde
         categories,
         prefer_gdef_categories_in_fea: false,
         infer_from_anchors: true,
+        mark_category_glyphs,
     }
 }
 

--- a/resources/testdata/glyphs3/MarkSpacingGdef.glyphs
+++ b/resources/testdata/glyphs3/MarkSpacingGdef.glyphs
@@ -1,0 +1,78 @@
+{
+.appVersion = "3259";
+.formatVersion = 3;
+familyName = "Mark Spacing Gdef Test";
+fontMaster = (
+{
+id = m01;
+name = Regular;
+}
+);
+glyphs = (
+{
+glyphname = space;
+layers = (
+{
+layerId = m01;
+width = 200;
+}
+);
+unicode = 32;
+},
+{
+glyphname = tildecomb;
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (100,400);
+},
+{
+name = top;
+pos = (100,600);
+}
+);
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(50,400,l),
+(150,400,l),
+(150,600,l),
+(50,600,l)
+);
+}
+);
+width = 0;
+}
+);
+unicode = 771;
+},
+{
+glyphname = tilde;
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (100,400);
+}
+);
+layerId = m01;
+shapes = (
+{
+ref = tildecomb;
+}
+);
+width = 0;
+}
+);
+unicode = 732;
+}
+);
+unitsPerEm = 1000;
+versionMajor = 1;
+versionMinor = 0;
+}

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -924,6 +924,7 @@ impl Work<Context, WorkId, Error> for StaticMetadataWork {
                 categories,
                 prefer_gdef_categories_in_fea: true,
                 infer_from_anchors: false,
+                mark_category_glyphs: Default::default(),
             })?;
 
         // https://unifiedfontobject.org/versions/ufo3/fontinfo.plist/#opentype-os2-table-fields


### PR DESCRIPTION
pointing claude at a diff that felt a little bit more subtle. This is an interesting case because it impacts a lot of fonts, but none of them have an existing annotation; this means that either it is a regression we didn't notice, or that it is somehow only showing up in recently added fonts. In any case I tested this locally and it gives us ~25 new identical.

In its own words:


`tilde` (U+02DC, Mark, Spacing) was incorrectly classified as GDEF Base (class 1) by fontc.              
  fontmake leaves it unclassified (class 0). The bug is in how fontc determines whether to skip            
  component anchor propagation for a glyph.                                                                
                                                                                                           
  ---                                                                                                      
                                                                                                           
  ### Step 1: Classify glyphs before anchor propagation                                                    
   
  **Python** (`glyphsLib._build_public_opentype_categories`):                                              
  ```python                                                 
  if subCategory == "Ligature" and has_attaching_anchor:                                                   
      categories[glyph_name] = "ligature"
  elif category == "Mark" and (                                                                            
      subCategory == "Nonspacing" or subCategory == "Spacing Combining"
  ):                                                                                                       
      categories[glyph_name] = "mark"                       
  elif has_attaching_anchor:                                                                               
      categories[glyph_name] = "base"                                                                      
 ```
  
  Rust (category_for_glyph_preliminary):
```rust                                                                   
  match (category, sub_category) {                          
      (Some(Category::Mark),                                                                               
       Some(Subcategory::Nonspacing) | Some(Subcategory::SpacingCombining))
          => Some(GlyphClassDef::Mark),                                                                    
      (_, Some(Subcategory::Ligature)) => Some(GlyphClassDef::Ligature),
      _ => None,                                                                                           
  }                                                                                                        
```
                                                                                                           
  These are structurally identical. tilde (Mark, Spacing) falls through to the wildcard in both —          
  no preliminary category is assigned. Base is not determined here at all; it comes from anchor            
  inspection later.                                                                                        
                                                                                                           
  ---                                                                                                      
  ### Step 2: Anchor propagation — the early-return for marks   
                                                                                                           
  Both implementations have a special case: if a glyph is a Mark and already has source-level
  anchors, skip looking at component anchors and return the existing anchors as-is.                        
                                                                                                           
  Python (anchors_traversing_components):
```python                                                                  
  if layer.anchors and _get_category(glyph, glyph_data) == "Mark":                                         
      return list(origin_adjusted_anchors(layer.anchors))         
```
  _get_category returns the raw Glyphs category string — "Mark" for any Mark subCategory,                  
  including Spacing.
                                                                                                           
  Rust (anchors_traversing_components) — before fix:
```rust
  if !existing_anchors.is_empty() && is_mark {
      return origin_adjusted_anchors(existing_anchors).collect();
  }

  /// Where is_mark was:
  gdef_categories.categories.get(&glyph_name)                                                              
      .is_some_and(|c| matches!(c, GlyphClassDef::Mark))    

```                                                         
  gdef_categories.categories only contains entries from step 1 — Nonspacing and SpacingCombining           
  glyphs. tilde has no entry there. is_mark was false for tilde, so the early return
  did not fire.                                                                                            
                                                            
  The consequence: propagation continued into tilde's components. tildecomb has both a _top                
  (mark entry) anchor and a top (base attachment) anchor — the latter was copied into tilde.

  ---                                                       
  ### Step 3: Final GDEF classification from anchors                                                           
                                                                                                           
  Python: _build_public_opentype_categories ran on the pre-propagation UFO glyph anchors.
  tilde only had _top in the UFO, so has_attaching_anchor = False → no entry in                            
  public.openTypeCategories → unclassified.                                                                

  Rust (recompute_gdef_categories):
  ```rust
  let has_attaching_anchor = context.anchors                                                               
      .try_get(&WorkId::Anchor(glyph_name.clone()))         
      .is_some_and(|ga| ga.anchors.iter()          
          .any(|a| !matches!(&a.kind, AnchorKind::Mark(_))));                                              
                                                             
  let final_cat = match preliminary.categories.get(&glyph_name) {                                          
      Some(GlyphClassDef::Mark) => Some(GlyphClassDef::Mark),                                              
      // ...                                                 
      _ if has_attaching_anchor => Some(GlyphClassDef::Base), // ← the trap                                
      _ => None,                                                           
  };                                                                                                       
```
  Before the fix: propagation had added tildecomb's top anchor to tilde.                                   
  has_attaching_anchor = true. tilde is not in preliminary categories. Hits                                
  _ if has_attaching_anchor → wrongly classified as Base.
                                                                                                           
  After the fix: propagation returns early for tilde (because it is now recognised as a                    
  Mark-category glyph), leaving it with only its source _top anchor. _top parses as
  AnchorKind::Mark, so has_attaching_anchor = false. Hits _ => None → unclassified,                        
  matching fontmake.                                                                                       
                                                                                                           
  ---                                                                                                      
  The fix                                                   
         
  Python checked "is this glyph's source category Mark?" to skip component propagation.
  Rust checked "is this glyph a GDEF Mark class?" — a strictly narrower condition that excludes            
  Mark, Spacing glyphs.                                                                                    
                                                                                                           
  The fix adds a `mark_category_glyphs: BTreeSet<GlyphName>` field to `PreliminaryGdefCategories`,             
  populated in glyphs2fontir with all glyphs whose source category is Mark (any subCategory).
  The propagation is_mark check now consults this set, so tilde correctly triggers the                     
  early-return and its component anchors are never examined.                                               
                                                                                                           
  mark_category_glyphs is kept separate from categories (the GDEF class map) because these                 
  are two different concepts: the former drives propagation behaviour, the latter drives the
  final binary GDEF table output.

----


