### PR TITLE
[fea-rs] Strip newlines from string literals

### DIFF
--- a/fea-rs/src/compile/compile_ctx.rs
+++ b/fea-rs/src/compile/compile_ctx.rs
@@ -1973,7 +1973,7 @@ impl<'a, F: FeatureProvider, V: VariationInfo> CompilationCtx<'a, F, V> {
             platform_id,
             encoding_id,
             language_id,
-            string: node.string().into(),
+            string: SmolStr::from(node.string().as_ref()),
         }
     }
 

--- a/fea-rs/src/parse/grammar/metrics.rs
+++ b/fea-rs/src/parse/grammar/metrics.rs
@@ -527,12 +527,11 @@ mod tests {
 
             crate::typed::NameSpec::cast(&token).unwrap()
         };
+        assert_eq!("", parse_name("3 1 0x409 \"\"").string());
+        assert_eq!("duck", parse_name("3 1 0x409 \"duck\"").string());
         assert_eq!(
-            ["", "duck"],
-            [
-                parse_name("3 1 0x409 \"\"").string(),
-                parse_name("3 1 0x409 \"duck\"").string(),
-            ]
+            "i have some newlines",
+            parse_name("3 1 0x409 \"i have\n some \rnewlines\"").string()
         );
     }
 }

--- a/fea-rs/src/token_tree/typed.rs
+++ b/fea-rs/src/token_tree/typed.rs
@@ -7,6 +7,7 @@
 //! This lets us implement useful methods on specific AST nodes, which are
 //! internally working on untyped `NodeOrToken`s.
 
+use std::borrow::Cow;
 use std::convert::TryFrom;
 use std::ops::Range;
 
@@ -1549,10 +1550,17 @@ impl NameSpec {
         self.find_token(Kind::String).unwrap()
     }
 
-    pub(crate) fn string(&self) -> &str {
+    pub(crate) fn string(&self) -> Cow<'_, str> {
         // The value is always doublequoted so slice out the actual string
         let s = self.string_token().as_str();
-        &s[1..s.len() - 1]
+        let s = &s[1..s.len() - 1];
+        // Per the FEA spec: "Newlines embedded within the string are removed
+        // from the character sequence to be stored."
+        if s.contains(['\n', '\r']) {
+            Cow::Owned(s.replace(['\n', '\r'], ""))
+        } else {
+            Cow::Borrowed(s)
+        }
     }
 }
 


### PR DESCRIPTION
see https://adobe-type-tools.github.io/afdko/OpenTypeFeatureFileSpecification.html#:~:text=Newlines%20embedded%20within%20the%20string%20are%20removed