### PR TITLE
Make WARN the default log level

### DIFF
--- a/fontc/src/args.rs
+++ b/fontc/src/args.rs
@@ -115,7 +115,7 @@ pub struct Args {
     #[arg(long = "vv", default_value = "false")]
     pub verbose_version: bool,
 
-    /// Set the log level, either globally or per module.
+    /// Set the log level, either globally or per module. Defaults to warn.
     ///
     /// See <https://docs.rs/env_logger/latest/env_logger/#enabling-logging> for format.
     #[arg(long)]

--- a/fontc/src/main.rs
+++ b/fontc/src/main.rs
@@ -13,7 +13,7 @@ fn main() {
     let args = Args::parse();
 
     // catch and print errors manually, to avoid just seeing the Debug impls
-    // The default log level is error so the user will see it unless they specifically turned off logging
+    // The default log level is warn so the user will see it unless they specifically turned off logging
     if let Err(e) = run(args) {
         let mut error_displayed = false;
         let mut additional = "";
@@ -46,7 +46,9 @@ fn run(args: Args) -> Result<(), Error> {
         .create_timer(AnyWorkId::InternalTiming("Init logger"), 0)
         .queued()
         .run();
-    let mut log_cfg = env_logger::builder();
+    // default to WARN; RUST_LOG or --log can still override
+    let mut log_cfg =
+        env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("warn"));
     log_cfg.format(|buf, record| {
         let ts = buf.timestamp_micros();
         let style = buf.default_level_style(record.level());


### PR DESCRIPTION
fontc inherited env_logger's default of ERROR, so genuine problems that are logged at warn (e.g. skipped missing components, glyphs absent from the default master) were invisible unless the user passed --log warn or set RUST_LOG.

fontmake shows warnings by default, and users rely on that to learn their source has issues.

Let's default the filter to warn instead. RUST_LOG and --log can still override in either direction (I verified locally that --log error and RUST_LOG=error both suppress the warnings).

Fixes #2032.