### PR TITLE
[kern] resolve partial-master kern exceptions per-cell to avoid phantom values

### DIFF
--- a/fontbe/src/features/kern.rs
+++ b/fontbe/src/features/kern.rs
@@ -265,23 +265,11 @@ fn build_variable_kern_adjustments(
             && let Some(members) = ir_groups.groups.get(second_group)
         {
             // group second-side members by their per-location cell value vector
-            let mut by_value: Vec<(KernAdjustments, Vec<GlyphName>)> = Vec::new();
-            for member in members {
-                if glyph_order.glyph_id(member).is_none() {
-                    continue;
-                }
-                let cell = (
-                    ir::KernSide::Glyph(first.clone()),
-                    ir::KernSide::Glyph(member.clone()),
-                );
+            let mut by_value = BTreeMap::<_, Vec<_>>::new();
+            for member in members.iter().filter(|name| glyph_order.contains(*name)) {
+                let cell = (first.clone().into(), member.clone().into());
                 let vector = resolve(&cell);
-                match by_value
-                    .iter_mut()
-                    .find(|(existing, _)| *existing == vector)
-                {
-                    Some((_, members)) => members.push(member.clone()),
-                    None => by_value.push((vector, vec![member.clone()])),
-                }
+                by_value.entry(vector).or_default().push(member.clone());
             }
             if by_value.len() == 1 {
                 // no cell diverges: keep the compact glyph-to-class pair, but

--- a/fontbe/src/features/kern.rs
+++ b/fontbe/src/features/kern.rs
@@ -151,7 +151,7 @@ impl Work<Context, AnyWorkId, Error> for GatherIrKerningWork {
             .map(|(_, ki)| (ki.location.clone(), ki.as_ref().to_owned()))
             .collect();
 
-        let adjustments = build_variable_kern_adjustments(&ir_groups, &kern_by_pos);
+        let adjustments = build_variable_kern_adjustments(&ir_groups, &glyph_order, &kern_by_pos);
 
         let adjustments: Vec<_> = adjustments
             .into_iter()
@@ -214,8 +214,22 @@ fn glyph_to_group_maps(
 ///
 /// in pythonland this happens in ufo2ft, here:
 /// <https://github.com/googlefonts/ufo2ft/blob/1a21d0071c69b1/Lib/ufo2ft/featureWriters/kernFeatureWriter.py#L748>
+///
+/// The exception is a glyph-to-class pair that is present in only some
+/// masters: the cascade would backfill it, where missing, with the more
+/// general class-to-class value, and -- since kern rules are ordered
+/// most-specific-first and the first match wins -- that backfill shadows
+/// competing class-to-glyph exceptions on the cells they share, rendering
+/// "phantom" values there that the sources never resolve to. Such a pair
+/// is instead resolved cell by cell: when every member of the class lands
+/// on the same values, the compact glyph-to-class pair is kept, carrying
+/// those cell values; otherwise it is split into one glyph-glyph pair per
+/// member. See <https://github.com/googlefonts/fontc/issues/2035>; this
+/// mirrors the equivalent fix in ufo2ft's kernFeatureWriter
+/// (<https://github.com/googlefonts/ufo2ft/issues/988>).
 fn build_variable_kern_adjustments(
     ir_groups: &KerningGroups,
+    glyph_order: &GlyphOrder,
     kern_by_pos: &HashMap<NormalizedLocation, KerningInstance>,
 ) -> BTreeMap<ir::KernPair, KernAdjustments> {
     let (side1_glyphs, side2_glyphs) = glyph_to_group_maps(ir_groups);
@@ -244,11 +258,81 @@ fn build_variable_kern_adjustments(
     };
 
     let mut adjustments: BTreeMap<ir::KernPair, KernAdjustments> = Default::default();
-    for pair in all_pairs {
-        let values = resolve(&pair);
-        adjustments.insert(pair, values);
+    for key in all_pairs {
+        // resolve glyph-to-class exceptions at the cell level (see the doc
+        // comment above)
+        if let (ir::KernSide::Glyph(first), ir::KernSide::Group(second_group)) = &key
+            && let Some(members) = ir_groups.groups.get(second_group)
+        {
+            // group second-side members by their per-location cell value vector
+            let mut by_value: Vec<(KernAdjustments, Vec<GlyphName>)> = Vec::new();
+            for member in members {
+                if glyph_order.glyph_id(member).is_none() {
+                    continue;
+                }
+                let cell = (
+                    ir::KernSide::Glyph(first.clone()),
+                    ir::KernSide::Glyph(member.clone()),
+                );
+                let vector = resolve(&cell);
+                match by_value
+                    .iter_mut()
+                    .find(|(existing, _)| *existing == vector)
+                {
+                    Some((_, members)) => members.push(member.clone()),
+                    None => by_value.push((vector, vec![member.clone()])),
+                }
+            }
+            if by_value.len() == 1 {
+                // no cell diverges: keep the compact glyph-to-class pair, but
+                // carrying the agreed *cell* value -- not the key-level value,
+                // which class-to-glyph exceptions covering every cell
+                // uniformly never resolve to.
+                let (vector, _members) = by_value.into_iter().next().unwrap();
+                insert_resolved(&mut adjustments, key, vector);
+            } else {
+                // cells diverge: replace the glyph-to-class pair with one
+                // glyph-glyph pair per second-side member, each carrying its
+                // own cell value vector. (With no members in the glyph order
+                // this emits nothing, dropping the pair like `exec` would.)
+                for (vector, members) in by_value {
+                    for member in members {
+                        let pair = (
+                            ir::KernSide::Glyph(first.clone()),
+                            ir::KernSide::Glyph(member),
+                        );
+                        insert_resolved(&mut adjustments, pair, vector.clone());
+                    }
+                }
+            }
+            continue;
+        }
+        let values = resolve(&key);
+        insert_resolved(&mut adjustments, key, values);
     }
     adjustments
+}
+
+/// Insert a resolved pair; colliding pairs always carry equal values.
+///
+/// Two keys can produce the same pair: the cell-level split of a
+/// glyph-to-class exception emits glyph-glyph pairs, and one of those may
+/// also be defined explicitly (encountered in either order). Both resolve
+/// the same cell against the same unmodified sources, so the values cannot
+/// differ and the overwrite is benign. The debug_assert cannot fire; it
+/// documents that invariant and is compiled out of release builds.
+fn insert_resolved(
+    adjustments: &mut BTreeMap<ir::KernPair, KernAdjustments>,
+    pair: ir::KernPair,
+    values: KernAdjustments,
+) {
+    debug_assert!(
+        adjustments
+            .get(&pair)
+            .is_none_or(|previous| previous == &values),
+        "conflicting variable kern values for {pair:?}"
+    );
+    adjustments.insert(pair, values);
 }
 
 // <https://github.com/fonttools/fonttools/blob/a3b9eddcafca/Lib/fontTools/ufoLib/kerning.py#L1>

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -2292,6 +2292,88 @@ mod tests {
         assert_simple_kerning("designspace_from_glyphs/WghtVar.designspace");
     }
 
+    // A glyph-to-class kern exception present in only some masters used to get
+    // backfilled, at the masters that omit it, with the class-to-class value.
+    // Because glyph-to-class outranks class-to-glyph, that backfill then shadows
+    // a competing class-to-glyph exception on the cells they share, producing --
+    // at those locations -- a value the source never resolves to for the cell
+    // (a "phantom"). We resolve such exceptions at the cell level instead,
+    // splitting out only the glyphs whose value diverges. This mirrors the
+    // equivalent fix in ufo2ft's kernFeatureWriter.
+    // See https://github.com/googlefonts/fontc/issues/2035.
+    #[test]
+    fn partial_master_kern_exception_is_resolved_per_cell() {
+        let result = TestCompile::compile_source("PartialKernException.designspace");
+        let all_kerns = result.be_context.all_kerning_pairs.get();
+
+        // one compact "side1 side2: [value at wght 0, value at wght 1]" line
+        // per pair, sorted, compared exhaustively: pairs untouched by the
+        // cell-level resolution must come through unchanged.
+        let mut kerns: Vec<(KernPair, Vec<(f64, f64)>)> = all_kerns
+            .adjustments
+            .iter()
+            .map(|(pair, adj)| {
+                let mut values: Vec<(f64, f64)> = adj
+                    .iter()
+                    .map(|(loc, val)| (loc.iter().map(|(_, v)| v.to_f64()).next().unwrap(), val.0))
+                    .collect();
+                values.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
+                (pair.clone(), values)
+            })
+            .collect();
+        kerns.sort_by(|(a, _), (b, _)| a.cmp(b));
+        let kerns: Vec<String> = kerns
+            .iter()
+            .map(|((first, second), values)| {
+                let values = values
+                    .iter()
+                    .map(|(_, val)| val.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                format!("{first} {second}: [{values}]")
+            })
+            .collect();
+
+        assert_eq!(
+            kerns,
+            vec![
+                // Greek: the exception (iotadasiaoxia, @GRK_iotaLeft)=30 is present
+                // only in the default master and its cells diverge, so the
+                // glyph-to-class pair is gone, replaced by per-member glyph-glyph
+                // pairs carrying the cell-faithful values: iotadasiaoxia falls
+                // through to the class-to-class value at wght 1 (50),
+                // iotapsilioxia to the class-to-glyph exception (30).
+                "iotadasiaoxia iotadasiaoxia: [30, 50]",
+                "iotadasiaoxia iotapsilioxia: [30, 30]",
+                // Ethiopic: the mirror case -- the exception
+                // (qhwee-ethiopic, @ethi_ca)=30 is present only in the *other*
+                // master, so the phantom would land on the default. Also split:
+                // ca-ethiopic keeps the class-to-glyph value (40) at wght 0.
+                "qhwee-ethiopic ca-ethiopic: [40, 30]",
+                "qhwee-ethiopic cee-ethiopic: [30, 30]",
+                // Uniform override: the class-to-glyph exceptions cover *every*
+                // member of @uoRight equally (one per member, same value), so no
+                // cell diverges and the compact glyph-to-class pair is kept, not
+                // split. But it must carry the agreed cell value [30, 70], not
+                // the class-to-class value (50) the backfill produced where the
+                // glyph-to-class exception is absent (which would shadow the
+                // class-to-glyph exceptions at wght 0 -- a phantom even though
+                // no two cells disagree).
+                "uoA @side2.uoRight: [30, 70]",
+                // The remaining pairs are untouched by the cell-level resolution;
+                // where a master omits one, the aligned value comes from the
+                // class-to-class backfill, which is correct for these kinds.
+                "@side1.GRK_iotaRight iotapsilioxia: [20, 30]",
+                "@side1.GRK_iotaRight @side2.GRK_iotaLeft: [60, 50]",
+                "@side1.ethi_qhee ca-ethiopic: [40, 50]",
+                "@side1.ethi_qhee @side2.ethi_ca: [30, 50]",
+                "@side1.uoLeft uoX: [30, 50]",
+                "@side1.uoLeft uoY: [30, 50]",
+                "@side1.uoLeft @side2.uoRight: [50, 50]",
+            ]
+        );
+    }
+
     fn assert_intermediate_layer(src: &str) {
         let result = TestCompile::compile_source(src);
         let font = result.font();


### PR DESCRIPTION
Fixes #2035 

A glyph-to-class kern exception that is present in only some masters gets backfilled with the more general class-to-class value, which may shadows competing class-to-glyph exceptions on the cells they share.

Resolve glyph-to-class exceptions cell by cell instead: when every member of the class lands on the same values, keep the compact glyph-to-class pair carrying those cell values; otherwise split it into one glyph-glyph pair per member.

Same fix as googlefonts/ufo2ft#990 (for googlefonts/ufo2ft#988), currently pending review there.

The first commit adds the regression test alone, pushed first so CI demonstrates the failure; the second makes it pass. 

Builds on #2038 and #2039.

(Note: until the ufo2ft fix lands and crater's fontmake picks it up, any affected fonts will show kern diffs against fontmake. I will coordinate the merges so crater doesn't got red)