### PR TITLE
[glyphs2fontir] Include all masters in KerningGroups.locations

### DIFF
--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -1118,20 +1118,7 @@ impl Work<Context, WorkId, Error> for KerningGroupWork {
             }
         }
 
-        groups.locations = font
-            .kerning_ltr
-            .iter()
-            .filter_map(
-                |(master_id, _)| match font_info.master_positions.get(master_id) {
-                    Some(pos) => Some(pos),
-                    None => {
-                        warn!("Kerning is present for non-existent master {master_id}");
-                        None
-                    }
-                },
-            )
-            .cloned()
-            .collect();
+        groups.locations = font_info.master_positions.values().cloned().collect();
 
         context.kerning_groups.set(groups);
         Ok(())
@@ -1218,23 +1205,21 @@ impl Work<Context, WorkId, Error> for KerningInstanceWork {
 
         let bracket_glyph_map = make_bracket_glyph_map(glyph_order);
 
-        let Some(kern_pairs) = kerning_at_location(font_info, &self.location) else {
-            return Ok(());
-        };
-
-        kern_pairs
-            .iter()
-            .filter_map(|((side1, side2), pos_adjust)| {
-                let side1 = kern_participant(glyph_order, groups, SIDE1_PREFIX, side1);
-                let side2 = kern_participant(glyph_order, groups, SIDE2_PREFIX, side2);
-                side1.zip(side2).map(|side| (side, *pos_adjust))
-            })
-            .flat_map(|(participants, value)| {
-                expand_kerning_to_brackets(&bracket_glyph_map, participants, value)
-            })
-            .for_each(|(participants, value)| {
-                *kerning.kerns.entry(participants).or_default() = value;
-            });
+        if let Some(kern_pairs) = kerning_at_location(font_info, &self.location) {
+            kern_pairs
+                .iter()
+                .filter_map(|((side1, side2), pos_adjust)| {
+                    let side1 = kern_participant(glyph_order, groups, SIDE1_PREFIX, side1);
+                    let side2 = kern_participant(glyph_order, groups, SIDE2_PREFIX, side2);
+                    side1.zip(side2).map(|side| (side, *pos_adjust))
+                })
+                .flat_map(|(participants, value)| {
+                    expand_kerning_to_brackets(&bracket_glyph_map, participants, value)
+                })
+                .for_each(|(participants, value)| {
+                    *kerning.kerns.entry(participants).or_default() = value;
+                });
+        }
 
         context.kerning_at.set(kerning);
         Ok(())

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -3017,6 +3017,41 @@ mod tests {
     }
 
     #[test]
+    fn empty_kerning_master_participates_in_variation() {
+        let (_, context) = build_kerning(glyphs3_dir().join("KerningEmptyMaster.glyphs"));
+
+        let groups = context.kerning_groups.get();
+        assert_eq!(
+            groups.locations.len(),
+            2,
+            "expected both masters in locations"
+        );
+
+        let all_kerns = context.kerning_at.all();
+        assert_eq!(
+            all_kerns.len(),
+            2,
+            "expected kerning instances at both masters"
+        );
+
+        let non_empty: Vec<_> = all_kerns
+            .iter()
+            .filter(|(_, k)| !k.kerns.is_empty())
+            .collect();
+        let empty: Vec<_> = all_kerns
+            .iter()
+            .filter(|(_, k)| k.kerns.is_empty())
+            .collect();
+        assert_eq!(non_empty.len(), 1);
+        assert_eq!(empty.len(), 1);
+
+        assert_eq!(
+            non_empty[0].1.kerns,
+            make_kerning(&[("@side1.A", "@side2.B", -50)])
+        );
+    }
+
+    #[test]
     fn captures_anchors() {
         let base_name = "A".into();
         let mark_name = "macroncomb".into();

--- a/resources/testdata/glyphs3/KerningEmptyMaster.glyphs
+++ b/resources/testdata/glyphs3/KerningEmptyMaster.glyphs
@@ -1,0 +1,69 @@
+{
+.appVersion = "3343";
+.formatVersion = 3;
+familyName = SparseKerning;
+axes = (
+{
+name = Weight;
+tag = wght;
+}
+);
+fontMaster = (
+{
+axesValues = (
+400
+);
+id = "master01";
+name = Regular;
+},
+{
+axesValues = (
+700
+);
+id = "master02";
+name = Bold;
+}
+);
+glyphs = (
+{
+glyphname = A;
+kernRight = A;
+layers = (
+{
+layerId = "master01";
+width = 500;
+},
+{
+layerId = "master02";
+width = 600;
+}
+);
+unicode = 65;
+},
+{
+glyphname = B;
+kernLeft = B;
+layers = (
+{
+layerId = "master01";
+width = 500;
+},
+{
+layerId = "master02";
+width = 600;
+}
+);
+unicode = 66;
+}
+);
+kerningLTR = {
+master01 = {
+"@MMK_L_A" = {
+"@MMK_R_B" = -50;
+};
+};
+};
+unitsPerEm = 1000;
+versionMajor = 1;
+versionMinor = 0;
+}


### PR DESCRIPTION
`KerningGroupWork` was building `groups.locations` only from `kerning_ltr` keys, so masters with empty kerning dicts were excluded from the variation model. This caused two symptoms:
 
- RTL-only kerning sources (e.g. NotoSansHebrew): no kern feature emitted at all, since `kerning_ltr` has no entries
 - Fonts where only some masters have kerning (e.g. Geom, 1 of 7 masters): constant kern values instead of interpolating toward zero at non-kerning masters
 
Both font source formats expects that empty kerning dict on a master should still participate in variation. ufo2fontir already does this: it includes all non-glyph-only designspace sources in `kerning_groups.locations` unconditionally.

(font source formats haven't been updated to support truly "sparse" kerning yet, all global font masters are expected to participate in kerning whether or not they contain a non-empty kerning dict, it's absence doesn't make them 'sparse'. An optional lib key has been proposed, I can find the link, but it's out of scope for this bugfix).

After the fix, ttx-diff now reports "output is identical" for NotoSansHebrew and Geom.

Fixes #1857 