### PR TITLE
[glyphs] Fix parse_int/_float for leading-zero ints

### DIFF
--- a/glyphs-reader/src/plist.rs
+++ b/glyphs-reader/src/plist.rs
@@ -655,20 +655,20 @@ impl From<Dictionary> for Plist {
 }
 
 pub(crate) fn parse_int(s: &str) -> Result<i64, Error> {
-    if numeric_ok(s) {
-        if let Ok(num) = s.parse::<i64>() {
-            return Ok(num);
-        }
-        if let Ok(num) = s.parse::<f64>() {
-            return Ok(num as i64);
-        }
+    if let Ok(num) = s.parse::<i64>() {
+        return Ok(num);
+    }
+    if let Ok(num) = s.parse::<f64>()
+        && num.is_finite()
+    {
+        return Ok(num as i64);
     }
     Err(Error::ExpectedNumber)
 }
 
 pub(crate) fn parse_float(s: &str) -> Result<f64, Error> {
-    if numeric_ok(s)
-        && let Ok(num) = s.parse::<f64>()
+    if let Ok(num) = s.parse::<f64>()
+        && num.is_finite()
     {
         return Ok(num);
     }
@@ -994,6 +994,30 @@ mod tests {
         let foobar = BTreeMap::<SmolStr, i64>::parse_plist(contents).unwrap();
         assert_eq!(foobar.get("foo"), Some(&5));
         assert_eq!(foobar.get("bar"), Some(&32));
+    }
+
+    #[test]
+    fn parse_int_leading_zero() {
+        let contents = r#"
+        {
+            versionMinor = 011;
+            other = 0;
+        }"#;
+
+        let map = BTreeMap::<SmolStr, i64>::parse_plist(contents).unwrap();
+        assert_eq!(map.get("versionMinor"), Some(&11));
+        assert_eq!(map.get("other"), Some(&0));
+    }
+
+    #[test]
+    #[should_panic(expected = "ExpectedNumber")]
+    fn parse_int_rejects_infinity() {
+        let contents = r#"
+        {
+            bad = infinity;
+        }"#;
+
+        let _map = BTreeMap::<SmolStr, i64>::parse_plist(contents).unwrap();
     }
 
     #[test]


### PR DESCRIPTION
The `numeric_ok` guard in `parse_int`/`parse_float` was rejecting all-digit strings with leading zeros (like "011") to prevent `parse_atom` from misclassifying hex codepoints (like "0041") as integers. But `parse_int`/`parse_float` are called from typed struct parsing where the field is already known to be numeric — the ambiguity that `numeric_ok` solves doesn't exist in that context.

Remove the `numeric_ok` gate entirely and just try parsing directly. Guard the f64 fallback with `is_finite()` to reject "infinity"/"nan".

Fixes compilation of Federant (versionMinor = 011).