### PR TITLE
Fix broken test fixtures: Bold instances missing weightClass

### DIFF
--- a/resources/testdata/glyphs2/InstancePostscript.glyphs
+++ b/resources/testdata/glyphs2/InstancePostscript.glyphs
@@ -84,6 +84,7 @@ instanceInterpolations = {
 isBold = 1;
 linkStyle = Regular;
 name = Bold;
+weightClass = Bold;
 }
 );
 unitsPerEm = 1000;

--- a/resources/testdata/glyphs2/IntermediateLayer.glyphs
+++ b/resources/testdata/glyphs2/IntermediateLayer.glyphs
@@ -664,7 +664,7 @@ weightClass = Bold;
 },
 {
 interpolationWeight = 800;
-interpolationWidth = 700;
+interpolationWidth = 900;
 instanceInterpolations = {
 "F969B945-4602-464F-B67C-A69BED6E6A4A" = 0.4;
 m01 = 0.6;

--- a/resources/testdata/glyphs2/WghtVar_Instances.glyphs
+++ b/resources/testdata/glyphs2/WghtVar_Instances.glyphs
@@ -208,6 +208,7 @@ instanceInterpolations = {
 isBold = 1;
 linkStyle = Regular;
 name = Bold;
+weightClass = Bold;
 }
 );
 unitsPerEm = 1000;

--- a/resources/testdata/glyphs2/WghtVar_Instances.glyphspackage/fontinfo.plist
+++ b/resources/testdata/glyphs2/WghtVar_Instances.glyphspackage/fontinfo.plist
@@ -70,6 +70,7 @@ instanceInterpolations = {
 isBold = 1;
 linkStyle = Regular;
 name = Bold;
+weightClass = Bold;
 }
 );
 unitsPerEm = 1000;

--- a/resources/testdata/glyphs3/InstanceNoPostscript.glyphs
+++ b/resources/testdata/glyphs3/InstanceNoPostscript.glyphs
@@ -61,6 +61,7 @@ instanceInterpolations = {
 isBold = 1;
 linkStyle = Regular;
 name = Bold;
+weightClass = 700;
 }
 );
 unitsPerEm = 1000;

--- a/resources/testdata/glyphs3/InstancePostscript.glyphs
+++ b/resources/testdata/glyphs3/InstancePostscript.glyphs
@@ -84,6 +84,7 @@ key = variablePostscriptFontName;
 value = "PostBold";
 }
 );
+weightClass = 700;
 }
 );
 unitsPerEm = 1000;

--- a/resources/testdata/glyphs3/WghtVar_Instances.glyphs
+++ b/resources/testdata/glyphs3/WghtVar_Instances.glyphs
@@ -219,6 +219,7 @@ instanceInterpolations = {
 isBold = 1;
 linkStyle = Regular;
 name = Bold;
+weightClass = 700;
 }
 );
 metrics = (

--- a/resources/testdata/glyphs3/WghtVar_Instances.glyphspackage/fontinfo.plist
+++ b/resources/testdata/glyphs3/WghtVar_Instances.glyphspackage/fontinfo.plist
@@ -80,6 +80,7 @@ instanceInterpolations = {
 isBold = 1;
 linkStyle = Regular;
 name = Bold;
+weightClass = 700;
 }
 );
 metrics = (


### PR DESCRIPTION
Several test fixtures have Bold instances with `isBold = 1` but no explicit `weightClass`. Without it, the heuristic in `Instance::new` defaults the wght user-space value to 400 — same as Regular — so both instances claim the same user coordinate. However, when building these with fontmake/glyphsLib the fonts are malformed with the wght axis collapsing to min=max=400, and the Bold master effectively discarded.

fontc's `add_if_new` happens to mask the problem by silently dropping the conflicting entry, but that's not how fontmake and glyphsLib do. 

I noticed this while working on a fix for https://github.com/googlefonts/fontc/issues/1866.
The fix I am working on (where I match glyphsLib's last-win overwrite semantics) surfaces these malformed test fonts, and I wanted to fix these separately to make the diff less noisy in the next PR.

To recap the changes:
* Added the correct weightClass to all affected Bold instances in:
  - WghtVar_Instances.glyphs
  - InstancePostscript.glyphs
  - InstanceNoPostscript.glyphs

* Also fixed IntermediateLayer.glyphs where "Tall Caps Black" had interpolationWidth=700 (wght design) but weightClass=Black (wght user=900), conflicting with "Black" which also maps user=900 -> design=900. glyphsLib would overwrite the mapping to {900: 700}, breaking the axis. Changed to interpolationWidth=900 for consistency.
