### PR TITLE
Read openTypeCategories from DS lib; infer from GlyphData.xml for UFO sources

### DIFF
--- a/fontir/src/glyph.rs
+++ b/fontir/src/glyph.rs
@@ -929,8 +929,7 @@ fn recompute_gdef_categories(context: &Context) -> Result<(), Error> {
 
     let preliminary = context.preliminary_gdef_categories.get();
 
-    // For sources that don't infer from anchors (e.g. DS+UFO), just clone
-    // preliminary->final categories directly
+    // For sources with explicit categories, just clone preliminary->final directly
     if !preliminary.infer_from_anchors {
         context.gdef_categories.set(GdefCategories {
             categories: preliminary.categories.clone(),

--- a/glyphs-reader/src/glyphdata.rs
+++ b/glyphs-reader/src/glyphdata.rs
@@ -254,7 +254,7 @@ pub struct GlyphData {
 
 impl GlyphData {
     /// Overrides, if provided, explicitly assign the result for a given query
-    pub(crate) fn new(overrides: Option<HashMap<SmolStr, QueryResult>>) -> Self {
+    pub fn new(overrides: Option<HashMap<SmolStr, QueryResult>>) -> Self {
         let overrrides_by_codepoint = overrides.as_ref().map(|overrides| {
             overrides
                 .iter()

--- a/ufo2fontir/Cargo.toml
+++ b/ufo2fontir/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["text-processing", "parsing", "graphics"]
 [dependencies]
 fontdrasil = { version = "0.4.0", path = "../fontdrasil" }
 fontir = { version = "0.5.0", path = "../fontir" }
+glyphs-reader = { version = "0.5.0", path = "../glyphs-reader" }
 
 kurbo.workspace = true
 serde.workspace = true

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -607,6 +607,59 @@ fn glyph_categories(
     Ok(categories)
 }
 
+/// Generate preliminary GDEF categories from GlyphData.xml for UFO sources
+/// without explicit `public.openTypeCategories`.
+///
+/// Only marks and ligatures are assigned here; bases are inferred after anchor
+/// propagation by `recompute_gdef_categories` (with `infer_from_anchors: true`).
+fn preliminary_gdef_categories_from_glyphdata(
+    glyph_names: &HashSet<GlyphName>,
+) -> PreliminaryGdefCategories {
+    use glyphs_reader::glyphdata::{Category, GlyphData, Subcategory};
+
+    let glyph_data = GlyphData::new(None);
+    let mut categories = BTreeMap::new();
+    let mut mark_category_glyphs = BTreeSet::new();
+
+    for name in glyph_names {
+        // TODO(anthrotype): pass codepoints for better resolution
+        // https://github.com/googlefonts/fontc/issues/2022
+        let Some(result) = glyph_data.query(name.as_str(), None) else {
+            continue;
+        };
+        if result.category == Category::Mark {
+            mark_category_glyphs.insert(name.clone());
+        }
+        match (result.category, result.subcategory) {
+            (Category::Mark, Some(Subcategory::Nonspacing | Subcategory::SpacingCombining)) => {
+                categories.insert(name.clone(), GlyphClassDef::Mark);
+            }
+            (_, Some(Subcategory::Ligature)) => {
+                categories.insert(name.clone(), GlyphClassDef::Ligature);
+            }
+            _ => {}
+        }
+    }
+
+    log::info!(
+        "Inferred preliminary GDEF categories from GlyphData.xml: {} mark, {} ligature",
+        categories
+            .values()
+            .filter(|c| **c == GlyphClassDef::Mark)
+            .count(),
+        categories
+            .values()
+            .filter(|c| **c == GlyphClassDef::Ligature)
+            .count(),
+    );
+
+    PreliminaryGdefCategories {
+        categories,
+        infer_from_anchors: true,
+        mark_category_glyphs,
+    }
+}
+
 fn postscript_names(lib_plist: &plist::Dictionary) -> Result<Option<PostscriptNames>, BadSource> {
     let Some(raw_postscript_names) = lib_plist.get("public.postscriptNames") else {
         // absence of 'public.postscriptNames' signals intention to keep original 'nice' names
@@ -915,8 +968,6 @@ impl Work<Context, WorkId, Error> for StaticMetadataWork {
             };
         let glyph_order = glyph_order(&lib_plist, &self.glyph_names)?;
 
-        // for DS+UFO, infer_from_anchors=false thus "preliminary" GDEF categories will
-        // simply be copied over to final ones (and potentially overridden by feature code).
         // Check the designspace lib first (canonical location), fall back to the default
         // master's UFO lib (legacy location).
         // <https://github.com/googlefonts/ufo2ft/blob/46196892e8/Lib/ufo2ft/util.py#L696-L704>
@@ -924,11 +975,19 @@ impl Work<Context, WorkId, Error> for StaticMetadataWork {
         if categories.is_empty() {
             categories = glyph_categories(&lib_plist)?;
         }
-        let preliminary_gdef_categories = PreliminaryGdefCategories {
-            categories,
-            infer_from_anchors: false,
-            mark_category_glyphs: Default::default(),
-        };
+        let preliminary_gdef_categories =
+            if categories.is_empty() && context.flags.contains(Flags::PROPAGATE_ANCHORS) {
+                // No explicit categories but propagateAnchors is enabled: infer from
+                // GlyphData.xml, matching fontmake's build-time category generation.
+                preliminary_gdef_categories_from_glyphdata(&self.glyph_names)
+            } else {
+                // Explicit categories or no propagateAnchors: use as-is
+                PreliminaryGdefCategories {
+                    categories,
+                    infer_from_anchors: false,
+                    mark_category_glyphs: Default::default(),
+                }
+            };
 
         // https://unifiedfontobject.org/versions/ufo3/fontinfo.plist/#opentype-os2-table-fields
         // Start with the bits from selection flags

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -620,6 +620,8 @@ fn preliminary_gdef_categories_from_glyphdata(
     let glyph_data = GlyphData::new(None);
     let mut categories = BTreeMap::new();
     let mut mark_category_glyphs = BTreeSet::new();
+    let mut num_mark = 0;
+    let mut num_ligature = 0;
 
     for name in glyph_names {
         // TODO(anthrotype): pass codepoints for better resolution
@@ -633,24 +635,18 @@ fn preliminary_gdef_categories_from_glyphdata(
         match (result.category, result.subcategory) {
             (Category::Mark, Some(Subcategory::Nonspacing | Subcategory::SpacingCombining)) => {
                 categories.insert(name.clone(), GlyphClassDef::Mark);
+                num_mark += 1;
             }
             (_, Some(Subcategory::Ligature)) => {
                 categories.insert(name.clone(), GlyphClassDef::Ligature);
+                num_ligature += 1;
             }
             _ => {}
         }
     }
 
     log::info!(
-        "Inferred preliminary GDEF categories from GlyphData.xml: {} mark, {} ligature",
-        categories
-            .values()
-            .filter(|c| **c == GlyphClassDef::Mark)
-            .count(),
-        categories
-            .values()
-            .filter(|c| **c == GlyphClassDef::Ligature)
-            .count(),
+        "Inferred preliminary GDEF categories from GlyphData.xml: {num_mark} mark, {num_ligature} ligature",
     );
 
     PreliminaryGdefCategories {

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -573,16 +573,16 @@ fn glyph_order(
 }
 
 fn glyph_categories(
-    lib_plist: &plist::Dictionary,
+    lib: &plist::Dictionary,
 ) -> Result<BTreeMap<GlyphName, GlyphClassDef>, BadSource> {
     const OPENTYPE_CATEGORIES: &str = "public.openTypeCategories";
 
-    let categories = match lib_plist.get(OPENTYPE_CATEGORIES) {
+    let categories = match lib.get(OPENTYPE_CATEGORIES) {
         Some(plist::Value::Dictionary(categories)) => categories,
         Some(_other) => {
             return Err(BadSource::custom(
-                "lib.plist",
-                format!("value for '{OPENTYPE_CATEGORIES}' is not a dictionary"),
+                OPENTYPE_CATEGORIES,
+                "value is not a dictionary",
             ));
         }
         None => return Ok(Default::default()),
@@ -916,13 +916,19 @@ impl Work<Context, WorkId, Error> for StaticMetadataWork {
         let glyph_order = glyph_order(&lib_plist, &self.glyph_names)?;
 
         // for DS+UFO, infer_from_anchors=false thus "preliminary" GDEF categories will
-        // simply be copied over to final ones (and potentially overridden by feature code)
-        let preliminary_gdef_categories =
-            glyph_categories(&lib_plist).map(|categories| PreliminaryGdefCategories {
-                categories,
-                infer_from_anchors: false,
-                mark_category_glyphs: Default::default(),
-            })?;
+        // simply be copied over to final ones (and potentially overridden by feature code).
+        // Check the designspace lib first (canonical location), fall back to the default
+        // master's UFO lib (legacy location).
+        // <https://github.com/googlefonts/ufo2ft/blob/46196892e8/Lib/ufo2ft/util.py#L696-L704>
+        let mut categories = glyph_categories(&self.designspace.lib)?;
+        if categories.is_empty() {
+            categories = glyph_categories(&lib_plist)?;
+        }
+        let preliminary_gdef_categories = PreliminaryGdefCategories {
+            categories,
+            infer_from_anchors: false,
+            mark_category_glyphs: Default::default(),
+        };
 
         // https://unifiedfontobject.org/versions/ufo3/fontinfo.plist/#opentype-os2-table-fields
         // Start with the bits from selection flags

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -2209,6 +2209,14 @@ mod tests {
 
     use super::*;
 
+    macro_rules! plist_dict {
+        ($($key:expr => $val:expr),* $(,)?) => {{
+            let mut d = plist::Dictionary::new();
+            $(d.insert($key.into(), $val.into());)*
+            d
+        }};
+    }
+
     fn testdata_dir() -> PathBuf {
         let dir = Path::new("../resources/testdata");
         assert!(dir.is_dir());
@@ -2258,8 +2266,17 @@ mod tests {
     }
 
     fn build_static_metadata(name: &str, flags: Flags) -> (impl Source + use<>, Context) {
+        build_static_metadata_with(name, flags, |_| {})
+    }
+
+    fn build_static_metadata_with<F: FnOnce(&mut DesignSpaceIrSource)>(
+        name: &str,
+        flags: Flags,
+        modify: F,
+    ) -> (DesignSpaceIrSource, Context) {
         let _ = env_logger::builder().is_test(true).try_init();
-        let source = load_designspace(name);
+        let mut source = load_designspace(name);
+        modify(&mut source);
         let context = Context::new_root(flags, None);
         let task_context = context.copy_for_work(
             Access::None,
@@ -3487,5 +3504,161 @@ mod tests {
                 .contains(Flags::DECOMPOSE_TRANSFORMED_COMPONENTS),
             "decomposeTransformedComponents in lib.plist should set DECOMPOSE_TRANSFORMED_COMPONENTS flag"
         );
+    }
+
+    #[test]
+    fn glyph_categories_from_plist() {
+        let categories = plist_dict! {
+            "A" => "base",
+            "f_i" => "ligature",
+            "acutecomb" => "mark",
+            "dotlessi" => "component",
+            "space" => "unassigned",
+        };
+        let dict = plist_dict! {
+            "public.openTypeCategories" => plist::Value::from(categories),
+        };
+
+        let result = glyph_categories(&dict).unwrap();
+        assert_eq!(result.get(&GlyphName::new("A")), Some(&GlyphClassDef::Base));
+        assert_eq!(
+            result.get(&GlyphName::new("f_i")),
+            Some(&GlyphClassDef::Ligature)
+        );
+        assert_eq!(
+            result.get(&GlyphName::new("acutecomb")),
+            Some(&GlyphClassDef::Mark)
+        );
+        assert_eq!(
+            result.get(&GlyphName::new("dotlessi")),
+            Some(&GlyphClassDef::Component)
+        );
+        // "unassigned" is valid but produces no entry
+        assert_eq!(result.get(&GlyphName::new("space")), None);
+        assert_eq!(result.len(), 4);
+    }
+
+    #[test]
+    fn glyph_categories_missing_key_returns_empty() {
+        let dict = plist::Dictionary::new();
+        let result = glyph_categories(&dict).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn glyph_categories_non_dict_value_is_error() {
+        let dict = plist_dict! { "public.openTypeCategories" => "oops" };
+        assert!(glyph_categories(&dict).is_err());
+    }
+
+    #[test]
+    fn preliminary_categories_from_glyphdata() {
+        use glyphs_reader::glyphdata::{Category, GlyphData, Subcategory};
+
+        // Verify our assumptions about GlyphData.xml classifications
+        let gd = GlyphData::new(None);
+        let acute = gd.query("acutecomb", None).unwrap();
+        assert_eq!(acute.category, Category::Mark);
+        assert_eq!(acute.subcategory, Some(Subcategory::Nonspacing));
+
+        let fi = gd.query("f_i", None).unwrap();
+        assert_eq!(fi.subcategory, Some(Subcategory::Ligature));
+
+        // "acute" is Mark/Spacing -- has its own advance width, not a combining mark.
+        // GlyphData still classifies it as Mark category, so it should appear in
+        // mark_category_glyphs but NOT in categories (only Nonspacing/SpacingCombining
+        // get GlyphClassDef::Mark).
+        let acute_spacing = gd.query("acute", None).unwrap();
+        assert_eq!(acute_spacing.category, Category::Mark);
+        assert_eq!(acute_spacing.subcategory, Some(Subcategory::Spacing));
+
+        let a_query = gd.query("A", None).unwrap();
+        assert_eq!(a_query.category, Category::Letter);
+
+        // Now test the function itself
+        let names: HashSet<GlyphName> = ["acutecomb", "gravecomb", "acute", "f_i", "A", "space"]
+            .iter()
+            .map(|n| GlyphName::new(*n))
+            .collect();
+
+        let result = preliminary_gdef_categories_from_glyphdata(&names);
+
+        assert!(result.infer_from_anchors);
+        assert_eq!(
+            result.categories.get(&GlyphName::new("acutecomb")),
+            Some(&GlyphClassDef::Mark)
+        );
+        assert_eq!(
+            result.categories.get(&GlyphName::new("gravecomb")),
+            Some(&GlyphClassDef::Mark)
+        );
+        assert_eq!(
+            result.categories.get(&GlyphName::new("f_i")),
+            Some(&GlyphClassDef::Ligature)
+        );
+        // Base glyphs are NOT assigned here; inferred later from anchors
+        assert_eq!(result.categories.get(&GlyphName::new("A")), None);
+        assert_eq!(result.categories.get(&GlyphName::new("space")), None);
+
+        assert!(
+            result
+                .mark_category_glyphs
+                .contains(&GlyphName::new("acutecomb"))
+        );
+        assert!(
+            result
+                .mark_category_glyphs
+                .contains(&GlyphName::new("gravecomb"))
+        );
+        // "acute" is Mark/Spacing: in mark_category_glyphs but not in categories
+        assert!(
+            result
+                .mark_category_glyphs
+                .contains(&GlyphName::new("acute"))
+        );
+        assert_eq!(result.categories.get(&GlyphName::new("acute")), None);
+        assert!(!result.mark_category_glyphs.contains(&GlyphName::new("A")));
+    }
+
+    #[test]
+    fn reads_categories_from_designspace_lib() {
+        let (_, context) =
+            build_static_metadata_with("wght_var.designspace", Flags::default(), |source| {
+                let ds = Arc::get_mut(&mut source.designspace).unwrap();
+                let categories = plist_dict! { "bar" => "base", "plus" => "ligature" };
+                ds.lib
+                    .insert("public.openTypeCategories".into(), categories.into());
+            });
+        let cats = context.preliminary_gdef_categories.get();
+        assert!(!cats.infer_from_anchors);
+        assert_eq!(
+            cats.categories.get(&GlyphName::new("bar")),
+            Some(&GlyphClassDef::Base)
+        );
+        assert_eq!(
+            cats.categories.get(&GlyphName::new("plus")),
+            Some(&GlyphClassDef::Ligature)
+        );
+    }
+
+    #[test]
+    fn no_categories_without_propagate_anchors() {
+        // wght_var has no openTypeCategories and no propagateAnchors
+        let (_, context) = build_static_metadata("wght_var.designspace", Flags::default());
+        let cats = context.preliminary_gdef_categories.get();
+        assert!(cats.categories.is_empty());
+        assert!(!cats.infer_from_anchors);
+    }
+
+    #[test]
+    fn infers_categories_from_glyphdata_with_propagate_anchors() {
+        // wght_var has no openTypeCategories; with PROPAGATE_ANCHORS flag,
+        // should infer from GlyphData.xml
+        let (_, context) = build_static_metadata("wght_var.designspace", Flags::PROPAGATE_ANCHORS);
+        let cats = context.preliminary_gdef_categories.get();
+        assert!(cats.infer_from_anchors);
+        // wght_var has glyphs "bar" and "plus" -- neither is a mark or ligature,
+        // so categories will be empty but infer_from_anchors is still true
+        assert!(cats.categories.is_empty());
     }
 }


### PR DESCRIPTION
Fixes #767. Companion to googlefonts/ufo2ft#985 and googlefonts/fontmake#1168.

Two changes to align fontc's UFO/DS category handling with fontmake:

1. Read `public.openTypeCategories` from the designspace lib first, falling back to the default master's UFO lib. The DS lib is the canonical location for designspace sources -- previously fontc only checked the UFO lib. Matches ufo2ft's `OpenTypeCategories.load()` [precedence](https://github.com/googlefonts/ufo2ft/blob/46196892e8/Lib/ufo2ft/util.py#L696-L704).
  
2. Infer preliminary GDEF categories from GlyphData.xml when no explicit `public.openTypeCategories` exist and `propagateAnchors` is enabled. Marks (Nonspacing, Spacing Combining) and ligatures are classified from GlyphData.xml; bases are inferred after anchor propagation via `recompute_gdef_categories` (with `infer_from_anchors: true`). This matches fontmake#1168's build-time category generation, producing identical GDEF output for DS/UFO sources without explicit categories.
  
`GlyphData::new()` made `pub` in `glyphs-reader` so `ufo2fontir` can construct a query instance. The `ufo2fontir` → `glyphs-reader` dependency is a stopgap. Since the `glyphdata` module is self-contained (no dependency on .glyphs parsing), ideally it could move to its own crate so both format-specific frontends can share it without the cross-format coupling. I can do that in a follow-up PR.

Verified locally against several crater fonts with GDEF diffs caused by missing categories (Assistant, MerriweatherSans, MerriweatherSans-Italic, Vollkorn, Vollkorn-Italic, OpenSans-Roman, OpenSans-Italic). The first 5 go from GDEF class diffs to "output is identical". The two OpenSans variants now have identical GDEF/GPOS; residual hmtx/maxp diffs are unrelated.
