### PR TITLE
Stamp fontc version in name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,8 @@ thiserror = "2.0"
 log = "0.4"
 env_logger = "0.11.0"
 parking_lot = "0.12.1"
-clap = { version = "4.0.32", features = ["derive"] }
+# "string" lets us pass a runtime-built version string to #[command(version = ...)]
+clap = { version = "4.0.32", features = ["derive", "string"] }
 rayon = "1.6"
 icu_properties = "=2.1"
 smallvec = {version = "1.15", features = ["const_new"]}

--- a/fontbe/src/colr.rs
+++ b/fontbe/src/colr.rs
@@ -489,7 +489,7 @@ mod tests {
         use fontir::orchestration::Context as IrContext;
 
         let ir_ctx = IrContext::new_root(Default::default(), None);
-        let context = Context::new_root(Default::default(), None, None, false, &ir_ctx);
+        let context = Context::new_root(Default::default(), None, None, None, false, &ir_ctx);
 
         let palette = ColorPalettes::default();
         let mut glyph_order = GlyphOrder::new();

--- a/fontbe/src/name.rs
+++ b/fontbe/src/name.rs
@@ -61,12 +61,11 @@ impl Work<Context, AnyWorkId, Error> for NameWork {
             name_records.sort();
         }
 
-        // Stamp the caller's compiler identity (e.g. "fontc 0.6.1-dev...") into
-        // the version string (name ID 5), so the tool that built a shipping font
-        // binary can be identified. The whole stamp is supplied by the caller;
-        // fontbe doesn't assume it was fontc.
-        if let Some(stamp) = context.compiler_version.as_deref() {
-            stamp_compiler_version(&mut name_records, stamp);
+        // Stamp the fontc version into the version string (name ID 5) so a
+        // shipping font binary records which fontc built it (see #2048). fontc
+        // threads the version in; None means don't stamp.
+        if let Some(version) = context.compiler_version.as_deref() {
+            stamp_compiler_version(&mut name_records, version);
         }
 
         context.name.set(Name::new(name_records));
@@ -74,41 +73,29 @@ impl Work<Context, AnyWorkId, Error> for NameWork {
     }
 }
 
-/// Append `;{stamp}` to every version string (name ID 5) record, replacing any
-/// prior stamp from the same tool.
+/// Append `;fontc {version}` to every version string (name ID 5) record,
+/// replacing any prior `;fontc ...` stamp.
 ///
-/// `stamp` is the caller's `<tool> <version>` (e.g. "fontc 0.6.1-dev..."); the
-/// replace marker `;<tool> ` is derived from its leading token. Replacing rather
-/// than keeping matters when a source version string carries a *stale* stamp
-/// from an earlier build (e.g. a round-tripped `openTypeNameVersion`).
-///
-/// A stamp not of that `<tool> <digit-led version>` shape is still appended, but
-/// re-runs won't detect/replace it (idempotence relies on the shape).
-fn stamp_compiler_version(records: &mut [NameRecord], stamp: &str) {
-    let tool = stamp.split(' ').next().unwrap_or(stamp);
-    let marker = format!(";{tool} ");
+/// Replacing rather than keeping matters when a source version string carries a
+/// *stale* stamp from an earlier build (e.g. a round-tripped
+/// `openTypeNameVersion`): the stamp must report the fontc that actually built
+/// the font. Our stamp always runs to the end (we append last), so truncating at
+/// the marker drops it; this also makes re-stamping idempotent.
+fn stamp_compiler_version(records: &mut [NameRecord], version: &str) {
+    const MARKER: &str = ";fontc ";
     for record in records.iter_mut() {
         if record.name_id != NameId::VERSION_STRING {
             continue;
         }
         let value = &mut *record.string;
-        // A prior stamp is always appended last, so it runs to the end; drop it
-        // before re-stamping. Only treat the marker as a stamp when a digit
-        // follows (the version is SemVer, digit-led), so a human-authored note
-        // like "...;fontc rules" is left untouched.
-        if let Some(idx) = value.find(&marker)
-            && value
-                .as_bytes()
-                .get(idx + marker.len())
-                .is_some_and(u8::is_ascii_digit)
-        {
+        if let Some(idx) = value.find(MARKER) {
             value.truncate(idx);
         }
-        // Don't emit a bare ";<tool> ..." when there's no actual version in
-        // front of it (an empty record, or one stripped down to nothing).
+        // Don't emit a bare ";fontc ..." when there's no actual version in front
+        // of it (an empty record, or one stripped down to nothing).
         if !value.is_empty() {
-            value.push(';');
-            value.push_str(stamp);
+            value.push_str(MARKER);
+            value.push_str(version);
         }
     }
 }
@@ -161,7 +148,7 @@ mod tests {
     #[test]
     fn stamps_version_string() {
         let mut records = vec![version_record("Version 1.000")];
-        stamp_compiler_version(&mut records, "fontc 0.6.1-dev.394+gd62ba016");
+        stamp_compiler_version(&mut records, "0.6.1-dev.394+gd62ba016");
         assert_eq!(
             records[0].string.as_str(),
             "Version 1.000;fontc 0.6.1-dev.394+gd62ba016"
@@ -171,9 +158,9 @@ mod tests {
     #[test]
     fn appends_after_existing_note() {
         // The version string may already carry a `;`-delimited note (allowed by
-        // the OT spec); the stamp is appended after it, leaving it intact.
+        // the OT spec); a note that isn't our stamp is left intact.
         let mut records = vec![version_record("Version 2.000; my custom note")];
-        stamp_compiler_version(&mut records, "fontc 0.6.0");
+        stamp_compiler_version(&mut records, "0.6.0");
         assert_eq!(
             records[0].string.as_str(),
             "Version 2.000; my custom note;fontc 0.6.0"
@@ -186,7 +173,7 @@ mod tests {
             NameRecord::new(3, 1, 0x409, NameId::FAMILY_NAME, "Foo".to_string().into()),
             version_record("Version 1.000"),
         ];
-        stamp_compiler_version(&mut records, "fontc 0.6.0");
+        stamp_compiler_version(&mut records, "0.6.0");
         assert_eq!(records[0].string.as_str(), "Foo");
         assert_eq!(records[1].string.as_str(), "Version 1.000;fontc 0.6.0");
     }
@@ -194,8 +181,8 @@ mod tests {
     #[test]
     fn stamp_is_idempotent() {
         let mut records = vec![version_record("Version 1.000")];
-        stamp_compiler_version(&mut records, "fontc 0.6.0");
-        stamp_compiler_version(&mut records, "fontc 0.6.0");
+        stamp_compiler_version(&mut records, "0.6.0");
+        stamp_compiler_version(&mut records, "0.6.0");
         assert_eq!(records[0].string.as_str(), "Version 1.000;fontc 0.6.0");
     }
 
@@ -205,22 +192,10 @@ mod tests {
         // must be re-stamped with the fontc that's actually building now,
         // otherwise the provenance lies.
         let mut records = vec![version_record("Version 1.000;fontc 0.5.0")];
-        stamp_compiler_version(&mut records, "fontc 0.6.1-dev.394+gd62ba016");
+        stamp_compiler_version(&mut records, "0.6.1-dev.394+gd62ba016");
         assert_eq!(
             records[0].string.as_str(),
             "Version 1.000;fontc 0.6.1-dev.394+gd62ba016"
-        );
-    }
-
-    #[test]
-    fn leaves_non_stamp_fontc_note() {
-        // A human note that merely starts a segment with "fontc " (no version)
-        // is not our stamp (a digit always follows ours) so it survives.
-        let mut records = vec![version_record("Version 1.000;fontc is great")];
-        stamp_compiler_version(&mut records, "fontc 0.6.0");
-        assert_eq!(
-            records[0].string.as_str(),
-            "Version 1.000;fontc is great;fontc 0.6.0"
         );
     }
 
@@ -229,7 +204,7 @@ mod tests {
         // An empty version record (e.g. an explicit empty nameID 5 from FEA) is
         // left empty rather than turned into a bare ";fontc ..." with no version.
         let mut records = vec![version_record("")];
-        stamp_compiler_version(&mut records, "fontc 0.6.0");
+        stamp_compiler_version(&mut records, "0.6.0");
         assert_eq!(records[0].string.as_str(), "");
     }
 
@@ -252,7 +227,7 @@ mod tests {
                 "Version 1.000".to_string().into(),
             ),
         ];
-        stamp_compiler_version(&mut records, "fontc 0.6.0");
+        stamp_compiler_version(&mut records, "0.6.0");
         assert!(
             records
                 .iter()

--- a/fontbe/src/name.rs
+++ b/fontbe/src/name.rs
@@ -61,8 +61,55 @@ impl Work<Context, AnyWorkId, Error> for NameWork {
             name_records.sort();
         }
 
+        // Stamp the caller's compiler identity (e.g. "fontc 0.6.1-dev...") into
+        // the version string (name ID 5), so the tool that built a shipping font
+        // binary can be identified. The whole stamp is supplied by the caller;
+        // fontbe doesn't assume it was fontc.
+        if let Some(stamp) = context.compiler_version.as_deref() {
+            stamp_compiler_version(&mut name_records, stamp);
+        }
+
         context.name.set(Name::new(name_records));
         Ok(())
+    }
+}
+
+/// Append `;{stamp}` to every version string (name ID 5) record, replacing any
+/// prior stamp from the same tool.
+///
+/// `stamp` is the caller's `<tool> <version>` (e.g. "fontc 0.6.1-dev..."); the
+/// replace marker `;<tool> ` is derived from its leading token. Replacing rather
+/// than keeping matters when a source version string carries a *stale* stamp
+/// from an earlier build (e.g. a round-tripped `openTypeNameVersion`).
+///
+/// A stamp not of that `<tool> <digit-led version>` shape is still appended, but
+/// re-runs won't detect/replace it (idempotence relies on the shape).
+fn stamp_compiler_version(records: &mut [NameRecord], stamp: &str) {
+    let tool = stamp.split(' ').next().unwrap_or(stamp);
+    let marker = format!(";{tool} ");
+    for record in records.iter_mut() {
+        if record.name_id != NameId::VERSION_STRING {
+            continue;
+        }
+        let value = &mut *record.string;
+        // A prior stamp is always appended last, so it runs to the end; drop it
+        // before re-stamping. Only treat the marker as a stamp when a digit
+        // follows (the version is SemVer, digit-led), so a human-authored note
+        // like "...;fontc rules" is left untouched.
+        if let Some(idx) = value.find(&marker)
+            && value
+                .as_bytes()
+                .get(idx + marker.len())
+                .is_some_and(u8::is_ascii_digit)
+        {
+            value.truncate(idx);
+        }
+        // Don't emit a bare ";<tool> ..." when there's no actual version in
+        // front of it (an empty record, or one stripped down to nothing).
+        if !value.is_empty() {
+            value.push(';');
+            value.push_str(stamp);
+        }
     }
 }
 
@@ -95,4 +142,121 @@ fn merge_name_records(records: Vec<NameRecord>, fea_names: &Name) -> Vec<NameRec
             NameRecord::new(platform, encoding, language, name, string.into())
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn version_record(value: &str) -> NameRecord {
+        NameRecord::new(
+            3,
+            1,
+            0x409,
+            NameId::VERSION_STRING,
+            value.to_string().into(),
+        )
+    }
+
+    #[test]
+    fn stamps_version_string() {
+        let mut records = vec![version_record("Version 1.000")];
+        stamp_compiler_version(&mut records, "fontc 0.6.1-dev.394+gd62ba016");
+        assert_eq!(
+            records[0].string.as_str(),
+            "Version 1.000;fontc 0.6.1-dev.394+gd62ba016"
+        );
+    }
+
+    #[test]
+    fn appends_after_existing_note() {
+        // The version string may already carry a `;`-delimited note (allowed by
+        // the OT spec); the stamp is appended after it, leaving it intact.
+        let mut records = vec![version_record("Version 2.000; my custom note")];
+        stamp_compiler_version(&mut records, "fontc 0.6.0");
+        assert_eq!(
+            records[0].string.as_str(),
+            "Version 2.000; my custom note;fontc 0.6.0"
+        );
+    }
+
+    #[test]
+    fn only_stamps_version_records() {
+        let mut records = vec![
+            NameRecord::new(3, 1, 0x409, NameId::FAMILY_NAME, "Foo".to_string().into()),
+            version_record("Version 1.000"),
+        ];
+        stamp_compiler_version(&mut records, "fontc 0.6.0");
+        assert_eq!(records[0].string.as_str(), "Foo");
+        assert_eq!(records[1].string.as_str(), "Version 1.000;fontc 0.6.0");
+    }
+
+    #[test]
+    fn stamp_is_idempotent() {
+        let mut records = vec![version_record("Version 1.000")];
+        stamp_compiler_version(&mut records, "fontc 0.6.0");
+        stamp_compiler_version(&mut records, "fontc 0.6.0");
+        assert_eq!(records[0].string.as_str(), "Version 1.000;fontc 0.6.0");
+    }
+
+    #[test]
+    fn replaces_stale_stamp() {
+        // A source version string copied from a font built by an earlier fontc
+        // must be re-stamped with the fontc that's actually building now,
+        // otherwise the provenance lies.
+        let mut records = vec![version_record("Version 1.000;fontc 0.5.0")];
+        stamp_compiler_version(&mut records, "fontc 0.6.1-dev.394+gd62ba016");
+        assert_eq!(
+            records[0].string.as_str(),
+            "Version 1.000;fontc 0.6.1-dev.394+gd62ba016"
+        );
+    }
+
+    #[test]
+    fn leaves_non_stamp_fontc_note() {
+        // A human note that merely starts a segment with "fontc " (no version)
+        // is not our stamp (a digit always follows ours) so it survives.
+        let mut records = vec![version_record("Version 1.000;fontc is great")];
+        stamp_compiler_version(&mut records, "fontc 0.6.0");
+        assert_eq!(
+            records[0].string.as_str(),
+            "Version 1.000;fontc is great;fontc 0.6.0"
+        );
+    }
+
+    #[test]
+    fn does_not_stamp_empty_version_string() {
+        // An empty version record (e.g. an explicit empty nameID 5 from FEA) is
+        // left empty rather than turned into a bare ";fontc ..." with no version.
+        let mut records = vec![version_record("")];
+        stamp_compiler_version(&mut records, "fontc 0.6.0");
+        assert_eq!(records[0].string.as_str(), "");
+    }
+
+    #[test]
+    fn stamps_every_platform_version_record() {
+        // e.g. when FEA adds a Mac (platform 1) version string alongside Windows.
+        let mut records = vec![
+            NameRecord::new(
+                3,
+                1,
+                0x409,
+                NameId::VERSION_STRING,
+                "Version 1.000".to_string().into(),
+            ),
+            NameRecord::new(
+                1,
+                0,
+                0,
+                NameId::VERSION_STRING,
+                "Version 1.000".to_string().into(),
+            ),
+        ];
+        stamp_compiler_version(&mut records, "fontc 0.6.0");
+        assert!(
+            records
+                .iter()
+                .all(|r| r.string.as_str() == "Version 1.000;fontc 0.6.0")
+        );
+    }
 }

--- a/fontbe/src/orchestration.rs
+++ b/fontbe/src/orchestration.rs
@@ -864,9 +864,8 @@ type BeContextMap<T> = ContextMap<AnyWorkId, T, BePersistentStorage>;
 pub struct Context {
     pub flags: Flags,
 
-    /// Stamp to append to the name table version string, e.g.
-    /// "fontc 0.6.1-dev.394+gd62ba016", or None to not stamp. Supplied whole by
-    /// the caller so fontbe stays tool-agnostic; see name.rs.
+    /// The fontc version to stamp into the name table version string (name ID 5),
+    /// e.g. "0.6.1-dev.394+gd62ba016", or None to not stamp. See name.rs.
     pub compiler_version: Option<Arc<str>>,
 
     pub debug_dir: Option<PathBuf>,

--- a/fontbe/src/orchestration.rs
+++ b/fontbe/src/orchestration.rs
@@ -864,6 +864,11 @@ type BeContextMap<T> = ContextMap<AnyWorkId, T, BePersistentStorage>;
 pub struct Context {
     pub flags: Flags,
 
+    /// Stamp to append to the name table version string, e.g.
+    /// "fontc 0.6.1-dev.394+gd62ba016", or None to not stamp. Supplied whole by
+    /// the caller so fontbe stays tool-agnostic; see name.rs.
+    pub compiler_version: Option<Arc<str>>,
+
     pub debug_dir: Option<PathBuf>,
     pub ir_dir: Option<PathBuf>,
     pub compile_debg: bool,
@@ -919,6 +924,7 @@ impl Context {
         let acl = Arc::from(acl);
         Context {
             flags: self.flags,
+            compiler_version: self.compiler_version.clone(),
             debug_dir: self.debug_dir.clone(),
             ir_dir: self.ir_dir.clone(),
             compile_debg: self.compile_debg,
@@ -965,6 +971,7 @@ impl Context {
 
     pub fn new_root(
         flags: Flags,
+        compiler_version: Option<Arc<str>>,
         ir_dir: Option<PathBuf>,
         debug_dir: Option<PathBuf>,
         compile_debg: bool,
@@ -976,6 +983,7 @@ impl Context {
         });
         Context {
             flags,
+            compiler_version,
             debug_dir,
             ir_dir,
             compile_debg,

--- a/fontc/Cargo.toml
+++ b/fontc/Cargo.toml
@@ -56,6 +56,7 @@ time = { workspace = true }
 clap = { workspace = true, optional = true }
 
 [dev-dependencies]
+semver = "1"
 diff.workspace = true
 tempfile.workspace = true
 pretty_assertions.workspace = true

--- a/fontc/build.rs
+++ b/fontc/build.rs
@@ -2,13 +2,25 @@ use std::error::Error;
 use vergen_gitcl::{CargoBuilder, Emitter, GitclBuilder, RustcBuilder};
 
 fn main() -> Result<(), Box<dyn Error>> {
-    // Emit the instructions
+    // Emit the git/cargo/rustc facts that fontc::version and `--vv` read; see
+    // fontbe::version and https://github.com/googlefonts/fontc/issues/2048.
+    let gitcl = GitclBuilder::default()
+        // describe(tags, dirty, match): `git describe --tags --dirty --match
+        // fontc-v*`. The match keeps it on fontc releases, not other crates'
+        // tags. Returns VERGEN_GIT_DESCRIBE, the canonical version source.
+        .describe(true, true, Some("fontc-v*"))
+        // `short = false` -> full commit SHA in VERGEN_GIT_SHA, shown by `--vv`.
+        .sha(false)
+        .build()?;
     Emitter::new()
         .quiet()
+        // On a git-less build (e.g. a published crate) the git lookups emit the
+        // VERGEN_IDEMPOTENT_OUTPUT sentinel instead of failing; fontbe::version
+        // detects it and falls back to the crate version.
         .idempotent()
-        .add_instructions(&CargoBuilder::all_cargo()?)?
-        .add_instructions(&GitclBuilder::all_git()?)?
-        .add_instructions(&RustcBuilder::all_rustc()?)?
+        .add_instructions(&CargoBuilder::all_cargo()?)? // VERGEN_CARGO_* for `--vv`
+        .add_instructions(&gitcl)?
+        .add_instructions(&RustcBuilder::all_rustc()?)? // VERGEN_RUSTC_* for `--vv`
         .emit()?;
     Ok(())
 }

--- a/fontc/src/args.rs
+++ b/fontc/src/args.rs
@@ -13,7 +13,7 @@ use crate::Error;
 
 /// What font can we build for you today?
 #[derive(Serialize, Deserialize, Parser, Debug, Clone, PartialEq)]
-#[command(version)]
+#[command(version = fontc::version())]
 pub struct Args {
     /// A designspace, ufo, or glyphs file
     #[arg(

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -228,7 +228,7 @@ fn generate_font_internal(
     let fe_root = FeContext::new_root(flags, options.ir_dir.clone());
     let be_root = BeContext::new_root(
         flags,
-        Some(format!("fontc {}", version()).into()),
+        Some(version().into()),
         options.ir_dir.clone(),
         options.debug_dir.clone(),
         options.compile_debg,
@@ -430,7 +430,7 @@ mod tests {
             let fe_context = FeContext::new_root(flags, options.ir_dir.clone());
             let be_context = BeContext::new_root(
                 flags,
-                Some(format!("fontc {}", crate::version()).into()),
+                Some(crate::version().into()),
                 options.ir_dir.clone(),
                 options.debug_dir.clone(),
                 options.compile_debg,

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -4,6 +4,7 @@ mod error;
 #[cfg(not(feature = "rayon"))]
 mod norayon;
 mod timing;
+mod version;
 pub mod work;
 mod workload;
 
@@ -122,6 +123,14 @@ impl std::ops::Not for DisableFlags {
     }
 }
 
+/// The canonical fontc version string (e.g. `0.6.1-dev.394+gd62ba016.dirty`),
+/// reported by `--version`/`--vv` and stamped into the `name` table of every
+/// font fontc builds. See the `version` module and
+/// <https://github.com/googlefonts/fontc/issues/2048>.
+pub fn version() -> String {
+    crate::version::version_string(env!("VERGEN_GIT_DESCRIBE"), env!("CARGO_PKG_VERSION"))
+}
+
 /// Options for font compilation.
 ///
 /// Configures how the font is compiled (flags, output paths, etc.)
@@ -219,6 +228,7 @@ fn generate_font_internal(
     let fe_root = FeContext::new_root(flags, options.ir_dir.clone());
     let be_root = BeContext::new_root(
         flags,
+        Some(format!("fontc {}", version()).into()),
         options.ir_dir.clone(),
         options.debug_dir.clone(),
         options.compile_debg,
@@ -420,6 +430,7 @@ mod tests {
             let fe_context = FeContext::new_root(flags, options.ir_dir.clone());
             let be_context = BeContext::new_root(
                 flags,
+                Some(format!("fontc {}", crate::version()).into()),
                 options.ir_dir.clone(),
                 options.debug_dir.clone(),
                 options.compile_debg,
@@ -1540,13 +1551,22 @@ mod tests {
         assert_eq!(vec![Path::new("font.ttf")], outputs);
     }
 
+    /// Strip the build-dependent ";fontc <version>" tag that fontc stamps onto
+    /// the version string (name ID 5), so tests can assert stable values.
+    /// See https://github.com/googlefonts/fontc/issues/2048
+    fn strip_fontc_version_tag(s: &str) -> &str {
+        s.split_once(";fontc ").map_or(s, |(head, _)| head)
+    }
+
     fn resolve_name(name: &Name, id: NameId) -> Option<String> {
         name.name_record().iter().find_map(|nr| {
             (nr.name_id() == id).then(|| {
-                nr.string(name.string_data())
+                let resolved = nr
+                    .string(name.string_data())
                     .unwrap()
                     .chars()
-                    .collect::<String>()
+                    .collect::<String>();
+                strip_fontc_version_tag(&resolved).to_string()
             })
         })
     }
@@ -4121,10 +4141,11 @@ mod tests {
             .name_record()
             .iter()
             .map(|rec| {
+                let value = rec.string(name.string_data()).unwrap().to_string();
                 (
                     rec.name_id(),
                     rec.language_id(),
-                    rec.string(name.string_data()).unwrap().to_string(),
+                    strip_fontc_version_tag(&value).to_string(),
                 )
             })
             .collect::<Vec<_>>();

--- a/fontc/src/main.rs
+++ b/fontc/src/main.rs
@@ -73,13 +73,21 @@ fn run(args: Args) -> Result<(), Error> {
 }
 
 fn print_verbose_version() -> Result<(), std::io::Error> {
-    writeln!(
-        std::io::stdout(),
-        "{} {} @ {}\n",
-        env!("CARGO_PKG_NAME"),
-        env!("CARGO_PKG_VERSION"),
-        env!("VERGEN_GIT_SHA")
-    )?;
+    let version = fontc::version();
+    // In a git-less build (e.g. `cargo install`) vergen's idempotent mode sets
+    // VERGEN_GIT_SHA to the literal "VERGEN_IDEMPOTENT_OUTPUT" sentinel (see
+    // fontbe::version); drop the "@ <sha>" rather than print that. is_empty()
+    // covers a var that wasn't emitted at all.
+    let sha = option_env!("VERGEN_GIT_SHA").unwrap_or_default();
+    if sha.is_empty() || sha.starts_with("VERGEN_") {
+        writeln!(std::io::stdout(), "{} {version}\n", env!("CARGO_PKG_NAME"))?;
+    } else {
+        writeln!(
+            std::io::stdout(),
+            "{} {version} @ {sha}\n",
+            env!("CARGO_PKG_NAME"),
+        )?;
+    }
     writeln!(std::io::stdout(), "{}", env!("VERGEN_RUSTC_HOST_TRIPLE"))?;
     writeln!(
         std::io::stdout(),

--- a/fontc/src/version.rs
+++ b/fontc/src/version.rs
@@ -1,0 +1,172 @@
+//! The canonical fontc version string, shared by the `name` table (see
+//! `name.rs`) and `fontc --version`/`--vv`, which must agree.
+//! See <https://github.com/googlefonts/fontc/issues/2048>.
+//!
+//! It's `git describe` rendered as SemVer: a build past a release tag is a dev
+//! pre-release of the *next* patch, e.g. `0.6.1-dev.394+gd62ba016.dirty` (394
+//! commits past `fontc-v0.6.0`, dirty tree); on the tag itself, just `0.6.0`.
+//!
+//! Two details are deliberate, both for ordering (see the sort test below):
+//! bumping to `0.6.1` rather than `0.6.0-dev.N`, since a pre-release sorts
+//! *below* its own version, so the bump keeps a dev build after the release it
+//! follows; and the `.` in `dev.394`, which makes the commit count a numeric
+//! identifier so it orders numerically (`dev.9 < dev.394`) instead of as text.
+
+/// Map a `git describe --tags --dirty --match fontc-v*` string
+/// (`fontc-v<tag>[-<distance>-g<sha>][-dirty]`) to the SemVer version.
+///
+/// `crate_version` (`CARGO_PKG_VERSION`) is the fallback when git is unavailable
+/// (e.g. a published crate, source tarball, or shallow clone) where `describe`
+/// is empty or vergen's `VERGEN_IDEMPOTENT_OUTPUT` sentinel. Both are passed in
+/// rather than read here so the tests can drive this with literal inputs; the
+/// `version()` wrapper supplies the real env values.
+pub(crate) fn version_string(describe: &str, crate_version: &str) -> String {
+    let Some(rest) = describe.strip_prefix("fontc-v") else {
+        return crate_version.to_string();
+    };
+    let (rest, dirty) = match rest.strip_suffix("-dirty") {
+        Some(clean) => (clean, true),
+        None => (rest, false),
+    };
+    // Past a tag, describe is "<tag>-<distance>-g<sha>".
+    if let Some((tag_and_distance, sha)) = rest.rsplit_once("-g")
+        && let Some((tag, distance)) = tag_and_distance.rsplit_once('-')
+        && !distance.is_empty()
+        && distance.bytes().all(|b| b.is_ascii_digit())
+    {
+        let mut version = format!("{}-dev.{distance}+g{sha}", bump_patch(tag));
+        if dirty {
+            version.push_str(".dirty");
+        }
+        return version;
+    }
+    // Exactly on a tag: git omits the distance and sha, leaving just "<tag>".
+    if dirty {
+        format!("{rest}+dirty")
+    } else {
+        rest.to_string()
+    }
+}
+
+/// The base of the candidate next release after `tag` (the `X.Y.Z` in `X.Y.Z-dev.N`):
+/// bumps the patch (`0.6.0` -> `0.6.1`), or returns `tag` unchanged if it isn't
+/// `MAJOR.MINOR.PATCH`.
+///
+/// Assumes plain `MAJOR.MINOR.PATCH` release tags, the only kind fontc cuts
+/// today. A pre-release tag like `0.6.0-rc.1` would wrongly become `0.6.1`,
+/// sorting *above* the eventual `0.6.0` -- that path is currently unreachable,
+/// and should be handled if/when fontc starts tagging pre-releases.
+fn bump_patch(tag: &str) -> String {
+    let release = tag.split('-').next().unwrap_or(tag);
+    let parts: Vec<&str> = release.split('.').collect();
+    if let Some(patch) = parts.last().and_then(|p| p.parse::<u64>().ok()) {
+        let prefix = &parts[..parts.len() - 1];
+        if prefix.is_empty() {
+            return (patch + 1).to_string();
+        }
+        return format!("{}.{}", prefix.join("."), patch + 1);
+    }
+    tag.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn past_a_tag() {
+        assert_eq!(
+            version_string("fontc-v0.6.0-394-gd62ba016", "0.6.0"),
+            "0.6.1-dev.394+gd62ba016"
+        );
+        assert_eq!(
+            version_string("fontc-v0.6.0-394-gd62ba016-dirty", "0.6.0"),
+            "0.6.1-dev.394+gd62ba016.dirty"
+        );
+    }
+
+    #[test]
+    fn on_a_release_tag() {
+        assert_eq!(version_string("fontc-v0.6.0", "0.6.0"), "0.6.0");
+        assert_eq!(version_string("fontc-v0.6.0-dirty", "0.6.0"), "0.6.0+dirty");
+    }
+
+    #[test]
+    fn without_git() {
+        // `cargo install`, source tarball, shallow clone with no reachable tag.
+        // The describe is empty or a vergen sentinel; fall back to crate version.
+        for describe in ["", "VERGEN_IDEMPOTENT_OUTPUT"] {
+            let v = version_string(describe, "0.6.0");
+            assert_eq!(v, "0.6.0");
+            assert!(!v.contains("VERGEN"), "{v:?}");
+        }
+    }
+
+    // The exact strings we emit, across the lifecycle. The tests above pin that
+    // `version_string` actually produces these; the tests below validate the
+    // strings *themselves* against the SemVer crate -- an independent oracle --
+    // so we're checking our own format, not git's.
+    const EMITTED: &[&str] = &[
+        "0.6.1-dev.394+gd62ba016",       // past a release tag
+        "0.6.1-dev.394+gd62ba016.dirty", // ...from a dirty tree
+        "0.6.0",                         // exactly on a release tag
+        "0.6.0+dirty",                   // ...from a dirty tree
+    ];
+
+    /// Each string we emit parses under the SemVer 2.0.0 grammar and round-trips.
+    #[test]
+    fn emitted_versions_are_valid_semver() {
+        for s in EMITTED {
+            let v = semver::Version::parse(s)
+                .unwrap_or_else(|e| panic!("{s:?} is not valid semver: {e}"));
+            assert_eq!(&v.to_string(), s, "did not round-trip");
+        }
+
+        // The dev form decomposes into the SemVer fields we documented:
+        // 0.6.1 release + "dev.<distance>" pre-release + "g<sha>.dirty" build.
+        let v = semver::Version::parse("0.6.1-dev.394+gd62ba016.dirty").unwrap();
+        assert_eq!((v.major, v.minor, v.patch), (0, 6, 1));
+        assert_eq!(v.pre.as_str(), "dev.394");
+        assert_eq!(v.build.as_str(), "gd62ba016.dirty");
+    }
+
+    /// Our strings sort the way the format intends, per SemVer precedence
+    /// (`cmp_precedence` is the spec compare, which ignores build metadata).
+    #[test]
+    fn emitted_versions_sort_per_semver() {
+        use std::cmp::Ordering;
+        let v = |s: &str| semver::Version::parse(s).unwrap();
+        let snapshot = v("0.6.1-dev.394+gd62ba016");
+
+        // A dev build sits above its base release and below any future release
+        // (SemVer §11: a pre-release has lower precedence than the normal version).
+        assert_eq!(v("0.6.0").cmp_precedence(&snapshot), Ordering::Less);
+        assert_eq!(snapshot.cmp_precedence(&v("0.6.1")), Ordering::Less);
+        assert_eq!(snapshot.cmp_precedence(&v("0.7.0")), Ordering::Less);
+
+        // The dot makes the commit distance a *numeric* identifier, so it orders
+        // numerically rather than as text: dev.9 < dev.394 < dev.1000.
+        assert_eq!(
+            v("0.6.1-dev.9+gd62ba016").cmp_precedence(&snapshot),
+            Ordering::Less
+        );
+        assert_eq!(
+            snapshot.cmp_precedence(&v("0.6.1-dev.1000+gd62ba016")),
+            Ordering::Less
+        );
+
+        // Build metadata (sha, dirty) does not affect precedence (SemVer §10).
+        assert_eq!(
+            snapshot.cmp_precedence(&v("0.6.1-dev.394+gd62ba016.dirty")),
+            Ordering::Equal
+        );
+    }
+
+    #[test]
+    fn patch_bump() {
+        assert_eq!(bump_patch("0.6.0"), "0.6.1");
+        assert_eq!(bump_patch("0.6.9"), "0.6.10");
+        assert_eq!(bump_patch("1.0.0"), "1.0.1");
+        assert_eq!(bump_patch("0.6.0-rc.1"), "0.6.1");
+    }
+}

--- a/ttx_diff/src/ttx_diff/core.py
+++ b/ttx_diff/src/ttx_diff/core.py
@@ -39,6 +39,7 @@ JSON:
 
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -551,6 +552,17 @@ def drop_weird_names(ttx):
     )
     for drop in drops:
         drop.getparent().remove(drop)
+
+
+def strip_fontc_version_tag(ttx):
+    # fontc appends ";fontc <version>" to the version string (nameID 5); fontmake
+    # does not, so strip it before comparing. Mirror the Rust predicate in
+    # name.rs: only ";fontc " followed by a digit (the SemVer) is the stamp --
+    # a human note like ";fontc is great" is left intact, and matched only
+    # through the end of that segment so any other content/whitespace survives.
+    for record in ttx.xpath("//name/namerecord[@nameID='5']"):
+        if record.text:
+            record.text = re.sub(r";fontc (?=\d)[^;\s]*", "", record.text)
 
 
 def erase_checksum(ttx):
@@ -1210,6 +1222,8 @@ def reduce_diff_noise(fontc: etree.ElementTree, fontmake: etree.ElementTree):
 
         # deal with https://github.com/googlefonts/fontmake/issues/1003
         drop_weird_names(ttx)
+
+        strip_fontc_version_tag(ttx)
 
         # for matching purposes checksum is just noise
         erase_checksum(ttx)

--- a/ttx_diff/tests/test_core.py
+++ b/ttx_diff/tests/test_core.py
@@ -2,7 +2,7 @@
 
 from lxml import etree
 
-from ttx_diff.core import unwrap_extension_lookups
+from ttx_diff.core import strip_fontc_version_tag, unwrap_extension_lookups
 
 
 def _make_tree(xml_str):
@@ -104,3 +104,43 @@ def test_no_extensions_is_noop():
     before = etree.tostring(tree)
     unwrap_extension_lookups(tree)
     assert etree.tostring(tree) == before
+
+
+def _name_tree(version_string):
+    return _make_tree(
+        f"""\
+<ttFont>
+  <name>
+    <namerecord nameID="5" platformID="3" platEncID="1" langID="0x409">
+      {version_string}
+    </namerecord>
+  </name>
+</ttFont>"""
+    )
+
+
+def test_strip_fontc_version_tag_matches_fontmake():
+    # After stripping, fontc's stamped version string is byte-identical to
+    # fontmake's unstamped one (including TTX indentation).
+    fontc = _name_tree("Version 1.000;fontc 0.6.1-dev.394+gd62ba016.dirty")
+    fontmake = _name_tree("Version 1.000")
+    strip_fontc_version_tag(fontc)
+    strip_fontc_version_tag(fontmake)
+    assert etree.tostring(fontc) == etree.tostring(fontmake)
+
+
+def test_strip_fontc_version_tag_is_noop_without_tag():
+    tree = _name_tree("Version 1.000")
+    before = etree.tostring(tree)
+    strip_fontc_version_tag(tree)
+    assert etree.tostring(tree) == before
+
+
+def test_strip_keeps_non_stamp_fontc_note():
+    # Only the digit-led ";fontc <version>" stamp is removed; a human note that
+    # merely starts a segment with "fontc " survives, so a real diff in it isn't
+    # masked.
+    got = _name_tree("Version 1.000;fontc is broken;fontc 0.6.1-dev.394+gd62ba016")
+    want = _name_tree("Version 1.000;fontc is broken")
+    strip_fontc_version_tag(got)
+    assert etree.tostring(got) == etree.tostring(want)


### PR DESCRIPTION
Fixes #2048

Append fontc's version at the end of the font version string (name ID 5), makeotf-style, so a shipping binary identifies the compiler that built it e.g. to count how many Google Fonts are built with fontc or which version they used etc.

Example: "Version 1.000;fontc 0.6.1-dev.394+gd62ba016.dirty".

The stamp is basically a [SemVer](http://semver.org/) rendering of [`git describe`](https://git-scm.com/docs/git-describe): just the tag on a release ("fontc 0.6.0"), a next-patch `dev` pre-release suffix with the commit count plus a short git SHA between releases; or the crate version when fontc is built without/outside of git (e.g. a `cargo install` build from tarball).

The ";" suffix is blessed by the OpenType [`name` table spec](https://learn.microsoft.com/en-us/typography/opentype/spec/name) as "helpful to separate different pieces of version information".
So it should pass QA tools' checks, and the font version itself before the semicolon is unchanged.

Also: `fontc --version` / `--vv` now report that same string instead of the bare crate version, so a development build no longer looks like a clean release as it is at the moment.

And ttx_diff strips the ";fontc ..." suffix before diffing against fontmake, so it stays out of crater.
