### PR TITLE
Update norad to v0.18.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ smallvec = {version = "1.15", features = ["const_new"]}
 # fontations etc
 write-fonts = { version = "0.48.0", features = ["serde", "read"] }
 skrifa = { version = "0.42.0", features = ["traversal"] }
-norad = { version = "0.18.3", default-features = false }
+norad = { version = "0.18.4", default-features = false }
 
 # dev dependencies
 criterion = "0.7"


### PR DESCRIPTION
This brings in a fix that allows parsing of legacy designspace rules (bare <condition>s that are not inside a <conditionset>.)

This matches fonttools, and exists in at least one extant font source (Bitcount)