### PR TITLE
[fea-rs] Add GlyphMap::new, error on too many glyphs

### DIFF
--- a/fea-rs/src/common.rs
+++ b/fea-rs/src/common.rs
@@ -3,6 +3,7 @@
 use std::fmt::{Display, Formatter};
 
 use fontdrasil::types::GlyphName;
+use smol_str::SmolStr;
 use write_fonts::tables::gpos::builders::AnchorBuilder;
 pub use write_fonts::types::GlyphId16;
 
@@ -41,8 +42,26 @@ pub(crate) struct MarkClass {
     pub(crate) members: Vec<(GlyphClass, Option<AnchorBuilder>)>,
 }
 
-impl<T: Into<GlyphName>> From<T> for GlyphIdent {
-    fn from(src: T) -> Self {
+impl From<u16> for GlyphIdent {
+    fn from(src: u16) -> GlyphIdent {
+        GlyphIdent::Cid(src)
+    }
+}
+
+impl From<GlyphName> for GlyphIdent {
+    fn from(src: GlyphName) -> GlyphIdent {
+        GlyphIdent::Name(src)
+    }
+}
+
+impl From<&str> for GlyphIdent {
+    fn from(src: &str) -> GlyphIdent {
+        GlyphIdent::Name(src.into())
+    }
+}
+
+impl From<SmolStr> for GlyphIdent {
+    fn from(src: SmolStr) -> GlyphIdent {
         GlyphIdent::Name(src.into())
     }
 }

--- a/fea-rs/src/common/glyph_map.rs
+++ b/fea-rs/src/common/glyph_map.rs
@@ -1,12 +1,12 @@
 use write_fonts::tables::post::Post;
 
+use crate::compile::error::GlyphOrderError;
+
 use super::{GlyphId16, GlyphIdent};
 use fontdrasil::types::GlyphName;
 use std::{
     borrow::Cow,
     collections::{BTreeMap, HashMap},
-    convert::TryInto,
-    iter::FromIterator,
 };
 
 /// A glyph map for mapping from raw glyph identifiers to numeral `GlyphId16`s.
@@ -20,7 +20,7 @@ use std::{
 ///
 /// ```
 /// # use fea_rs::GlyphMap;
-/// let myglyphs = GlyphMap::from_iter(["a", "b", "gee", "whiz"]);
+/// let myglyphs = GlyphMap::new(["a", "b", "gee", "whiz"]).unwrap();
 /// ```
 #[derive(Clone, Debug, Default, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -30,6 +30,27 @@ pub struct GlyphMap {
 }
 
 impl GlyphMap {
+    /// Construct a new GlyphMap from an iterator of idents.
+    ///
+    /// Idents
+    pub fn new<T, I>(iter: I) -> Result<Self, GlyphOrderError>
+    where
+        T: Into<GlyphIdent>,
+        I: IntoIterator<Item = T>,
+    {
+        let mut names = HashMap::new();
+        let mut cids = HashMap::new();
+        for (idx, item) in iter.into_iter().enumerate() {
+            let idx = u16::try_from(idx)
+                .map(GlyphId16::new)
+                .map_err(|_| GlyphOrderError::TooManyGlyphs { found: idx as _ })?;
+            match item.into() {
+                GlyphIdent::Cid(cid) => cids.insert(cid, idx),
+                GlyphIdent::Name(name) => names.insert(name, idx),
+            };
+        }
+        Ok(GlyphMap { names, cids })
+    }
     /// The total number of glyphs
     pub fn len(&self) -> usize {
         self.names.len() + self.cids.len()
@@ -95,21 +116,6 @@ impl GlyphMap {
             .collect::<Vec<_>>();
 
         Post::new_v2(rev_vec.iter().map(Cow::as_ref))
-    }
-}
-
-impl<T: Into<GlyphIdent>> FromIterator<T> for GlyphMap {
-    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
-        let mut names = HashMap::new();
-        let mut cids = HashMap::new();
-        for (idx, item) in iter.into_iter().enumerate() {
-            let idx = GlyphId16::new(idx.try_into().unwrap());
-            match item.into() {
-                GlyphIdent::Cid(cid) => cids.insert(cid, idx),
-                GlyphIdent::Name(name) => names.insert(name, idx),
-            };
-        }
-        GlyphMap { names, cids }
     }
 }
 

--- a/fea-rs/src/compile.rs
+++ b/fea-rs/src/compile.rs
@@ -93,9 +93,10 @@ pub fn get_ufo_glyph_order(font: &norad::Font) -> Result<GlyphMap, UfoGlyphOrder
             name_array
                 .iter()
                 .map(|val| val.as_string().map(GlyphName::new))
-                .collect()
+                .collect::<Option<Vec<_>>>()
         })
         .ok_or(UfoGlyphOrderError::Malformed)
