### PR TITLE
Update GitHub Actions to latest stable versions

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -28,7 +28,7 @@ jobs:
         # https://github.com/googlefonts/gftools/blob/d4c06f5d88e0a849fabf7089d80835a96dc42f30/pyproject.toml#L47-L49
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -78,7 +78,7 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/ttx-diff-v')
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -90,7 +90,7 @@ jobs:
         run: pipx run build
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: python-packages
           path: ttx_diff/dist/
@@ -105,7 +105,7 @@ jobs:
 
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: python-packages
           path: dist/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,9 +100,9 @@ jobs:
     env:
       TOOL: ${{ needs.detect.outputs.tool }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
           architecture: ${{ matrix.platform.python-architecture }}
@@ -170,13 +170,13 @@ jobs:
           cd -
 
       - name: Upload wheel artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wheels-${{ env.TOOL }}-${{ matrix.platform.target }}
           path: ${{ needs.detect.outputs.working-directory }}/dist
 
       - name: Upload binary artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: binaries-${{ env.TOOL }}-${{ matrix.platform.target }}
           path: |
@@ -198,7 +198,7 @@ jobs:
           - target: "aarch64-unknown-linux-gnu"
             manylinux: "2014"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Build Wheels
         uses: PyO3/maturin-action@v1
@@ -220,13 +220,13 @@ jobs:
         run: tar czvf target/release/${TOOL}-${{ matrix.platform.target }}.tar.gz -C target/${{ matrix.platform.target }}/release ${TOOL}
 
       - name: Upload wheel artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wheels-${{ env.TOOL }}-${{ matrix.platform.target }}
           path: ${{ needs.detect.outputs.working-directory }}/dist
 
       - name: Upload binary artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: binaries-${{ env.TOOL }}-${{ matrix.platform.target }}
           path: target/release/${{ env.TOOL }}-${{ matrix.platform.target }}.tar.gz
@@ -252,10 +252,10 @@ jobs:
     steps:
       # checkout@v3 doesn't work inside the manylinux container:
       # https://github.com/actions/checkout/issues/1487
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Build Wheels
-        uses: PyO3/maturin-action@main
+        uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
           manylinux: ${{ matrix.platform.compatibility }}
@@ -267,13 +267,13 @@ jobs:
         run: tar czvf target/release/${TOOL}-${{ matrix.platform.target }}.tar.gz -C target/${{ matrix.platform.target }}/release ${TOOL}
 
       - name: Upload wheel artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wheels-${{ env.TOOL }}-${{ matrix.platform.target }}
           path: ${{ needs.detect.outputs.working-directory }}/dist
 
       - name: Upload binary artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: binaries-${{ env.TOOL }}-${{ matrix.platform.target }}
           path: target/release/${{ env.TOOL }}-${{ matrix.platform.target }}.tar.gz
@@ -289,7 +289,7 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           pattern: wheels-${{ needs.detect.outputs.tool }}-*
           # so that all artifacts are downloaded in the same directory specified by 'path'
@@ -311,12 +311,12 @@ jobs:
     env:
       TOOL: ${{ needs.detect.outputs.tool }}
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           pattern: binaries-${{ needs.detect.outputs.tool }}-*
           merge-multiple: true
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           pattern: wheels-${{ needs.detect.outputs.tool }}-*
           merge-multiple: true
@@ -364,7 +364,7 @@ jobs:
           fi
 
       - name: Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           name: ${{ steps.before_release.outputs.release_title }}
           files: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,7 +28,7 @@ jobs:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: install stable toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -51,7 +51,7 @@ jobs:
     name: Clippy lints
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -73,7 +73,7 @@ jobs:
     name: fontbe tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: install stable toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -91,7 +91,7 @@ jobs:
       #    default set of font sources.
       FONTC_BENCH_SRCS: ""
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: install stable toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -103,7 +103,7 @@ jobs:
     name: tests other than fontbe,fontc
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: install stable toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -127,7 +127,7 @@ jobs:
     name: cargo check no std
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: install stable toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -154,7 +154,7 @@ jobs:
     name: resources/scripts/ots_test.sh
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: install stable toolchain
         uses: dtolnay/rust-toolchain@stable
 
@@ -167,15 +167,13 @@ jobs:
     steps:
       - name: install stable toolchain
         uses: dtolnay/rust-toolchain@stable
-      - uses: actions/checkout@v3
-      - uses: getsentry/action-setup-venv@v1.0.0
+      - uses: actions/checkout@v6
+      - uses: getsentry/action-setup-venv@v3.2.0
         id: venv
         with:
           python-version: 3.10.7
-          requirement-files: resources/scripts/fea_ci_requirements.txt
-      - run: pip install -r resources/scripts/fea_ci_requirements.txt
-        if: steps.venv.outputs.cache-hit != 'true'
-
+          cache-dependency-path: resources/scripts/fea_ci_requirements.txt
+          install-cmd: pip install -r resources/scripts/fea_ci_requirements.txt
 
       - name: cargo test fea-rs
         run: cargo test -p fea-rs
@@ -187,8 +185,8 @@ jobs:
     steps:
       - name: install stable toolchain
         uses: dtolnay/rust-toolchain@stable
-      - uses: actions/checkout@v4
-      - uses: getsentry/action-setup-venv@v3.0.0
+      - uses: actions/checkout@v6
+      - uses: getsentry/action-setup-venv@v3.2.0
         id: venv
         with:
           python-version: 3.13
@@ -207,7 +205,7 @@ jobs:
     if: github.event.pull_request.head.repo.fork == false
     steps:
       - name: Check out fontc source repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install the latest stable Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -232,7 +230,7 @@ jobs:
       # here would fail CI. Drop this `ref` once variable FEA lands on the GS default branch
       # (tracked in googlefonts/googlesans#708).
       - name: Check out GS source repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: googlefonts/googlesans
           ref: merge-fea-ast
@@ -240,7 +238,7 @@ jobs:
           token: ${{ secrets.GS_READ_FONTC }}
 
       - name: Check out Oswald source repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: googlefonts/OswaldFont
           path: oswald
@@ -263,7 +261,7 @@ jobs:
       - name: OTS tests, Oswald
         run: ots-9.1.0-Linux/ots-sanitize build/Oswald.ttf
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: failure()
         with:
           path: build/*.ttf
@@ -274,7 +272,7 @@ jobs:
     name: cargo check wasm
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: install stable toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -294,7 +292,7 @@ jobs:
 
     steps:
       - name: Check out fontc source repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: run tidy_glyphs.py
         run: python3 ./resources/scripts/tidy_glyphs.py just_check


### PR DESCRIPTION
GitHub deprecates Node 20 actions on June 16th 2026 (runners will force Node 24), so I took the oppurtunity to bump everything to the current stable major.

JMM