### PR TITLE
[tests] add PartialKernException test sources

### DIFF
--- a/resources/testdata/PartialKernException-Bold.ufo/fontinfo.plist
+++ b/resources/testdata/PartialKernException-Bold.ufo/fontinfo.plist
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>ascender</key>
+    <integer>800</integer>
+    <key>capHeight</key>
+    <integer>700</integer>
+    <key>descender</key>
+    <integer>-200</integer>
+    <key>familyName</key>
+    <string>PartialKernException</string>
+    <key>styleName</key>
+    <string>Bold</string>
+    <key>unitsPerEm</key>
+    <integer>1000</integer>
+    <key>xHeight</key>
+    <integer>500</integer>
+  </dict>
+</plist>

--- a/resources/testdata/PartialKernException-Bold.ufo/glyphs/_notdef.glif
+++ b/resources/testdata/PartialKernException-Bold.ufo/glyphs/_notdef.glif
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name=".notdef" format="2">
+  <advance width="600"/>
+  <outline>
+    <contour>
+      <point x="50" y="0" type="line"/>
+      <point x="550" y="0" type="line"/>
+      <point x="550" y="700" type="line"/>
+      <point x="50" y="700" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/resources/testdata/PartialKernException-Bold.ufo/glyphs/ca-ethiopic.glif
+++ b/resources/testdata/PartialKernException-Bold.ufo/glyphs/ca-ethiopic.glif
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="ca-ethiopic" format="2">
+  <advance width="600"/>
+  <unicode hex="1278"/>
+  <outline>
+    <contour>
+      <point x="50" y="0" type="line"/>
+      <point x="550" y="0" type="line"/>
+      <point x="550" y="700" type="line"/>
+      <point x="50" y="700" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/resources/testdata/PartialKernException-Bold.ufo/glyphs/cee-ethiopic.glif
+++ b/resources/testdata/PartialKernException-Bold.ufo/glyphs/cee-ethiopic.glif
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="cee-ethiopic" format="2">
+  <advance width="600"/>
+  <unicode hex="127C"/>
+  <outline>
+    <contour>
+      <point x="50" y="0" type="line"/>
+      <point x="550" y="0" type="line"/>
+      <point x="550" y="700" type="line"/>
+      <point x="50" y="700" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/resources/testdata/PartialKernException-Bold.ufo/glyphs/contents.plist
+++ b/resources/testdata/PartialKernException-Bold.ufo/glyphs/contents.plist
@@ -1,0 +1,30 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>.notdef</key>
+    <string>_notdef.glif</string>
+    <key>ca-ethiopic</key>
+    <string>ca-ethiopic.glif</string>
+    <key>cee-ethiopic</key>
+    <string>cee-ethiopic.glif</string>
+    <key>iotadasiaoxia</key>
+    <string>iotadasiaoxia.glif</string>
+    <key>iotadasiavaria</key>
+    <string>iotadasiavaria.glif</string>
+    <key>iotapsilioxia</key>
+    <string>iotapsilioxia.glif</string>
+    <key>qhee-ethiopic</key>
+    <string>qhee-ethiopic.glif</string>
+    <key>qhwee-ethiopic</key>
+    <string>qhwee-ethiopic.glif</string>
+    <key>uoA</key>
+    <string>uoA_.glif</string>
+    <key>uoB</key>
+    <string>uoB_.glif</string>
+    <key>uoX</key>
+    <string>uoX_.glif</string>
+    <key>uoY</key>
+    <string>uoY_.glif</string>
+  </dict>
+</plist>

