### PR TITLE
[fontdrasil] Fix many-to-one axis map handling

### DIFF
--- a/fontdrasil/src/piecewise_linear_map.rs
+++ b/fontdrasil/src/piecewise_linear_map.rs
@@ -136,6 +136,62 @@ mod tests {
     }
 
     #[test]
+    fn many_to_one_reverse() {
+        // https://github.com/googlefonts/ufo2ft/issues/978
+        // user=900 and user=1000 both map to design=1000
+        let user_to_design = PiecewiseLinearMap::new(vec![
+            (OrderedFloat(100_f64), OrderedFloat(100_f64)),
+            (OrderedFloat(800_f64), OrderedFloat(780_f64)),
+            (OrderedFloat(900_f64), OrderedFloat(1000_f64)),
+            (OrderedFloat(1000_f64), OrderedFloat(1000_f64)),
+        ]);
+        let design_to_user = user_to_design.reverse();
+
+        // Exact match at the flat value should return the first user value
+        assert_eq!(
+            design_to_user.map(OrderedFloat(1000_f64)),
+            OrderedFloat(900_f64)
+        );
+
+        // Interpolation before the flat segment
+        let result = design_to_user.map(OrderedFloat(800_f64)).0;
+        let expected = 800.0 + (800.0 - 780.0) / (1000.0 - 780.0) * (900.0 - 800.0);
+        assert!(
+            (result - expected).abs() < 1e-10,
+            "expected {expected}, got {result}"
+        );
+    }
+
+    #[test]
+    fn many_to_one_mid_range() {
+        // Flat segment in the middle: both user=400 and user=500 map to design=50
+        let user_to_design = PiecewiseLinearMap::new(vec![
+            (OrderedFloat(100_f64), OrderedFloat(10_f64)),
+            (OrderedFloat(400_f64), OrderedFloat(50_f64)),
+            (OrderedFloat(500_f64), OrderedFloat(50_f64)),
+            (OrderedFloat(700_f64), OrderedFloat(80_f64)),
+            (OrderedFloat(900_f64), OrderedFloat(100_f64)),
+        ]);
+        let design_to_user = user_to_design.reverse();
+
+        // Before the flat segment
+        let result = design_to_user.map(OrderedFloat(45_f64)).0;
+        let expected = 100.0 + (45.0 - 10.0) / (50.0 - 10.0) * (400.0 - 100.0);
+        assert!(
+            (result - expected).abs() < 1e-10,
+            "expected {expected}, got {result}"
+        );
+
+        // After the flat segment
+        let result = design_to_user.map(OrderedFloat(65_f64)).0;
+        let expected = 500.0 + (65.0 - 50.0) / (80.0 - 50.0) * (700.0 - 500.0);
+        assert!(
+            (result - expected).abs() < 1e-10,
+            "expected {expected}, got {result}"
+        );
+    }
+
+    #[test]
     fn float_precision() {
         // https://github.com/googlefonts/fontc/issues/1117
         let from_to = vec![

--- a/fontdrasil/src/piecewise_linear_map.rs
+++ b/fontdrasil/src/piecewise_linear_map.rs
@@ -56,7 +56,13 @@ impl PiecewiseLinearMap {
         #[allow(clippy::indexing_slicing)]
         // Either the binary_search found it, or it's within 0..len
         match self.from.binary_search(&value) {
-            Ok(idx) => self.to[idx], // This value is just right
+            Ok(_) => {
+                // Find the first occurrence; binary_search may return any
+                // index when there are duplicates (many-to-one maps).
+                // https://github.com/googlefonts/ufo2ft/issues/978
+                let first = self.from.partition_point(|x| x < &value);
+                self.to[first]
+            }
             Err(idx) => {
                 // idx is where we would insert from.
                 // Interpolate between the values left/right of it, if any.

--- a/glyphs2fontir/src/toir.rs
+++ b/glyphs2fontir/src/toir.rs
@@ -204,7 +204,7 @@ fn to_ir_axis(
         && !font.axis_mappings.get(&axis.name).unwrap().is_identity()
         && min != max;
 
-    let converter = if has_non_identity_mapping {
+    let (converter, user_min, user_default, user_max) = if has_non_identity_mapping {
         let mappings: Vec<_> = font
             .axis_mappings
             .get(&axis.name)
@@ -213,16 +213,30 @@ fn to_ir_axis(
             .map(|(u, d)| (UserCoord::new(*u), DesignCoord::new(*d)))
             .collect();
         let default_idx = find_by_design_coord(&mappings, default, axis.name.as_str(), "default")?;
-        // Make sure we have min and max mappings
-        find_by_design_coord(&mappings, min, axis.name.as_str(), "min")?;
-        find_by_design_coord(&mappings, max, axis.name.as_str(), "max")?;
-        CoordConverter::new(mappings, default_idx)?
+        let min_idx = find_by_design_coord(&mappings, min, axis.name.as_str(), "min")?;
+        let max_idx = find_by_design_coord(&mappings, max, axis.name.as_str(), "max")?;
+        // Use user-space values directly from the mapping, matching glyphsLib.
+        // Don't round-trip via design_to_user which is lossy for many-to-one maps.
+        let user_min = mappings[min_idx].0;
+        let user_default = mappings[default_idx].0;
+        let user_max = mappings[max_idx].0;
+        (
+            CoordConverter::new(mappings, default_idx)?,
+            user_min,
+            user_default,
+            user_max,
+        )
     } else {
         // There is no meaningful mapping; design == user
         let min = UserCoord::new(min.into_inner());
         let max = UserCoord::new(max.into_inner());
         let default = UserCoord::new(default.into_inner());
-        CoordConverter::unmapped(min, default, max)
+        (
+            CoordConverter::unmapped(min, default, max),
+            min,
+            default,
+            max,
+        )
     };
 
     Ok(fontdrasil::types::Axis {
@@ -232,9 +246,9 @@ fn to_ir_axis(
             cause,
         })?,
         hidden: axis.hidden.unwrap_or(false),
-        min: min.to_user(&converter),
-        default: default.to_user(&converter),
-        max: max.to_user(&converter),
+        min: user_min,
+        default: user_default,
+        max: user_max,
         converter,
         // localized axis names from .glyphs sources aren't supported yet
         // https://forum.glyphsapp.com/t/localisable-axis-names/19028
@@ -724,8 +738,9 @@ pub(crate) fn to_ir_paint(
 mod tests {
     use glyphs_reader::{Font, Glyph, Layer, LayerAttributes, Node, Path};
     use std::path::PathBuf;
+    use std::str::FromStr;
 
-    use super::{split_color_glyphs, to_ir_path};
+    use super::{FontInfo, split_color_glyphs, to_ir_path};
 
     fn testdata_dir() -> PathBuf {
         let dir = PathBuf::from("../resources/testdata");
@@ -877,6 +892,21 @@ mod tests {
             !color_glyphs.contains_key("empty_color"),
             "COLRv1 glyph with empty color layer should not be added to color_glyphs"
         );
+    }
+
+    /// When multiple user-space values map to the same design-space value
+    /// (a many-to-one axis map), the axis max should reflect the largest
+    /// user-space value, not the result of a lossy design-to-user round-trip.
+    /// https://github.com/googlefonts/ufo2ft/issues/978
+    #[test]
+    fn many_to_one_axis_map_preserves_max() {
+        let font = Font::load(&testdata_dir().join("glyphs3/ManyToOneAxisMap.glyphs")).unwrap();
+        let font_info = FontInfo::try_from(font).unwrap();
+        let wght_tag = write_fonts::types::Tag::from_str("wght").unwrap();
+        let wght = font_info.axes.get(&wght_tag).unwrap();
+        // user=900 and user=1000 both map to design=1000;
+        // axis max must be 1000 (the largest user value), not 900
+        assert_eq!(wght.max, fontdrasil::coords::UserCoord::new(1000.0));
     }
 
     /// Test that a layer with palette index 0xFFFF produces a PaintSolid with color `None`.

--- a/resources/testdata/glyphs3/ManyToOneAxisMap.glyphs
+++ b/resources/testdata/glyphs3/ManyToOneAxisMap.glyphs
@@ -1,0 +1,78 @@
+{
+.appVersion = "3436";
+.formatVersion = 3;
+axes = (
+{
+name = Weight;
+tag = wght;
+}
+);
+customParameters = (
+{
+name = "Axis Mappings";
+value = {
+wght = {
+100 = 100;
+800 = 780;
+900 = 1000;
+1000 = 1000;
+};
+};
+}
+);
+fontMaster = (
+{
+axesValues = (
+100
+);
+iconName = Light;
+id = master01;
+name = Light;
+},
+{
+axesValues = (
+1000
+);
+id = master02;
+name = Black;
+}
+);
+glyphs = (
+{
+glyphname = space;
+layers = (
+{
+layerId = master01;
+width = 200;
+},
+{
+layerId = master02;
+width = 250;
+}
+);
+}
+);
+instances = (
+{
+axesValues = (
+100
+);
+instanceInterpolations = {
+master01 = 1;
+};
+name = Light;
+},
+{
+axesValues = (
+1000
+);
+instanceInterpolations = {
+master02 = 1;
+};
+name = Black;
+}
+);
+unitsPerEm = 1000;
+versionMajor = 1;
+versionMinor = 1;
+}


### PR DESCRIPTION
This is the companion to fonttools/fonttools#4085.

Fixes the remaining `ttx_diff` discrepancy on [SUSE-Italic at 7159afb255](https://github.com/SUSE/suse-font/tree/7159afb255) reported in https://github.com/googlefonts/ufo2ft/issues/978

"output is identical" in ttx-diff after updated fonttools is installed in the fontc `.venv`.

---

`PiecewiseLinearMap::map()` uses `binary_search`, which returns an arbitrary/unspecified index when there are multiple matches:

https://doc.rust-lang.org/std/primitive.slice.html#method.binary_search

When a many-to-one forward map (e.g. user=900 -> design=1000 and user=1000 -> design=1000) is reversed, the value returned from binary_search can differ from fontmake's (which takes the first match).

I changed it to use `partition_point` to always find the first occurrence.

After fixing this I found a second related issue: `to_ir_axis` derived fvar axis min/default/max by round-tripping design coords through `design_to_user`, which is lossy for many-to-one maps.

Changed it to take min/max directly from the user-space values in the mapping, [matching glyphsLib's approach](https://github.com/googlefonts/glyphsLib/blob/75c07d4213e1e7693a220d54c2fed4755cfc4131/Lib/glyphsLib/builder/axes.py#L284-L285).

(I will release a patched fonttools soon and bump fontc requirements after)
