### PR TITLE
Remove 'prefer_gdef_categories_in_fea'

### DIFF
--- a/fontbe/src/features.rs
+++ b/fontbe/src/features.rs
@@ -167,19 +167,13 @@ pub(crate) fn get_gdef_classes(
     ast: &FeaFirstPassOutput,
     glyph_order: &GlyphOrder,
 ) -> HashMap<GlyphId16, GlyphClassDef> {
-    ast.gdef_classes
-        .as_ref()
-        .filter(|_| gdef_categories.prefer_gdef_categories_in_fea)
-        .cloned()
-        .unwrap_or_else(|| {
-            gdef_categories
-                .categories
-                .iter()
-                .filter_map(|(name, category)| {
-                    glyph_order.glyph_id(name).map(|gid| (gid, *category))
-                })
-                .collect()
-        })
+    ast.gdef_classes.clone().unwrap_or_else(|| {
+        gdef_categories
+            .categories
+            .iter()
+            .filter_map(|(name, category)| glyph_order.glyph_id(name).map(|gid| (gid, *category)))
+            .collect()
+    })
 }
 
 //NOTE: this is basically identical to the same method on FeaVariationInfo,

--- a/fontbe/src/features/kern.rs
+++ b/fontbe/src/features/kern.rs
@@ -1272,7 +1272,6 @@ mod tests {
         fn build(self) -> (FeaRsKerns, String) {
             let pairs = self.pairs.iter().collect::<Vec<_>>();
             let categories = GdefCategories {
-                prefer_gdef_categories_in_fea: self.opentype_categories.is_empty(),
                 categories: self.opentype_categories,
             };
             let layout_output = LayoutOutputBuilder::new()

--- a/fontbe/src/features/marks.rs
+++ b/fontbe/src/features/marks.rs
@@ -1114,7 +1114,6 @@ mod tests {
     /// A helper for testing our mark generation code
     #[derive(Clone, Debug)]
     struct MarksInput<const N: usize> {
-        prefer_gdef_categories_in_fea: bool,
         locations: [NormalizedLocation; N],
         anchors: BTreeMap<GlyphName, Vec<Anchor>>,
         categories: BTreeMap<GlyphName, GlyphClassDef>,
@@ -1205,7 +1204,6 @@ mod tests {
                 anchors: Default::default(),
                 categories: Default::default(),
                 char_map: Default::default(),
-                prefer_gdef_categories_in_fea: false,
             }
         }
 
@@ -1214,15 +1212,6 @@ mod tests {
         /// By default we use a single 'languagesytem DFLT dflt' statement.
         fn set_user_fea(&mut self, fea: &'static str) -> &mut Self {
             self.user_fea = fea;
-            self
-        }
-
-        /// Set whether or not to prefer GDEF categories defined in FEA vs in metadata
-        ///
-        /// this is 'true' for UFO sources and 'false' for glyphs sources; default
-        /// here is false.
-        fn set_prefer_fea_gdef_categories(&mut self, flag: bool) -> &mut Self {
-            self.prefer_gdef_categories_in_fea = flag;
             self
         }
 
@@ -1282,7 +1271,6 @@ mod tests {
             let glyph_locations = self.locations.iter().cloned().collect();
             let categories = GdefCategories {
                 categories: self.categories.clone(),
-                prefer_gdef_categories_in_fea: self.prefer_gdef_categories_in_fea,
             };
             LayoutOutputBuilder::new()
                 .with_axes(axes)
@@ -1687,60 +1675,6 @@ mod tests {
             # 1 MarkToBase rules
             # lookupflag LookupFlag(0)
             A @(x: 100, y: 400)
-              @(x: 50, y: 50) acutecomb
-            "#
-        );
-    }
-
-    // shared between two tests below
-    fn gdef_test_input() -> MarksInput<1> {
-        let mut out = simple_test_input();
-        out.set_user_fea(
-            r#"
-            @Bases = [A];
-            @Marks = [acutecomb];
-            table GDEF {
-                GlyphClassDef @Bases, [], @Marks,;
-            } GDEF;
-            "#,
-        )
-        // is not in the FEA classes defined above
-        .add_glyph("gravecomb", GlyphClassDef::Mark, |anchors| {
-            anchors.add("_top", [(5, 15)]);
-        });
-        out
-    }
-
-    #[test]
-    fn prefer_fea_gdef_categories_true() {
-        let out = gdef_test_input()
-            .set_prefer_fea_gdef_categories(true)
-            .get_normalized_output();
-        assert_eq_ignoring_ws!(
-            out,
-            r#"
-            # mark: DFLT/dflt
-            # 1 MarkToBase rules
-            # lookupflag LookupFlag(0)
-            A @(x: 100, y: 400)
-              @(x: 50, y: 50) acutecomb
-            "#
-        );
-    }
-
-    #[test]
-    fn prefer_fea_gdef_categories_false() {
-        let out = gdef_test_input()
-            .set_prefer_fea_gdef_categories(false)
-            .get_normalized_output();
-        assert_eq_ignoring_ws!(
-            out,
-            r#"
-            # mark: DFLT/dflt
-            # 1 MarkToBase rules
-            # lookupflag LookupFlag(0)
-            A @(x: 100, y: 400)
-              @(x: 5, y: 15) gravecomb
               @(x: 50, y: 50) acutecomb
             "#
         );

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -2067,26 +2067,6 @@ mod tests {
     }
 
     #[test]
-    fn ufo_and_glyphs_set_prefer_fea_flag() {
-        let glyphs = TestCompile::compile_source("glyphs3/Oswald-glyph-categories.glyphs");
-        let ufo = TestCompile::compile_source("Oswald-glyph-categories/Oswald-Regular.designspace");
-
-        assert!(
-            !glyphs
-                .fe_context
-                .gdef_categories
-                .get()
-                .prefer_gdef_categories_in_fea
-        );
-        assert!(
-            ufo.fe_context
-                .gdef_categories
-                .get()
-                .prefer_gdef_categories_in_fea
-        );
-    }
-
-    #[test]
     fn captures_vendor_id() {
         let result = TestCompile::compile_source("glyphs3/TheBestNames.glyphs");
         let font = result.font();

--- a/fontir/src/glyph.rs
+++ b/fontir/src/glyph.rs
@@ -934,7 +934,6 @@ fn recompute_gdef_categories(context: &Context) -> Result<(), Error> {
     if !preliminary.infer_from_anchors {
         context.gdef_categories.set(GdefCategories {
             categories: preliminary.categories.clone(),
-            prefer_gdef_categories_in_fea: preliminary.prefer_gdef_categories_in_fea,
         });
         return Ok(());
     }
@@ -978,7 +977,6 @@ fn recompute_gdef_categories(context: &Context) -> Result<(), Error> {
     // Write final categories directly to context (no StaticMetadata cloning!)
     context.gdef_categories.set(GdefCategories {
         categories: final_categories,
-        prefer_gdef_categories_in_fea: preliminary.prefer_gdef_categories_in_fea,
     });
 
     Ok(())
@@ -2354,7 +2352,6 @@ mod tests {
         ctx.preliminary_gdef_categories
             .set(PreliminaryGdefCategories {
                 categories: Default::default(),
-                prefer_gdef_categories_in_fea: false,
                 infer_from_anchors: true,
                 mark_category_glyphs: Default::default(),
             });

--- a/fontir/src/ir/static_metadata.rs
+++ b/fontir/src/ir/static_metadata.rs
@@ -147,10 +147,6 @@ impl NameKey {
 pub struct PreliminaryGdefCategories {
     /// A map of glyphs to categories from source.
     pub categories: BTreeMap<GlyphName, GlyphClassDef>,
-    /// If set, we should prefer categories defined in FEA source to ones here.
-    ///
-    /// This is set for UFO/DS sources, but not for glyphs sources.
-    pub prefer_gdef_categories_in_fea: bool,
     /// Controls whether final GDEF categories should be inferred from the presence
     /// of anchors (similarly to how glyphsLib does) or used as-is as defined in
     /// the source (as standard in DS+UFO workflows).
@@ -172,10 +168,6 @@ pub struct PreliminaryGdefCategories {
 pub struct GdefCategories {
     /// A map of glyphs to categories.
     pub categories: BTreeMap<GlyphName, GlyphClassDef>,
-    /// If set, we should prefer categories defined in FEA source to ones here.
-    ///
-    /// This is set for UFO/DS sources, but not for glyphs sources.
-    pub prefer_gdef_categories_in_fea: bool,
 }
 
 /// Metadata primarily feeding the OS/2 table.

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -793,7 +793,6 @@ fn make_preliminary_glyph_categories(font: &Font, axes: &Axes) -> PreliminaryGde
 
     PreliminaryGdefCategories {
         categories,
-        prefer_gdef_categories_in_fea: false,
         infer_from_anchors: true,
         mark_category_glyphs,
     }

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -920,7 +920,6 @@ impl Work<Context, WorkId, Error> for StaticMetadataWork {
         let preliminary_gdef_categories =
             glyph_categories(&lib_plist).map(|categories| PreliminaryGdefCategories {
                 categories,
-                prefer_gdef_categories_in_fea: true,
                 infer_from_anchors: false,
                 mark_category_glyphs: Default::default(),
             })?;


### PR DESCRIPTION
This was intended to better match the behaviour of glyphs sources, but apparently some of those sources also use FEA to override GDEF categories.


- closes https://github.com/googlefonts/fontc/issues/767

@anthrotype I did run crater locally and this was only green, so 🤷 