### PR TITLE
Merge OS/2 table from FEA into compiled results

### DIFF
--- a/fea-rs/src/compile.rs
+++ b/fea-rs/src/compile.rs
@@ -20,6 +20,7 @@ pub use language_system::LanguageSystem;
 pub use lookups::{FeatureKey, LookupId};
 pub use opts::Opts;
 pub use output::Compilation;
+pub use tables::Os2Builder;
 pub use variations::{AxisLocation, NopVariationInfo, VariationInfo};
 
 #[cfg(any(test, feature = "test", feature = "cli"))]

--- a/fea-rs/src/compile/compile_ctx.rs
+++ b/fea-rs/src/compile/compile_ctx.rs
@@ -286,6 +286,7 @@ impl<'a, F: FeatureProvider, V: VariationInfo> CompilationCtx<'a, F, V> {
                 hhea: self.tables.hhea.clone(),
                 vhea: self.tables.vhea.clone(),
                 os2: self.tables.os2.as_ref().map(|raw| raw.build()),
+                os2_builder: self.tables.os2.clone(),
                 gdef,
                 base: self.tables.base.as_ref().map(|raw| raw.build()),
                 name: name_builder.build(),

--- a/fea-rs/src/compile/compile_ctx.rs
+++ b/fea-rs/src/compile/compile_ctx.rs
@@ -1671,51 +1671,55 @@ impl<'a, F: FeatureProvider, V: VariationInfo> CompilationCtx<'a, F, V> {
                 typed::Os2TableItem::Number(val) => {
                     let value = val.number().parse_unsigned().unwrap();
                     match val.keyword().text.as_str() {
-                        "WeightClass" => os2.us_weight_class = value,
-                        "WidthClass" => os2.us_width_class = value,
+                        "WeightClass" => os2.us_weight_class = Some(value),
+                        "WidthClass" => os2.us_width_class = Some(value),
                         "LowerOpSize" => os2.us_lower_optical_point_size = Some(value),
                         "UpperOpSize" => os2.us_upper_optical_point_size = Some(value),
-                        "FSType" => os2.fs_type = value,
+                        "FSType" => os2.fs_type = Some(value),
                         _ => unreachable!("checked at parse time"),
                     }
                 }
                 typed::Os2TableItem::Metric(val) => {
                     let value = val.metric().parse_simple().expect("checked in validation");
                     match val.keyword().kind {
-                        Kind::TypoAscenderKw => os2.s_typo_ascender = value,
-                        Kind::TypoDescenderKw => os2.s_typo_descender = value,
-                        Kind::TypoLineGapKw => os2.s_typo_line_gap = value,
-                        Kind::XHeightKw => os2.sx_height = value,
-                        Kind::CapHeightKw => os2.s_cap_height = value,
-                        Kind::WinAscentKw => os2.us_win_ascent = value as u16,
-                        Kind::WinDescentKw => os2.us_win_descent = value as u16,
+                        Kind::TypoAscenderKw => os2.s_typo_ascender = Some(value),
+                        Kind::TypoDescenderKw => os2.s_typo_descender = Some(value),
+                        Kind::TypoLineGapKw => os2.s_typo_line_gap = Some(value),
+                        Kind::XHeightKw => os2.sx_height = Some(value),
+                        Kind::CapHeightKw => os2.s_cap_height = Some(value),
+                        Kind::WinAscentKw => os2.us_win_ascent = Some(value as u16),
+                        Kind::WinDescentKw => os2.us_win_descent = Some(value as u16),
                         _ => unreachable!("checked at parse time"),
                     }
                 }
                 typed::Os2TableItem::NumberList(list) => match list.keyword().kind {
                     Kind::PanoseKw => {
+                        let panose = os2.panose_10.get_or_insert_default();
                         for (i, val) in list.values().enumerate() {
-                            os2.panose_10[i] = val.parse_signed() as u8;
+                            panose[i] = val.parse_signed() as u8;
                         }
                     }
                     Kind::UnicodeRangeKw => {
                         for val in list.values() {
-                            os2.unicode_range.set_bit(val.parse_signed() as _);
+                            os2.unicode_range
+                                .get_or_insert_default()
+                                .set_bit(val.parse_signed() as _);
                         }
                     }
                     Kind::CodePageRangeKw => {
                         for val in list.values() {
                             os2.code_page_range
+                                .get_or_insert_default()
                                 .add_code_page(val.parse_unsigned().unwrap());
                         }
                     }
                     _ => unreachable!("checked at parse time"),
                 },
                 typed::Os2TableItem::Vendor(item) => {
-                    os2.ach_vend_id = item.parse_tag().expect("validated");
+                    os2.ach_vend_id = Some(item.parse_tag().expect("validated"));
                 }
                 typed::Os2TableItem::FamilyClass(item) => {
-                    os2.s_family_class = item.value().parse().unwrap() as i16
+                    os2.s_family_class = Some(item.value().parse().unwrap() as i16)
                 }
             }
         }

