### PR TITLE
[glyphs] maintain start point when reversing closed path

### DIFF
--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -789,9 +789,29 @@ impl Shape {
     }
 
     /// If the shape is a path, reverse it
+    ///
+    /// In Glyphs, the last node in the node list is the "start" node of a
+    /// closed contour (see `to_ir_path`). A naive `reverse()` would move the
+    /// start node to position 0, so `to_ir_path` would pick the wrong start.
+    ///
+    /// Python's `GSPath.reverse()` (which works via segments) is equivalent to
+    /// `reverse() + rotate_left(1)`, which keeps the start node at the last
+    /// position. We match that here.
+    ///
+    /// Note: this logic is only correct for closed paths. For open paths the
+    /// start node is `nodes[0]` (see `to_ir_path`), so a plain `reverse()`
+    /// without rotation would be correct. Python's segment-based `reverse()`
+    /// also appears to mishandle open paths (it silently drops the new start
+    /// node via `setSegments`). In practice this method is only called when
+    /// handling smart components, which are always closed?
+    ///
+    /// <https://github.com/googlefonts/glyphsLib/blob/d42d3b15/Lib/glyphsLib/classes.py#L2369>
     pub(crate) fn reverse(&mut self) {
         if let Shape::Path(path) = self {
             path.reverse();
+            if path.closed && !path.nodes.is_empty() {
+                path.nodes.rotate_left(1);
+            }
         }
     }
 }

--- a/glyphs-reader/src/smart_components.rs
+++ b/glyphs-reader/src/smart_components.rs
@@ -714,6 +714,53 @@ mod tests {
         }
     }
 
+    // Test that a flipped smart component preserves the Glyphs "start node"
+    // (last in the node list) after decomposition and reversal.
+    //
+    // Bug: a naive nodes.reverse() moves the start node from last position to
+    // first, causing to_ir_path to pick the wrong start point. The fix is to
+    // also rotate_left(1) so the start stays at the end.
+    #[test]
+    fn test_smart_component_flipped_x_start_point() {
+        let master_id = "master01";
+        let glyphs = smart_glyphs(master_id);
+        let rectangle = glyphs.get(&SmolStr::new("_part.rectangle")).unwrap();
+
+        // Default layer: rectangle_path(100, 100, 100, 100)
+        // Nodes: [(100,100), (200,100), (200,200), (100,200)]
+        // In Glyphs convention, the last node (100,200) is the "start" node.
+        // After flipping x (transform = [-1,0,0,1,0,0]):
+        //   (100,100) → (-100,100), (200,100) → (-200,100),
+        //   (200,200) → (-200,200), (100,200) → (-100,200) [start]
+        // The decomposed path should start at (-100,200).
+        let component = Component {
+            name: SmolStr::new("_part.rectangle"),
+            transform: Affine::new([-1.0, 0.0, 0.0, 1.0, 0.0, 0.0]),
+            smart_component_values: BTreeMap::from([
+                ("Width".into(), 0.0),
+                ("Height".into(), 100.0),
+                ("Shift".into(), 0.0),
+            ]),
+            ..Default::default()
+        };
+        assert!(component.transform.determinant() < 0.0);
+
+        let instance =
+            instantiate_for_layer(master_id, &component, rectangle).expect("should succeed");
+        let path = instance.shapes[0].as_path().unwrap();
+
+        // The last node in the returned path is the Glyphs "start" node. After
+        // decomposing with a flip transform it should be the transformed original
+        // start, i.e. (-100, 200).
+        let last = path.nodes.last().expect("path has nodes");
+        assert_eq!(
+            last.pt,
+            kurbo::Point::new(-100.0, 200.0),
+            "start node after flip should be (-100, 200), got {:?}",
+            last.pt
+        );
+    }
+
     /// Helper to create a smart component with anchors for testing.
     /// Test data adapted from glyphsLib's test_smart_component_anchors
     /// (googlefonts/glyphsLib#1131, credit: @khaledhosny).


### PR DESCRIPTION
This is a small detail on a very cold code path, but still is the cause of at least one crater diff.

Concretely, when a smart component is flipped (via transform) we reverse the path; however our reversal logic was naive, and didn't keep the same start point.