### PR TITLE
crater: More robust caching

### DIFF
--- a/fontc_crater/src/ci/html.rs
+++ b/fontc_crater/src/ci/html.rs
@@ -1,7 +1,7 @@
 //! generating html reports from crater results
 
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap},
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     ffi::OsStr,
     fmt::Display,
     ops::Sub,
@@ -551,6 +551,20 @@ fn make_diff_report(
     let mut current_diff = current_diff.into_iter().collect::<Vec<_>>();
     current_diff.sort_by_key(|(_, r)| -(r * 1e6) as i64);
 
+    // Pre-compute short source names and find which are ambiguous
+    let ambiguous_sources = {
+        let mut counts = HashMap::<String, usize>::new();
+        for (target, _) in &current_diff {
+            let short = short_source_name(target);
+            *counts.entry(short).or_default() += 1;
+        }
+        counts
+            .into_iter()
+            .filter(|(_, count)| *count > 1)
+            .map(|(name, _)| name)
+            .collect::<HashSet<String>>()
+    };
+
     let mut items = Vec::new();
     for (target, ratio) in &current_diff {
         let diff_details = current.success.get(*target).unwrap();
@@ -588,7 +602,7 @@ fn make_diff_report(
         } else {
             ""
         };
-        let target_description = make_target_description(target);
+        let target_description = make_target_description(target, &ambiguous_sources);
 
         items.push(html! {
             details {
@@ -649,9 +663,21 @@ fn format_annotations(target: &Target, annotations: &BTreeMap<Target, Vec<Annota
     }
 }
 
-fn make_target_description(target: &Target) -> Markup {
+/// Compute the short source name for a target (just the filename).
+fn short_source_name(target: &Target) -> String {
     let bare_path = target.source_path(Path::new(""));
-    let source = bare_path.file_name().unwrap().to_str().unwrap();
+    bare_path.file_name().unwrap().to_string_lossy().to_string()
+}
+
+fn make_target_description(target: &Target, ambiguous_sources: &HashSet<String>) -> Markup {
+    let short = short_source_name(target);
+    // If the short name is ambiguous (used by multiple targets), prepend repo
+    // name to disambiguate (e.g. "myrepo/font.glyphs" instead of "font.glyphs").
+    let source = if ambiguous_sources.contains(&short) {
+        format!("{}/{short}", target.repo_name())
+    } else {
+        short
+    };
     let annotation = match target.build {
         BuildType::Default => "default".to_string(),
         BuildType::GfTools if target.config.file_stem() != Some(OsStr::new("config")) => {

--- a/fontc_crater/src/target.rs
+++ b/fontc_crater/src/target.rs
@@ -128,7 +128,17 @@ impl Target {
         let config = self.config.file_stem().unwrap_or(OsStr::new("config"));
         let mut result = in_dir.join(self.source_dir());
         result.push(config);
-        result.push(self.source.file_stem().unwrap());
+        // Flatten the full source path (minus extension) into a single directory
+        // name by replacing path separators, to avoid cache collisions when
+        // multiple sources share the same filename in different directories
+        // (e.g., styles/Light/font.ufo vs styles/Medium/font.ufo).
+        let source_no_ext = self
+            .source
+            .with_extension("")
+            .display()
+            .to_string()
+            .replace('/', "_");
+        result.push(source_no_ext);
         result.push(self.build.name());
         result
     }

--- a/fontc_crater/src/target.rs
+++ b/fontc_crater/src/target.rs
@@ -83,6 +83,17 @@ impl Target {
         &self.repo_dir
     }
 
+    /// The repo name without org prefix or sha suffix (e.g. "derp" from "org/derp_deadbeef")
+    pub(crate) fn repo_name(&self) -> &str {
+        let dir = self
+            .repo_dir
+            .file_name()
+            .unwrap_or(self.repo_dir.as_os_str());
+        let name = dir.to_str().unwrap_or("");
+        let suffix = format!("_{}", self.sha);
+        name.strip_suffix(&suffix).unwrap_or(name)
+    }
+
     pub(crate) fn source_path(&self, git_cache: &Path) -> PathBuf {
         let mut out = git_cache.join(self.source_dir());
         out.push(&self.source);


### PR DESCRIPTION
Specifically it had not occurred to me that we might have ~20 different sources in the same repo that were all named "font.ufo". The cache key now includes the full path to the source file.

Crater will also display more of the path in the html output in these sorts of cases, to make it less ambiguous.


This should fix the default builds; the gftools builds of these fonts are failing for a related reason that I will investigate shortly.

JMM
