### PR TITLE
[fontir] don't leak interpolated sources from non-export flattening into gvar/HVAR

### DIFF
--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -3269,6 +3269,109 @@ mod tests {
         assert_noexport("designspace_from_glyphs/WghtVar_NoExport.designspace");
     }
 
+    fn gvar_tuple_count(result: &TestCompile, glyph_name: &str) -> usize {
+        let font = result.font();
+        let gvar = font.gvar().unwrap();
+        gvar.glyph_variation_data(result.get_gid(glyph_name).into())
+            .unwrap()
+            .unwrap()
+            .tuples()
+            .count()
+    }
+
+    /// Number of variation regions used by the given glyph's HVAR advance-width delta set.
+    fn hvar_region_count(result: &TestCompile, glyph_name: &str) -> usize {
+        let font = result.font();
+        let hvar = font.hvar().unwrap();
+        let mapping = hvar.advance_width_mapping().unwrap().unwrap();
+        let delta_set_index = mapping.get(result.get_gid(glyph_name).to_u32()).unwrap();
+        let varstore = hvar.item_variation_store().unwrap();
+        let vardata = varstore
+            .item_variation_data()
+            .get(delta_set_index.outer as usize)
+            .unwrap()
+            .unwrap();
+        vardata.region_indexes().len()
+    }
+
+    /// Regression test for <https://github.com/googlefonts/fontc/issues/1840>.
+    ///
+    /// When a composite references a non-export component AND another component
+    /// with a brace (intermediate) layer, flattening the non-export component calls
+    /// `ensure_composite_defined_at_component_locations` which adds virtual sources
+    /// at the brace layer's location. These extra sources leak into gvar, producing
+    /// spurious intermediate tuples on composites that should only have endpoint
+    /// master tuples.
+    #[test]
+    fn non_export_flatten_does_not_leak_brace_layer_sources_into_gvar() {
+        let result = TestCompile::compile_source("glyphs3/NonExportWithBraceLayer.glyphs");
+
+        // "A" has a brace layer — it legitimately gets intermediate tuples
+        assert_eq!(gvar_tuple_count(&result, "A"), 2);
+        // "acutecomb" has no brace layer — just 1 tuple
+        assert_eq!(gvar_tuple_count(&result, "acutecomb"), 1);
+
+        // "Aacute" = A + _acutecomb (non-export, composite of acutecomb, NO brace layer).
+        // After flattening: A + acutecomb (still purely composite).
+        // _acutecomb has no brace layer, so its intermediate is purely interpolated.
+        // Should have 1 gvar tuple, not 2 leaked from A's brace.
+        assert_eq!(gvar_tuple_count(&result, "Aacute"), 1);
+
+        // HVAR encoding should also be free of leaked brace data: Aacute's
+        // advance width variation should use a single peak region, not an
+        // intermediate split.
+        assert_eq!(hvar_region_count(&result, "Aacute"), 1);
+    }
+
+    /// Counterpart to `non_export_flatten_does_not_leak_brace_layer_sources_into_gvar`:
+    /// when the non-export component itself HAS a brace layer, the intermediate
+    /// tuple must be preserved.
+    #[test]
+    fn non_export_composite_brace_layer_preserved_in_gvar() {
+        let result = TestCompile::compile_source("glyphs3/NonExportWithBraceLayer.glyphs");
+
+        // Agraveacute = A + _graveacute (non-export, composite of gravecomb + acutecomb,
+        // WITH a brace layer at wght=700 that non-linearly adjusts acutecomb's offset).
+        // After flattening: A + gravecomb + acutecomb (purely composite).
+        // Unlike Aacute above, _graveacute's brace layer is its own, so the
+        // intermediate is kept — 2 gvar tuples, and HVAR uses the intermediate split.
+        assert_eq!(gvar_tuple_count(&result, "Agraveacute"), 2);
+        assert_eq!(hvar_region_count(&result, "Agraveacute"), 2);
+    }
+
+    /// When non-export flattening produces mixed contours+components, the glyph
+    /// gets decomposed by `convert_components_to_contours`, which adds an
+    /// intermediate at any remaining component's brace layer. This covers the
+    /// end-to-end path that the first test's "non-leak" assertion relies on
+    /// indirectly.
+    #[test]
+    fn non_export_flatten_plus_decompose_adds_brace_intermediate() {
+        let result = TestCompile::compile_source("glyphs3/NonExportWithBraceLayer.glyphs");
+
+        // Adot = A + _dot (non-export, simple glyph with contours, NO brace layer).
+        // After flattening: contours (from _dot) + component A → mixed content.
+        // convert_components_to_contours then decomposes A into contours, adding
+        // an intermediate at A's brace layer (wght=700). Result: simple glyph
+        // with 2 gvar tuples.
+        let font = result.font();
+        let gid = result.get_gid("Adot");
+
+        // Adot should be a simple glyph (decomposed)
+        let is_long = font.head().unwrap().index_to_loc_format() == 1;
+        let glyf = font.glyf().unwrap();
+        let loca = font.loca(is_long).unwrap();
+        let glyph_data = loca.get_glyf(gid.into(), &glyf).unwrap().unwrap();
+        assert!(
+            matches!(glyph_data, glyf::Glyph::Simple(_)),
+            "Adot should be decomposed to a simple glyph (mixed content + non-export flatten)"
+        );
+
+        // And both gvar and HVAR should reflect A's brace layer (wght=700)
+        // via the intermediate split.
+        assert_eq!(gvar_tuple_count(&result, "Adot"), 2);
+        assert_eq!(hvar_region_count(&result, "Adot"), 2);
+    }
+
     #[test]
     fn compile_do_not_decompose_nested_no_export_glyphs() {
         let result = TestCompile::compile("glyphs3/NestedNoExportComponent.glyphs", |mut args| {

--- a/fontir/src/glyph.rs
+++ b/fontir/src/glyph.rs
@@ -254,15 +254,20 @@ fn flatten_non_export_components_for_glyph(
     context: &Context,
     glyph: &Glyph,
 ) -> Result<Glyph, BadGlyph> {
-    let glyph = ensure_composite_defined_at_component_locations(context, glyph)?;
-    let mut builder = GlyphBuilder::from(glyph.clone());
-    builder.clear_components();
+    let expanded = ensure_composite_defined_at_component_locations(context, glyph)?;
+    let mut new_sources = HashMap::with_capacity(expanded.sources().len());
 
     log::debug!("flattening non-export components of '{}'", glyph.name);
-    for (loc, instance) in glyph.sources() {
-        let mut new_instance = instance.clone();
-        new_instance.components.clear();
+    for (loc, instance) in expanded.sources() {
+        let mut new_instance = GlyphInstance {
+            width: instance.width,
+            height: instance.height,
+            vertical_origin: instance.vertical_origin,
+            contours: instance.contours.clone(),
+            components: Vec::with_capacity(instance.components.len()),
+        };
 
+        let mut non_export_has_location = false;
         for component in &instance.components {
             let id = WorkId::Glyph(component.base.clone());
             let referenced_glyph = context.glyphs.get(&id);
@@ -273,6 +278,7 @@ fn flatten_non_export_components_for_glyph(
 
             // okay so now we have a component that is not going to be exported,
             // and we need to flatten.
+            non_export_has_location |= referenced_glyph.sources().contains_key(loc);
             let xform = component.transform;
             let referenced_instance = get_or_instantiate_instance(&referenced_glyph, loc, context)?;
 
@@ -291,10 +297,22 @@ fn flatten_non_export_components_for_glyph(
                 new_instance.contours.push(contour);
             }
         }
-        builder.sources.insert(loc.clone(), new_instance);
+        // Keep sources at the glyph's original locations, plus any locations
+        // where a non-export component being flattened has its own source.
+        // Drop the other virtual sources added by
+        // ensure_composite_defined_at_component_locations — they would leak
+        // into gvar as superfluous intermediate tuples.
+        // https://github.com/googlefonts/fontc/issues/1840
+        if glyph.sources().contains_key(loc) || non_export_has_location {
+            new_sources.insert(loc.clone(), new_instance);
+        }
     }
-    // unwrap is okay because all used locations are from previously validated glyph
-    builder.build()
+    Glyph::new(
+        expanded.name,
+        expanded.emit_to_binary,
+        expanded.codepoints,
+        new_sources,
+    )
 }
 
 fn glyph_has_non_export_components(glyph: &Glyph, context: &Context) -> bool {
@@ -1928,7 +1946,12 @@ mod tests {
 
         flatten_all_non_export_components(&context).unwrap();
         let after = context.get_glyph("Aogonek");
-        assert_eq!(after.sources().len(), 3);
+        // The intermediate at wght=0.5 comes from ogonek (a sub-component of the
+        // *export* component ogonekcomb.case), not from the non-export A.ogonekAccent.
+        // Since no non-export component has a source at the intermediate, the virtual
+        // source is not kept here. It gets added later by convert_components_to_contours
+        // (see fontc::non_export_flatten_plus_decompose_adds_brace_intermediate).
+        assert_eq!(after.sources().len(), 2);
     }
 
     fn make_wght_locations<const N: usize>(positions: [f64; N]) -> [NormalizedLocation; N] {

--- a/resources/testdata/glyphs3/NonExportWithBraceLayer.glyphs
+++ b/resources/testdata/glyphs3/NonExportWithBraceLayer.glyphs
@@ -1,0 +1,407 @@
+{
+.appVersion = "3414";
+.formatVersion = 3;
+axes = (
+{
+name = Weight;
+tag = wght;
+}
+);
+customParameters = (
+{
+name = "Write lastChange";
+value = 0;
+},
+{
+name = "Write DisplayStrings";
+value = 0;
+}
+);
+familyName = NonExportWithBraceLayer;
+fontMaster = (
+{
+axesValues = (
+400
+);
+id = light;
+name = Regular;
+},
+{
+axesValues = (
+900
+);
+id = bold;
+name = Bold;
+}
+);
+glyphs = (
+{
+glyphname = space;
+layers = (
+{
+layerId = light;
+width = 200;
+},
+{
+layerId = bold;
+width = 250;
+}
+);
+unicode = 32;
+},
+{
+glyphname = A;
+layers = (
+{
+layerId = light;
+shapes = (
+{
+closed = 1;
+nodes = (
+(0,0,l),
+(200,700,l),
+(400,0,l),
+(350,0,l),
+(200,600,l),
+(50,0,l)
+);
+}
+);
+width = 400;
+},
+{
+associatedMasterId = light;
+attr = {
+coordinates = (
+700
+);
+};
+layerId = "brace-A";
+shapes = (
+{
+closed = 1;
+nodes = (
+(0,0,l),
+(250,700,l),
+(500,0,l),
+(420,0,l),
+(250,550,l),
+(80,0,l)
+);
+}
+);
+width = 500;
+},
+{
+layerId = bold;
+shapes = (
+{
+closed = 1;
+nodes = (
+(0,0,l),
+(300,700,l),
+(600,0,l),
+(490,0,l),
+(300,500,l),
+(110,0,l)
+);
+}
+);
+width = 600;
+}
+);
+unicode = 65;
+},
+{
+glyphname = acutecomb;
+layers = (
+{
+layerId = light;
+shapes = (
+{
+closed = 1;
+nodes = (
+(100,600,l),
+(200,800,l),
+(150,800,l),
+(50,600,l)
+);
+}
+);
+width = 0;
+},
+{
+layerId = bold;
+shapes = (
+{
+closed = 1;
+nodes = (
+(80,600,l),
+(230,800,l),
+(150,800,l),
+(0,600,l)
+);
+}
+);
+width = 0;
+}
+);
+unicode = 769;
+},
+{
+export = 0;
+glyphname = _acutecomb;
+layers = (
+{
+layerId = light;
+shapes = (
+{
+pos = (10,0);
+ref = acutecomb;
+}
+);
+width = 0;
+},
+{
+layerId = bold;
+shapes = (
+{
+pos = (20,0);
+ref = acutecomb;
+}
+);
+width = 0;
+}
+);
+},
+{
+glyphname = Aacute;
+layers = (
+{
+layerId = light;
+shapes = (
+{
+ref = A;
+},
+{
+pos = (100,0);
+ref = _acutecomb;
+}
+);
+width = 400;
+},
+{
+layerId = bold;
+shapes = (
+{
+ref = A;
+},
+{
+pos = (150,0);
+ref = _acutecomb;
+}
+);
+width = 600;
+}
+);
+unicode = 193;
+},
+{
+glyphname = gravecomb;
+layers = (
+{
+layerId = light;
+shapes = (
+{
+closed = 1;
+nodes = (
+(50,600,l),
+(150,800,l),
+(100,800,l),
+(0,600,l)
+);
+}
+);
+width = 0;
+},
+{
+layerId = bold;
+shapes = (
+{
+closed = 1;
+nodes = (
+(80,600,l),
+(230,800,l),
+(150,800,l),
+(0,600,l)
+);
+}
+);
+width = 0;
+}
+);
+unicode = 768;
+},
+{
+export = 0;
+glyphname = _graveacute;
+layers = (
+{
+layerId = light;
+shapes = (
+{
+pos = (0,0);
+ref = gravecomb;
+},
+{
+pos = (100,0);
+ref = acutecomb;
+}
+);
+width = 0;
+},
+{
+associatedMasterId = light;
+attr = {
+coordinates = (
+700
+);
+};
+layerId = "brace-graveacute";
+shapes = (
+{
+pos = (0,0);
+ref = gravecomb;
+},
+{
+pos = (200,0);
+ref = acutecomb;
+}
+);
+width = 0;
+},
+{
+layerId = bold;
+shapes = (
+{
+pos = (0,0);
+ref = gravecomb;
+},
+{
+pos = (300,0);
+ref = acutecomb;
+}
+);
+width = 0;
+}
+);
+},
+{
+glyphname = Agraveacute;
+layers = (
+{
+layerId = light;
+shapes = (
+{
+ref = A;
+},
+{
+pos = (50,0);
+ref = _graveacute;
+}
+);
+width = 400;
+},
+{
+layerId = bold;
+shapes = (
+{
+ref = A;
+},
+{
+pos = (80,0);
+ref = _graveacute;
+}
+);
+width = 600;
+}
+);
+unicode = 192;
+},
+{
+export = 0;
+glyphname = _dot;
+layers = (
+{
+layerId = light;
+shapes = (
+{
+closed = 1;
+nodes = (
+(100,700,l),
+(150,700,l),
+(150,750,l),
+(100,750,l)
+);
+}
+);
+width = 0;
+},
+{
+layerId = bold;
+shapes = (
+{
+closed = 1;
+nodes = (
+(100,700,l),
+(160,700,l),
+(160,760,l),
+(100,760,l)
+);
+}
+);
+width = 0;
+}
+);
+},
+{
+glyphname = Adot;
+layers = (
+{
+layerId = light;
+shapes = (
+{
+ref = A;
+},
+{
+ref = _dot;
+}
+);
+width = 400;
+},
+{
+layerId = bold;
+shapes = (
+{
+ref = A;
+},
+{
+ref = _dot;
+}
+);
+width = 600;
+}
+);
+unicode = 229;
+}
+);
+instances = (
+{
+name = Regular;
+type = variable;
+}
+);
+unitsPerEm = 1000;
+versionMajor = 1;
+versionMinor = 0;
+}


### PR DESCRIPTION
Fixes https://github.com/googlefonts/fontc/issues/1840

When a composite has a non-export component, `flatten_non_export_components_for_glyph` calls `ensure_composite_defined_at_component_locations`, which adds virtual interpolated sources at every location defined by any component — including brace layers on sibling/export components. These extra sources persist on the
composite and produce superfluous intermediate tuples in both gvar and HVAR.

`ensure_composite_defined_at_component_locations` is needed during the flattening loop (for correct nested component resolution), but its interpolated sources should be kept only when they carry data the composite glyph actually needs, that is when a non-export component being flattened has an explicit source at that intermediate location.

As usual, I first push a test that fails without the fix: a composite referencing a non-export component AND a different component with an intermediate layer that leaks into the composite's gvar and HVAR. 
Then a second commit follows with the fix.

I verified that both RedditSansCondensed and NotoSans-Italic become **ttx-diff-identical** after these changes.