### PR TITLE
Parse decomposeTransformedComponents from ufo2ft filters in source metadata

### DIFF
--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -5266,6 +5266,13 @@ mod tests {
         assert!(result.fe_context.flags.contains(Flags::FLATTEN_COMPONENTS));
         assert!(!result.fe_context.flags.contains(Flags::ERASE_OPEN_CORNERS));
         assert!(result.fe_context.flags.contains(Flags::PROPAGATE_ANCHORS));
+        assert!(
+            result
+                .fe_context
+                .flags
+                .contains(Flags::DECOMPOSE_TRANSFORMED_COMPONENTS),
+            "decomposeTransformedComponents filter in userData should set DECOMPOSE_TRANSFORMED_COMPONENTS flag"
+        );
     }
 
     #[test]

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -170,6 +170,9 @@ impl Source for GlyphsIrSource {
                     "flattenComponents" => flags.set(Flags::FLATTEN_COMPONENTS, true),
                     "eraseOpenCorners" => flags.set(Flags::ERASE_OPEN_CORNERS, true),
                     "propagateAnchors" => flags.set(Flags::PROPAGATE_ANCHORS, true),
+                    "decomposeTransformedComponents" => {
+                        flags.set(Flags::DECOMPOSE_TRANSFORMED_COMPONENTS, true)
+                    }
                     other => log::info!("unhandled ufo2ft filter '{other}'"),
                 }
             }
@@ -3962,5 +3965,36 @@ mod tests {
         // https://github.com/googlefonts/fontc/issues/1859
         let (_, context) = build_static_metadata(glyphs3_dir().join("VheaParams.glyphs"));
         assert!(context.static_metadata.get().build_vertical);
+    }
+
+    // https://github.com/googlefonts/fontc/issues/1900
+    #[test]
+    fn decompose_transformed_components_filter_sets_flag() {
+        let source = GlyphsIrSource::new_from_memory(
+            r#"{
+.appVersion = "3227";
+.formatVersion = 3;
+fontMaster = (
+{
+id = "master01";
+userData = {
+com.github.googlei18n.ufo2ft.filters = (
+{
+name = decomposeTransformedComponents;
+}
+);
+};
+}
+);
+unitsPerEm = 1000;
+}"#,
+        )
+        .unwrap();
+        assert!(
+            source
+                .compilation_flags()
+                .contains(Flags::DECOMPOSE_TRANSFORMED_COMPONENTS),
+            "decomposeTransformedComponents in userData should set DECOMPOSE_TRANSFORMED_COMPONENTS flag"
+        );
     }
 }

--- a/resources/testdata/DecomposeTransformed.ufo/fontinfo.plist
+++ b/resources/testdata/DecomposeTransformed.ufo/fontinfo.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>familyName</key>
+    <string>DecomposeTransformed</string>
+    <key>unitsPerEm</key>
+    <integer>1000</integer>
+  </dict>
+</plist>

--- a/resources/testdata/DecomposeTransformed.ufo/glyphs/contents.plist
+++ b/resources/testdata/DecomposeTransformed.ufo/glyphs/contents.plist
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+  </dict>
+</plist>

--- a/resources/testdata/DecomposeTransformed.ufo/layercontents.plist
+++ b/resources/testdata/DecomposeTransformed.ufo/layercontents.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <array>
+    <array>
+      <string>public.default</string>
+      <string>glyphs</string>
+    </array>
+  </array>
+</plist>

--- a/resources/testdata/DecomposeTransformed.ufo/lib.plist
+++ b/resources/testdata/DecomposeTransformed.ufo/lib.plist
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.github.googlei18n.ufo2ft.filters</key>
+    <array>
+      <dict>
+        <key>name</key>
+        <string>decomposeTransformedComponents</string>
+      </dict>
+    </array>
+  </dict>
+</plist>

--- a/resources/testdata/DecomposeTransformed.ufo/metainfo.plist
+++ b/resources/testdata/DecomposeTransformed.ufo/metainfo.plist
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>formatVersion</key>
+    <integer>3</integer>
+  </dict>
+</plist>

--- a/resources/testdata/glyphs3/UfoFilters.glyphs
+++ b/resources/testdata/glyphs3/UfoFilters.glyphs
@@ -21,6 +21,9 @@ pre = 1;
 },
 {
 name = flattenComponents;
+},
+{
+name = decomposeTransformedComponents;
 }
 );
 };

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -410,6 +410,9 @@ impl Source for DesignSpaceIrSource {
                     "flattenComponents" => flags.set(Flags::FLATTEN_COMPONENTS, true),
                     "eraseOpenCorners" => flags.set(Flags::ERASE_OPEN_CORNERS, true),
                     "propagateAnchors" => flags.set(Flags::PROPAGATE_ANCHORS, true),
+                    "decomposeTransformedComponents" => {
+                        flags.set(Flags::DECOMPOSE_TRANSFORMED_COMPONENTS, true)
+                    }
                     other => log::info!("unhandled ufo2ft filter '{other}'"),
                 }
             }
@@ -3354,6 +3357,18 @@ mod tests {
         assert!(
             format!("{err}").contains("out of u16 range"),
             "expected 'out of u16 range' error, got: {err}"
+        );
+    }
+
+    // https://github.com/googlefonts/fontc/issues/1900
+    #[test]
+    fn decompose_transformed_components_filter_sets_flag() {
+        let source = load_designspace("DecomposeTransformed.ufo");
+        assert!(
+            source
+                .compilation_flags()
+                .contains(Flags::DECOMPOSE_TRANSFORMED_COMPONENTS),
+            "decomposeTransformedComponents in lib.plist should set DECOMPOSE_TRANSFORMED_COMPONENTS flag"
         );
     }
 }


### PR DESCRIPTION
Fixes #1900

`Source::compilation_flags()` now recognises the `decomposeTransformedComponents` filter in `com.github.googlei18n.ufo2ft.filters` lib key in DS+UFO (ufo2fontir) as well as (glyphsLib-exported) .glyphs sources' `userData` (glyphs2fontir), by setting the `Flags::DECOMPOSE_TRANSFORMED_COMPONENTS` accordingly.