--- a/fea-rs/src/compile/output.rs
+++ b/fea-rs/src/compile/output.rs
@@ -38,6 +38,11 @@ pub struct Compilation {
     pub vhea: Option<wtables::vhea::Vhea>,
     /// The `OS/2` table, if one was generated
     pub os2: Option<wtables::os2::Os2>,
+    /// The OS/2 builder, preserving which fields were explicitly set in FEA.
+    ///
+    /// Use this to determine which fields should override computed values:
+    /// a field with `Some` was explicitly specified in the FEA source.
+    pub os2_builder: Option<super::tables::Os2Builder>,
     /// The `GDEF` table, if one was generated
     pub gdef: Option<wtables::gdef::Gdef>,
     /// The `BASE` table, if one was generated

--- a/fea-rs/src/compile/tables.rs
+++ b/fea-rs/src/compile/tables.rs
@@ -31,7 +31,8 @@ pub(crate) use base::{BASELINE_TAGS, BaseAxisBuilder, BaseBuilder, ScriptRecord}
 pub(crate) use debg::{DEBG_TAG, DebgBuilder, LookupDebugInfo};
 pub(crate) use gdef::{GdefBuilder, GlyphClassDefExt};
 pub(crate) use name::{NameBuilder, NameSpec};
-pub(crate) use os2::{CodePageRange, Os2Builder};
+pub(crate) use os2::CodePageRange;
+pub use os2::Os2Builder;
 pub(crate) use stat::{AxisLocation, AxisRecord, AxisValue, StatBuilder, StatFallbackName};
 
 /// The explicit tables allowed in a fea file

--- a/fea-rs/src/compile/tables/os2.rs
+++ b/fea-rs/src/compile/tables/os2.rs
@@ -3,15 +3,20 @@
 use write_fonts::types::Tag;
 
 /// [ulUnicodeRangeN](https://learn.microsoft.com/en-us/typography/opentype/spec/os2#ulunicoderange1-bits-031ulunicoderange2-bits-3263ulunicoderange3-bits-6495ulunicoderange4-bits-96127)
-#[derive(Clone, Debug, Default)]
-pub(crate) struct UnicodeRange([u32; 4]);
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct UnicodeRange([u32; 4]);
 
 /// [ulCodePageRangeN](https://learn.microsoft.com/en-us/typography/opentype/spec/os2#ulcodepagerange1-bits-031ulcodepagerange2-bits-3263)
-#[derive(Clone, Debug, Default)]
-pub(crate) struct CodePageRange([u32; 2]);
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct CodePageRange([u32; 2]);
 
-#[derive(Clone, Debug, Default)]
-pub(crate) struct Os2Builder {
+/// Builder for the OS/2 table from FEA `table OS/2 { ... }` blocks.
+///
+/// Fields are `Option<T>` — `Some` means the field was explicitly set in FEA,
+/// `None` means it was not mentioned and should not override computed values.
+#[allow(missing_docs)]
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct Os2Builder {
     pub us_weight_class: Option<u16>,
     pub us_width_class: Option<u16>,
     pub fs_type: Option<u16>,
@@ -59,6 +64,7 @@ fn set_bit_impl<const N: usize>(array: &mut [u32; N], bit: u8) {
 }
 
 impl Os2Builder {
+    /// Build the write-fonts `Os2` table, using defaults for unset fields.
     pub fn build(&self) -> write_fonts::tables::os2::Os2 {
         let code_page_range = self.code_page_range.as_ref().map_or([0; 2], |r| r.0);
         let unicode_range = self.unicode_range.as_ref().map_or([0; 4], |r| r.0);

--- a/fea-rs/src/compile/tables/os2.rs
+++ b/fea-rs/src/compile/tables/os2.rs
@@ -12,21 +12,21 @@ pub(crate) struct CodePageRange([u32; 2]);
 
 #[derive(Clone, Debug, Default)]
 pub(crate) struct Os2Builder {
-    pub us_weight_class: u16,
-    pub us_width_class: u16,
-    pub fs_type: u16,
-    pub s_family_class: i16,
-    pub panose_10: [u8; 10],
-    pub unicode_range: UnicodeRange,
-    pub ach_vend_id: Tag,
-    pub us_win_ascent: u16,
-    pub us_win_descent: u16,
-    pub code_page_range: CodePageRange,
-    pub sx_height: i16,
-    pub s_cap_height: i16,
-    pub s_typo_ascender: i16,
-    pub s_typo_descender: i16,
-    pub s_typo_line_gap: i16,
+    pub us_weight_class: Option<u16>,
+    pub us_width_class: Option<u16>,
+    pub fs_type: Option<u16>,
+    pub s_family_class: Option<i16>,
+    pub panose_10: Option<[u8; 10]>,
+    pub unicode_range: Option<UnicodeRange>,
+    pub ach_vend_id: Option<Tag>,
+    pub us_win_ascent: Option<u16>,
+    pub us_win_descent: Option<u16>,
+    pub code_page_range: Option<CodePageRange>,
+    pub sx_height: Option<i16>,
+    pub s_cap_height: Option<i16>,
+    pub s_typo_ascender: Option<i16>,
+    pub s_typo_descender: Option<i16>,
+    pub s_typo_line_gap: Option<i16>,
     pub us_lower_optical_point_size: Option<u16>,
     pub us_upper_optical_point_size: Option<u16>,
 }
@@ -60,34 +60,29 @@ fn set_bit_impl<const N: usize>(array: &mut [u32; N], bit: u8) {
 
 impl Os2Builder {
     pub fn build(&self) -> write_fonts::tables::os2::Os2 {
-        let [ul_code_page_range_1, ul_code_page_range_2] = self.code_page_range.0;
-        let [
-            ul_unicode_range_1,
-            ul_unicode_range_2,
-            ul_unicode_range_3,
-            ul_unicode_range_4,
-        ] = self.unicode_range.0;
+        let code_page_range = self.code_page_range.as_ref().map_or([0; 2], |r| r.0);
+        let unicode_range = self.unicode_range.as_ref().map_or([0; 4], |r| r.0);
 
         write_fonts::tables::os2::Os2 {
-            us_weight_class: self.us_weight_class,
-            us_width_class: self.us_width_class,
-            fs_type: self.fs_type,
-            s_family_class: self.s_family_class,
-            ul_unicode_range_1,
-            ul_unicode_range_2,
-            ul_unicode_range_3,
-            ul_unicode_range_4,
-            panose_10: self.panose_10,
-            ach_vend_id: self.ach_vend_id,
-            s_typo_ascender: self.s_typo_ascender,
-            s_typo_descender: self.s_typo_descender,
-            s_typo_line_gap: self.s_typo_line_gap,
-            us_win_ascent: self.us_win_ascent,
-            us_win_descent: self.us_win_descent,
-            ul_code_page_range_1: Some(ul_code_page_range_1),
-            ul_code_page_range_2: Some(ul_code_page_range_2),
-            sx_height: Some(self.sx_height),
-            s_cap_height: Some(self.s_cap_height),
+            us_weight_class: self.us_weight_class.unwrap_or_default(),
+            us_width_class: self.us_width_class.unwrap_or_default(),
+            fs_type: self.fs_type.unwrap_or_default(),
+            s_family_class: self.s_family_class.unwrap_or_default(),
+            ul_unicode_range_1: unicode_range[0],
+            ul_unicode_range_2: unicode_range[1],
+            ul_unicode_range_3: unicode_range[2],
+            ul_unicode_range_4: unicode_range[3],
+            panose_10: self.panose_10.unwrap_or_default(),
+            ach_vend_id: self.ach_vend_id.unwrap_or_default(),
+            s_typo_ascender: self.s_typo_ascender.unwrap_or_default(),
+            s_typo_descender: self.s_typo_descender.unwrap_or_default(),
+            s_typo_line_gap: self.s_typo_line_gap.unwrap_or_default(),
+            us_win_ascent: self.us_win_ascent.unwrap_or_default(),
+            us_win_descent: self.us_win_descent.unwrap_or_default(),
+            ul_code_page_range_1: Some(code_page_range[0]),
+            ul_code_page_range_2: Some(code_page_range[1]),
+            sx_height: Some(self.sx_height.unwrap_or_default()),
+            s_cap_height: Some(self.s_cap_height.unwrap_or_default()),
             //TODO: these are defined in fea, but we want them to be present
             //since other v2 fields are? I assume they get overwritten anyway?
             us_default_char: Some(0),

--- a/fontbe/src/features.rs
+++ b/fontbe/src/features.rs
@@ -664,7 +664,7 @@ impl Work<Context, AnyWorkId, Error> for FeatureCompilationWork {
         // so we can merge later on
         if result.has_non_layout_tables() {
             let extras = ExtraFeaTables::from(result);
-            // we're currently only handling 'name'; if other tables are in
+            // we're currently only handling 'name' and OS/2; if other tables are in
             // here we probably need to do something with them too, so let's warn
             extras.log_unhandled_extras();
             context.extra_fea_tables.set(extras);

--- a/fontbe/src/orchestration.rs
+++ b/fontbe/src/orchestration.rs
@@ -231,6 +231,11 @@ pub struct ExtraFeaTables {
     pub base: Option<Base>,
     pub stat: Option<Stat>,
     pub debg: Option<Vec<u8>>,
+    /// The OS/2 builder, preserving which fields were explicitly set in FEA.
+    ///
+    /// Not serialized — only available in the same compilation session.
+    #[serde(skip)]
+    pub os2_builder: Option<fea_rs::compile::Os2Builder>,
 }
 
 impl From<Compilation> for ExtraFeaTables {
@@ -240,6 +245,7 @@ impl From<Compilation> for ExtraFeaTables {
             hhea,
             vhea,
             os2,
+            os2_builder,
             base,
             name,
             stat,
@@ -255,6 +261,7 @@ impl From<Compilation> for ExtraFeaTables {
             stat,
             name,
             debg,
+            os2_builder,
         }
     }
 }
@@ -265,7 +272,6 @@ impl ExtraFeaTables {
             ("head", self.head.is_some()),
             ("hhea", self.hhea.is_some()),
             ("vhea", self.vhea.is_some()),
-            ("os2", self.os2.is_some()),
             ("base", self.base.is_some()),
             ("stat", self.stat.is_some()),
         ] {
@@ -297,6 +303,7 @@ impl Persistable for ExtraFeaTables {
             stat: read_table(stat.as_ref()),
             name: read_table(name.as_ref()),
             debg,
+            os2_builder: None, // not persisted
         }
     }
 
@@ -313,6 +320,7 @@ impl Persistable for ExtraFeaTables {
             stat,
             name,
             debg,
+            os2_builder: _, // not persisted
         } = self;
 
         let out = [

--- a/fontbe/src/os2.rs
+++ b/fontbe/src/os2.rs
@@ -522,6 +522,7 @@ impl Work<Context, AnyWorkId, Error> for Os2Work {
             .variant(WorkId::Gpos)
             .variant(WorkId::Gsub)
             .variant(FeWorkId::ALL_GLYPHS)
+            .variant(WorkId::ExtraFeaTables)
             .build()
     }
 
@@ -591,8 +592,67 @@ impl Work<Context, AnyWorkId, Error> for Os2Work {
 
         apply_max_context(&mut os2, context);
 
+        // Apply FEA `table OS/2 { ... }` overrides for explicitly set fields.
+        // Uses the builder to determine which fields were actually specified in FEA,
+        // matching fonttools feaLib behavior where only mentioned fields are overridden:
+        // https://github.com/fonttools/fonttools/blob/47813b21/Lib/fontTools/feaLib/builder.py#L466-L525
+        if let Some(extras) = context.extra_fea_tables.try_get()
+            && let (Some(fea_os2), Some(builder)) = (&extras.os2, &extras.os2_builder)
+        {
+            merge_fea_os2(&mut os2, fea_os2, builder);
+        }
+
         context.os2.set(os2);
         Ok(())
+    }
+}
+
+/// Merge FEA `table OS/2 { ... }` overrides into the OS/2 table.
+///
+/// Only fields that were explicitly set in the FEA source are applied, using the
+/// builder's `Option` fields to determine presence.  Values come from `fea_os2`
+/// (the fully built table) rather than the builder, since the builder's compound
+/// types (`UnicodeRange`, `CodePageRange`) are not publicly accessible.
+fn merge_fea_os2(os2: &mut Os2, fea_os2: &Os2, builder: &fea_rs::compile::Os2Builder) {
+    macro_rules! apply {
+        ($field:ident) => {
+            if builder.$field.is_some() {
+                os2.$field = fea_os2.$field;
+            }
+        };
+    }
+
+    apply!(us_weight_class);
+    apply!(us_width_class);
+    apply!(fs_type);
+    apply!(s_family_class);
+    apply!(ach_vend_id);
+    apply!(s_typo_ascender);
+    apply!(s_typo_descender);
+    apply!(s_typo_line_gap);
+    apply!(us_win_ascent);
+    apply!(us_win_descent);
+    apply!(sx_height);
+    apply!(s_cap_height);
+    apply!(us_lower_optical_point_size);
+    apply!(us_upper_optical_point_size);
+
+    if builder.panose_10.is_some() {
+        os2.panose_10 = fea_os2.panose_10;
+    }
+
+    // unicode_range and code_page_range are compound fields in the builder
+    // but map to individual u32 fields in the Os2 table
+    if builder.unicode_range.is_some() {
+        os2.ul_unicode_range_1 = fea_os2.ul_unicode_range_1;
+        os2.ul_unicode_range_2 = fea_os2.ul_unicode_range_2;
+        os2.ul_unicode_range_3 = fea_os2.ul_unicode_range_3;
+        os2.ul_unicode_range_4 = fea_os2.ul_unicode_range_4;
+    }
+
+    if builder.code_page_range.is_some() {
+        os2.ul_code_page_range_1 = fea_os2.ul_code_page_range_1;
+        os2.ul_code_page_range_2 = fea_os2.ul_code_page_range_2;
     }
 }
 
@@ -702,5 +762,78 @@ mod tests {
             (0xFFFF, 0xFFFF),
             (os2.us_first_char_index, os2.us_last_char_index)
         );
+    }
+
+    #[test]
+    fn merge_fea_os2_only_applies_set_fields() {
+        // Simulate: FEA says `FSType 8;` and `TypoAscender 950;` but nothing else.
+        // The computed OS/2 has its own values that should be preserved for unset fields.
+        let mut os2 = Os2 {
+            us_weight_class: 400,
+            us_width_class: 5,
+            fs_type: 4,             // will be overridden
+            s_typo_ascender: 800,   // will be overridden
+            s_typo_descender: -200, // not overridden
+            us_win_ascent: 1000,
+            ..Default::default()
+        };
+
+        // The FEA-built table has values for everything (build() fills defaults)
+        let fea_os2 = Os2 {
+            fs_type: 8,
+            s_typo_ascender: 950,
+            ..Default::default()
+        };
+
+        // The builder only has Some for fields explicitly in the FEA source
+        let builder = fea_rs::compile::Os2Builder {
+            fs_type: Some(8),
+            s_typo_ascender: Some(950),
+            ..Default::default()
+        };
+
+        merge_fea_os2(&mut os2, &fea_os2, &builder);
+
+        // Explicitly set fields are overridden
+        assert_eq!(8, os2.fs_type);
+        assert_eq!(950, os2.s_typo_ascender);
+        // Unset fields are preserved from the computed table
+        assert_eq!(400, os2.us_weight_class);
+        assert_eq!(5, os2.us_width_class);
+        assert_eq!(-200, os2.s_typo_descender);
+        assert_eq!(1000, os2.us_win_ascent);
+    }
+
+    #[test]
+    fn merge_fea_os2_explicit_zero_overrides() {
+        // Key bug case: FEA explicitly sets `FSType 0;` and `TypoLineGap 0;`
+        // to override non-zero values from fontinfo. The builder has Some(0)
+        // which must still cause an override.
+        let mut os2 = Os2 {
+            fs_type: 4,
+            s_typo_line_gap: 200,
+            us_win_ascent: 1000,
+            ..Default::default()
+        };
+
+        let fea_os2 = Os2 {
+            fs_type: 0,
+            s_typo_line_gap: 0,
+            ..Default::default()
+        };
+
+        let builder = fea_rs::compile::Os2Builder {
+            fs_type: Some(0),
+            s_typo_line_gap: Some(0),
+            ..Default::default()
+        };
+
+        merge_fea_os2(&mut os2, &fea_os2, &builder);
+
+        // Explicit zeros override non-zero computed values
+        assert_eq!(0, os2.fs_type);
+        assert_eq!(0, os2.s_typo_line_gap);
+        // Unset fields preserved
+        assert_eq!(1000, os2.us_win_ascent);
     }
 }


### PR DESCRIPTION
This is annoying because we need to make sure we only merge in fields that were explicitly set in FEA, and that state is not currently preserved. This handles that by exposing the `Os2Builder` type, and making fields on that type be `Option`s.

Other tables should be more straightforward, and I'll do them afterwards.


progress on #1364 