### PR TITLE
[ufo] Use codepoints declared in default glyph instance

### DIFF
--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -1148,6 +1148,29 @@ mod tests {
         }
     }
 
+    /// When instances disagree on codepoints, we use the default master's codepoints.
+    /// This must not produce a cmap conflict (duplicate mappings or missing entries).
+    #[test]
+    fn codepoint_mismatch_uses_default_in_cmap() {
+        // default has U+007C for "bar", non-default has U+00A6
+        let result =
+            TestCompile::compile_source("codepoint_mismatch/codepoint_mismatch.designspace");
+        let font = result.font();
+        let cmap = font.cmap().unwrap();
+
+        // U+007C (from default) should map to the "bar" glyph
+        assert!(
+            cmap.map_codepoint(0x007Cu32).is_some(),
+            "U+007C from default master should be in cmap"
+        );
+        // U+00A6 (from non-default only) should NOT be in cmap
+        assert_eq!(
+            None,
+            cmap.map_codepoint(0x00A6u32),
+            "U+00A6 from non-default master should not be in cmap"
+        );
+    }
+
     #[test]
     fn hmtx_of_one() {
         let result = TestCompile::compile_source("glyphs2/NotDef.glyphs");

--- a/resources/testdata/codepoint_mismatch/CpMismatch-Bold.ufo/fontinfo.plist
+++ b/resources/testdata/codepoint_mismatch/CpMismatch-Bold.ufo/fontinfo.plist
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>familyName</key>
+    <string>CpMismatch</string>
+    <key>unitsPerEm</key>
+    <integer>1000</integer>
+    <key>ascender</key>
+    <integer>800</integer>
+    <key>descender</key>
+    <integer>-200</integer>
+  </dict>
+</plist>

--- a/resources/testdata/codepoint_mismatch/CpMismatch-Bold.ufo/glyphs/bar.glif
+++ b/resources/testdata/codepoint_mismatch/CpMismatch-Bold.ufo/glyphs/bar.glif
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="bar" format="2">
+  <advance width="540"/>
+  <unicode hex="00A6"/>
+  <outline>
+    <contour>
+      <point x="200" y="0" type="line"/>
+      <point x="340" y="0" type="line"/>
+      <point x="340" y="700" type="line"/>
+      <point x="200" y="700" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/resources/testdata/codepoint_mismatch/CpMismatch-Bold.ufo/glyphs/contents.plist
+++ b/resources/testdata/codepoint_mismatch/CpMismatch-Bold.ufo/glyphs/contents.plist
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>bar</key>
+    <string>bar.glif</string>
+  </dict>
+</plist>

--- a/resources/testdata/codepoint_mismatch/CpMismatch-Bold.ufo/layercontents.plist
+++ b/resources/testdata/codepoint_mismatch/CpMismatch-Bold.ufo/layercontents.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <array>
+    <array>
+      <string>public.default</string>
+      <string>glyphs</string>
+    </array>
+  </array>
+</plist>

--- a/resources/testdata/codepoint_mismatch/CpMismatch-Bold.ufo/metainfo.plist
+++ b/resources/testdata/codepoint_mismatch/CpMismatch-Bold.ufo/metainfo.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>creator</key>
+    <string>org.googlefonts.fontc</string>
+    <key>formatVersion</key>
+    <integer>3</integer>
+  </dict>
+</plist>

--- a/resources/testdata/codepoint_mismatch/CpMismatch-Regular.ufo/fontinfo.plist
+++ b/resources/testdata/codepoint_mismatch/CpMismatch-Regular.ufo/fontinfo.plist
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>familyName</key>
+    <string>CpMismatch</string>
+    <key>unitsPerEm</key>
+    <integer>1000</integer>
+    <key>ascender</key>
+    <integer>800</integer>
+    <key>descender</key>
+    <integer>-200</integer>
+  </dict>
+</plist>

--- a/resources/testdata/codepoint_mismatch/CpMismatch-Regular.ufo/glyphs/bar.glif
+++ b/resources/testdata/codepoint_mismatch/CpMismatch-Regular.ufo/glyphs/bar.glif
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="bar" format="2">
+  <advance width="500"/>
+  <unicode hex="007C"/>
+  <outline>
+    <contour>
+      <point x="200" y="0" type="line"/>
+      <point x="300" y="0" type="line"/>
+      <point x="300" y="700" type="line"/>
+      <point x="200" y="700" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/resources/testdata/codepoint_mismatch/CpMismatch-Regular.ufo/glyphs/contents.plist
+++ b/resources/testdata/codepoint_mismatch/CpMismatch-Regular.ufo/glyphs/contents.plist
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>bar</key>
+    <string>bar.glif</string>
+  </dict>
+</plist>

--- a/resources/testdata/codepoint_mismatch/CpMismatch-Regular.ufo/layercontents.plist
+++ b/resources/testdata/codepoint_mismatch/CpMismatch-Regular.ufo/layercontents.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <array>
+    <array>
+      <string>public.default</string>
+      <string>glyphs</string>
+    </array>
+  </array>
+</plist>

--- a/resources/testdata/codepoint_mismatch/CpMismatch-Regular.ufo/lib.plist
+++ b/resources/testdata/codepoint_mismatch/CpMismatch-Regular.ufo/lib.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>public.glyphOrder</key>
+    <array>
+      <string>bar</string>
+    </array>
+  </dict>
+</plist>

--- a/resources/testdata/codepoint_mismatch/CpMismatch-Regular.ufo/metainfo.plist
+++ b/resources/testdata/codepoint_mismatch/CpMismatch-Regular.ufo/metainfo.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>creator</key>
+    <string>org.googlefonts.fontc</string>
+    <key>formatVersion</key>
+    <integer>3</integer>
+  </dict>
+</plist>

--- a/resources/testdata/codepoint_mismatch/codepoint_mismatch.designspace
+++ b/resources/testdata/codepoint_mismatch/codepoint_mismatch.designspace
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<designspace format="4.1">
+  <axes>
+    <axis tag="wght" name="Weight" minimum="400" maximum="700" default="400"/>
+  </axes>
+  <sources>
+    <source filename="CpMismatch-Regular.ufo" familyname="CpMismatch" stylename="Regular">
+      <lib copy="1"/>
+      <info copy="1"/>
+      <location>
+        <dimension name="Weight" xvalue="400"/>
+      </location>
+    </source>
+    <source filename="CpMismatch-Bold.ufo" familyname="CpMismatch" stylename="Bold">
+      <location>
+        <dimension name="Weight" xvalue="700"/>
+      </location>
+    </source>
+  </sources>
+</designspace>

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -1834,14 +1834,19 @@ impl Work<Context, WorkId, Error> for GlyphIrWork {
         );
         let static_metadata = context.static_metadata.get();
 
-        // Migrate glif_files into internal coordinates
-        let mut glif_files = HashMap::new();
+        // Migrate glif_files into internal coordinates, default location first
+        let mut glif_files = Vec::new();
+        //let mut default_idx = None;
         for (path, design_locations) in self.glif_files.iter() {
             let normalized_locations: Vec<NormalizedLocation> = design_locations
                 .iter()
                 .map(|dl| dl.to_normalized(&static_metadata.all_source_axes).unwrap())
                 .collect();
-            glif_files.insert(path, normalized_locations);
+            if normalized_locations.iter().any(|loc| loc.is_default()) {
+                glif_files.insert(0, (normalized_locations, path));
+            } else {
+                glif_files.push((normalized_locations, path));
+            }
         }
 
         let erase_open_corners = context.flags.contains(Flags::ERASE_OPEN_CORNERS);

--- a/ufo2fontir/src/toir.rs
+++ b/ufo2fontir/src/toir.rs
@@ -235,22 +235,24 @@ pub fn to_ir_axis(axis: &designspace::Axis) -> Result<fontdrasil::types::Axis, E
     })
 }
 
