### PR TITLE
Canonicalize include paths when checking features.fea compatibility

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -226,10 +226,16 @@ jobs:
           which ttx
           ttx --version
 
+      # Temporarily build the variable-FEA branch of GoogleSans (googlefonts/googlesans#740)
+      # as a smoke test. The static per-master features.fea on the GS default branch are
+      # intentionally rejected as incompatible by this check (see #1829), so building main
+      # here would fail CI. Drop this `ref` once variable FEA lands on the GS default branch
+      # (tracked in googlefonts/googlesans#708).
       - name: Check out GS source repository
         uses: actions/checkout@v4
         with:
           repository: googlefonts/googlesans
+          ref: merge-fea-ast
           path: googlesans
           token: ${{ secrets.GS_READ_FONTC }}
 

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -676,6 +676,11 @@ mod tests {
     }
 
     #[test]
+    fn compile_fea_with_includes_resolved() {
+        assert_compiles_with_gpos_and_gsub("fea_include_resolve.designspace", |o| o);
+    }
+
+    #[test]
     fn compile_fea_with_includes_no_ir() {
         assert_compiles_with_gpos_and_gsub("fea_include.designspace", |mut args| {
             args.ir_dir = None;

--- a/resources/testdata/fea_include_resolve.designspace
+++ b/resources/testdata/fea_include_resolve.designspace
@@ -1,0 +1,22 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<designspace format="4.1">
+  <axes>
+    <axis tag="wght" name="Weight" minimum="400" maximum="700" default="400"/>
+  </axes>
+  <sources>
+    <source filename="fea_include_resolve/Regular.ufo" name="Regular" familyname="FeaIncResolve" stylename="Regular">
+      <lib copy="1"/>
+      <groups copy="1"/>
+      <features copy="1"/>
+      <info copy="1"/>
+      <location>
+        <dimension name="Weight" xvalue="400"/>
+      </location>
+    </source>
+    <source filename="fea_include_resolve/sub/Bold.ufo" name="Bold" familyname="FeaIncResolve" stylename="Bold">
+      <location>
+        <dimension name="Weight" xvalue="700"/>
+      </location>
+    </source>
+  </sources>
+</designspace>

--- a/resources/testdata/fea_include_resolve/Regular.ufo/features.fea
+++ b/resources/testdata/fea_include_resolve/Regular.ufo/features.fea
@@ -1,0 +1,8 @@
+languagesystem DFLT dflt;
+languagesystem latn dflt;
+
+feature kern {
+    position bar plus -100;
+} kern;
+
+include(../features/shared.fea)

--- a/resources/testdata/fea_include_resolve/Regular.ufo/glyphs/bar.glif
+++ b/resources/testdata/fea_include_resolve/Regular.ufo/glyphs/bar.glif
@@ -1,0 +1,5 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="bar" format="2">
+  <advance width="500"/>
+  <unicode hex="007C"/>
+</glyph>

--- a/resources/testdata/fea_include_resolve/Regular.ufo/glyphs/contents.plist
+++ b/resources/testdata/fea_include_resolve/Regular.ufo/glyphs/contents.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>bar</key>
+    <string>bar.glif</string>
+    <key>plus</key>
+    <string>plus.glif</string>
+  </dict>
+</plist>

--- a/resources/testdata/fea_include_resolve/Regular.ufo/glyphs/plus.glif
+++ b/resources/testdata/fea_include_resolve/Regular.ufo/glyphs/plus.glif
@@ -1,0 +1,5 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="plus" format="2">
+  <advance width="500"/>
+  <unicode hex="002B"/>
+</glyph>

--- a/resources/testdata/fea_include_resolve/Regular.ufo/layercontents.plist
+++ b/resources/testdata/fea_include_resolve/Regular.ufo/layercontents.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <array>
+    <array>
+      <string>public.default</string>
+      <string>glyphs</string>
+    </array>
+  </array>
+</plist>

--- a/resources/testdata/fea_include_resolve/Regular.ufo/metainfo.plist
+++ b/resources/testdata/fea_include_resolve/Regular.ufo/metainfo.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>creator</key>
+    <string>com.github.fonttools.ufoLib</string>
+    <key>formatVersion</key>
+    <integer>3</integer>
+  </dict>
+</plist>

--- a/resources/testdata/fea_include_resolve/features/shared.fea
+++ b/resources/testdata/fea_include_resolve/features/shared.fea
@@ -1,0 +1,3 @@
+feature liga {
+    substitute bar bar by plus;
+} liga;

--- a/resources/testdata/fea_include_resolve/sub/Bold.ufo/features.fea
+++ b/resources/testdata/fea_include_resolve/sub/Bold.ufo/features.fea
@@ -1,0 +1,8 @@
+languagesystem DFLT dflt;
+languagesystem latn dflt;
+
+feature kern {
+    position bar plus -100;
+} kern;
+
+include(../../features/shared.fea)

--- a/resources/testdata/fea_include_resolve/sub/Bold.ufo/glyphs/bar.glif
+++ b/resources/testdata/fea_include_resolve/sub/Bold.ufo/glyphs/bar.glif
@@ -1,0 +1,5 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="bar" format="2">
+  <advance width="600"/>
+  <unicode hex="007C"/>
+</glyph>

--- a/resources/testdata/fea_include_resolve/sub/Bold.ufo/glyphs/contents.plist
+++ b/resources/testdata/fea_include_resolve/sub/Bold.ufo/glyphs/contents.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>bar</key>
+    <string>bar.glif</string>
+    <key>plus</key>
+    <string>plus.glif</string>
+  </dict>
+</plist>

--- a/resources/testdata/fea_include_resolve/sub/Bold.ufo/glyphs/plus.glif
+++ b/resources/testdata/fea_include_resolve/sub/Bold.ufo/glyphs/plus.glif
@@ -1,0 +1,5 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="plus" format="2">
+  <advance width="600"/>
+  <unicode hex="002B"/>
+</glyph>

--- a/resources/testdata/fea_include_resolve/sub/Bold.ufo/layercontents.plist
+++ b/resources/testdata/fea_include_resolve/sub/Bold.ufo/layercontents.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <array>
+    <array>
+      <string>public.default</string>
+      <string>glyphs</string>
+    </array>
+  </array>
+</plist>

--- a/resources/testdata/fea_include_resolve/sub/Bold.ufo/metainfo.plist
+++ b/resources/testdata/fea_include_resolve/sub/Bold.ufo/metainfo.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>creator</key>
+    <string>com.github.fonttools.ufoLib</string>
+    <key>formatVersion</key>
+    <integer>3</integer>
+  </dict>
+</plist>

--- a/ufo2fontir/Cargo.toml
+++ b/ufo2fontir/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["text-processing", "parsing", "graphics"]
 [features]
 
 [dependencies]
+fea-rs = { version = "0.22.0", path = "../fea-rs" }
 fontdrasil = { version = "0.4.0", path = "../fontdrasil" }
 fontir = { version = "0.5.0", path = "../fontir" }
 glyphs-reader = { version = "0.5.0", path = "../glyphs-reader" }

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -2256,6 +2256,55 @@ mod tests {
 
     use super::*;
 
+    #[test]
+    fn fea_files_differing_only_by_trailing_newline_are_identical() {
+        // https://github.com/.../Intel-One-Mono: two masters whose features.fea
+        // differ only by a trailing newline must be treated as compatible (as
+        // ufo2ft does, since it compares tokens and ignores whitespace).
+        let tmp = tempfile::tempdir().unwrap();
+        let f1 = tmp.path().join("a.fea");
+        let f2 = tmp.path().join("b.fea");
+        std::fs::write(&f1, "feature kern { pos a b -5; } kern;").unwrap();
+        std::fs::write(&f2, "feature kern { pos a b -5; } kern;\n").unwrap();
+        assert!(fea_files_identical(&f1, &f2).unwrap());
+    }
+
+    #[test]
+    fn fea_files_differing_only_by_comments_are_identical() {
+        // comments don't affect the compiled features, so two masters that
+        // differ only by comments must be treated as compatible (as ufo2ft,
+        // which excludes comments from its token comparison).
+        let tmp = tempfile::tempdir().unwrap();
+        let f1 = tmp.path().join("a.fea");
+        let f2 = tmp.path().join("b.fea");
+        std::fs::write(&f1, "# master A\nfeature kern { pos a b -5; } kern;\n").unwrap();
+        std::fs::write(&f2, "feature kern { pos a b -5; } kern; # note\n").unwrap();
+        assert!(fea_files_identical(&f1, &f2).unwrap());
+    }
+
+    #[test]
+    fn fea_files_include_whitespace_and_relative_paths_normalized() {
+        // `include (path)` with whitespace before the paren is valid FEA (the
+        // old literal "include(" scan missed it), and two masters including the
+        // same file via paths that resolve identically must compare equal.
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join("shared.fea"),
+            "feature liga { sub a b by c; } liga;\n",
+        )
+        .unwrap();
+        let write_master = |name: &str, include: &str| {
+            let ufo = tmp.path().join(name);
+            std::fs::create_dir(&ufo).unwrap();
+            let fea = ufo.join("features.fea");
+            std::fs::write(&fea, include).unwrap();
+            fea
+        };
+        let a = write_master("A.ufo", "include(../shared.fea)");
+        let b = write_master("B.ufo", "include (../shared.fea)\n");
+        assert!(fea_files_identical(&a, &b).unwrap());
+    }
+
     macro_rules! plist_dict {
         ($($key:expr => $val:expr),* $(,)?) => {{
             let mut d = plist::Dictionary::new();

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -740,23 +740,81 @@ fn units_per_em<'a>(font_infos: impl Iterator<Item = &'a norad::FontInfo>) -> Re
     }
 }
 
-fn files_identical(f1: &Path, f2: &Path) -> Result<bool, BadSource> {
+fn fea_files_identical(f1: &Path, f2: &Path) -> Result<bool, BadSource> {
     if !f1.is_file() {
         return Err(BadSource::new(f1, BadSourceKind::ExpectedFile));
     }
     if !f2.is_file() {
         return Err(BadSource::new(f2, BadSourceKind::ExpectedFile));
     }
-    let m1 = f1
-        .metadata()
-        .map_err(|e| BadSource::new(f1, BadSourceKind::Io(e)))?;
-    let m2 = f2
-        .metadata()
-        .map_err(|e| BadSource::new(f2, BadSourceKind::Io(e)))?;
-    if m1.len() != m2.len() {
-        return Ok(false);
+    let c1 = std::fs::read_to_string(f1).map_err(|e| BadSource::new(f1, BadSourceKind::Io(e)))?;
+    let c2 = std::fs::read_to_string(f2).map_err(|e| BadSource::new(f2, BadSourceKind::Io(e)))?;
+    if c1 == c2 {
+        return Ok(true);
     }
-    Ok(true)
+    debug!(
+        "Feature files differ, canonicalizing include paths: {} vs {}",
+        f1.display(),
+        f2.display()
+    );
+    let n1 = canonicalize_fea_includes(&c1, f1);
+    let n2 = canonicalize_fea_includes(&c2, f2);
+    Ok(n1 == n2)
+}
+
+/// Replace `include(relative/path)` with `include(/canonical/path)` so that
+/// two files with different relative include paths to the same target compare
+/// as equal.
+///
+/// Follows the same resolution order as fea-rs's `FileSystemResolver` and
+/// fontTools' `IncludingLexer` (used by ufo2ft): try the UFO's parent
+/// directory first, then the directory containing the including file.
+///
+/// Per the UFO spec, includes resolve relative to the directory where the
+/// UFO lives, not inside the UFO package itself.
+fn canonicalize_fea_includes(content: &str, fea_path: &Path) -> String {
+    let fea_dir = fea_path.parent().unwrap_or(Path::new("."));
+    let ufo_parent_dir = fea_dir.parent().unwrap_or(fea_dir);
+    let mut result = String::with_capacity(content.len());
+    let mut remaining = content;
+    while let Some(start) = remaining.find("include(") {
+        result.push_str(&remaining[..start]);
+        let after = &remaining[start + 8..];
+        if let Some(end) = after.find(')') {
+            let raw_path = Path::new(after[..end].trim());
+            let resolved = resolve_include(raw_path, ufo_parent_dir, fea_dir);
+            let canonical = std::fs::canonicalize(&resolved)
+                .unwrap_or(resolved)
+                .display()
+                .to_string();
+            result.push_str("include(");
+            result.push_str(&canonical);
+            result.push(')');
+            remaining = &after[end + 1..];
+        } else {
+            result.push_str(&remaining[start..start + 8]);
+            remaining = after;
+        }
+    }
+    result.push_str(remaining);
+    result
+}
+
+/// Resolve an include path the same way fea-rs does: try the UFO's parent
+/// directory first, then the including file's directory.
+fn resolve_include(path: &Path, ufo_parent_dir: &Path, including_dir: &Path) -> PathBuf {
+    if path.is_absolute() {
+        return path.to_path_buf();
+    }
+    let from_root = ufo_parent_dir.join(path);
+    if from_root.exists() {
+        return from_root;
+    }
+    let from_parent = including_dir.join(path);
+    if from_parent.exists() {
+        return from_parent;
+    }
+    from_parent
 }
 
 /// Creates a map from UFO directory name => fontinfo.
@@ -1564,7 +1622,7 @@ impl Work<Context, WorkId, Error> for FeatureWork {
 
         let fea_files = self.fea_files.as_ref();
         for fea_file in fea_files.iter().skip(1) {
-            if !files_identical(&fea_files[0], fea_file)? {
+            if !fea_files_identical(&fea_files[0], fea_file)? {
                 warn!(
                     "Bailing out due to non-identical feature files. This is an unnecessary limitation."
                 );

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -1,4 +1,5 @@
 use std::{
+    borrow::Cow,
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     ffi::OsStr,
     path::{Path, PathBuf},
@@ -7,6 +8,10 @@ use std::{
 };
 
 use chrono::{DateTime, NaiveDateTime, Utc};
+use fea_rs::{
+    Kind, ParseTree,
+    parse::{FileSystemResolver, SourceResolver, parse_string},
+};
 use fontdrasil::{
     coords::{DesignCoord, DesignLocation, NormalizedLocation, UserCoord},
     orchestration::{Access, AccessBuilder, Work},
@@ -749,72 +754,60 @@ fn fea_files_identical(f1: &Path, f2: &Path) -> Result<bool, BadSource> {
     }
     let c1 = std::fs::read_to_string(f1).map_err(|e| BadSource::new(f1, BadSourceKind::Io(e)))?;
     let c2 = std::fs::read_to_string(f2).map_err(|e| BadSource::new(f2, BadSourceKind::Io(e)))?;
-    if c1 == c2 {
-        return Ok(true);
-    }
-    debug!(
-        "Feature files differ, canonicalizing include paths: {} vs {}",
-        f1.display(),
-        f2.display()
-    );
-    let n1 = canonicalize_fea_includes(&c1, f1);
-    let n2 = canonicalize_fea_includes(&c2, f2);
-    Ok(n1 == n2)
+    let (ast1, _) = parse_string(c1);
+    let (ast2, _) = parse_string(c2);
+    let resolver1 = FileSystemResolver::new(ufo_parent_dir(f1));
+    let resolver2 = FileSystemResolver::new(ufo_parent_dir(f2));
+    // Compare the significant tokens -- include paths canonicalized, whitespace
+    // and comments ignored -- rather than the raw text, matching how ufo2ft
+    // decides feature compatibility. This tolerates trailing-newline,
+    // reformatting and comment-only differences, and different relative include
+    // paths that point at the same file, while still erroring on real changes.
+    // `Iterator::eq` walks both streams lazily and stops at the first mismatch,
+    // and only the (canonicalized) include paths allocate.
+    Ok(significant_fea_tokens(&ast1, f1, &resolver1)
+        .eq(significant_fea_tokens(&ast2, f2, &resolver2)))
 }
 
-/// Replace `include(relative/path)` with `include(/canonical/path)` so that
-/// two files with different relative include paths to the same target compare
-/// as equal.
-///
-/// Follows the same resolution order as fea-rs's `FileSystemResolver` and
-/// fontTools' `IncludingLexer` (used by ufo2ft): try the UFO's parent
-/// directory first, then the directory containing the including file.
-///
-/// Per the UFO spec, includes resolve relative to the directory where the
-/// UFO lives, not inside the UFO package itself.
-fn canonicalize_fea_includes(content: &str, fea_path: &Path) -> String {
+/// The directory an include path is resolved against: per the UFO spec, the
+/// directory the UFO lives in (the parent of the UFO package).
+fn ufo_parent_dir(fea_path: &Path) -> PathBuf {
     let fea_dir = fea_path.parent().unwrap_or(Path::new("."));
-    let ufo_parent_dir = fea_dir.parent().unwrap_or(fea_dir);
-    let mut result = String::with_capacity(content.len());
-    let mut remaining = content;
-    while let Some(start) = remaining.find("include(") {
-        result.push_str(&remaining[..start]);
-        let after = &remaining[start + 8..];
-        if let Some(end) = after.find(')') {
-            let raw_path = Path::new(after[..end].trim());
-            let resolved = resolve_include(raw_path, ufo_parent_dir, fea_dir);
-            let canonical = std::fs::canonicalize(&resolved)
-                .unwrap_or(resolved)
-                .display()
-                .to_string();
-            result.push_str("include(");
-            result.push_str(&canonical);
-            result.push(')');
-            remaining = &after[end + 1..];
-        } else {
-            result.push_str(&remaining[start..start + 8]);
-            remaining = after;
-        }
-    }
-    result.push_str(remaining);
-    result
+    fea_dir.parent().unwrap_or(fea_dir).to_path_buf()
 }
 
-/// Resolve an include path the same way fea-rs does: try the UFO's parent
-/// directory first, then the including file's directory.
-fn resolve_include(path: &Path, ufo_parent_dir: &Path, including_dir: &Path) -> PathBuf {
-    if path.is_absolute() {
-        return path.to_path_buf();
-    }
-    let from_root = ufo_parent_dir.join(path);
-    if from_root.exists() {
-        return from_root;
-    }
-    let from_parent = including_dir.join(path);
-    if from_parent.exists() {
-        return from_parent;
-    }
-    from_parent
+/// Iterate the significant tokens of a features.fea for compatibility comparison:
+/// whitespace and comments are dropped (as ufo2ft does), and each `include()`
+/// path is canonicalized so that include paths resolving to the same file
+/// compare equal even when the masters spell them differently (e.g. relative
+/// paths that differ because the master UFOs sit at different directory depths).
+///
+/// Paths are resolved with fea-rs's own [`FileSystemResolver`], the same
+/// machinery used when the features are compiled for real, so the compatibility
+/// check and the compile agree on what each include points to.
+fn significant_fea_tokens<'a>(
+    ast: &'a ParseTree,
+    fea_path: &'a Path,
+    resolver: &'a FileSystemResolver,
+) -> impl Iterator<Item = (Kind, Cow<'a, str>)> + 'a {
+    ast.root()
+        .iter_tokens()
+        .filter_map(move |token| match token.kind {
+            // ignore trivia, matching ufo2ft (which excludes comments and whitespace)
+            Kind::Whitespace | Kind::Comment => None,
+            // the Path token text is the raw include path, including any whitespace
+            // inside the parens; trim before resolving.
+            Kind::Path => {
+                let raw_path = Path::new(token.as_str().trim());
+                let resolved = resolver.resolve_raw_path(raw_path, Some(fea_path));
+                let canonical = std::fs::canonicalize(&resolved)
+                    .unwrap_or(resolved)
+                    .display()
+                    .to_string();
+                Some((Kind::Path, Cow::Owned(canonical)))
+            }
+            kind => Some((kind, Cow::Borrowed(token.as_str()))),
+        })
 }
 
 /// Creates a map from UFO directory name => fontinfo.


### PR DESCRIPTION
This is an attempt to fix part of #1829, the easier bit (not the merge multiple master features.fea into a variable FEA problem).

Some designspace/UFOs sources (e.g. Roboto-Flex) have masters at different directory depths with features.fea containing relative include paths that point to the _same_ shared file.

Currently we naively check only the lengths of the master UFOs' features.fea files to determine if they are compatible or not. When they only differ because the relative include path differs (while the included file is the same), we reject them as incompatible.

So in this PR, when features.fea files differ across masters, I canonicalize include() paths to absolute paths before comparing them.

Include paths are resolved following the same logic as fea-rs and ufo2ft/feaLib: try the UFO's parent directory first (per the UFO spec, includes resolve relative to where the UFO lives, not inside it), then the directory of the including file.

I decided not to add fea-rs as a dependency to ufo2fontir because it feels a bit like breaking the layer separation between frontend and backend (only fontbe depends on fea-rs right now). Also, parsing the features.fea files just to compare them for equality and then throwing them away feels a bit wasteful, though that's more or less what ufo2ft does when it uses the IncludingLexer (not a full parser) to resolve include statements before comparing them.

This also fixes another latent bug: by only comparing file lengths, we can sometimes assume master features.fea are compatible when in fact they aren't (e.g. they vary in the value records but happen to have the same total file length) and silently take the first one and produce an incorrect font without variations. The correct thing to do in this case is to error (until a proper merge variable feature support is added).



