### PR TITLE
Temporarily pin `time` to 0.3.47 to fix 0.3.48 regression

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,10 @@ rayon = "1.6"
 icu_properties = "=2.1"
 smallvec = {version = "1.15", features = ["const_new"]}
 
+# TEMPORARY: see https://github.com/googlefonts/fontc/issues/2042
+# and https://github.com/time-rs/time/issues/783.
+time = "=0.3.47"
+
 # fontations etc
 write-fonts = { version = "0.49.1", features = ["serde", "read"] }
 skrifa = { version = "0.43.2", features = ["traversal"] }

--- a/fontc/Cargo.toml
+++ b/fontc/Cargo.toml
@@ -49,6 +49,10 @@ rayon = { workspace = true, optional = true }
 # just for fontc!
 crossbeam-channel = "0.5.6"
 
+# Not used directly: this only exists so the workspace pin on `time` (see the
+# root Cargo.toml) takes effect on resolution. Remove together with that pin.
+time = { workspace = true }
+
 clap = { workspace = true, optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
remove it once 0.3.49 lands.

See https://github.com/time-rs/time/issues/783

Fixes #2042 

JMM