### PR TITLE
[fea-rs] Allow NULL anchor without mark class in pos ligature rules

### DIFF
--- a/fea-rs/src/parse/grammar/gpos.rs
+++ b/fea-rs/src/parse/grammar/gpos.rs
@@ -217,12 +217,18 @@ fn anchor_mark(parser: &mut Parser, recovery: TokenSet) -> bool {
         return false;
     }
     parser.in_node(AstKind::AnchorMarkNode, |parser| {
+        let is_null = parser.matches(2, Kind::NullKw);
         metrics::anchor(parser, recovery.union(RECOVERY));
-        // we will verify later that the anchor was NULL
-        if !parser.matches(0, Kind::Semi) {
+        if parser.matches(0, Kind::MarkKw) {
+            parser.eat_raw();
+            parser.expect_recover(Kind::NamedGlyphClass, recovery.union(RECOVERY));
+        } else if !is_null {
             parser.expect_recover(Kind::MarkKw, recovery.union(RECOVERY));
             parser.expect_recover(Kind::NamedGlyphClass, recovery.union(RECOVERY));
         }
+        // <anchor NULL> without mark class is valid in ligature rules (GPOS type 5)
+        // to denote a component with no mark attachment point.
+        // cf. https://github.com/fonttools/fonttools/blob/67ff24a36/Lib/fontTools/feaLib/parser.py#L200-L201
     });
     true
 }

--- a/fea-rs/test-data/parse-tests/bad/GPOS_5_non_null_no_mark.ERR
+++ b/fea-rs/test-data/parse-tests/bad/GPOS_5_non_null_no_mark.ERR
@@ -1,0 +1,35 @@
+error: Expected MarkKw found ID
+in ./test-data/parse-tests/bad/GPOS_5_non_null_no_mark.fea at 4:4
+  | 
+4 |     ligComponent
+  |     ^^^^^^^^^^^^
+
+error: Expected @GlyphClass found <
+in ./test-data/parse-tests/bad/GPOS_5_non_null_no_mark.fea at 5:4
+  | 
+5 |     <anchor 100 500> mark @TOP_MARKS;
+  |     ^
+
+error: Expected ';'
+in ./test-data/parse-tests/bad/GPOS_5_non_null_no_mark.fea at 5:5
+  | 
+5 |     <anchor 100 500> mark @TOP_MARKS;
+  |      ^
+
+error: 'anchor' Not valid in a feature block
+in ./test-data/parse-tests/bad/GPOS_5_non_null_no_mark.fea at 5:5
+  | 
+5 |     <anchor 100 500> mark @TOP_MARKS;
+  |      ^^^^^^
+
+error: Expected = found ;
+in ./test-data/parse-tests/bad/GPOS_5_non_null_no_mark.fea at 5:36
+  | 
+5 |     <anchor 100 500> mark @TOP_MARKS;
+  |                                     ^
+
+error: Expected named glyph class or '['.
+in ./test-data/parse-tests/bad/GPOS_5_non_null_no_mark.fea at 5:36
+  | 
+5 |     <anchor 100 500> mark @TOP_MARKS;
+  |                                     ^

--- a/fea-rs/test-data/parse-tests/bad/GPOS_5_non_null_no_mark.fea
+++ b/fea-rs/test-data/parse-tests/bad/GPOS_5_non_null_no_mark.fea
@@ -1,0 +1,6 @@
+feature test {
+    position ligature f_i
+    <anchor 100 200>
+    ligComponent
+    <anchor 100 500> mark @TOP_MARKS;
+} test;

--- a/fea-rs/test-data/parse-tests/good/GPOS_5_null_lig_component.PARSE_TREE
+++ b/fea-rs/test-data/parse-tests/good/GPOS_5_null_lig_component.PARSE_TREE
@@ -1,0 +1,47 @@
+FILE@[0; 122)
+    FeatureNode@[0; 121)
+      FeatureKw@0 "feature"
+      WS@7 " "
+      Tag@8 "test"
+      WS@12 " "
+      {@13 "{"
+      WS@14 "\n    "
+        GposType5@[19; 113)
+          PosKw@19 "position"
+          WS@27 " "
+          LigatureKw@28 "ligature"
+          WS@36 " "
+          GlyphName@37 "f_i"
+          WS@40 "\n    "
+            LigatureComponentNode@[45; 58)
+                AnchorMarkNode@[45; 58)
+                    AnchorNode@[45; 58)
+                      <@45 "<"
+                      AnchorKw@46 "anchor"
+                      WS@52 " "
+                      NullKw@53 "NULL"
+                      >@57 ">"
+          WS@58 "\n    "
+            LigatureComponentNode@[63; 112)
+              ID@63 "ligComponent"
+              WS@75 "\n    "
+                AnchorMarkNode@[80; 112)
+                    AnchorNode@[80; 96)
+                      <@80 "<"
+                      AnchorKw@81 "anchor"
+                      WS@87 " "
+                      NUM@88 "100"
+                      WS@91 " "
+                      NUM@92 "500"
+                      >@95 ">"
+                  WS@96 " "
+                  MarkKw@97 "mark"
+                  WS@101 " "
+                  @GlyphClass@102 "@TOP_MARKS"
+          ;@112 ";"
+      WS@113 "\n"
+      }@114 "}"
+      WS@115 " "
+      Tag@116 "test"
+      ;@120 ";"
+  WS@121 "\n"

--- a/fea-rs/test-data/parse-tests/good/GPOS_5_null_lig_component.fea
+++ b/fea-rs/test-data/parse-tests/good/GPOS_5_null_lig_component.fea
@@ -1,0 +1,6 @@
+feature test {
+    position ligature f_i
+    <anchor NULL>
+    ligComponent
+    <anchor 100 500> mark @TOP_MARKS;
+} test;


### PR DESCRIPTION
Part of #2014.

In GPOS type 5 (mark-to-ligature) rules, `<anchor NULL>` denotes a ligature component with no mark attachment point. fea-rs required `mark @class` after every anchor, rejecting `<anchor NULL>` on non-final components followed by `ligComponent`.

The FEA spec grammar says `<anchor> mark <named mark class>` for each attachment, but the spec's own [GPOS type 5 example](https://adobe-type-tools.github.io/afdko/OpenTypeFeatureFileSpecification.html#6.e) uses `<anchor NULL>;` without `mark @class`. feaLib has followed the example rather than the grammar since its [original GPOS type 5 implementation](https://github.com/fonttools/fonttools/blob/0532ec85d30b/Lib/fontTools/feaLib/parser.py#L200-L201) (Dec 2015).

The fix peeks at the anchor before consuming it: if NULL and no `mark` follows, skip mark-class parsing. Non-NULL anchors without `mark` still error as before.


