### PR TITLE
[glyphs-reader] instances Axis Locations override masters' (#1866)

### DIFF
--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -1438,6 +1438,44 @@ mod tests {
         );
     }
 
+    /// Instance Axis Location may override a master's Axis Location for the same user value.
+    /// <https://github.com/googlefonts/fontc/issues/1866>
+    #[test]
+    fn instance_axis_location_overrides_master() {
+        let result =
+            TestCompile::compile_source("glyphs3/WghtVar_AxisLocation_InstanceOverride.glyphs");
+        let font = result.font();
+
+        let axis_maps: Vec<_> = font
+            .avar()
+            .unwrap()
+            .axis_segment_maps()
+            .iter()
+            .map(|m| m.unwrap())
+            .map(|m| {
+                m.axis_value_maps()
+                    .iter()
+                    .map(|e| (e.from_coordinate().to_f32(), e.to_coordinate().to_f32()))
+                    .collect::<Vec<_>>()
+            })
+            .collect();
+
+        // Modeled on SUSE-Italic.glyphs (https://github.com/googlefonts/fontc/issues/1866):
+        // Masters: Thin(100→100), ExtraBold(800→800), Black(1000→1000).
+        // The ExtraBold *instance* redefines user=800 → design=780 (not 800).
+        // Normalized (default=100, max=1000): user 0.7778 should map to design 0.7556
+        // (not 0.7778 as it would if the instance override were silently dropped).
+        assert_eq!(
+            vec![vec![
+                (-1.0, -1.0),
+                (0.0, 0.0),
+                (0.777771, 0.7555542),
+                (1.0, 1.0)
+            ]],
+            axis_maps
+        );
+    }
+
     #[test]
     fn compile_without_ir() {
         let result = TestCompile::compile("glyphs2/WghtVar.glyphs", |mut args| {

--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -2819,12 +2819,18 @@ fn user_to_design_from_axis_location(
             let design = master.axes_values[idx];
             // Last master wins, matching glyphsLib overwrite semantics:
             // https://github.com/googlefonts/glyphsLib/blob/71f487f9d24e/Lib/glyphsLib/builder/axes.py#L221
-            let source_label = format!("master '{}'", master.name.as_deref().unwrap_or(&master.id));
-
-            axis_mappings
+            let old = axis_mappings
                 .entry(axis_location.axis_name.clone())
                 .or_default()
-                .add_or_replace(user, design, &axis.name, &source_label);
+                .add_or_replace(user, design);
+            if let Some(old) = old {
+                let name = master.name.as_deref().unwrap_or(&master.id);
+                warn!(
+                    "Axis {}: master '{}' redefines mapping for user \
+                     location {user} from {old} to {design}",
+                    axis.name, name
+                );
+            }
         }
     }
     Some(axis_mappings)
@@ -2839,37 +2845,23 @@ impl AxisUserToDesignMap {
         self.0.push((user, design));
     }
 
-    fn add_any_or_replace(
-        &mut self,
-        incoming: &AxisUserToDesignMap,
-        axis_name: &str,
-        source_label: &str,
-    ) {
-        for (user, design) in incoming.0.iter() {
-            self.add_or_replace(*user, *design, axis_name, source_label);
-        }
-    }
-
-    /// Insert or overwrite mapping for `user`. Warns when overwriting a different value.
+    /// Insert or overwrite mapping for `user`.
+    /// Returns the previous design value if an existing entry was overwritten.
     fn add_or_replace(
         &mut self,
         user: OrderedFloat<f64>,
         design: OrderedFloat<f64>,
-        axis_name: &str,
-        source_label: &str,
-    ) {
+    ) -> Option<OrderedFloat<f64>> {
         if let Some(entry) = self.0.iter_mut().find(|(u, _)| *u == user) {
             if entry.1 != design {
-                warn!(
-                    "Axis {axis_name}: {source_label} redefines mapping for user \
-                     location {user} from {} to {design}",
-                    entry.1
-                );
+                let old = entry.1;
                 entry.1 = design;
+                return Some(old);
             }
         } else {
             self.0.push((user, design));
         }
+        None
     }
 
     fn add_identity_map(&mut self, value: OrderedFloat<f64>) {
@@ -2932,11 +2924,16 @@ impl UserToDesignMapping {
             .filter(|i| i.active && i.type_ == InstanceType::Single)
         {
             for (axis_name, inst_mapping) in instance.axis_mappings.iter() {
-                let source_label = format!("instance '{}'", instance.name);
-                self.0
-                    .entry(axis_name.clone())
-                    .or_default()
-                    .add_any_or_replace(inst_mapping, axis_name, &source_label);
+                let entry = self.0.entry(axis_name.clone()).or_default();
+                for (user, design) in inst_mapping.iter() {
+                    if let Some(old) = entry.add_or_replace(*user, *design) {
+                        warn!(
+                            "Axis {axis_name}: instance '{}' redefines mapping for user \
+                             location {user} from {old} to {design}",
+                            instance.name
+                        );
+                    }
+                }
             }
         }
     }

--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -2817,29 +2817,59 @@ fn user_to_design_from_axis_location(
             };
             let user = axis_location.location;
             let design = master.axes_values[idx];
+            // Last master wins, matching glyphsLib overwrite semantics:
+            // https://github.com/googlefonts/glyphsLib/blob/71f487f9d24e/Lib/glyphsLib/builder/axes.py#L221
+            let source_label = format!("master '{}'", master.name.as_deref().unwrap_or(&master.id));
 
             axis_mappings
                 .entry(axis_location.axis_name.clone())
                 .or_default()
-                .add_if_new(user, design);
+                .add_or_replace(user, design, &axis.name, &source_label);
         }
     }
     Some(axis_mappings)
 }
 
 impl AxisUserToDesignMap {
-    fn add_any_new(&mut self, incoming: &AxisUserToDesignMap) {
-        for (user, design) in incoming.0.iter() {
-            self.add_if_new(*user, *design);
-        }
-    }
-
     fn add_if_new(&mut self, user: OrderedFloat<f64>, design: OrderedFloat<f64>) {
         // only keys (input/user-space) should be unique, values (output/design-space) can be duplicated
         if self.0.iter().any(|(u, _)| *u == user) {
             return;
         }
         self.0.push((user, design));
+    }
+
+    fn add_any_or_replace(
+        &mut self,
+        incoming: &AxisUserToDesignMap,
+        axis_name: &str,
+        source_label: &str,
+    ) {
+        for (user, design) in incoming.0.iter() {
+            self.add_or_replace(*user, *design, axis_name, source_label);
+        }
+    }
+
+    /// Insert or overwrite mapping for `user`. Warns when overwriting a different value.
+    fn add_or_replace(
+        &mut self,
+        user: OrderedFloat<f64>,
+        design: OrderedFloat<f64>,
+        axis_name: &str,
+        source_label: &str,
+    ) {
+        if let Some(entry) = self.0.iter_mut().find(|(u, _)| *u == user) {
+            if entry.1 != design {
+                warn!(
+                    "Axis {axis_name}: {source_label} redefines mapping for user \
+                     location {user} from {} to {design}",
+                    entry.1
+                );
+                entry.1 = design;
+            }
+        } else {
+            self.0.push((user, design));
+        }
     }
 
     fn add_identity_map(&mut self, value: OrderedFloat<f64>) {
@@ -2878,7 +2908,7 @@ impl UserToDesignMapping {
         let mut result = Self(result);
         if incomplete_mapping {
             //https://github.com/googlefonts/glyphsLib/blob/682ff4b17/Lib/glyphsLib/builder/axes.py#L251
-            result.add_instance_mappings_if_new(instances);
+            result.add_instance_mappings(instances);
             if result.0.is_empty() || result.0.values().all(|v| v.is_identity()) {
                 result.add_master_mappings_if_new(from);
             }
@@ -2894,18 +2924,19 @@ impl UserToDesignMapping {
         self.0.get(axis_name)
     }
 
-    /// * <https://github.com/googlefonts/glyphsLib/blob/6f243c1f732ea1092717918d0328f3b5303ffe56/Lib/glyphsLib/builder/axes.py#L128>
-    /// * <https://github.com/googlefonts/glyphsLib/blob/6f243c1f732ea1092717918d0328f3b5303ffe56/Lib/glyphsLib/builder/axes.py#L353>
-    fn add_instance_mappings_if_new(&mut self, instances: &[Instance]) {
+    /// Last instance wins, matching glyphsLib overwrite semantics:
+    /// * <https://github.com/googlefonts/glyphsLib/blob/71f487f9d24e/Lib/glyphsLib/builder/axes.py#L153>
+    fn add_instance_mappings(&mut self, instances: &[Instance]) {
         for instance in instances
             .iter()
             .filter(|i| i.active && i.type_ == InstanceType::Single)
         {
             for (axis_name, inst_mapping) in instance.axis_mappings.iter() {
+                let source_label = format!("instance '{}'", instance.name);
                 self.0
                     .entry(axis_name.clone())
                     .or_default()
-                    .add_any_new(inst_mapping);
+                    .add_any_or_replace(inst_mapping, axis_name, &source_label);
             }
         }
     }

--- a/resources/testdata/glyphs2/WghtVar_Instances_implied_axes.glyphs
+++ b/resources/testdata/glyphs2/WghtVar_Instances_implied_axes.glyphs
@@ -31,6 +31,7 @@ instanceInterpolations = {
 isBold = 1;
 linkStyle = Regular;
 name = Bold;
+weightClass = Bold;
 }
 );
 unitsPerEm = 1000;

--- a/resources/testdata/glyphs3/LinkMetricsWithFirstMaster.glyphs
+++ b/resources/testdata/glyphs3/LinkMetricsWithFirstMaster.glyphs
@@ -79,6 +79,7 @@ instanceInterpolations = {
 m02 = 1;
 };
 name = Bold;
+weightClass = 700;
 }
 );
 kerningLTR = {

--- a/resources/testdata/glyphs3/LinkMetricsWithIntermediateLayer.glyphs
+++ b/resources/testdata/glyphs3/LinkMetricsWithIntermediateLayer.glyphs
@@ -74,6 +74,7 @@ instanceInterpolations = {
 m02 = 1;
 };
 name = Bold;
+weightClass = 700;
 }
 );
 unitsPerEm = 1000;

--- a/resources/testdata/glyphs3/LinkMetricsWithMaster.glyphs
+++ b/resources/testdata/glyphs3/LinkMetricsWithMaster.glyphs
@@ -94,6 +94,7 @@ instanceInterpolations = {
 m02 = 1;
 };
 name = Bold;
+weightClass = 700;
 },
 {
 axesValues = (
@@ -103,6 +104,7 @@ instanceInterpolations = {
 m03 = 1;
 };
 name = Black;
+weightClass = 900;
 }
 );
 kerningLTR = {

--- a/resources/testdata/glyphs3/LinkMetricsWithMissingMaster.glyphs
+++ b/resources/testdata/glyphs3/LinkMetricsWithMissingMaster.glyphs
@@ -79,6 +79,7 @@ instanceInterpolations = {
 m02 = 1;
 };
 name = Bold;
+weightClass = 700;
 }
 );
 kerningLTR = {

--- a/resources/testdata/glyphs3/WghtVar_AxisLocation_InstanceOverride.glyphs
+++ b/resources/testdata/glyphs3/WghtVar_AxisLocation_InstanceOverride.glyphs
@@ -1,0 +1,143 @@
+{
+.appVersion = "3414";
+.formatVersion = 3;
+axes = (
+{
+name = Weight;
+tag = wght;
+}
+);
+familyName = WghtVar;
+fontMaster = (
+{
+axesValues = (
+100
+);
+customParameters = (
+{
+name = "Axis Location";
+value = (
+{
+Axis = Weight;
+Location = 100;
+}
+);
+}
+);
+id = "thin-master";
+name = "Thin Italic";
+},
+{
+axesValues = (
+800
+);
+customParameters = (
+{
+name = "Axis Location";
+value = (
+{
+Axis = Weight;
+Location = 800;
+}
+);
+}
+);
+id = "extrabold-master";
+name = "ExtraBold Italic";
+},
+{
+axesValues = (
+1000
+);
+customParameters = (
+{
+name = "Axis Location";
+value = (
+{
+Axis = Weight;
+Location = 1000;
+}
+);
+}
+);
+id = "black-master";
+name = "Black Italic";
+}
+);
+glyphs = (
+{
+glyphname = space;
+layers = (
+{
+layerId = "thin-master";
+width = 200;
+},
+{
+layerId = "extrabold-master";
+width = 500;
+},
+{
+layerId = "black-master";
+width = 600;
+}
+);
+unicode = 32;
+}
+);
+instances = (
+{
+axesValues = (
+100
+);
+customParameters = (
+{
+name = "Axis Location";
+value = (
+{
+Axis = Weight;
+Location = 100;
+}
+);
+}
+);
+name = "Thin Italic";
+},
+{
+axesValues = (
+780
+);
+customParameters = (
+{
+name = "Axis Location";
+value = (
+{
+Axis = Weight;
+Location = 800;
+}
+);
+}
+);
+name = "ExtraBold Italic";
+},
+{
+axesValues = (
+1000
+);
+customParameters = (
+{
+name = "Axis Location";
+value = (
+{
+Axis = Weight;
+Location = 1000;
+}
+);
+}
+);
+name = "Black Italic";
+}
+);
+unitsPerEm = 1000;
+versionMajor = 1;
+versionMinor = 0;
+}


### PR DESCRIPTION
When a font uses Axis Location custom params on both masters and instances, an instance can legitimately redefine a master's user→design mapping. Previously `add_if_new()` silently dropped the instance entry if the user value was already present (from the master), producing wrong output for fonts like SUSE-Italic (ExtraBold user=800 should map to design=780, not 800).

Switch to last-wins overwrite semantics everywhere, matching glyphsLib's `mapping[userLoc] = designLoc`. 

https://github.com/googlefonts/glyphsLib/blob/71f487f9d24e/Lib/glyphsLib/builder/axes.py#L221

https://github.com/googlefonts/glyphsLib/blob/71f487f9d24e/Lib/glyphsLib/builder/axes.py#L153

Both the master Axis Location path and the instance mapping path now use `add_or_replace` (with a log::warn when overwriting a different value). Removed `add_any_new`, no longer needed.

Rename `add_instance_mappings_if_new` => `add_instance_mappings` since it now always overwrites.

Add an integration test with a minimal .glyphs fixture modeled on SUSE-Italic that compiles end-to-end and checks the avar output.

Fixes #1866