+        .and_then(|names| GlyphMap::new(names).map_err(Into::into))
 }
 
 /// A helper function for extracting glyph order from a font with a 'post' table
@@ -122,9 +123,10 @@ pub fn get_post_glyph_order(font_data: &[u8]) -> Result<GlyphMap, FontGlyphOrder
                         .get((i - 258) as usize)
                         .map(GlyphName::new),
                 })
-                .collect()
+                .collect::<Option<Vec<_>>>()
         })
         .ok_or(FontGlyphOrderError::MissingNames)
+        .and_then(|names| GlyphMap::new(names).map_err(Into::into))
 }
 
 /// Extract a glyph order from an ordered list of glyph names.
@@ -136,14 +138,13 @@ pub fn parse_glyph_order(glyphs: &str) -> Result<GlyphMap, GlyphOrderError> {
         .filter(|l| !l.is_empty() && !l.starts_with('#'))
         .map(|line| {
             if line.bytes().any(|b| b.is_ascii_whitespace()) {
-                Err(GlyphOrderError::NameError {
-                    name: line.to_owned(),
-                })
+                Err(GlyphOrderError::NameError { name: line.into() })
             } else {
                 Ok(GlyphName::new(line))
             }
         })
-        .collect::<Result<_, _>>()?;
+        .collect::<Result<Vec<_>, _>>()
+        .and_then(GlyphMap::new)?;
     if map.get(".notdef") != Some(GlyphId16::NOTDEF) {
         Err(GlyphOrderError::MissingNotDef)
     } else {

--- a/fea-rs/src/compile/error.rs
+++ b/fea-rs/src/compile/error.rs
@@ -2,12 +2,14 @@
 
 use std::fmt::Display;
 
+use smol_str::SmolStr;
 use write_fonts::{BuilderError, read::ReadError};
 
 use crate::{DiagnosticSet, parse::SourceLoadError};
 
 /// An error that occurs when extracting a glyph order from a UFO.
 #[derive(Clone, Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum UfoGlyphOrderError {
     /// Missing 'public.glyphOrder' key
     #[error("No public.glyphOrder key in lib.plist")]
@@ -15,10 +17,14 @@ pub enum UfoGlyphOrderError {
     /// Glyph order is present, but malformed
     #[error("public.glyphOrder exists, but is not an array of strings")]
     Malformed,
+    /// Glyphs were present but not a valid glyph order.
+    #[error(transparent)]
+    BadGlyphOrder(#[from] GlyphOrderError),
 }
 
 /// An error that occurs when extracting a glyph order from a font file.
 #[derive(Clone, Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum FontGlyphOrderError {
     /// Failed to read font data
     #[error("Failed to read font data: '{0}'")]
@@ -30,18 +36,25 @@ pub enum FontGlyphOrderError {
     /// Post table is missing glyph names
     #[error("The post table exists, but did not include all glyph names")]
     MissingNames,
+    /// Glyphs were present but not a valid glyph order.
+    #[error(transparent)]
+    BadGlyphOrder(#[from] GlyphOrderError),
 }
 
 /// An error that occurs when loading a raw glyph order.
 #[derive(Clone, Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum GlyphOrderError {
     /// Invalid name
     #[error("Invalid name '{name}' in glyph order")]
     #[allow(missing_docs)]
-    NameError { name: String },
+    NameError { name: SmolStr },
     /// Missing .notdef glyph
     #[error("The first glyph must be '.notdef'")]
     MissingNotDef,
+    #[error("Order contains too many glyphs ({found})")]
+    #[allow(missing_docs)]
+    TooManyGlyphs { found: u32 },
 }
 
 /// An error reported by the compiler

--- a/fea-rs/src/compile/glyph_range.rs
+++ b/fea-rs/src/compile/glyph_range.rs
@@ -199,7 +199,7 @@ mod tests {
     fn cid_range() {
         let range = make_range_node(Kind::Cid, "4", Kind::Cid, "12");
         let idents = glyph_range(&range).unwrap();
-        let map: GlyphMap = idents.into_iter().collect();
+        let map = GlyphMap::new(idents).unwrap();
         for val in 4u16..=12 {
             assert!(map.contains(&val));
         }
@@ -230,7 +230,7 @@ mod tests {
     fn named_range_() {
         let range = make_range_node(Kind::GlyphName, "A.hi", Kind::GlyphName, "E.hi");
         let idents = glyph_range(&range).unwrap();
-        let map: GlyphMap = idents.into_iter().collect();
+        let map = GlyphMap::new(idents).unwrap();
         assert_eq!(map.len(), 5, "{map:?}");
         for val in ["A.hi", "B.hi", "C.hi", "D.hi", "E.hi"] {
             assert!(map.contains(val));

--- a/fea-rs/src/parse/grammar/glyph.rs
+++ b/fea-rs/src/parse/grammar/glyph.rs
@@ -216,7 +216,6 @@ mod tests {
     use crate::GlyphMap;
     use crate::parse::FileId;
     use crate::token_tree::AstSink;
-    use fontdrasil::types::GlyphName;
 
     #[test]
     fn name_like() {
@@ -265,7 +264,7 @@ mod tests {
         assert_eq!(cursor.next_token().unwrap().kind, AstKind::RSquare);
 
         // now we parse with a glyph map
-        let glyphs: GlyphMap = ["a", "b"].iter().cloned().map(GlyphName::from).collect();
+        let glyphs = GlyphMap::new(["a", "b"]).unwrap();
 
         let mut sink = AstSink::new(fea, FileId::CURRENT_FILE, Some(&glyphs));
         let mut parser = Parser::new(fea, &mut sink);

--- a/fea-rs/src/tests/compile.rs
+++ b/fea-rs/src/tests/compile.rs
@@ -73,7 +73,7 @@ fn iter_test_groups(
         let glyph_order_path = dir.join(GLYPH_ORDER);
         let glyph_order =
             std::fs::read_to_string(glyph_order_path).expect("failed to read glyph order");
-        let glyph_map = glyph_order.lines().map(GlyphName::new).collect();
+        let glyph_map = GlyphMap::new(glyph_order.lines()).unwrap();
         let var_info = test_utils::make_var_info();
         let tests_dir = dir.join(test_dir);
         let tests = test_utils::iter_fea_files(tests_dir, Filter::from_env()).collect::<Vec<_>>();
@@ -120,7 +120,7 @@ fn compile_fea(fea: &str, test_name: &str) -> Compilation {
         .join("mini-latin")
         .join(GLYPH_ORDER);
     let glyph_order = std::fs::read_to_string(glyph_order_path).unwrap();
-    let glyph_map: GlyphMap = glyph_order.lines().map(GlyphName::new).collect();
+    let glyph_map = GlyphMap::new(glyph_order.lines()).unwrap();
 
     Compiler::<'_, NopFeatureProvider, MockVariationInfo>::new(fea_path, &glyph_map)
         .compile()
@@ -138,7 +138,7 @@ fn compile_fea_variable(fea: &str, test_name: &str) -> Compilation {
         .join("mini-latin")
         .join(GLYPH_ORDER);
     let glyph_order = std::fs::read_to_string(glyph_order_path).unwrap();
-    let glyph_map: GlyphMap = glyph_order.lines().map(GlyphName::new).collect();
+    let glyph_map = GlyphMap::new(glyph_order.lines()).unwrap();
     let var_info = test_utils::make_var_info();
 
     Compiler::<'_, NopFeatureProvider, MockVariationInfo>::new(fea_path, &glyph_map)
@@ -313,7 +313,7 @@ fn compile_debg(fea: &str, test_name: &str) -> Option<serde_json::Value> {
         .join("mini-latin")
         .join(GLYPH_ORDER);
     let glyph_order = std::fs::read_to_string(glyph_order_path).unwrap();
-    let glyph_map: GlyphMap = glyph_order.lines().map(GlyphName::new).collect();
+    let glyph_map = GlyphMap::new(glyph_order.lines().map(GlyphName::new)).unwrap();
 
     let fea = fea.to_string();
     Compiler::<NopFeatureProvider, MockVariationInfo>::new(fea_path, &glyph_map)

--- a/fea-rs/src/tests/parse.rs
+++ b/fea-rs/src/tests/parse.rs
@@ -49,14 +49,16 @@ fn parse_bad() -> Result<(), Report> {
 
 fn parse_test_glyph_order() -> GlyphMap {
     let raw_glyphs = std::fs::read_to_string(GLYPH_ORDER_PATH).unwrap();
-    crate::compile::parse_glyph_order(&raw_glyphs)
-        .unwrap()
-        .iter()
-        // we add one extra glyph, which could be a glyph range.
-        // during parsing, when provided a glyphmap, we can disambiguate this,
-        // but we can't do that otherwise
-        .chain([GlyphIdent::from("two-four")])
-        .collect()
+    GlyphMap::new(
+        crate::compile::parse_glyph_order(&raw_glyphs)
+            .unwrap()
+            .iter()
+            // we add one extra glyph, which could be a glyph range.
+            // during parsing, when provided a glyphmap, we can disambiguate this,
+            // but we can't do that otherwise
+            .chain([GlyphIdent::from("two-four")]),
+    )
+    .unwrap()
 }
 
 fn run_good_test(path: PathBuf, glyphmap: &GlyphMap) -> Result<PathBuf, TestCase> {

--- a/fea-rs/src/util/ttx.rs
+++ b/fea-rs/src/util/ttx.rs
@@ -566,11 +566,13 @@ pub(crate) fn fonttools_test_glyph_order() -> GlyphMap {
         panic!("could not locate glyph map at {}", path.display());
     }
     let order_str = std::fs::read_to_string(path).unwrap();
-    crate::compile::parse_glyph_order(&order_str)
-        .unwrap()
-        .iter()
-        .chain((800_u16..=1001).map(GlyphIdent::Cid))
-        .collect()
+    GlyphMap::new(
+        crate::compile::parse_glyph_order(&order_str)
+            .unwrap()
+            .iter()
+            .chain((800_u16..=1001).map(GlyphIdent::Cid)),
+    )
+    .unwrap()
 }
 
 /// Generate variation info

--- a/fontbe/src/error.rs
+++ b/fontbe/src/error.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Display, io, path::PathBuf};
 
-use fea_rs::compile::error::CompilerError;
+use fea_rs::compile::error::{CompilerError, GlyphOrderError};
 use fontdrasil::{
     coords::NormalizedLocation,
     types::GlyphName,
@@ -27,6 +27,8 @@ pub enum Error {
     IoError(#[from] io::Error),
     #[error(transparent)]
     FeaCompileError(#[from] CompilerError),
+    #[error(transparent)]
+    GlyphOrderError(#[from] GlyphOrderError),
     #[error("'{0}' {1}")]
     GlyphError(GlyphName, GlyphProblem),
     #[error("'{glyph_name}' {kurbo_problem:?} {context}")]

--- a/fontbe/src/features.rs
+++ b/fontbe/src/features.rs
@@ -470,7 +470,7 @@ impl Work<Context, AnyWorkId, Error> for FeatureFirstPassWork {
         let features = context.ir.features.get();
         let glyph_order = context.ir.glyph_order.get();
         let static_metadata = context.ir.static_metadata.get();
-        let glyph_map = glyph_order.names().cloned().collect();
+        let glyph_map = GlyphMap::new(glyph_order.names().cloned())?;
 
         let result = self.parse(&features, &glyph_map);
 

--- a/fontbe/src/features/marks.rs
+++ b/fontbe/src/features/marks.rs
@@ -3,7 +3,7 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
 use fea_rs::{
-    GlyphSet,
+    GlyphMap, GlyphSet,
     compile::{FeatureProvider, LookupId, PendingLookup},
 };
 use fontdrasil::{
@@ -345,7 +345,7 @@ impl<'a> MarkLookupBuilder<'a> {
         };
 
         Ok(FeaRsMarks {
-            glyphmap: self.glyph_order.names().cloned().collect(),
+            glyphmap: GlyphMap::new(self.glyph_order.names().cloned())?,
             mark_mkmk,
             abvm,
             blwm,

--- a/fontbe/src/features/test_helpers.rs
+++ b/fontbe/src/features/test_helpers.rs
@@ -79,7 +79,7 @@ impl LayoutOutputBuilder {
 
         let gdef_categories = self.categories.clone().unwrap_or_default();
 
-        let glyph_map = self.glyph_order.names().cloned().collect();
+        let glyph_map = fea_rs::GlyphMap::new(self.glyph_order.names().cloned()).unwrap();
         // first get the AST, which we need to use as input
         let fea = self.user_fea.clone();
         let (ast, _) = fea_rs::parse::parse_root(
@@ -108,7 +108,7 @@ impl LayoutOutputBuilder {
 impl LayoutOutput {
     pub(crate) fn compile(&self, feature_writer: &impl FeatureProvider) -> Compilation {
         let var_info = FeaVariationInfo::new(&self.static_metadata);
-        let glyph_map = self.glyph_order.names().cloned().collect();
+        let glyph_map = fea_rs::GlyphMap::new(self.glyph_order.names().cloned()).unwrap();
         fea_rs::compile::compile(
             &self.first_pass_fea.ast,
             &glyph_map,


### PR DESCRIPTION
This replaces the previous API, which relied on FromIterator, but which would panic if the input iterator contained more than u16::MAX glyphs.

closes #2031