### PR TITLE
[kern] skip non-default kernless sources in the variable kern path

### DIFF
--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -4088,6 +4088,17 @@ impl Font {
         &self.masters[self.default_master_idx]
     }
 
+    /// Whether the given master declares any kerning, LTR or RTL.
+    pub fn has_kerns_for_master(&self, master_id: &str) -> bool {
+        self.kerning_ltr
+            .get(master_id)
+            .is_some_and(|k| !k.is_empty())
+            || self
+                .kerning_rtl
+                .get(master_id)
+                .is_some_and(|k| !k.is_empty())
+    }
+
     /// <https://handbook.glyphsapp.com/exports/>
     pub fn variable_export_settings(&self, master: &FontMaster) -> Option<&Instance> {
         variable_instance_for(&self.instances, &master.name)

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -1131,14 +1131,7 @@ impl Work<Context, WorkId, Error> for KerningGroupWork {
             .iter()
             .filter_map(|(master_id, pos)| {
                 let keep = master_id.as_str() == default_master_id.as_str()
-                    || font
-                        .kerning_ltr
-                        .get(master_id)
-                        .is_some_and(|k| !k.is_empty())
-                    || font
-                        .kerning_rtl
-                        .get(master_id)
-                        .is_some_and(|k| !k.is_empty());
+                    || font.has_kerns_for_master(master_id);
                 keep.then(|| pos.clone())
             })
             .collect();

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -1120,7 +1120,28 @@ impl Work<Context, WorkId, Error> for KerningGroupWork {
             }
         }
 
-        groups.locations = font_info.master_positions.values().cloned().collect();
+        // ufo2ft#995: keep the default master (it anchors the variation model)
+        // and any master that actually kerns; drop non-default masters with no
+        // kerning so the kern interpolates across them instead of being pinned
+        // toward 0. Check both LTR and RTL kerning -- a master that kerns only
+        // RTL is not kernless (fontc#1857 was exactly that miss).
+        let default_master_id = font.default_master().id.clone();
+        groups.locations = font_info
+            .master_positions
+            .iter()
+            .filter_map(|(master_id, pos)| {
+                let keep = master_id.as_str() == default_master_id.as_str()
+                    || font
+                        .kerning_ltr
+                        .get(master_id)
+                        .is_some_and(|k| !k.is_empty())
+                    || font
+                        .kerning_rtl
+                        .get(master_id)
+                        .is_some_and(|k| !k.is_empty());
+                keep.then(|| pos.clone())
+            })
+            .collect();
 
         context.kerning_groups.set(groups);
         Ok(())
@@ -3062,36 +3083,35 @@ mod tests {
     }
 
     #[test]
-    fn empty_kerning_master_participates_in_variation() {
+    fn non_default_empty_kerning_master_is_skipped() {
+        // ufo2ft#995: a non-default master with no kerning must NOT become a
+        // variation location, else the kern hollows toward 0 there instead of
+        // interpolating across. In KerningEmptyMaster.glyphs master01 (Regular,
+        // the default) kerns and master02 (Bold) is empty, so only the default's
+        // location survives and the kern stays constant across the axis.
+        //
+        // This reverses fontc#2013's expectation for the Geom-like empty-master
+        // case, realigning fontc with ufo2ft main after ufo2ft#997. It does NOT
+        // regress fontc#1857 (NotoSansHebrew): that font's masters all carry RTL
+        // kerning, so they are not kernless -- see combine_ltr_and_rtl_kerning
+        // and the kerning_ltr/kerning_rtl check in KerningGroupWork.
         let (_, context) = build_kerning(glyphs3_dir().join("KerningEmptyMaster.glyphs"));
 
         let groups = context.kerning_groups.get();
         assert_eq!(
             groups.locations.len(),
-            2,
-            "expected both masters in locations"
+            1,
+            "the empty non-default master should be skipped"
         );
 
         let all_kerns = context.kerning_at.all();
         assert_eq!(
             all_kerns.len(),
-            2,
-            "expected kerning instances at both masters"
+            1,
+            "only the kerning (default) master gets an instance"
         );
-
-        let non_empty: Vec<_> = all_kerns
-            .iter()
-            .filter(|(_, k)| !k.kerns.is_empty())
-            .collect();
-        let empty: Vec<_> = all_kerns
-            .iter()
-            .filter(|(_, k)| k.kerns.is_empty())
-            .collect();
-        assert_eq!(non_empty.len(), 1);
-        assert_eq!(empty.len(), 1);
-
         assert_eq!(
-            non_empty[0].1.kerns,
+            all_kerns[0].1.kerns,
             make_kerning(&[("@side1.A", "@side2.B", -50)])
         );
     }

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -3117,6 +3117,21 @@ mod tests {
     }
 
     #[test]
+    fn non_default_rtl_only_kerning_master_is_kept() {
+        // fontc#1857 guard: a non-default master with ONLY RTL kerning (no LTR)
+        // still kerns, so it must keep its variation location. master02 (Bold,
+        // non-default) has only RTL kerning here; a kernless check that looked at
+        // kerning_ltr alone -- the original #1857 miss -- would wrongly skip it.
+        let (_, context) = build_kerning(glyphs3_dir().join("KerningRtlOnlyMaster.glyphs"));
+        let groups = context.kerning_groups.get();
+        assert_eq!(
+            groups.locations.len(),
+            2,
+            "the RTL-only non-default master must be kept"
+        );
+    }
+
+    #[test]
     fn captures_anchors() {
         let base_name = "A".into();
         let mark_name = "macroncomb".into();

--- a/resources/testdata/KernlessMid-Bold.ufo/fontinfo.plist
+++ b/resources/testdata/KernlessMid-Bold.ufo/fontinfo.plist
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>ascender</key>
+    <integer>800</integer>
+    <key>descender</key>
+    <integer>-200</integer>
+    <key>familyName</key>
+    <string>KernlessMid</string>
+    <key>styleName</key>
+    <string>Bold</string>
+    <key>unitsPerEm</key>
+    <integer>1000</integer>
+  </dict>
+</plist>

--- a/resources/testdata/KernlessMid-Bold.ufo/glyphs/A_.glif
+++ b/resources/testdata/KernlessMid-Bold.ufo/glyphs/A_.glif
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="A" format="2">
+  <advance width="600"/>
+  <unicode hex="0041"/>
+  <outline>
+    <contour>
+      <point x="50" y="0" type="line"/>
+      <point x="550" y="0" type="line"/>
+      <point x="550" y="700" type="line"/>
+      <point x="50" y="700" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/resources/testdata/KernlessMid-Bold.ufo/glyphs/B_.glif
+++ b/resources/testdata/KernlessMid-Bold.ufo/glyphs/B_.glif
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="B" format="2">
+  <advance width="600"/>
+  <unicode hex="0042"/>
+  <outline>
+    <contour>
+      <point x="50" y="0" type="line"/>
+      <point x="550" y="0" type="line"/>
+      <point x="550" y="700" type="line"/>
+      <point x="50" y="700" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/resources/testdata/KernlessMid-Bold.ufo/glyphs/X_.glif
+++ b/resources/testdata/KernlessMid-Bold.ufo/glyphs/X_.glif
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="X" format="2">
+  <advance width="600"/>
+  <unicode hex="0058"/>
+  <outline>
+    <contour>
+      <point x="50" y="0" type="line"/>
+      <point x="550" y="0" type="line"/>
+      <point x="550" y="700" type="line"/>
+      <point x="50" y="700" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/resources/testdata/KernlessMid-Bold.ufo/glyphs/Y_.glif
+++ b/resources/testdata/KernlessMid-Bold.ufo/glyphs/Y_.glif
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="Y" format="2">
+  <advance width="600"/>
+  <unicode hex="0059"/>
+  <outline>
+    <contour>
+      <point x="50" y="0" type="line"/>
+      <point x="550" y="0" type="line"/>
+      <point x="550" y="700" type="line"/>
+      <point x="50" y="700" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/resources/testdata/KernlessMid-Bold.ufo/glyphs/_notdef.glif
+++ b/resources/testdata/KernlessMid-Bold.ufo/glyphs/_notdef.glif
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name=".notdef" format="2">
+  <advance width="600"/>
+  <outline>
+  </outline>
+</glyph>

--- a/resources/testdata/KernlessMid-Bold.ufo/glyphs/contents.plist
+++ b/resources/testdata/KernlessMid-Bold.ufo/glyphs/contents.plist
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>.notdef</key>
+    <string>_notdef.glif</string>
+    <key>A</key>
+    <string>A_.glif</string>
+    <key>B</key>
+    <string>B_.glif</string>
+    <key>X</key>
+    <string>X_.glif</string>
+    <key>Y</key>
+    <string>Y_.glif</string>
+  </dict>
+</plist>

--- a/resources/testdata/KernlessMid-Bold.ufo/groups.plist
+++ b/resources/testdata/KernlessMid-Bold.ufo/groups.plist
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>public.kern1.left</key>
+    <array>
+      <string>A</string>
+      <string>B</string>
+    </array>
+    <key>public.kern2.right</key>
+    <array>
+      <string>X</string>
+      <string>Y</string>
+    </array>
+  </dict>
+</plist>

--- a/resources/testdata/KernlessMid-Bold.ufo/kerning.plist
+++ b/resources/testdata/KernlessMid-Bold.ufo/kerning.plist
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>public.kern1.left</key>
+    <dict>
+      <key>public.kern2.right</key>
+      <integer>-100</integer>
+    </dict>
+  </dict>
+</plist>

--- a/resources/testdata/KernlessMid-Bold.ufo/layercontents.plist
+++ b/resources/testdata/KernlessMid-Bold.ufo/layercontents.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <array>
+    <array>
+      <string>public.default</string>
+      <string>glyphs</string>
+    </array>
+  </array>
+</plist>

--- a/resources/testdata/KernlessMid-Bold.ufo/lib.plist
+++ b/resources/testdata/KernlessMid-Bold.ufo/lib.plist
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>public.glyphOrder</key>
+    <array>
+      <string>.notdef</string>
+      <string>A</string>
+      <string>B</string>
+      <string>X</string>
+      <string>Y</string>
+    </array>
+  </dict>
+</plist>

--- a/resources/testdata/KernlessMid-Bold.ufo/metainfo.plist
+++ b/resources/testdata/KernlessMid-Bold.ufo/metainfo.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>creator</key>
+    <string>com.github.fonttools.ufoLib</string>
+    <key>formatVersion</key>
+    <integer>3</integer>
+  </dict>
+</plist>

--- a/resources/testdata/KernlessMid-Medium.ufo/fontinfo.plist
+++ b/resources/testdata/KernlessMid-Medium.ufo/fontinfo.plist
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>ascender</key>
+    <integer>800</integer>
+    <key>descender</key>
+    <integer>-200</integer>
+    <key>familyName</key>
+    <string>KernlessMid</string>
+    <key>styleName</key>
+    <string>Medium</string>
+    <key>unitsPerEm</key>
+    <integer>1000</integer>
+  </dict>
+</plist>

--- a/resources/testdata/KernlessMid-Medium.ufo/glyphs/A_.glif
+++ b/resources/testdata/KernlessMid-Medium.ufo/glyphs/A_.glif
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="A" format="2">
+  <advance width="600"/>
+  <unicode hex="0041"/>
+  <outline>
+    <contour>
+      <point x="50" y="0" type="line"/>
+      <point x="550" y="0" type="line"/>
+      <point x="550" y="700" type="line"/>
+      <point x="50" y="700" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/resources/testdata/KernlessMid-Medium.ufo/glyphs/B_.glif
+++ b/resources/testdata/KernlessMid-Medium.ufo/glyphs/B_.glif
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="B" format="2">
+  <advance width="600"/>
+  <unicode hex="0042"/>
+  <outline>
+    <contour>
+      <point x="50" y="0" type="line"/>
+      <point x="550" y="0" type="line"/>
+      <point x="550" y="700" type="line"/>
+      <point x="50" y="700" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/resources/testdata/KernlessMid-Medium.ufo/glyphs/X_.glif
+++ b/resources/testdata/KernlessMid-Medium.ufo/glyphs/X_.glif
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="X" format="2">
+  <advance width="600"/>
+  <unicode hex="0058"/>
+  <outline>
+    <contour>
+      <point x="50" y="0" type="line"/>
+      <point x="550" y="0" type="line"/>
+      <point x="550" y="700" type="line"/>
+      <point x="50" y="700" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/resources/testdata/KernlessMid-Medium.ufo/glyphs/Y_.glif
+++ b/resources/testdata/KernlessMid-Medium.ufo/glyphs/Y_.glif
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="Y" format="2">
+  <advance width="600"/>
+  <unicode hex="0059"/>
+  <outline>
+    <contour>
+      <point x="50" y="0" type="line"/>
+      <point x="550" y="0" type="line"/>
+      <point x="550" y="700" type="line"/>
+      <point x="50" y="700" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/resources/testdata/KernlessMid-Medium.ufo/glyphs/_notdef.glif
+++ b/resources/testdata/KernlessMid-Medium.ufo/glyphs/_notdef.glif
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name=".notdef" format="2">
+  <advance width="600"/>
+  <outline>
+  </outline>
+</glyph>

--- a/resources/testdata/KernlessMid-Medium.ufo/glyphs/contents.plist
+++ b/resources/testdata/KernlessMid-Medium.ufo/glyphs/contents.plist
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>.notdef</key>
+    <string>_notdef.glif</string>
+    <key>A</key>
+    <string>A_.glif</string>
+    <key>B</key>
+    <string>B_.glif</string>
+    <key>X</key>
+    <string>X_.glif</string>
+    <key>Y</key>
+    <string>Y_.glif</string>
+  </dict>
+</plist>

--- a/resources/testdata/KernlessMid-Medium.ufo/groups.plist
+++ b/resources/testdata/KernlessMid-Medium.ufo/groups.plist
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>public.kern1.left</key>
+    <array>
+      <string>A</string>
+      <string>B</string>
+    </array>
+    <key>public.kern2.right</key>
+    <array>
+      <string>X</string>
+      <string>Y</string>
+    </array>
+  </dict>
+</plist>

--- a/resources/testdata/KernlessMid-Medium.ufo/layercontents.plist
+++ b/resources/testdata/KernlessMid-Medium.ufo/layercontents.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <array>
+    <array>
+      <string>public.default</string>
+      <string>glyphs</string>
+    </array>
+  </array>
+</plist>

--- a/resources/testdata/KernlessMid-Medium.ufo/lib.plist
+++ b/resources/testdata/KernlessMid-Medium.ufo/lib.plist
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>public.glyphOrder</key>
+    <array>
+      <string>.notdef</string>
+      <string>A</string>
+      <string>B</string>
+      <string>X</string>
+      <string>Y</string>
+    </array>
+  </dict>
+</plist>

--- a/resources/testdata/KernlessMid-Medium.ufo/metainfo.plist
+++ b/resources/testdata/KernlessMid-Medium.ufo/metainfo.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>creator</key>
+    <string>com.github.fonttools.ufoLib</string>
+    <key>formatVersion</key>
+    <integer>3</integer>
+  </dict>
+</plist>

--- a/resources/testdata/KernlessMid-Regular.ufo/fontinfo.plist
+++ b/resources/testdata/KernlessMid-Regular.ufo/fontinfo.plist
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>ascender</key>
+    <integer>800</integer>
+    <key>descender</key>
+    <integer>-200</integer>
+    <key>familyName</key>
+    <string>KernlessMid</string>
+    <key>styleName</key>
+    <string>Regular</string>
+    <key>unitsPerEm</key>
+    <integer>1000</integer>
+  </dict>
+</plist>

--- a/resources/testdata/KernlessMid-Regular.ufo/glyphs/A_.glif
+++ b/resources/testdata/KernlessMid-Regular.ufo/glyphs/A_.glif
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="A" format="2">
+  <advance width="600"/>
+  <unicode hex="0041"/>
+  <outline>
+    <contour>
+      <point x="50" y="0" type="line"/>
+      <point x="550" y="0" type="line"/>
+      <point x="550" y="700" type="line"/>
+      <point x="50" y="700" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/resources/testdata/KernlessMid-Regular.ufo/glyphs/B_.glif
+++ b/resources/testdata/KernlessMid-Regular.ufo/glyphs/B_.glif
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="B" format="2">
+  <advance width="600"/>
+  <unicode hex="0042"/>
+  <outline>
+    <contour>
+      <point x="50" y="0" type="line"/>
+      <point x="550" y="0" type="line"/>
+      <point x="550" y="700" type="line"/>
+      <point x="50" y="700" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/resources/testdata/KernlessMid-Regular.ufo/glyphs/X_.glif
+++ b/resources/testdata/KernlessMid-Regular.ufo/glyphs/X_.glif
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="X" format="2">
+  <advance width="600"/>
+  <unicode hex="0058"/>
+  <outline>
+    <contour>
+      <point x="50" y="0" type="line"/>
+      <point x="550" y="0" type="line"/>
+      <point x="550" y="700" type="line"/>
+      <point x="50" y="700" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/resources/testdata/KernlessMid-Regular.ufo/glyphs/Y_.glif
+++ b/resources/testdata/KernlessMid-Regular.ufo/glyphs/Y_.glif
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="Y" format="2">
+  <advance width="600"/>
+  <unicode hex="0059"/>
+  <outline>
+    <contour>
+      <point x="50" y="0" type="line"/>
+      <point x="550" y="0" type="line"/>
+      <point x="550" y="700" type="line"/>
+      <point x="50" y="700" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/resources/testdata/KernlessMid-Regular.ufo/glyphs/_notdef.glif
+++ b/resources/testdata/KernlessMid-Regular.ufo/glyphs/_notdef.glif
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name=".notdef" format="2">
+  <advance width="600"/>
+  <outline>
+  </outline>
+</glyph>

--- a/resources/testdata/KernlessMid-Regular.ufo/glyphs/contents.plist
+++ b/resources/testdata/KernlessMid-Regular.ufo/glyphs/contents.plist
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>.notdef</key>
+    <string>_notdef.glif</string>
+    <key>A</key>
+    <string>A_.glif</string>
+    <key>B</key>
+    <string>B_.glif</string>
+    <key>X</key>
+    <string>X_.glif</string>
+    <key>Y</key>
+    <string>Y_.glif</string>
+  </dict>
+</plist>

--- a/resources/testdata/KernlessMid-Regular.ufo/groups.plist
+++ b/resources/testdata/KernlessMid-Regular.ufo/groups.plist
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>public.kern1.left</key>
+    <array>
+      <string>A</string>
+      <string>B</string>
+    </array>
+    <key>public.kern2.right</key>
+    <array>
+      <string>X</string>
+      <string>Y</string>
+    </array>
+  </dict>
+</plist>

--- a/resources/testdata/KernlessMid-Regular.ufo/kerning.plist
+++ b/resources/testdata/KernlessMid-Regular.ufo/kerning.plist
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>public.kern1.left</key>
+    <dict>
+      <key>public.kern2.right</key>
+      <integer>-100</integer>
+    </dict>
+  </dict>
+</plist>

--- a/resources/testdata/KernlessMid-Regular.ufo/layercontents.plist
+++ b/resources/testdata/KernlessMid-Regular.ufo/layercontents.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <array>
+    <array>
+      <string>public.default</string>
+      <string>glyphs</string>
+    </array>
+  </array>
+</plist>

--- a/resources/testdata/KernlessMid-Regular.ufo/lib.plist
+++ b/resources/testdata/KernlessMid-Regular.ufo/lib.plist
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>public.glyphOrder</key>
+    <array>
+      <string>.notdef</string>
+      <string>A</string>
+      <string>B</string>
+      <string>X</string>
+      <string>Y</string>
+    </array>
+  </dict>
+</plist>

--- a/resources/testdata/KernlessMid-Regular.ufo/metainfo.plist
+++ b/resources/testdata/KernlessMid-Regular.ufo/metainfo.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>creator</key>
+    <string>com.github.fonttools.ufoLib</string>
+    <key>formatVersion</key>
+    <integer>3</integer>
+  </dict>
+</plist>

--- a/resources/testdata/KernlessMid.designspace
+++ b/resources/testdata/KernlessMid.designspace
@@ -1,0 +1,23 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<designspace format="5.0">
+  <axes>
+    <axis tag="wght" name="Weight" minimum="0" maximum="1000" default="0"/>
+  </axes>
+  <sources>
+    <source filename="KernlessMid-Regular.ufo" familyname="KernlessMid" stylename="Regular">
+      <location>
+        <dimension name="Weight" xvalue="0"/>
+      </location>
+    </source>
+    <source filename="KernlessMid-Medium.ufo" familyname="KernlessMid" stylename="Medium">
+      <location>
+        <dimension name="Weight" xvalue="500"/>
+      </location>
+    </source>
+    <source filename="KernlessMid-Bold.ufo" familyname="KernlessMid" stylename="Bold">
+      <location>
+        <dimension name="Weight" xvalue="1000"/>
+      </location>
+    </source>
+  </sources>
+</designspace>

--- a/resources/testdata/glyphs3/KerningRtlOnlyMaster.glyphs
+++ b/resources/testdata/glyphs3/KerningRtlOnlyMaster.glyphs
@@ -1,0 +1,102 @@
+{
+.appVersion = "3343";
+.formatVersion = 3;
+familyName = RtlOnlyKerning;
+axes = (
+{
+name = Weight;
+tag = wght;
+}
+);
+fontMaster = (
+{
+axesValues = (
+400
+);
+id = "master01";
+name = Regular;
+},
+{
+axesValues = (
+700
+);
+id = "master02";
+name = Bold;
+}
+);
+glyphs = (
+{
+glyphname = A;
+layers = (
+{
+layerId = "master01";
+width = 500;
+},
+{
+layerId = "master02";
+width = 600;
+}
+);
+unicode = 65;
+},
+{
+glyphname = B;
+layers = (
+{
+layerId = "master01";
+width = 500;
+},
+{
+layerId = "master02";
+width = 600;
+}
+);
+unicode = 66;
+},
+{
+glyphname = "alef-hb";
+layers = (
+{
+layerId = "master01";
+width = 500;
+},
+{
+layerId = "master02";
+width = 600;
+}
+);
+unicode = 1488;
+},
+{
+glyphname = "bet-hb";
+layers = (
+{
+layerId = "master01";
+width = 500;
+},
+{
+layerId = "master02";
+width = 600;
+}
+);
+unicode = 1489;
+}
+);
+kerningLTR = {
+master01 = {
+A = {
+B = -50;
+};
+};
+};
+kerningRTL = {
+master02 = {
+"alef-hb" = {
+"bet-hb" = 29;
+};
+};
+};
+unitsPerEm = 1000;
+versionMajor = 1;
+versionMinor = 0;
+}

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -2785,6 +2785,22 @@ mod tests {
         );
     }
 
+    #[test]
+    fn non_default_kernless_source_skipped_from_variation() {
+        // ufo2ft#995 port: KernlessMid has 3 masters; the middle Medium master
+        // (non-default) has no kerning, so it must NOT add a kern variation
+        // location -- otherwise the class kern hollows toward 0 there instead of
+        // interpolating across. Regular (the default) and Bold kern, Medium does
+        // not, so exactly those two locations survive.
+        let (_, context) = build_kerning("KernlessMid.designspace");
+        let groups = context.kerning_groups.get();
+        assert_eq!(
+            groups.locations.len(),
+            2,
+            "the kernless non-default Medium master should be skipped"
+        );
+    }
+
     // UFO2 sources use @MMK_L_X/@MMK_R_X group naming instead of public.kern1.X/public.kern2.X.
     // norad's upconversion only fires when groups are loaded alongside kerning, so we must
     // request both. Regression test for https://github.com/googlefonts/fontc/issues/XXXX

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -1242,6 +1242,18 @@ fn is_glyph_only(source: &norad::designspace::Source) -> bool {
     source.layer.is_some()
 }
 
+/// Whether a source declares any kerning at all (mirrors ufo2ft's
+/// `not source.font.kerning`). Reads only the UFO's kerning, no glyphs.
+fn source_has_kerning(
+    designspace_dir: &Path,
+    source: &norad::designspace::Source,
+) -> Result<bool, Error> {
+    let ufo_dir = designspace_dir.join(&source.filename);
+    let font = norad::Font::load_requested_data(&ufo_dir, norad::DataRequest::none().kerning(true))
+        .map_err(|e| BadSource::custom(ufo_dir, e))?;
+    Ok(!font.kerning.is_empty())
+}
+
 fn parse_meta_table_values(plist: &plist::Value) -> Option<MetaTableValues> {
     let plist = plist.as_dictionary()?;
     let mut ret = MetaTableValues::default();
@@ -1724,7 +1736,7 @@ impl Work<Context, WorkId, Error> for KerningGroupWork {
         let static_metadata = context.static_metadata.get();
         let master_locations =
             master_locations(&static_metadata.all_source_axes, &self.designspace.sources);
-        let (_, default_master) = default_master(&self.designspace)?;
+        let (default_master_idx, default_master) = default_master(&self.designspace)?;
 
         // Step 1: find the groups
 
@@ -1735,12 +1747,20 @@ impl Work<Context, WorkId, Error> for KerningGroupWork {
             ..Default::default()
         };
 
-        for source in self
+        for (idx, source) in self
             .designspace
             .sources
             .iter()
-            .filter(|s| !is_glyph_only(s))
+            .enumerate()
+            .filter(|(_, s)| !is_glyph_only(s))
         {
+            // ufo2ft#995: keep the default source (it anchors the variation
+            // model) and any source that kerns; drop non-default sources with no
+            // kerning so the kern interpolates across them instead of being
+            // pinned toward 0 there.
+            if idx != default_master_idx && !source_has_kerning(designspace_dir, source)? {
+                continue;
+            }
             let pos = master_locations.get(source.name.as_ref().unwrap()).unwrap();
             kerning_groups.locations.insert(pos.clone());
         }


### PR DESCRIPTION
Match googlefonts/ufo2ft#995 (merged as googlefonts/ufo2ft#997): a non-default full source with no kerning must not add a variation-model location, or the kern hollows toward 0 there instead of interpolating across it. The default is always kept, since it anchors the model.

Applies to both frontends:

* glyphs2fontir filters `master_positions` (checking LTR+RTL, so an RTL-only master like NotoSansHebrew/fontc#1857 stays)
* ufo2fontir filters the `KerningGroupWork` location loop via a kerning-only UFO read.

This refines my #2013's blunt include-all-masters, which had matched the pre- googlefonts/ufo2ft#995. The KerningEmptyMaster test flips to the new constant-kern expectation.