--- a/resources/testdata/PartialKernException-Bold.ufo/glyphs/iotadasiaoxia.glif
+++ b/resources/testdata/PartialKernException-Bold.ufo/glyphs/iotadasiaoxia.glif
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="iotadasiaoxia" format="2">
+  <advance width="600"/>
+  <unicode hex="1F35"/>
+  <outline>
+    <contour>
+      <point x="50" y="0" type="line"/>
+      <point x="550" y="0" type="line"/>
+      <point x="550" y="700" type="line"/>
+      <point x="50" y="700" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/resources/testdata/PartialKernException-Bold.ufo/glyphs/iotadasiavaria.glif
+++ b/resources/testdata/PartialKernException-Bold.ufo/glyphs/iotadasiavaria.glif
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="iotadasiavaria" format="2">
+  <advance width="600"/>
+  <unicode hex="1F33"/>
+  <outline>
+    <contour>
+      <point x="50" y="0" type="line"/>
+      <point x="550" y="0" type="line"/>
+      <point x="550" y="700" type="line"/>
+      <point x="50" y="700" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/resources/testdata/PartialKernException-Bold.ufo/glyphs/iotapsilioxia.glif
+++ b/resources/testdata/PartialKernException-Bold.ufo/glyphs/iotapsilioxia.glif
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="iotapsilioxia" format="2">
+  <advance width="600"/>
+  <unicode hex="1F34"/>
+  <outline>
+    <contour>
+      <point x="50" y="0" type="line"/>
+      <point x="550" y="0" type="line"/>
+      <point x="550" y="700" type="line"/>
+      <point x="50" y="700" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/resources/testdata/PartialKernException-Bold.ufo/glyphs/qhee-ethiopic.glif
+++ b/resources/testdata/PartialKernException-Bold.ufo/glyphs/qhee-ethiopic.glif
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="qhee-ethiopic" format="2">
+  <advance width="600"/>
+  <unicode hex="1254"/>
+  <outline>
+    <contour>
+      <point x="50" y="0" type="line"/>
+      <point x="550" y="0" type="line"/>
+      <point x="550" y="700" type="line"/>
+      <point x="50" y="700" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/resources/testdata/PartialKernException-Bold.ufo/glyphs/qhwee-ethiopic.glif
+++ b/resources/testdata/PartialKernException-Bold.ufo/glyphs/qhwee-ethiopic.glif
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="qhwee-ethiopic" format="2">
+  <advance width="600"/>
+  <unicode hex="1258"/>
+  <outline>
+    <contour>
+      <point x="50" y="0" type="line"/>
+      <point x="550" y="0" type="line"/>
+      <point x="550" y="700" type="line"/>
+      <point x="50" y="700" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/resources/testdata/PartialKernException-Bold.ufo/glyphs/uoA_.glif
+++ b/resources/testdata/PartialKernException-Bold.ufo/glyphs/uoA_.glif
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uoA" format="2">
+  <advance width="600"/>
+  <unicode hex="E000"/>
+  <outline>
+    <contour>
+      <point x="50" y="0" type="line"/>
+      <point x="550" y="0" type="line"/>
+      <point x="550" y="700" type="line"/>
+      <point x="50" y="700" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/resources/testdata/PartialKernException-Bold.ufo/glyphs/uoB_.glif
+++ b/resources/testdata/PartialKernException-Bold.ufo/glyphs/uoB_.glif
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uoB" format="2">
+  <advance width="600"/>
+  <unicode hex="E001"/>
+  <outline>
+    <contour>
+      <point x="50" y="0" type="line"/>
+      <point x="550" y="0" type="line"/>
+      <point x="550" y="700" type="line"/>
+      <point x="50" y="700" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/resources/testdata/PartialKernException-Bold.ufo/glyphs/uoX_.glif
+++ b/resources/testdata/PartialKernException-Bold.ufo/glyphs/uoX_.glif
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uoX" format="2">
+  <advance width="600"/>
+  <unicode hex="E002"/>
+  <outline>
+    <contour>
+      <point x="50" y="0" type="line"/>
+      <point x="550" y="0" type="line"/>
+      <point x="550" y="700" type="line"/>
+      <point x="50" y="700" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/resources/testdata/PartialKernException-Bold.ufo/glyphs/uoY_.glif
+++ b/resources/testdata/PartialKernException-Bold.ufo/glyphs/uoY_.glif
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uoY" format="2">
+  <advance width="600"/>
+  <unicode hex="E003"/>
+  <outline>
+    <contour>
+      <point x="50" y="0" type="line"/>
+      <point x="550" y="0" type="line"/>
+      <point x="550" y="700" type="line"/>
+      <point x="50" y="700" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/resources/testdata/PartialKernException-Bold.ufo/groups.plist
+++ b/resources/testdata/PartialKernException-Bold.ufo/groups.plist
@@ -1,0 +1,36 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>public.kern1.GRK_iotaRight</key>
+    <array>
+      <string>iotadasiaoxia</string>
+      <string>iotadasiavaria</string>
+    </array>
+    <key>public.kern1.ethi_qhee</key>
+    <array>
+      <string>qhwee-ethiopic</string>
+      <string>qhee-ethiopic</string>
+    </array>
+    <key>public.kern1.uoLeft</key>
+    <array>
+      <string>uoA</string>
+      <string>uoB</string>
+    </array>
+    <key>public.kern2.GRK_iotaLeft</key>
+    <array>
+      <string>iotapsilioxia</string>
+      <string>iotadasiaoxia</string>
+    </array>
+    <key>public.kern2.ethi_ca</key>
+    <array>
+      <string>ca-ethiopic</string>
+      <string>cee-ethiopic</string>
+    </array>
+    <key>public.kern2.uoRight</key>
+    <array>
+      <string>uoX</string>
+      <string>uoY</string>
+    </array>
+  </dict>
+</plist>

