### PR TITLE
[fontir] Normalize carriage returns in name table strings

### DIFF
--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -859,6 +859,13 @@ impl NameBuilder {
     }
 
     pub fn add(&mut self, name_id: NameId, value: String) {
+        // Work around plist crate not performing XML end-of-line normalization
+        // (XML 1.0 §2.11: \r\n → \n, bare \r → \n)
+        let value = if value.contains('\r') {
+            value.replace("\r\n", "\n").replace('\r', "\n")
+        } else {
+            value
+        };
         let key = NameKey::new(name_id, &value);
         self.names.insert(key, value);
         self.name_to_key.insert(name_id, key);
@@ -2661,5 +2668,20 @@ mod tests {
         }
 
         assert_eq!(new_instance.components[0].transform.as_coeffs(), [-1.; 6]);
+    }
+
+    #[test]
+    fn name_builder_normalizes_cr() {
+        let mut builder = NameBuilder::default();
+        builder.add(NameId::COPYRIGHT_NOTICE, "hello\rworld".to_string());
+        assert_eq!(builder.get(NameId::COPYRIGHT_NOTICE), Some("hello\nworld"));
+
+        let mut builder = NameBuilder::default();
+        builder.add(NameId::COPYRIGHT_NOTICE, "hello\r\nworld".to_string());
+        assert_eq!(builder.get(NameId::COPYRIGHT_NOTICE), Some("hello\nworld"));
+
+        let mut builder = NameBuilder::default();
+        builder.add(NameId::COPYRIGHT_NOTICE, "a\r\nb\rc\nd".to_string());
+        assert_eq!(builder.get(NameId::COPYRIGHT_NOTICE), Some("a\nb\nc\nd"));
     }
 }


### PR DESCRIPTION
This should be worth a +1/2 on crater.

-----

The plist crate does not perform XML end-of-line normalization per XML 1.0 section 2.11, so bare \r and \r\n sequences from .plist source files are preserved as-is. This causes fontc to emit name table strings (e.g. copyright notices) containing literal \r characters, while fontmake correctly normalizes them to \n.

Fix this by normalizing \r\n -> \n and bare \r -> \n in NameBuilder::add(), which is the single entry point for all name table values.