### PR TITLE
[glyphs] Fix missing v2 interpolationCustom fallback

### DIFF
--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -1932,6 +1932,7 @@ struct RawInstance {
     interpolation_width: Option<OrderedFloat<f64>>,
 
     custom_value: Option<OrderedFloat<f64>>,
+    interpolation_custom: Option<OrderedFloat<f64>>,
 
     weight_class: Option<String>,
     width_class: Option<String>,
@@ -1953,6 +1954,7 @@ trait GlyphsV2OrderedAxes {
     fn width_value(&self) -> Option<OrderedFloat<f64>>;
     fn interpolation_width(&self) -> Option<OrderedFloat<f64>>;
     fn custom_value(&self) -> Option<OrderedFloat<f64>>;
+    fn interpolation_custom(&self) -> Option<OrderedFloat<f64>>;
 
     fn value_for_nth_axis(&self, nth_axis: usize) -> Result<OrderedFloat<f64>, Error> {
         // Per https://github.com/googlefonts/fontmake-rs/pull/42#pullrequestreview-1211619812
@@ -1969,7 +1971,10 @@ trait GlyphsV2OrderedAxes {
                 .width_value()
                 .or(self.interpolation_width())
                 .unwrap_or(100.0.into()),
-            2 => self.custom_value().unwrap_or(0.0.into()),
+            2 => self
+                .custom_value()
+                .or(self.interpolation_custom())
+                .unwrap_or(0.0.into()),
             _ => {
                 return Err(Error::StructuralError(format!(
                     "We don't know what field to use for axis {nth_axis}"
@@ -2005,6 +2010,11 @@ impl GlyphsV2OrderedAxes for RawFontMaster {
     fn custom_value(&self) -> Option<OrderedFloat<f64>> {
         self.custom_value
     }
+
+    fn interpolation_custom(&self) -> Option<OrderedFloat<f64>> {
+        // Masters use customValue, not interpolationCustom
+        None
+    }
 }
 
 impl GlyphsV2OrderedAxes for RawInstance {
@@ -2026,6 +2036,10 @@ impl GlyphsV2OrderedAxes for RawInstance {
 
     fn custom_value(&self) -> Option<OrderedFloat<f64>> {
         self.custom_value
+    }
+
+    fn interpolation_custom(&self) -> Option<OrderedFloat<f64>> {
+        self.interpolation_custom
     }
 }
 
@@ -6403,6 +6417,38 @@ name = _corner.hi;
         assert_eq!(
             font.custom_parameters.codepage_range_bits,
             Some(BTreeSet::from([0, 1, 19, 63]))
+        );
+    }
+
+    #[test]
+    fn v2_instance_interpolation_custom_third_axis() {
+        // In Glyphs v2, instances store the third axis value as interpolationCustom
+        // (masters use customValue). Without the interpolationCustom fallback, the
+        // third axis value would incorrectly be 0.0.
+        let font =
+            Font::load(&glyphs2_dir().join("ThreeAxisWithInterpolationCustom.glyphs")).unwrap();
+        assert_eq!(
+            vec![
+                (
+                    "Regular Caption",
+                    vec![("Weight", 400.0), ("Width", 100.0), ("Optical Size", 12.0)]
+                ),
+                (
+                    "Bold Display",
+                    vec![("Weight", 700.0), ("Width", 100.0), ("Optical Size", 72.0)]
+                ),
+            ],
+            font.instances
+                .iter()
+                .map(|inst| (
+                    inst.name.as_str(),
+                    font.axes
+                        .iter()
+                        .zip(&inst.axes_values)
+                        .map(|(a, v)| (a.name.as_str(), v.0))
+                        .collect::<Vec<_>>()
+                ))
+                .collect::<Vec<_>>()
         );
     }
 }

--- a/resources/testdata/glyphs2/ThreeAxisWithInterpolationCustom.glyphs
+++ b/resources/testdata/glyphs2/ThreeAxisWithInterpolationCustom.glyphs
@@ -1,0 +1,92 @@
+{
+.appVersion = "3219";
+customParameters = (
+{
+name = Axes;
+value = (
+{
+Name = Weight;
+Tag = wght;
+},
+{
+Name = Width;
+Tag = wdth;
+},
+{
+Name = "Optical Size";
+Tag = opsz;
+}
+);
+}
+);
+familyName = ThreeAxis;
+fontMaster = (
+{
+id = m01;
+weightValue = 400;
+widthValue = 100;
+customValue = 12;
+},
+{
+id = m02;
+weight = Bold;
+weightValue = 700;
+widthValue = 100;
+customValue = 12;
+},
+{
+id = m03;
+weightValue = 400;
+widthValue = 100;
+customValue = 72;
+},
+{
+id = m04;
+weight = Bold;
+weightValue = 700;
+widthValue = 100;
+customValue = 72;
+}
+);
+glyphs = (
+{
+glyphname = space;
+layers = (
+{
+layerId = m01;
+width = 200;
+},
+{
+layerId = m02;
+width = 250;
+},
+{
+layerId = m03;
+width = 200;
+},
+{
+layerId = m04;
+width = 250;
+}
+);
+unicode = 0020;
+}
+);
+instances = (
+{
+interpolationWeight = 400;
+interpolationWidth = 100;
+interpolationCustom = 12;
+name = "Regular Caption";
+},
+{
+interpolationWeight = 700;
+interpolationWidth = 100;
+interpolationCustom = 72;
+name = "Bold Display";
+}
+);
+unitsPerEm = 1000;
+versionMajor = 1;
+versionMinor = 0;
+}


### PR DESCRIPTION
Glyphs v2 instances store the third axis value as `interpolationCustom`, not `customValue` (which masters use). The fallback was already in place for axes 0 and 1 (interpolationWeight, interpolationWidth) but missing for axis 2, causing all instances to get 0.0 for the third axis.

Fixes Truculenta opsz=0.0 in all named instances.