### PR TITLE
Pack F2Dot14 transforms and normalized coords in f64

### DIFF
--- a/fea-rs/src/compile/compile_ctx.rs
+++ b/fea-rs/src/compile/compile_ctx.rs
@@ -26,7 +26,7 @@ use write_fonts::{
         },
         variations::{common_builder::RemapVarStore, ivs_builder::VariationStoreBuilder},
     },
-    types::{F2Dot14, NameId, Tag},
+    types::{NameId, Tag},
 };
 
 use crate::{
@@ -2159,12 +2159,8 @@ impl<'a, F: FeatureProvider, V: VariationInfo> CompilationCtx<'a, F, V> {
 
                 ConditionFormat1 {
                     axis_index: axis_index as u16,
-                    filter_range_min_value: F2Dot14::from_f32(
-                        min.to_normalized(&axis.converter).to_f64() as _,
-                    ),
-                    filter_range_max_value: F2Dot14::from_f32(
-                        max.to_normalized(&axis.converter).to_f64() as _,
-                    ),
+                    filter_range_min_value: min.to_normalized(&axis.converter).to_f2dot14(),
+                    filter_range_max_value: max.to_normalized(&axis.converter).to_f2dot14(),
                 }
                 .into()
             })

--- a/fontbe/src/glyphs.rs
+++ b/fontbe/src/glyphs.rs
@@ -96,8 +96,10 @@ fn create_component_ref_gid(
 
     // By this point, fontir should have decomposed any components with transforms
     // outside the -2.0 to +2.0 range. For values between MAX_F2DOT14 and 2.0,
-    // F2Dot14::from_f32() will saturate to MAX_F2DOT14, matching fonttools behavior:
+    // F2Dot14::from_f64() will saturate to MAX_F2DOT14, matching fonttools behavior:
     // https://github.com/googlefonts/fontc/issues/1638
+    // The coeffs are f64; pack directly in f64 to avoid an intermediate narrowing
+    // to f32 that can flip rounding ties (https://github.com/googlefonts/fontc/issues/1966).
 
     let component = Component::new(
         gid,
@@ -106,10 +108,10 @@ fn create_component_ref_gid(
             y: f.ot_round(),
         },
         Transform {
-            xx: F2Dot14::from_f32(a as f32),
-            yx: F2Dot14::from_f32(b as f32),
-            xy: F2Dot14::from_f32(c as f32),
-            yy: F2Dot14::from_f32(d as f32),
+            xx: F2Dot14::from_f64(a),
+            yx: F2Dot14::from_f64(b),
+            xy: F2Dot14::from_f64(c),
+            yy: F2Dot14::from_f64(d),
         },
         flags,
     );
@@ -1065,7 +1067,7 @@ mod tests {
     #[test]
     fn test_component_transform_saturation() {
         // Test that component 2x2 transforms with values exceeding F2Dot14's range
-        // get saturated to min/max by font-types' F2Dot14::from_f32.
+        // get saturated to min/max by font-types' F2Dot14::from_f64.
         // We are interested in particular to values > MAX_F2DOT14 but <= 2.0 (e.g.
         // 'xx' below), which fonttools TTGlyphPen clamps to MAX_F2DOT14.
         // Components with transform values < -2.0 or > 2.0 are always decomposed

--- a/fontbe/src/glyphs.rs
+++ b/fontbe/src/glyphs.rs
@@ -1085,6 +1085,21 @@ mod tests {
         assert_eq!(c.anchor, Anchor::Offset { x: 100, y: -200 });
     }
 
+    #[test]
+    fn component_transform_rounds_in_f64() {
+        // Regression test for https://github.com/googlefonts/fontc/issues/1966.
+        // Component scales are f64 and must be packed to F2Dot14 in f64; narrowing
+        // to f32 first can nudge a value onto an exact .5 tie and round it the
+        // "wrong" way. ShipporiAntique has a 0.98526 component scale: fonttools and
+        // fontmake pack it to 0x3F0E (16142), but F2Dot14::from_f32(0.98526 as f32)
+        // gives 16143 because 0.98526_f32 * 16384 is exactly 16142.5.
+        let transform = Affine::new([0.98526, 0.0, 0.0, 1.0, 0.0, 0.0]);
+        let (c, _) = create_component_ref_gid(GlyphId16::new(1), &transform).unwrap();
+        assert_eq!(c.transform.xx, F2Dot14::from_bits(16142));
+        // Guard against a regression to the f32-narrowing path:
+        assert_ne!(c.transform.xx, F2Dot14::from_f32(0.98526_f32));
+    }
+
     #[rstest]
     #[case::empty(GlyphType::Simple, 0)]
     #[case::simple(GlyphType::Simple, 4)]

--- a/fontdrasil/src/coords.rs
+++ b/fontdrasil/src/coords.rs
@@ -167,7 +167,7 @@ impl Coord<NormalizedSpace> {
     };
 
     pub fn to_f2dot14(self) -> F2Dot14 {
-        F2Dot14::from_f32(self.to_f64() as _)
+        F2Dot14::from_f64(self.to_f64())
     }
 }
 
@@ -295,7 +295,7 @@ impl From<UserCoord> for Fixed {
 
 impl From<NormalizedCoord> for F2Dot14 {
     fn from(value: NormalizedCoord) -> Self {
-        F2Dot14::from_f32(value.to_f64() as _)
+        F2Dot14::from_f64(value.to_f64())
     }
 }
 

--- a/fontdrasil/src/variations.rs
+++ b/fontdrasil/src/variations.rs
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use write_fonts::{
     tables::{gvar, variations::RegionAxisCoordinates},
-    types::{F2Dot14, Tag},
+    types::Tag,
 };
 
 #[derive(Debug, Error)]
@@ -767,9 +767,9 @@ impl Tent {
     /// Create an equivalent [RegionAxisCoordinates] instance.
     pub fn to_region_axis_coords(&self) -> RegionAxisCoordinates {
         RegionAxisCoordinates {
-            start_coord: F2Dot14::from_f32(self.min.to_f64() as _),
-            peak_coord: F2Dot14::from_f32(self.peak.to_f64() as _),
-            end_coord: F2Dot14::from_f32(self.max.to_f64() as _),
+            start_coord: self.min.to_f2dot14(),
+            peak_coord: self.peak.to_f2dot14(),
+            end_coord: self.max.to_f2dot14(),
         }
     }
 }

--- a/fontir/src/feature_variations.rs
+++ b/fontir/src/feature_variations.rs
@@ -14,7 +14,7 @@ use indexmap::IndexMap;
 use smallvec::SmallVec;
 use write_fonts::{
     tables::layout::{ConditionFormat1, ConditionSet},
-    types::{F2Dot14, Tag},
+    types::Tag,
 };
 
 /// A rectilinear region of an n-dimensional designspace.
@@ -56,8 +56,8 @@ impl NBox {
                     .position(|a| a.tag == *tag)
                     .expect("should be checked before now");
                 let axis = static_meta.axes.iter().nth(axis_index).unwrap();
-                let min = F2Dot14::from_f32(min.to_f64() as _);
-                let max = F2Dot14::from_f32(max.to_f64() as _);
+                let min = min.to_f2dot14();
+                let max = max.to_f2dot14();
                 let axis_min = axis.min.to_normalized(&axis.converter).to_f2dot14();
                 let axis_max = axis.max.to_normalized(&axis.converter).to_f2dot14();
 

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -1461,7 +1461,7 @@ fn has_overflowing_2x2_transforms(
 ) -> bool {
     // MAX_F2DOT14 is 1.99993896484375 but we still allow up to 2.0 to match fonttools
     // https://github.com/fonttools/fonttools/blob/c4e96980/Lib/fontTools/pens/ttGlyphPen.py#L89-L128
-    // fontbe uses F2Dot14::from_f32() which saturates at MAX_F2DOT14
+    // fontbe uses F2Dot14::from_f64() which saturates at MAX_F2DOT14
     let overflow_info = sources.iter().find_map(|(location, instance)| {
         instance.components.iter().find_map(|component| {
             component.transform.as_coeffs()[..4]


### PR DESCRIPTION
Fixes #1966 and #1841.

The component transform writer and the normalized coordinate F2Dot14 conversions narrowed f64 source values to f32 before calling `F2Dot14::from_f32`. That narrowing can nudge a value that is below .5 in f64 onto exactly .5 in f32, and end up one ULP away from what fonttools/fontmake (which do the math in f64) produce.

The canonical case is ShipporiAntique's 0.98526 component scale: f64 gives 16142.49984 -> 16142, but 0.98526 as f32 times 16384 is exactly 16142.5 -> 16143.

This switches the affected emit sites to `F2Dot14::from_f64` (added in font-types 0.12.0 #2037) so the rounding happens end-to-end in f64: component transforms in fontbe (the #1966 case), fontdrasil's coordinates, the conditionset ranges in fontir and fea-rs.

The first commit adds only the failing regression test, followed by the actual fix.

I ran a local crater (I finally found some use for my remote cloudtop) on this fontc branch against its parent which confirmed only ShipporiAntique becomes identical, no changes for the rest of the targets.

We still have one residual difference, which I left deliberately out of scope: on genuine f64 ties, font-types rounds half away from zero while fonttools' `otRound` rounds half toward +infinity, so _negative_ ties could still potentially differ by one ULP.

AFAICT the crater corpus doesn't hit this. It could be a follow-up if it ever matters.


