### PR TITLE
Remove the time =0.3.47 pin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,6 @@ rayon = "1.6"
 icu_properties = "=2.1"
 smallvec = {version = "1.15", features = ["const_new"]}
 
-# TEMPORARY: see https://github.com/googlefonts/fontc/issues/2042
-# and https://github.com/time-rs/time/issues/783.
-time = "=0.3.47"
-
 # fontations etc
 write-fonts = { version = "0.49.1", features = ["serde", "read"] }
 skrifa = { version = "0.43.2", features = ["traversal"] }

--- a/fontc/Cargo.toml
+++ b/fontc/Cargo.toml
@@ -49,10 +49,6 @@ rayon = { workspace = true, optional = true }
 # just for fontc!
 crossbeam-channel = "0.5.6"
 
-# Not used directly: this only exists so the workspace pin on `time` (see the
-# root Cargo.toml) takes effect on resolution. Remove together with that pin.
-time = { workspace = true }
-
 clap = { workspace = true, optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
time 0.3.49 shipped the upstream fix for the 0.3.48 coherence regression (time-rs/time#784), so the equality pin is no longer needed. Drops both the workspace pin and the fontc shim that only existed to make it bite.

Verified cargo doc --workspace --all-features (the CI job that broke) is clean with time 0.3.51.

Fixes #2042

JMM