### PR TITLE
[smart_components] Fix transform composition and single-layer flattening

### DIFF
--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -1910,6 +1910,44 @@ mod tests {
         );
     }
 
+    /// Verify anchors propagate through a single-layer smart component.
+    ///
+    /// Regression test for <https://github.com/googlefonts/fontc/issues/1973>.
+    /// When a smart component has only one layer per master, we preserve
+    /// the component reference and return no anchors from instantiation.
+    /// Anchors must still reach the outermost composite via propagation
+    /// through the component chain: composite → flipped(smart) → base.
+    #[test]
+    fn propagate_anchors_through_single_layer_smart_component() {
+        let result =
+            TestCompile::compile_source("glyphs3/SmartComponentSingleLayerAnchors.glyphs");
+
+        let anchors = result
+            .fe_context
+            .anchors
+            .try_get(&FeWorkIdentifier::Anchor("composite".into()))
+            .expect("composite should have propagated anchors");
+
+        // base "top" at (200, 400), propagated through:
+        //   flipped [-1, 0, 0, -1, 417, 353] → (217, -47)
+        //   composite translate(0, 376)       → (217, 329)
+        // The 180° rotation renames "top" → "bottom" (see rename_anchor_for_scale).
+        let bottom = anchors
+            .anchors
+            .iter()
+            .find(|a| a.original_name == "bottom")
+            .unwrap_or_else(|| {
+                let names: Vec<_> = anchors.anchors.iter().map(|a| &a.original_name).collect();
+                panic!("composite should have a 'bottom' anchor (renamed from base's 'top'), found: {names:?}")
+            });
+        let pos = bottom.default_pos();
+        assert_eq!(
+            (pos.x as i32, pos.y as i32),
+            (217, 329),
+            "anchor should be transformed through the full component chain"
+        );
+    }
+
     /// Verify anchor propagation works correctly for bracket layers.
     ///
     /// Bracket layers become separate glyphs in IR (e.g., A.BRACKET.varAlt01).

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -1919,8 +1919,7 @@ mod tests {
     /// through the component chain: composite → flipped(smart) → base.
     #[test]
     fn propagate_anchors_through_single_layer_smart_component() {
-        let result =
-            TestCompile::compile_source("glyphs3/SmartComponentSingleLayerAnchors.glyphs");
+        let result = TestCompile::compile_source("glyphs3/SmartComponentSingleLayerAnchors.glyphs");
 
         let anchors = result
             .fe_context

--- a/glyphs-reader/src/smart_components.rs
+++ b/glyphs-reader/src/smart_components.rs
@@ -897,4 +897,83 @@ mod tests {
         assert_eq!((top.pos.x, top.pos.y), (48.0, 123.0));
         assert_eq!((bottom.pos.x, bottom.pos.y), (56.0, -41.0));
     }
+
+    // Regression tests for https://github.com/googlefonts/fontc/issues/1973
+    //
+    // MonaSans ninesuperior → nineinferior(smart, rotate 180°) → sixinferior
+
+    #[test]
+    fn apply_affine_component_transform_order() {
+        // Inner component: rotate 180° + translate (like nineinferior → sixinferior)
+        let mut shape = Shape::Component(Component {
+            name: "base".into(),
+            transform: Affine::new([-1.0, 0.0, 0.0, -1.0, 417.0, 353.0]),
+            ..Default::default()
+        });
+
+        // Outer: translate(0, 376) (like ninesuperior → nineinferior)
+        shape.apply_affine(Affine::translate((0.0, 376.0)));
+
+        let c = shape.as_component().unwrap().transform.as_coeffs();
+        // outer * inner = translate(0,376) * [-1,0,0,-1,417,353] = [-1,0,0,-1,417,729]
+        assert_eq!(
+            (c[4], c[5]),
+            (417.0, 729.0),
+            "should compose as outer * inner; wrong order gives (417, -23)"
+        );
+    }
+
+    #[test]
+    fn single_layer_smart_component_preserves_component_ref() {
+        let master_id = "master01";
+
+        // Smart component with 1 layer per master — smart axes can't vary.
+        // Its shape is a Component (like nineinferior → sixinferior).
+        let mut inner = Glyph {
+            name: "inner".into(),
+            ..Default::default()
+        };
+        inner
+            .smart_component_axes
+            .insert(SmolStr::new("Axis"), 0..=100);
+
+        let inner_layer = Layer {
+            layer_id: master_id.into(),
+            width: 500.0.into(),
+            shapes: vec![Shape::Component(Component {
+                name: "base".into(),
+                transform: Affine::new([-1.0, 0.0, 0.0, -1.0, 417.0, 353.0]),
+                ..Default::default()
+            })],
+            smart_component_positions: [(SmolStr::new("Axis"), AxisPole::Min)]
+                .into_iter()
+                .collect(),
+            ..Default::default()
+        };
+        inner.layers.push(inner_layer);
+
+        // Caller references "inner" with translate(0, 376)
+        let caller = Component {
+            name: "inner".into(),
+            transform: Affine::translate((0.0, 376.0)),
+            ..Default::default()
+        };
+
+        let instance = instantiate_for_layer(master_id, &caller, &inner).expect("should succeed");
+
+        // glyphsLib keeps this as a regular component ref (model=None fallback).
+        // fontc should do the same — not flatten "inner" into its child "base".
+        assert_eq!(instance.shapes.len(), 1);
+        let comp = instance.shapes[0]
+            .as_component()
+            .expect("should preserve as Component, not inline inner shapes");
+        assert_eq!(
+            comp.name.as_str(),
+            "inner",
+            "should keep reference to 'inner', not flatten to 'base'"
+        );
+        assert_eq!(comp.transform, Affine::translate((0.0, 376.0)));
+        assert!(comp.smart_component_values.is_empty());
+        assert!(instance.anchors.is_empty());
+    }
 }

--- a/glyphs-reader/src/smart_components.rs
+++ b/glyphs-reader/src/smart_components.rs
@@ -82,20 +82,21 @@ pub(crate) fn instantiate_for_layer(
         return Err(BadSmartComponent::NoLayer(layer_master_id.to_string()));
     }
     if relevant_layers.len() == 1 {
-        log::debug!("smart component {} only has one layer?", component.name);
-        let mut shapes = relevant_layers[0].shapes.clone();
-        shapes
-            .iter_mut()
-            .for_each(|shape| shape.apply_affine(component.transform));
-        let anchors = relevant_layers[0]
-            .anchors
-            .iter()
-            .map(|a| Anchor {
-                name: a.name.clone(),
-                pos: component.transform * a.pos,
-            })
-            .collect();
-        return Ok(SmartComponentInstance { shapes, anchors });
+        // Only one layer for this master — the smart axes can't vary, so treat
+        // as a regular component reference, matching glyphsLib's model=None fallback:
+        // https://github.com/googlefonts/glyphsLib/blob/044f19e4/Lib/glyphsLib/builder/smart_components.py#L182-L184
+        log::debug!(
+            "smart component {} only has one layer, keeping as regular component",
+            component.name
+        );
+        let mut kept = component.clone();
+        kept.smart_component_values.clear();
+        // No anchors here; they'll be propagated through the component ref
+        // by propagate_all_anchors in fontir (see propagate_anchors.rs).
+        return Ok(SmartComponentInstance {
+            shapes: vec![Shape::Component(kept)],
+            anchors: vec![],
+        });
     }
 
     validate_relevant_layers(&relevant_layers)?;
@@ -351,7 +352,7 @@ impl Shape {
                     .for_each(|node| node.apply_affine(affine));
             }
             Shape::Component(component) => {
-                component.transform *= affine;
+                component.transform = affine * component.transform;
             }
         }
     }

