### PR TITLE
[fea-rs] Fix silent loss of features from .fea files with CR line endings

### DIFF
--- a/fea-rs/src/parse/lexer.rs
+++ b/fea-rs/src/parse/lexer.rs
@@ -134,7 +134,7 @@ impl<'a> Lexer<'a> {
     }
 
     fn comment(&mut self) -> Kind {
-        while ![b'\n', EOF].contains(&self.nth(0)) {
+        while ![b'\n', b'\r', EOF].contains(&self.nth(0)) {
             self.bump();
         }
         Kind::Comment

--- a/fea-rs/src/parse/lexer.rs
+++ b/fea-rs/src/parse/lexer.rs
@@ -436,6 +436,28 @@ mod tests {
     }
 
     #[test]
+    fn comment_cr_line_endings() {
+        // CR-only line endings (classic Mac) must terminate comments
+        let fea = "# comment\rlanguagesystem DFLT cool;";
+        let tokens = tokenize(fea);
+        let token_strs = debug_tokens2(&tokens, fea);
+        assert_eq!(token_strs[0], "#(# comment)");
+        assert_eq!(token_strs[1], "WS(\r)");
+        assert_eq!(token_strs[2], "LanguagesystemKw");
+    }
+
+    #[test]
+    fn comment_crlf_line_endings() {
+        // CRLF line endings must terminate comments at the CR
+        let fea = "# comment\r\nlanguagesystem DFLT cool;";
+        let tokens = tokenize(fea);
+        let token_strs = debug_tokens2(&tokens, fea);
+        assert_eq!(token_strs[0], "#(# comment)");
+        assert_eq!(token_strs[1], "WS(\r\n)");
+        assert_eq!(token_strs[2], "LanguagesystemKw");
+    }
+
+    #[test]
     fn suffixes_good() {
         let fea = "1n -5.3u 31.1d 0n";
         let tokens = tokenize(fea);

--- a/fea-rs/src/parse/source.rs
+++ b/fea-rs/src/parse/source.rs
@@ -237,7 +237,7 @@ impl Source {
 
         (
             offset_idx + 1,
-            self.contents[start_offset..end_offset].trim_end_matches('\n'),
+            self.contents[start_offset..end_offset].trim_end_matches(['\n', '\r']),
         )
     }
 
@@ -250,13 +250,19 @@ impl Source {
 }
 
 fn line_offsets(text: &str) -> Arc<[usize]> {
-    // we could use memchar for this; benefits would require benchmarking
     let mut result = vec![0];
-    result.extend(
-        text.bytes()
-            .enumerate()
-            .filter_map(|(i, b)| if b == b'\n' { Some(i + 1) } else { None }),
-    );
+    let mut iter = text.bytes().enumerate().peekable();
+    while let Some((i, b)) = iter.next() {
+        match b {
+            b'\r' if iter.peek().map(|(_, b)| *b) == Some(b'\n') => {
+                // treat \r\n as a single line ending
+                let _ = iter.next();
+                result.push(i + 2);
+            }
+            b'\n' | b'\r' => result.push(i + 1),
+            _ => (),
+        }
+    }
     result.into()
 }
 
@@ -366,5 +372,35 @@ impl SourceLoadError {
             cause: cause.to_string().into(),
             path,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn line_offsets_lf() {
+        let offsets = line_offsets("aaa\nbbb\nccc");
+        assert_eq!(&*offsets, &[0, 4, 8]);
+    }
+
+    #[test]
+    fn line_offsets_cr() {
+        let offsets = line_offsets("aaa\rbbb\rccc");
+        assert_eq!(&*offsets, &[0, 4, 8]);
+    }
+
+    #[test]
+    fn line_offsets_crlf() {
+        let offsets = line_offsets("aaa\r\nbbb\r\nccc");
+        assert_eq!(&*offsets, &[0, 5, 10]);
+    }
+
+    #[test]
+    fn line_offsets_mixed() {
+        // LF then CR then CRLF
+        let offsets = line_offsets("a\nb\rc\r\nd");
+        assert_eq!(&*offsets, &[0, 2, 4, 7]);
     }
 }


### PR DESCRIPTION
fea-rs's lexer `comment()` only terminated `#` comments at `\n` (LF), not `\r` (CR). Files with CR-only line endings (classic Mac) had their entire contents consumed as a single comment token starting from the first `#`.

This silently drops all features from any included `.fea` file that uses CR-only line endings. Discovered via Bungee-Shade, where `sources/1-drawing/features/features.fea` uses CR terminators. fontc lost 13 GSUB features, the entire `latn` script, and 6 `name` UINameIDs.

Repro (on current `main`, before this PR):

```
python -m ttx_diff 'https://github.com/djrrb/Bungee?eb03cf69ad#sources/2-build/Bungee_Basic/Bungee-Shade.ufo'
```

After this PR: output is identical.


Also, `line_offsets()` and `line_containing_offset()` in `parse/source.rs` only recognized `\n`, producing wrong line numbers and garbled context in diagnostics for such files.