--- a/resources/testdata/PartialKernException-Bold.ufo/kerning.plist
+++ b/resources/testdata/PartialKernException-Bold.ufo/kerning.plist
@@ -1,0 +1,33 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>public.kern1.GRK_iotaRight</key>
+    <dict>
+      <key>iotapsilioxia</key>
+      <integer>30</integer>
+      <key>public.kern2.GRK_iotaLeft</key>
+      <integer>50</integer>
+    </dict>
+    <key>public.kern1.ethi_qhee</key>
+    <dict>
+      <key>public.kern2.ethi_ca</key>
+      <integer>50</integer>
+    </dict>
+    <key>public.kern1.uoLeft</key>
+    <dict>
+      <key>public.kern2.uoRight</key>
+      <integer>50</integer>
+    </dict>
+    <key>qhwee-ethiopic</key>
+    <dict>
+      <key>public.kern2.ethi_ca</key>
+      <integer>30</integer>
+    </dict>
+    <key>uoA</key>
+    <dict>
+      <key>public.kern2.uoRight</key>
+      <integer>70</integer>
+    </dict>
+  </dict>
+</plist>

--- a/resources/testdata/PartialKernException-Bold.ufo/layercontents.plist
+++ b/resources/testdata/PartialKernException-Bold.ufo/layercontents.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <array>
+    <array>
+      <string>public.default</string>
+      <string>glyphs</string>
+    </array>
+  </array>
+</plist>

--- a/resources/testdata/PartialKernException-Bold.ufo/lib.plist
+++ b/resources/testdata/PartialKernException-Bold.ufo/lib.plist
@@ -1,0 +1,21 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>public.glyphOrder</key>
+    <array>
+      <string>.notdef</string>
+      <string>iotadasiaoxia</string>
+      <string>iotadasiavaria</string>
+      <string>iotapsilioxia</string>
+      <string>qhwee-ethiopic</string>
+      <string>qhee-ethiopic</string>
+      <string>ca-ethiopic</string>
+      <string>cee-ethiopic</string>
+      <string>uoA</string>
+      <string>uoB</string>
+      <string>uoX</string>
+      <string>uoY</string>
+    </array>
+  </dict>
+</plist>

--- a/resources/testdata/PartialKernException-Bold.ufo/metainfo.plist
+++ b/resources/testdata/PartialKernException-Bold.ufo/metainfo.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>creator</key>
+    <string>com.github.fonttools.ufoLib</string>
+    <key>formatVersion</key>
+    <integer>3</integer>
+  </dict>
+</plist>

--- a/resources/testdata/PartialKernException-Regular.ufo/fontinfo.plist
+++ b/resources/testdata/PartialKernException-Regular.ufo/fontinfo.plist
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>ascender</key>
+    <integer>800</integer>
+    <key>capHeight</key>
+    <integer>700</integer>
+    <key>descender</key>
+    <integer>-200</integer>
+    <key>familyName</key>
+    <string>PartialKernException</string>
+    <key>styleName</key>
+    <string>Regular</string>
+    <key>unitsPerEm</key>
+    <integer>1000</integer>
+    <key>xHeight</key>
+    <integer>500</integer>
+  </dict>
+</plist>

