### PR TITLE
[glyphs-reader] Fix glyph production name lookup order in glyphdata

### DIFF
--- a/glyphs-reader/src/glyphdata.rs
+++ b/glyphs-reader/src/glyphdata.rs
@@ -533,13 +533,13 @@ impl GlyphData {
 
         // No override, perhaps we have a direct answer?
         bundled::find_pos_by_name(name)
+            .or_else(|| find_pos_by_prod_name(name.into()))
             .or_else(|| {
                 codepoints
                     .into_iter()
                     .flat_map(|cps| cps.iter())
                     .find_map(|cp| bundled::find_pos_by_codepoint(*cp))
             })
-            .or_else(|| find_pos_by_prod_name(name.into()))
             .map(|i| {
                 bundled::get(i).unwrap_or_else(|| panic!("We found invalid index {i} somehow"))
             })

--- a/glyphs-reader/src/glyphdata.rs
+++ b/glyphs-reader/src/glyphdata.rs
@@ -1341,4 +1341,23 @@ mod tests {
             "{name}: {production_name:?} != {expected:?}"
         );
     }
+
+    // https://github.com/googlefonts/fontc/issues/XXXX
+    #[test]
+    fn prod_name_lookup_before_codepoint_lookup() {
+        // Inter-Italic has a glyph named "triagrt" (AGLFN name for U+25BA)
+        // with unicode = (0x25BA, 0x25B6). The codepoint fallback must not
+        // match U+25B6 → "uni25B6" before the production name lookup can
+        // match "triagrt" → U+25BA (which needs no rename).
+        let codepoints: BTreeSet<u32> = [0x25BA, 0x25B6].into_iter().collect();
+        let result = GlyphData::new(None)
+            .query("triagrt", Some(&codepoints))
+            .unwrap();
+        // "triagrt" IS the AGLFN production name for U+25BA, so the result's
+        // production name must be "triagrt" (a no-op rename), NOT "uni25B6".
+        assert_eq!(
+            result.production_name.as_ref().map(|p| p.to_string()),
+            Some("triagrt".to_string()),
+        );
+    }
 }


### PR DESCRIPTION
To match glyphsLib's resolution order, `query_no_synthesis` must look up a glyph's name by its production name before looking it up by codepoint.

https://github.com/googlefonts/glyphsLib/blob/v6.13.0/Lib/glyphsLib/glyphdata.py#L120-L128
https://github.com/googlefonts/glyphsLib/blob/v6.13.0/Lib/glyphsLib/glyphdata.py#L163-L166

Currently we are doing the opposite of that, doing `find_pos_by_codepoint` before `find_pos_by_prod_name`:

https://github.com/googlefonts/fontc/blob/7f631b66246051868093f7f07581db08f8d337c2/glyphs-reader/src/glyphdata.rs#L534-L545

... which leads to different production glyph names in Inter-Italic and Roman.
In there, a glyph named "triagrt" (with codepoints {0x25BA, 0x25B6} gets incorrectly renamed to "uni25B6" because the codepoint fallback matches U+25B6 before the production name lookup can match "triagrt" (same as original). The correct production name is indeed the latter (AGLFN name for U+25BA).