### PR TITLE
Warn when default master customParameters differ from font-level values

### DIFF
--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -387,6 +387,8 @@ impl Work<Context, WorkId, Error> for StaticMetadataWork {
             .map(|v| -v)
             .unwrap_or(0.0);
 
+        warn_master_font_custom_param_mismatch(font);
+
         let mut selection_flags = match font.custom_parameters.use_typo_metrics.unwrap_or_default() {
             true => SelectionFlags::USE_TYPO_METRICS,
             false => SelectionFlags::empty(),
@@ -1885,6 +1887,44 @@ impl Work<Context, WorkId, Error> for ColorGlyphsWork {
     }
 }
 
+/// Warn when the default master has font-wide customParameters that differ from font-level values.
+///
+/// fontc uses font-level values; fontmake/glyphsLib would use the default master's
+/// (because master-level handlers happen to run after font-level ones).
+/// <https://github.com/googlefonts/fontc/issues/1856>
+fn warn_master_font_custom_param_mismatch(font: &Font) {
+    let default_master = font.default_master();
+    let fc = &font.custom_parameters;
+    let mc = &default_master.custom_parameters;
+
+    macro_rules! check {
+        ($field:ident, $name:expr) => {
+            if mc.$field.is_some() && mc.$field != fc.$field {
+                warn!(
+                    "Default master '{}' has customParameter '{}' that differs from \
+                     font-level value; fontc uses the font-level value \
+                     (fontmake/glyphsLib would use the master's). \
+                     Consider removing the master-level parameter or aligning it \
+                     with the font-level value.",
+                    default_master.name, $name
+                );
+            }
+        };
+    }
+
+    check!(use_typo_metrics, "Use Typo Metrics");
+    check!(has_wws_names, "Has WWS Names");
+    check!(fs_type, "fsType");
+    check!(is_fixed_pitch, "isFixedPitch");
+    check!(unicode_range_bits, "unicodeRanges");
+    check!(codepage_range_bits, "codePageRanges");
+    check!(head_flags, "headFlags");
+    check!(lowest_rec_ppem, "lowestRecPPEM");
+    check!(dont_use_production_names, "Don't use Production Names");
+    check!(gasp_table, "GASP Table");
+    check!(panose, "panose");
+}
+
 #[cfg(test)]
 mod tests {
     use std::{
@@ -3103,6 +3143,31 @@ mod tests {
     fn reads_fs_type_0x0104() {
         let (_, context) = build_static_metadata(glyphs3_dir().join("fstype_0x0104.glyphs"));
         assert_eq!(Some(0x104), context.static_metadata.get().misc.fs_type);
+    }
+
+    // When font-level and default master customParameters disagree, fontc uses
+    // font-level values (and warns). fontmake/glyphsLib would use the master's.
+    // https://github.com/googlefonts/fontc/issues/1856
+    #[test]
+    fn font_level_custom_params_take_precedence_over_master() {
+        let (_, context) =
+            build_static_metadata(glyphs3_dir().join("master_custom_params_override.glyphs"));
+        let static_metadata = context.static_metadata.get();
+
+        // font-level unicodeRanges has 14 bits; master has 9 => font wins
+        assert_eq!(
+            Some(HashSet::from([
+                0u32, 1, 2, 3, 5, 6, 15, 16, 29, 31, 33, 35, 38, 45
+            ])),
+            static_metadata.misc.unicode_range_bits
+        );
+        // font-level Use Typo Metrics = 1 => flag set (master has 0)
+        assert!(
+            static_metadata
+                .misc
+                .selection_flags
+                .contains(SelectionFlags::USE_TYPO_METRICS),
+        );
     }
 
     #[test]

--- a/resources/testdata/glyphs3/master_custom_params_override.glyphs
+++ b/resources/testdata/glyphs3/master_custom_params_override.glyphs
@@ -1,0 +1,223 @@
+{
+.appVersion = "3414";
+.formatVersion = 3;
+customParameters = (
+{
+name = fsType;
+value = (
+);
+},
+{
+name = unicodeRanges;
+value = (
+0,
+1,
+2,
+3,
+5,
+6,
+15,
+16,
+29,
+31,
+33,
+35,
+38,
+45
+);
+},
+{
+name = "Use Typo Metrics";
+value = 1;
+},
+{
+name = "Has WWS Names";
+value = 1;
+},
+{
+name = trademark;
+value = "Font level trademark";
+}
+);
+familyName = TestOverride;
+fontMaster = (
+{
+axesValues = (
+400
+);
+customParameters = (
+{
+name = unicodeRanges;
+value = (
+0,
+1,
+5,
+15,
+16,
+31,
+33,
+38,
+45
+);
+},
+{
+name = vendorID;
+value = MAST;
+},
+{
+name = license;
+value = "Master license text with slash/";
+},
+{
+name = "Use Typo Metrics";
+value = 0;
+},
+{
+name = trademark;
+value = "Default master trademark";
+}
+);
+id = "master01";
+metricValues = (
+{
+over = 16;
+pos = 800;
+},
+{
+over = 16;
+pos = 700;
+},
+{
+over = 16;
+pos = 500;
+},
+{
+over = -16;
+pos = -200;
+},
+{
+over = -16;
+},
+{
+}
+);
+name = Regular;
+},
+{
+axesValues = (
+700
+);
+customParameters = (
+{
+name = unicodeRanges;
+value = (
+7,
+8,
+9
+);
+},
+{
+name = vendorID;
+value = BOLD;
+},
+{
+name = license;
+value = "Bold master license (ignored)";
+},
+{
+name = "Use Typo Metrics";
+value = 1;
+},
+{
+name = trademark;
+value = "Bold master trademark (ignored)";
+}
+);
+id = "master02";
+metricValues = (
+{
+over = 16;
+pos = 800;
+},
+{
+over = 16;
+pos = 700;
+},
+{
+over = 16;
+pos = 500;
+},
+{
+over = -16;
+pos = -200;
+},
+{
+over = -16;
+},
+{
+}
+);
+name = Bold;
+}
+);
+axes = (
+{
+name = Weight;
+tag = wght;
+}
+);
+metrics = (
+{
+type = ascender;
+},
+{
+type = "cap height";
+},
+{
+type = "x-height";
+},
+{
+type = descender;
+},
+{
+type = baseline;
+},
+{
+type = "italic angle";
+}
+);
+glyphs = (
+{
+glyphname = space;
+layers = (
+{
+layerId = master01;
+width = 200;
+},
+{
+layerId = master02;
+width = 200;
+}
+);
+unicode = 0020;
+}
+);
+properties = (
+{
+key = vendorID;
+value = FONT;
+},
+{
+key = licenses;
+values = (
+{
+language = dflt;
+value = "Font level license text";
+}
+);
+}
+);
+unitsPerEm = 1000;
+versionMajor = 1;
+versionMinor = 0;
+}


### PR DESCRIPTION
Closes #1856

fontc correctly uses font-level custom parameters for font-wide properties like unicodeRanges, fsType, Use Typo Metrics, etc. fontmake (via glyphsLib) accidentally also lets the default master override these, simply because master-level handlers run after font-level ones, overwriting them, and they don't clearly distinguish what belongs to the font as a whole or a particular master.

Glyphs.app doesn't let one add these to a master but some fonts (e.g. NotoSerifBengali.glyphspackage) happen to have some of these in both the font and the default master, and with different values!
It's not worth trying to match this because it's clearly a font source bug that happens to rely on an unintentional quirk in glyphsLib. 

So in this PR, we simply detect when this happen and emit a warning about any such discepancies, so that font developers can fix their sources.

The full list of the font-level custom parameters which are _not_ supported at master level, and for which fontc from now on will emit a helpful message is the following:

- Use Typo Metrics
- Has WWS Names
- fsType / openTypeOS2Type
- isFixedPitch / postscriptIsFixedPitch
- unicodeRanges / openTypeOS2UnicodeRanges
- codePageRanges
- openTypeHeadFlags
- openTypeHeadLowestRecPPEM
- Don't use Production Names
- GASP Table
- panose / openTypeOS2Panose

There are also Glyphs format 2 font-level custom parameters related to name table that have moved to font "properties" in format 3, and which were never supported at the master level. For these we already emit a generic "unknown custom parameter" warning if ever found inside a master, and this is correct because they only belong to the font:

- vendorID / openTypeOS2VendorID
- license / openTypeNameLicense
- licenseURL / openTypeNameLicenseURL
- trademark
- description / openTypeNameDescription
- sampleText / openTypeNameSampleText
- compatibleFullName
- WWSFamilyName / openTypeNameWWSFamilyName
- designers
- designerURL
- manufacturers
- manufacturerURL