--- a/resources/testdata/PartialKernException-Regular.ufo/glyphs/_notdef.glif
+++ b/resources/testdata/PartialKernException-Regular.ufo/glyphs/_notdef.glif
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name=".notdef" format="2">
+  <advance width="600"/>
+  <outline>
+    <contour>
+      <point x="50" y="0" type="line"/>
+      <point x="550" y="0" type="line"/>
+      <point x="550" y="700" type="line"/>
+      <point x="50" y="700" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/resources/testdata/PartialKernException-Regular.ufo/glyphs/ca-ethiopic.glif
+++ b/resources/testdata/PartialKernException-Regular.ufo/glyphs/ca-ethiopic.glif
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="ca-ethiopic" format="2">
+  <advance width="600"/>
+  <unicode hex="1278"/>
+  <outline>
+    <contour>
+      <point x="50" y="0" type="line"/>
+      <point x="550" y="0" type="line"/>
+      <point x="550" y="700" type="line"/>
+      <point x="50" y="700" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/resources/testdata/PartialKernException-Regular.ufo/glyphs/cee-ethiopic.glif
+++ b/resources/testdata/PartialKernException-Regular.ufo/glyphs/cee-ethiopic.glif
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="cee-ethiopic" format="2">
+  <advance width="600"/>
+  <unicode hex="127C"/>
+  <outline>
+    <contour>
+      <point x="50" y="0" type="line"/>
+      <point x="550" y="0" type="line"/>
+      <point x="550" y="700" type="line"/>
+      <point x="50" y="700" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/resources/testdata/PartialKernException-Regular.ufo/glyphs/contents.plist
+++ b/resources/testdata/PartialKernException-Regular.ufo/glyphs/contents.plist
@@ -1,0 +1,30 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>.notdef</key>
+    <string>_notdef.glif</string>
+    <key>ca-ethiopic</key>
+    <string>ca-ethiopic.glif</string>
+    <key>cee-ethiopic</key>
+    <string>cee-ethiopic.glif</string>
+    <key>iotadasiaoxia</key>
+    <string>iotadasiaoxia.glif</string>
+    <key>iotadasiavaria</key>
+    <string>iotadasiavaria.glif</string>
+    <key>iotapsilioxia</key>
+    <string>iotapsilioxia.glif</string>
+    <key>qhee-ethiopic</key>
+    <string>qhee-ethiopic.glif</string>
+    <key>qhwee-ethiopic</key>
+    <string>qhwee-ethiopic.glif</string>
+    <key>uoA</key>
+    <string>uoA_.glif</string>
+    <key>uoB</key>
+    <string>uoB_.glif</string>
+    <key>uoX</key>
+    <string>uoX_.glif</string>
+    <key>uoY</key>
+    <string>uoY_.glif</string>
+  </dict>
+</plist>

