### PR TITLE
[glyphs] Fix issue with no-export marks

### DIFF
--- a/fontbe/src/features.rs
+++ b/fontbe/src/features.rs
@@ -616,14 +616,18 @@ impl Work<Context, AnyWorkId, Error> for FeatureCompilationWork {
             // so let's use the ones from the source, if present (i.e. from
             // `public.openTypeCatgories` or computed from GlyphData.xml
 
-            let gdef = result.gdef.get_or_insert_with(Default::default);
             let class_def: ClassDef = gdef_categories
                 .categories
                 .iter()
                 .filter_map(|(name, cls)| glyph_order.glyph_id(name).map(|id| (id, *cls as u16)))
                 .collect();
 
-            gdef.glyph_class_def.set(class_def);
+            // could be class_def.is_empty() when
+            // https://github.com/googlefonts/fontations/pull/1836 lands
+            if class_def.iter().next().is_some() {
+                let gdef = result.gdef.get_or_insert_with(Default::default);
+                gdef.glyph_class_def.set(class_def);
+            }
         }
 
         debug!(

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -3610,6 +3610,22 @@ mod tests {
         assert_eq!(classdef.iter().count(), 1)
     }
 
+    // when gdef categories exist but the glyphs are all non-exported (absent from glyph order),
+    // no GlyphClassDef (and thus no GDEF table) should be created.
+    // https://github.com/googlefonts/fontc/issues/XXXX
+    #[test]
+    fn no_gdef_when_mark_glyphs_are_non_exported() {
+        let compile =
+            TestCompile::compile_source("glyphs3/gdef_categories_non_exported_mark.glyphs");
+        let font = compile.font();
+        // the only mark glyph has export=0, so it is absent from the glyph order.
+        // this means no GlyphClassDef should be set, and no GDEF table should exist.
+        assert!(
+            font.gdef().is_err(),
+            "expected no GDEF when all mark glyphs are non-exported"
+        );
+    }
+
     // <https://github.com/googlefonts/fontc/issues/1008>
     #[test]
     fn no_names_for_instances_in_a_static_font() {

--- a/resources/testdata/glyphs3/gdef_categories_non_exported_mark.glyphs
+++ b/resources/testdata/glyphs3/gdef_categories_non_exported_mark.glyphs
@@ -1,0 +1,43 @@
+{
+.appVersion = "3260";
+.formatVersion = 3;
+familyName = Dated;
+fontMaster = (
+{
+id = m01;
+name = Regular;
+}
+);
+glyphs = (
+{
+glyphname = space;
+layers = (
+{
+layerId = m01;
+width = 200;
+}
+);
+},
+{
+category = Mark;
+export = 0;
+glyphname = mycustommark;
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (187,388);
+}
+);
+layerId = m01;
+width = 600;
+}
+);
+subCategory = Nonspacing;
+}
+);
+unitsPerEm = 1000;
+versionMajor = 1;
+versionMinor = 1;
+}


### PR DESCRIPTION
The presence of only no-export glyphs in the gdef_categories would cause us to create a GlyphClassDef that would end up being empty, since these glyphs are not in the glyph order.

fixes at least Manrope.glyphs on crater.