### PR TITLE
[ttx_diff] Match fontc's logic for detecting variable vs static sources

### DIFF
--- a/ttx_diff/src/ttx_diff/core.py
+++ b/ttx_diff/src/ttx_diff/core.py
@@ -438,10 +438,27 @@ def source_is_variable(path: Path) -> bool:
         return False
     if path.suffix == ".designspace":
         dspace = DesignSpaceDocument.fromfile(path)
-        return len(dspace.sources) > 1
+        return any(
+            a.minimum != a.default or a.maximum != a.default for a in dspace.axes
+        )
     if path.suffix == ".glyphs" or path.suffix == ".glyphspackage":
         font = GSFont(path)
-        return len(font.masters) > 1
+        # Virtual masters can extend axis min/max beyond what real masters define
+        # https://github.com/googlefonts/glyphsLib/blob/75c07d42/Lib/glyphsLib/builder/axes.py#L168-L173
+        virtual_masters = [
+            cp.value
+            for cp in font.customParameters
+            if cp.name == "Virtual Master" and not getattr(cp, "disabled", False)
+        ]
+        for i, axis in enumerate(font.axes):
+            values = [m.axes[i] for m in font.masters]
+            for vm in virtual_masters:
+                for entry in vm:
+                    if entry.get("Axis") == axis.name:
+                        values.append(entry["Location"])
+            if min(values) != max(values):
+                return True
+        return False
     # fallback to variable, the existing default, but we should never get here?
     return True
 

--- a/ttx_diff/tests/test_cli.py
+++ b/ttx_diff/tests/test_cli.py
@@ -3,6 +3,73 @@
 import subprocess
 import sys
 
+from ttx_diff.core import source_is_variable
+
+
+def _write_designspace(tmp_path, axes, sources):
+    from fontTools.designspaceLib import (
+        AxisDescriptor,
+        DesignSpaceDocument,
+        SourceDescriptor,
+    )
+
+    ds = DesignSpaceDocument()
+    for tag, name, mn, df, mx in axes:
+        a = AxisDescriptor()
+        a.tag, a.name = tag, name
+        a.minimum, a.default, a.maximum = mn, df, mx
+        ds.addAxis(a)
+    for loc in sources:
+        s = SourceDescriptor()
+        s.location = loc
+        ds.addSource(s)
+    path = tmp_path / "test.designspace"
+    ds.write(path)
+    return path
+
+
+def _write_glyphs(tmp_path, masters, virtual_masters=None, name="test.glyphs"):
+    """Create a minimal .glyphs file using glyphsLib and save to tmp_path."""
+    from glyphsLib.classes import (
+        GSAxis,
+        GSCustomParameter,
+        GSFont,
+        GSFontMaster,
+        GSGlyph,
+        GSLayer,
+    )
+
+    font = GSFont()
+    font.familyName = "Test"
+    font.upm = 1000
+    font.versionMajor = 1
+    axis = GSAxis()
+    axis.name = "Weight"
+    axis.axisTag = "wght"
+    font.axes = [axis]
+    for val in masters:
+        m = GSFontMaster()
+        m.axes = [val]
+        font.masters.append(m)
+    if virtual_masters:
+        for vm_val in virtual_masters:
+            font.customParameters.append(
+                GSCustomParameter(
+                    "Virtual Master", [{"Axis": "Weight", "Location": vm_val}]
+                )
+            )
+    glyph = GSGlyph("space")
+    glyph.unicode = "0020"
+    for m in font.masters:
+        layer = GSLayer()
+        layer.layerId = m.id
+        layer.width = 200
+        glyph.layers.append(layer)
+    font.glyphs.append(glyph)
+    path = tmp_path / name
+    font.save(str(path))
+    return path
+
 
 def test_version():
     import ttx_diff
@@ -20,3 +87,64 @@ def test_cli_missing_source():
     )
     assert result.returncode != 0
     assert "No such source" in result.stderr
+
+
+class TestSourceIsVariable:
+    def test_ufo_is_static(self, tmp_path):
+        ufo = tmp_path / "test.ufo"
+        ufo.mkdir()
+        (ufo / "metainfo.plist").write_text("")
+        assert not source_is_variable(ufo)
+
+    def test_designspace_multiple_sources(self, tmp_path):
+        path = _write_designspace(
+            tmp_path,
+            axes=[("wght", "Weight", 400, 400, 700)],
+            sources=[{"Weight": 400}, {"Weight": 700}],
+        )
+        assert source_is_variable(path)
+
+    def test_designspace_single_source_with_axis_range(self, tmp_path):
+        # 1 source but axis has min != max, like NotoSerifMakasar
+        # https://github.com/googlefonts/fontc/issues/1860
+        path = _write_designspace(
+            tmp_path,
+            axes=[("wght", "Weight", 400, 400, 700)],
+            sources=[{"Weight": 400}],
+        )
+        assert source_is_variable(path)
+
+    def test_designspace_point_axes_only(self, tmp_path):
+        path = _write_designspace(
+            tmp_path,
+            axes=[("wght", "Weight", 400, 400, 400)],
+            sources=[{"Weight": 400}],
+        )
+        assert not source_is_variable(path)
+
+    def test_designspace_mixed_point_and_range_axes(self, tmp_path):
+        # Like Mingzat: wght 400-700, wdth 100-100, XXXX 0-0
+        # https://github.com/googlefonts/fontc/issues/1860
+        path = _write_designspace(
+            tmp_path,
+            axes=[
+                ("wght", "Weight", 400, 400, 700),
+                ("wdth", "Width", 100, 100, 100),
+                ("XXXX", "Custom", 0, 0, 0),
+            ],
+            sources=[{"Weight": 400, "Width": 100, "Custom": 0}],
+        )
+        assert source_is_variable(path)
+
+    def test_glyphs_multiple_masters(self, tmp_path):
+        path = _write_glyphs(tmp_path, masters=[400, 700])
+        assert source_is_variable(path)
+
+    def test_glyphs_single_master(self, tmp_path):
+        path = _write_glyphs(tmp_path, masters=[400])
+        assert not source_is_variable(path)
+
+    def test_glyphs_virtual_masters_extend_axis_range(self, tmp_path):
+        # 1 master at wght=400, virtual master at wght=700
+        path = _write_glyphs(tmp_path, masters=[400], virtual_masters=[700])
+        assert source_is_variable(path)


### PR DESCRIPTION
ttx_diff was using source/master count to decide whether to tell fontmake to build variable or static. fontc uses a different criterion: whether any axis has a non-zero range (min != default or max != default), or in other words it's not a "point" axis. 

This caused ttx_diff to instruct fontmake to build static for single-source designspaces that declare axis ranges, while fontc built them as variable (arguably degenerate having a single master, but GIGO), making the comparison meaningless.

I changed ttx_diff to use fontc's axis-range check for both .designspace and .glyphs sources.

For .glyphs, axis ranges need to be computed from master axis values plus virtual master positions, matching fontc's ir_axes() logic and glyphsLib/builder/axes.py.

I verified that NotoSerifMakasar (1 source, wght 400-700) now produces "output is identical".
Mingzat (1 source, 3 axes, 2 point) now produces a comparable variable build (the remaining fvar/STAT/HVAR/name diffs are #1814: fontc drops point axes that the designspace explicitly declares).

Supersedes #1422.
Fixes #1860