+/// Invariant: the default location is always first in the glif_files list.
 pub fn to_ir_glyph(
     glyph_name: GlyphName,
     emit_to_binary: bool,
     erase_open_corners: bool,
-    glif_files: &HashMap<&PathBuf, Vec<NormalizedLocation>>,
+    glif_files: &[(Vec<NormalizedLocation>, &PathBuf)],
     anchors: &mut AnchorBuilder,
 ) -> Result<ir::Glyph, Error> {
     let mut glyph = ir::GlyphBuilder::new(glyph_name.clone());
     glyph.emit_to_binary = emit_to_binary;
-    for (glif_file, locations) in glif_files {
-        let norad_glyph =
+
+    // We stash the codepoints from the default location so we can warn
+    // if any other instances have different codepoints
+    let mut default_loc_codepoints = None;
+    for (locations, glif_file) in glif_files.iter() {
+        let mut norad_glyph =
             norad::Glyph::load(glif_file).map_err(|e| BadSource::custom(glif_file, e))?;
 
-        norad_glyph.codepoints.iter().for_each(|cp| {
-            glyph.codepoints.insert(cp as u32);
-        });
         for location in locations {
             glyph.try_add_source(
                 location,
@@ -268,6 +270,19 @@ pub fn to_ir_glyph(
                     )?;
                 }
             }
+        }
+        match default_loc_codepoints.as_ref() {
+            None => {
+                glyph.codepoints = norad_glyph.codepoints.iter().map(|cp| cp as u32).collect();
+                default_loc_codepoints = Some(std::mem::take(&mut norad_glyph.codepoints));
+            }
+            Some(cps) if !norad_glyph.codepoints.is_empty() && cps != &norad_glyph.codepoints => {
+                log::warn!(
+                    "Glyph '{glyph_name}' codepoints differ between instances. Default: '{cps:?}', {glif_file:?}: {:?}",
+                    norad_glyph.codepoints
+                );
+            }
+            Some(_) => (),
         }
     }
     glyph.build().map_err(Into::into)
@@ -335,14 +350,12 @@ mod tests {
         let mut norm_loc = NormalizedLocation::new();
         norm_loc.insert(Tag::new(b"wght"), NormalizedCoord::new(0.0));
         let mut anchors = AnchorBuilder::new("bar".into());
+        let glif_path = testdata_dir().join("WghtVar-Regular.ufo/glyphs/bar.glif");
         let glyph = to_ir_glyph(
             "bar".into(),
             true,
             false,
-            &HashMap::from([(
-                &testdata_dir().join("WghtVar-Regular.ufo/glyphs/bar.glif"),
-                vec![norm_loc],
-            )]),
+            &[(vec![norm_loc], &glif_path)],
             &mut anchors,
         )
         .unwrap();


### PR DESCRIPTION
finishing up a last WIP from the weekend: this fixes another crater crash.

----

Instead of taking the union of all codepoints assigned to all instances, which in some cases would cause us to fail to compile due to a Cmap conflict, if one instance happened to have an incorrect or out of date codepoint entry that was also assigned to another glyph.

We will now warn if there is a codepoint conflict, but will not fail to compile.