--- a/resources/testdata/glyphs3/SmartComponentSingleLayerAnchors.glyphs
+++ b/resources/testdata/glyphs3/SmartComponentSingleLayerAnchors.glyphs
@@ -1,0 +1,101 @@
+{
+.appVersion = "3434";
+.formatVersion = 3;
+familyName = SmartComponentSingleLayerAnchorsTest;
+fontMaster = (
+{
+id = m01;
+metricValues = (
+{
+pos = 800;
+},
+{
+pos = -200;
+}
+);
+name = Regular;
+}
+);
+glyphs = (
+{
+glyphname = base;
+layers = (
+{
+anchors = (
+{
+name = top;
+pos = (200,400);
+}
+);
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(0,0,l),
+(400,0,l),
+(400,400,l),
+(0,400,l)
+);
+}
+);
+width = 400;
+}
+);
+unicode = 0062;
+},
+{
+glyphname = flipped;
+layers = (
+{
+layerId = m01;
+partSelection = {
+Axis = 1;
+};
+shapes = (
+{
+angle = 180;
+pos = (417,353);
+ref = base;
+}
+);
+width = 500;
+}
+);
+partsSettings = (
+{
+bottomValue = 0;
+name = Axis;
+topValue = 100;
+}
+);
+},
+{
+glyphname = composite;
+layers = (
+{
+layerId = m01;
+shapes = (
+{
+pos = (0,376);
+ref = flipped;
+}
+);
+width = 500;
+}
+);
+unicode = 0063;
+}
+);
+metrics = (
+{
+type = ascender;
+},
+{
+type = descender;
+}
+);
+unitsPerEm = 1000;
+versionMajor = 1;
+versionMinor = 0;
+}


### PR DESCRIPTION
Fix two bugs in smart component instantiation:

1. Shape::apply_affine composed transforms as `inner*outer` instead of `outer*inner` for Component shapes (the Path branch was correct). With a non-identity 2x2 (rotation/flip), this flips the sign of translations: e.g. y=729 became y=-23 in MonaSans ninesuperior.

 2. Single-layer fast path inlined inner component shapes, flattening the component graph (e.g. ninesuperior -> sixinferior instead of ninesuperior -> nineinferior). Now preserves the component reference, matching glyphsLib's model=None fallback.

Fixes #1973
