### PR TITLE
[gvar] Fix racy GvarWork scheduling when .notdef is synthesized

### DIFF
--- a/fontbe/src/gvar.rs
+++ b/fontbe/src/gvar.rs
@@ -1,10 +1,10 @@
 //! Generates a [gvar](https://learn.microsoft.com/en-us/typography/opentype/spec/gvar) table.
 
 use fontdrasil::{
-    orchestration::{Access, AccessBuilder, Work},
+    orchestration::{Access, Work},
     types::GlyphName,
 };
-use fontir::{ir::GlyphOrder, orchestration::WorkId as FeWorkId};
+use fontir::ir::GlyphOrder;
 use write_fonts::{
     dump_table,
     tables::gvar::{GlyphDeltas, GlyphVariations, Gvar},
@@ -39,12 +39,22 @@ impl Work<Context, AnyWorkId, Error> for GvarWork {
         WorkId::Gvar.into()
     }
 
+    /// We need to block on all `GvarFragment`s to build gvar, but the final glyph
+    /// order may not be known yet as it may be extended with e.g. a generated '.notdef'.
+    ///
+    /// A generic `variant(WorkId::ALL_GVAR_FRAGMENTS)` dependency can occasionally be racy
+    /// and lead to a panic if `GvarWork` is started too early.
+    /// For a `variant` access type, the dependency is deemed "fulfilled" if the pending work
+    /// count drops to 0, which may occur when all the "static" glyph fragments have been
+    /// generated before the dynamic ones have yet to be scheduled.
+    ///
+    /// So here instead we use `Access::Unknown` to start in a hard block and update our
+    /// `read_access` with `specific_instance` GvarFragments once the final `GlyphOrder`
+    /// work completes (see `fontc::workload::Workload::handle_success`).
+    ///
+    /// Also see <https://github.com/googlefonts/fontc/issues/1436>
     fn read_access(&self) -> Access<AnyWorkId> {
-        AccessBuilder::new()
-            .variant(FeWorkId::StaticMetadata)
-            .variant(FeWorkId::GlyphOrder)
-            .variant(WorkId::ALL_GVAR_FRAGMENTS)
-            .build()
+        Access::Unknown
     }
 
     /// Generate [gvar](https://learn.microsoft.com/en-us/typography/opentype/spec/gvar)

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -5179,6 +5179,31 @@ mod tests {
     }
 
     #[test]
+    fn gvar_work_waits_for_dynamic_notdef() {
+        // https://github.com/googlefonts/fontc/issues/1436
+        let mut test = TestCompile::new("wght_var.designspace", |options| options);
+
+        // GvarWork must start with Access::Unknown so it can't run before the final
+        // glyph order is resolved (which may add a synthesized .notdef).
+        let gvar_job = test
+            .workload
+            .jobs_pending
+            .get(&AnyWorkId::Be(BeWorkIdentifier::Gvar))
+            .expect("GvarWork should exist");
+        assert_eq!(
+            gvar_job.read_access,
+            AnyAccess::Be(Access::Unknown),
+            "GvarWork.read_access should start with Access::Unknown"
+        );
+
+        // Run the whole workload without panics to prove the dependencies are resolved correctly.
+        test.run();
+
+        let completed = test.work_executed.iter().cloned().collect::<HashSet<_>>();
+        assert!(completed.contains(&AnyWorkId::Be(BeWorkIdentifier::Gvar)));
+    }
+
+    #[test]
     fn component_point_rounding() {
         // if a component of a composite glyph has a non-integer offset,
         // rounding needs to occur before deltas are computed.

--- a/fontc/src/workload.rs
+++ b/fontc/src/workload.rs
@@ -408,6 +408,20 @@ impl Workload {
                 .get_mut(&BeWorkIdentifier::Glyf.into())
                 .expect("Glyf has to be pending");
             glyf_loca_job.read_access = glyf_loca_deps.build().into();
+
+            // Resolve the Access::Unknown for gvar, same race as glyf/loca; see issue #1436
+            let mut gvar_deps = AccessBuilder::<AnyWorkId>::new()
+                .variant(FeWorkIdentifier::StaticMetadata)
+                .variant(FeWorkIdentifier::GlyphOrder);
+            for glyph_name in final_glyph_order.names() {
+                gvar_deps =
+                    gvar_deps.specific_instance(BeWorkIdentifier::GvarFragment(glyph_name.clone()));
+            }
+            let gvar_job = self
+                .jobs_pending
+                .get_mut(&BeWorkIdentifier::Gvar.into())
+                .expect("Gvar has to be pending");
+            gvar_job.read_access = gvar_deps.build().into();
         }
 
         if let AnyWorkId::Fe(FeWorkIdentifier::KerningGroups) = success {


### PR DESCRIPTION
This is equivalent to #1436, but for Gvar instead of Glyf.

GvarWork used variant(ALL_GVAR_FRAGMENTS) as its dependency, which is satisfied when a shared count_pending atomic hits zero. Rayon workers decrement that counter before the completion message reaches the main thread, so GvarWork could be scheduled and start iterating the final glyph order before handle_success(Fe(GlyphOrder)) had added BE jobs for glyphs that only appear in the final order (e.g. a synthesized .notdef, or glyphs produced by move_contours_to_new_component).

The fix is just to copy what we did for GlyfLoca.

this fixes some non-deterministic crashes, such as with MontaguSlab.glyphs and BeVietnamPro.