--- a/resources/testdata/PartialKernException-Regular.ufo/glyphs/iotadasiaoxia.glif
+++ b/resources/testdata/PartialKernException-Regular.ufo/glyphs/iotadasiaoxia.glif
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="iotadasiaoxia" format="2">
+  <advance width="600"/>
+  <unicode hex="1F35"/>
+  <outline>
+    <contour>
+      <point x="50" y="0" type="line"/>
+      <point x="550" y="0" type="line"/>
+      <point x="550" y="700" type="line"/>
+      <point x="50" y="700" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/resources/testdata/PartialKernException-Regular.ufo/glyphs/iotadasiavaria.glif
+++ b/resources/testdata/PartialKernException-Regular.ufo/glyphs/iotadasiavaria.glif
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="iotadasiavaria" format="2">
+  <advance width="600"/>
+  <unicode hex="1F33"/>
+  <outline>
+    <contour>
+      <point x="50" y="0" type="line"/>
+      <point x="550" y="0" type="line"/>
+      <point x="550" y="700" type="line"/>
+      <point x="50" y="700" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/resources/testdata/PartialKernException-Regular.ufo/glyphs/iotapsilioxia.glif
+++ b/resources/testdata/PartialKernException-Regular.ufo/glyphs/iotapsilioxia.glif
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="iotapsilioxia" format="2">
+  <advance width="600"/>
+  <unicode hex="1F34"/>
+  <outline>
+    <contour>
+      <point x="50" y="0" type="line"/>
+      <point x="550" y="0" type="line"/>
+      <point x="550" y="700" type="line"/>
+      <point x="50" y="700" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/resources/testdata/PartialKernException-Regular.ufo/glyphs/qhee-ethiopic.glif
+++ b/resources/testdata/PartialKernException-Regular.ufo/glyphs/qhee-ethiopic.glif
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="qhee-ethiopic" format="2">
+  <advance width="600"/>
+  <unicode hex="1254"/>
+  <outline>
+    <contour>
+      <point x="50" y="0" type="line"/>
+      <point x="550" y="0" type="line"/>
+      <point x="550" y="700" type="line"/>
+      <point x="50" y="700" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/resources/testdata/PartialKernException-Regular.ufo/glyphs/qhwee-ethiopic.glif
+++ b/resources/testdata/PartialKernException-Regular.ufo/glyphs/qhwee-ethiopic.glif
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="qhwee-ethiopic" format="2">
+  <advance width="600"/>
+  <unicode hex="1258"/>
+  <outline>
+    <contour>
+      <point x="50" y="0" type="line"/>
+      <point x="550" y="0" type="line"/>
+      <point x="550" y="700" type="line"/>
+      <point x="50" y="700" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/resources/testdata/PartialKernException-Regular.ufo/glyphs/uoA_.glif
+++ b/resources/testdata/PartialKernException-Regular.ufo/glyphs/uoA_.glif
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uoA" format="2">
+  <advance width="600"/>
+  <unicode hex="E000"/>
+  <outline>
+    <contour>
+      <point x="50" y="0" type="line"/>
+      <point x="550" y="0" type="line"/>
+      <point x="550" y="700" type="line"/>
+      <point x="50" y="700" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/resources/testdata/PartialKernException-Regular.ufo/glyphs/uoB_.glif
+++ b/resources/testdata/PartialKernException-Regular.ufo/glyphs/uoB_.glif
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uoB" format="2">
+  <advance width="600"/>
+  <unicode hex="E001"/>
+  <outline>
+    <contour>
+      <point x="50" y="0" type="line"/>
+      <point x="550" y="0" type="line"/>
+      <point x="550" y="700" type="line"/>
+      <point x="50" y="700" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/resources/testdata/PartialKernException-Regular.ufo/glyphs/uoX_.glif
+++ b/resources/testdata/PartialKernException-Regular.ufo/glyphs/uoX_.glif
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uoX" format="2">
+  <advance width="600"/>
+  <unicode hex="E002"/>
+  <outline>
+    <contour>
+      <point x="50" y="0" type="line"/>
+      <point x="550" y="0" type="line"/>
+      <point x="550" y="700" type="line"/>
+      <point x="50" y="700" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/resources/testdata/PartialKernException-Regular.ufo/glyphs/uoY_.glif
+++ b/resources/testdata/PartialKernException-Regular.ufo/glyphs/uoY_.glif
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uoY" format="2">
+  <advance width="600"/>
+  <unicode hex="E003"/>
+  <outline>
+    <contour>
+      <point x="50" y="0" type="line"/>
+      <point x="550" y="0" type="line"/>
+      <point x="550" y="700" type="line"/>
+      <point x="50" y="700" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/resources/testdata/PartialKernException-Regular.ufo/groups.plist
+++ b/resources/testdata/PartialKernException-Regular.ufo/groups.plist
@@ -1,0 +1,36 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>public.kern1.GRK_iotaRight</key>
+    <array>
+      <string>iotadasiaoxia</string>
+      <string>iotadasiavaria</string>
+    </array>
+    <key>public.kern1.ethi_qhee</key>
+    <array>
+      <string>qhwee-ethiopic</string>
+      <string>qhee-ethiopic</string>
+    </array>
+    <key>public.kern1.uoLeft</key>
+    <array>
+      <string>uoA</string>
+      <string>uoB</string>
+    </array>
+    <key>public.kern2.GRK_iotaLeft</key>
+    <array>
+      <string>iotapsilioxia</string>
+      <string>iotadasiaoxia</string>
+    </array>
+    <key>public.kern2.ethi_ca</key>
+    <array>
+      <string>ca-ethiopic</string>
+      <string>cee-ethiopic</string>
+    </array>
+    <key>public.kern2.uoRight</key>
+    <array>
+      <string>uoX</string>
+      <string>uoY</string>
+    </array>
+  </dict>
+</plist>

