### PR TITLE
Bump fontations deps: write-fonts 0.49.1, skrifa 0.43.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,8 @@ icu_properties = "=2.1"
 smallvec = {version = "1.15", features = ["const_new"]}
 
 # fontations etc
-write-fonts = { version = "0.48.0", features = ["serde", "read"] }
-skrifa = { version = "0.42.0", features = ["traversal"] }
+write-fonts = { version = "0.49.1", features = ["serde", "read"] }
+skrifa = { version = "0.43.2", features = ["traversal"] }
 norad = { version = "0.18.4", default-features = false }
 
 # dev dependencies


### PR DESCRIPTION
Pulls in read-fonts 0.40.1 and font-types 0.12.0, which adds F2Dot14::from_f64 (and f64 conversions for the other fixed types). Needed as the prerequisite for the #1966 component-transform rounding fix (but lands on its own since fontc was several releases behind).

No source changes required.