### PR TITLE
Bump fontmake to 3.12.1

### DIFF
--- a/resources/scripts/requirements.in
+++ b/resources/scripts/requirements.in
@@ -4,7 +4,7 @@
 # Pin versions for CI stability (overrides ttx-diff's minimum versions)
 # keep fontmake version pinned to ensure output from ttx-diff is stable;
 # the 'repacker' option enables faster GSUB/GPOS serialization via uharfbuzz
-fontmake[repacker]==3.12.0
+fontmake[repacker]==3.12.1
 # keep gftools pinned as well to ensure ttx-diff output is stable.
 # 0.9.74 is when experimental support for fontc was added to gftools.
 gftools==0.9.93

--- a/resources/scripts/requirements.txt
+++ b/resources/scripts/requirements.txt
@@ -74,7 +74,7 @@ font-v==2.1.0
     # via gftools
 fontfeatures==1.9.0
     # via gftools
-fontmake[json,repacker]==3.12.0
+fontmake[json,repacker]==3.12.1
     # via
     #   -r resources/scripts/requirements.in
     #   gftools


### PR DESCRIPTION
fontmake 3.12.1 fixes the "AssertionError: Default source not found!" crash when building static fonts from a single-master source whose only master sits at a non-default axis location. That crash was introduced in fontmake 3.11.1 and started biting fontc_crater once we bumped to 3.12.0, failing ~52 ttx-diff builds.

fontmake release: https://github.com/googlefonts/fontmake/releases/tag/v3.12.1