--- a/resources/testdata/PartialKernException-Regular.ufo/kerning.plist
+++ b/resources/testdata/PartialKernException-Regular.ufo/kerning.plist
@@ -1,0 +1,34 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>iotadasiaoxia</key>
+    <dict>
+      <key>public.kern2.GRK_iotaLeft</key>
+      <integer>30</integer>
+    </dict>
+    <key>public.kern1.GRK_iotaRight</key>
+    <dict>
+      <key>iotapsilioxia</key>
+      <integer>20</integer>
+      <key>public.kern2.GRK_iotaLeft</key>
+      <integer>60</integer>
+    </dict>
+    <key>public.kern1.ethi_qhee</key>
+    <dict>
+      <key>ca-ethiopic</key>
+      <integer>40</integer>
+      <key>public.kern2.ethi_ca</key>
+      <integer>30</integer>
+    </dict>
+    <key>public.kern1.uoLeft</key>
+    <dict>
+      <key>public.kern2.uoRight</key>
+      <integer>50</integer>
+      <key>uoX</key>
+      <integer>30</integer>
+      <key>uoY</key>
+      <integer>30</integer>
+    </dict>
+  </dict>
+</plist>

--- a/resources/testdata/PartialKernException-Regular.ufo/layercontents.plist
+++ b/resources/testdata/PartialKernException-Regular.ufo/layercontents.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <array>
+    <array>
+      <string>public.default</string>
+      <string>glyphs</string>
+    </array>
+  </array>
+</plist>

--- a/resources/testdata/PartialKernException-Regular.ufo/lib.plist
+++ b/resources/testdata/PartialKernException-Regular.ufo/lib.plist
@@ -1,0 +1,21 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>public.glyphOrder</key>
+    <array>
+      <string>.notdef</string>
+      <string>iotadasiaoxia</string>
+      <string>iotadasiavaria</string>
+      <string>iotapsilioxia</string>
+      <string>qhwee-ethiopic</string>
+      <string>qhee-ethiopic</string>
+      <string>ca-ethiopic</string>
+      <string>cee-ethiopic</string>
+      <string>uoA</string>
+      <string>uoB</string>
+      <string>uoX</string>
+      <string>uoY</string>
+    </array>
+  </dict>
+</plist>

--- a/resources/testdata/PartialKernException-Regular.ufo/metainfo.plist
+++ b/resources/testdata/PartialKernException-Regular.ufo/metainfo.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>creator</key>
+    <string>com.github.fonttools.ufoLib</string>
+    <key>formatVersion</key>
+    <integer>3</integer>
+  </dict>
+</plist>

--- a/resources/testdata/PartialKernException.designspace
+++ b/resources/testdata/PartialKernException.designspace
@@ -1,0 +1,18 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<designspace format="5.0">
+  <axes>
+    <axis tag="wght" name="Weight" minimum="0" maximum="1000" default="0"/>
+  </axes>
+  <sources>
+    <source filename="PartialKernException-Regular.ufo" familyname="PartialKernException" stylename="Regular">
+      <location>
+        <dimension name="Weight" xvalue="0"/>
+      </location>
+    </source>
+    <source filename="PartialKernException-Bold.ufo" familyname="PartialKernException" stylename="Bold">
+      <location>
+        <dimension name="Weight" xvalue="1000"/>
+      </location>
+    </source>
+  </sources>
+</designspace>


### PR DESCRIPTION
A two-master designspace with glyph-to-class kern exceptions that are present in only one master (one in the default, one in the other) plus one that competing class-to-glyph exceptions override for every member of its class.

It's exercised by an upcoming regression test for https://github.com/googlefonts/fontc/issues/2035.

I PR this first to make the next PR's diff less noisy. 

The kerning structure mimics where the bug was first observed in Google Sans (outlines and values are synthetic).