### PR TITLE
[kern] Reconcile divergent per-master kerning groups

### DIFF
--- a/fontbe/src/features/kern.rs
+++ b/fontbe/src/features/kern.rs
@@ -117,10 +117,20 @@ impl Work<Context, AnyWorkId, Error> for GatherIrKerningWork {
         let ir_groups = context.ir.kerning_groups.get();
         let ir_kerns = context.ir.kerning_at.all();
 
-        // convert the groups stored in the Kerning object into the glyph classes
-        // expected by fea-rs:
-        let groups = ir_groups
-            .groups
+        // Add IR kerns to builder. IR kerns are split by location so put them back together again.
+        let kern_by_pos: HashMap<_, _> = ir_kerns
+            .iter()
+            .map(|(_, ki)| (ki.location.clone(), ki.as_ref().to_owned()))
+            .collect();
+
+        // Resolve every pair at every location, reconciling sources whose
+        // kerning groups disagree. `refined_groups` is the reconciled output
+        // class partition (see build_variable_kern_adjustments).
+        let (refined_groups, adjustments) =
+            build_variable_kern_adjustments(&ir_groups, &kern_by_pos);
+
+        // convert the refined groups into the glyph classes expected by fea-rs:
+        let groups = refined_groups
             .iter()
             .filter_map(|(class_name, glyph_set)| {
                 let glyph_class: GlyphSet = glyph_set
@@ -144,14 +154,6 @@ impl Work<Context, AnyWorkId, Error> for GatherIrKerningWork {
                 }
             })
             .collect::<BTreeMap<_, _>>();
-
-        // Add IR kerns to builder. IR kerns are split by location so put them back together again.
-        let kern_by_pos: HashMap<_, _> = ir_kerns
-            .iter()
-            .map(|(_, ki)| (ki.location.clone(), ki.as_ref().to_owned()))
-            .collect();
-
-        let adjustments = build_variable_kern_adjustments(&ir_groups, &glyph_order, &kern_by_pos);
 
         let adjustments: Vec<_> = adjustments
             .into_iter()
@@ -187,58 +189,464 @@ impl Work<Context, AnyWorkId, Error> for GatherIrKerningWork {
     }
 }
 
-/// Build the glyph -> containing-group lookups for each side, used by the UFO
-/// kerning value cascade in [`lookup_kerning_value`].
-fn glyph_to_group_maps(
-    groups: &KerningGroups,
-) -> (
-    HashMap<&GlyphName, &KernGroup>,
-    HashMap<&GlyphName, &KernGroup>,
-) {
-    let map_for = |is_side1: bool| {
-        groups
-            .groups
-            .iter()
-            .filter(move |(group, _)| matches!(group, KernGroup::Side1(_)) == is_side1)
-            .flat_map(|(group, glyphs)| glyphs.iter().map(move |glyph| (glyph, group)))
-            .collect::<HashMap<_, _>>()
-    };
-    (map_for(true), map_for(false))
+/// Which logical side of a kern pair a glyph or group sits on.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Side {
+    First,
+    Second,
 }
 
-/// Resolve every kern pair defined in any master to a value at every location.
+/// Per-source kerning state for the variable cascade.
 ///
-/// missing pairs are filled in via the UFO kerning value lookup algorithm:
+/// Each source resolves its kerning against its *own* groups, so we keep the
+/// per-side glyph -> group maps alongside that source's raw kern values.
+struct KernSource<'a> {
+    location: &'a NormalizedLocation,
+    kerns: &'a BTreeMap<ir::KernPair, OrderedFloat<f64>>,
+    side1: HashMap<&'a GlyphName, &'a KernGroup>,
+    side2: HashMap<&'a GlyphName, &'a KernGroup>,
+}
+
+impl<'a> KernSource<'a> {
+    fn new(instance: &'a KerningInstance) -> Self {
+        let mut side1 = HashMap::new();
+        let mut side2 = HashMap::new();
+        for (group, members) in &instance.groups {
+            let map = match group {
+                KernGroup::Side1(_) => &mut side1,
+                KernGroup::Side2(_) => &mut side2,
+            };
+            for member in members {
+                map.insert(member, group);
+            }
+        }
+        KernSource {
+            location: &instance.location,
+            kerns: &instance.kerns,
+            side1,
+            side2,
+        }
+    }
+
+    fn map_for(&self, side: Side) -> &HashMap<&'a GlyphName, &'a KernGroup> {
+        match side {
+            Side::First => &self.side1,
+            Side::Second => &self.side2,
+        }
+    }
+
+    fn group_of(&self, side: Side, glyph: &GlyphName) -> Option<&'a KernGroup> {
+        self.map_for(side).get(glyph).copied()
+    }
+
+    /// The groups referenced by this source's kerning on one side.
+    fn kerned_names(&self, side: Side) -> HashSet<&'a KernGroup> {
+        self.kerns
+            .keys()
+            .filter_map(|(first, second)| {
+                let name = match side {
+                    Side::First => first,
+                    Side::Second => second,
+                };
+                match name {
+                    ir::KernSide::Group(group) => Some(group),
+                    ir::KernSide::Glyph(_) => None,
+                }
+            })
+            .collect()
+    }
+}
+
+/// A glyph "diverges" on a side when its containing group there is not the same
+/// across every source -- a different group, or grouped in some and
+/// ungrouped/absent in others. Such a glyph cannot stay whole in a shared
+/// output class; the class is refined around it (see
+/// [`refine_divergent_groups`]).
+fn is_divergent(sources: &[KernSource], glyph: &GlyphName, side: Side) -> bool {
+    let mut groups = sources.iter().map(|src| src.group_of(side, glyph));
+    match groups.next() {
+        Some(first) => groups.any(|group| group != first),
+        None => false,
+    }
+}
+
+/// Resolve a pair to a value at every source location, each against that
+/// source's own groups (see [`lookup_kerning_value`]).
+fn resolve_pair(sources: &[KernSource], pair: &ir::KernPair) -> KernAdjustments {
+    sources
+        .iter()
+        .map(|src| {
+            (
+                src.location.clone(),
+                lookup_kerning_value(pair, src.kerns, &src.side1, &src.side2),
+            )
+        })
+        .collect()
+}
+
+/// One refined output class: a maximal set of a divergent group's members
+/// sharing the same kerned group in every source.
+struct RefinedClass<'a> {
+    /// The output class name. Synthesized, never surfaces in the compiled font.
+    name: KernGroup,
+    members: BTreeSet<&'a GlyphName>,
+    /// The class's kerned group in each source; `None` means its members are
+    /// in no kerned group there and the class resolves to 0 (varLib.merger's
+    /// implicit class 0).
+    signature: Vec<Option<&'a KernGroup>>,
+}
+
+/// The per-source lookup names for one side of a refined pair.
+enum Names<'a> {
+    /// One name, looked up in every source: a bare glyph, for which
+    /// [`lookup_kerning_value`] falls back to each source's own groups, or a
+    /// consistent class, named the same in every source.
+    Uniform(ir::KernSide),
+    /// A refined class's kerned group in each source; `None` resolves to 0.
+    PerSource(&'a [Option<&'a KernGroup>]),
+}
+
+impl Names<'_> {
+    fn at(&self, source_idx: usize) -> Option<ir::KernSide> {
+        match self {
+            Names::Uniform(side) => Some(side.clone()),
+            Names::PerSource(signature) => {
+                signature[source_idx].map(|group| ir::KernSide::Group(group.clone()))
+            }
+        }
+    }
+}
+
+/// One participant of a refined output pair: the per-source names that resolve
+/// its value, and the glyph or class it is emitted as.
+struct Unit<'a> {
+    names: Names<'a>,
+    emit: ir::KernSide,
+}
+
+/// Per-side reconciliation state.
 ///
-/// <https://unifiedfontobject.org/versions/ufo3/kerning.plist/#kerning-value-lookup-algorithm>
+/// The full group maps carry what the sources declare, the kerned maps what
+/// reaches the compiled ClassDefs that varLib.merger partitions: divergence is
+/// detected on the former (so mere differences in kern coverage don't count),
+/// the refined partition computed on the latter (so distinctions carrying no
+/// kerning don't split).
+struct SideState<'a> {
+    /// Union of each group's membership across every source.
+    ///
+    /// Inverted from the per-source maps rather than the declared groups so
+    /// membership stays consistent with value resolution: a glyph in two
+    /// same-side groups of one source (invalid per UFO3) resolves to the
+    /// lexicographically-last one.
+    all_members: BTreeMap<&'a KernGroup, BTreeSet<&'a GlyphName>>,
+    /// Glyphs whose group assignment differs between sources.
+    divergent_glyphs: HashSet<&'a GlyphName>,
+    /// The refined classes of the divergent groups.
+    refined_classes: Vec<RefinedClass<'a>>,
+    /// Each divergent group's partition, as indices into `refined_classes`. A refined
+    /// class two groups refine to (same members, hence same signature) is
+    /// shared, so it emits as one output class no matter which group's key
+    /// produced it.
+    refined_by_group: BTreeMap<&'a KernGroup, Vec<usize>>,
+}
+
+/// Each source's kerned glyph -> group map: only the groups that source's
+/// kerning references. Unkerned groups don't exist in compiled ClassDefs, so
+/// treating their members as ungrouped matches varLib.merger.
+fn kerned_maps<'a>(
+    sources: &[KernSource<'a>],
+    side: Side,
+) -> Vec<HashMap<&'a GlyphName, &'a KernGroup>> {
+    sources
+        .iter()
+        .map(|source| {
+            let kerned = source.kerned_names(side);
+            source
+                .map_for(side)
+                .iter()
+                .filter(|(_, group)| kerned.contains(*group))
+                .map(|(glyph, group)| (*glyph, *group))
+                .collect()
+        })
+        .collect()
+}
+
+/// Partition each divergent group's members into refined classes by
+/// per-source kerned-group signature: the coarsest common refinement, the
+/// same partition varLib's merger derives with classifyTools.classify on the
+/// compiled per-master ClassDefs.
 ///
-/// in pythonland this happens in ufo2ft, here:
-/// <https://github.com/googlefonts/ufo2ft/blob/1a21d0071c69b1/Lib/ufo2ft/featureWriters/kernFeatureWriter.py#L748>
+/// Returns the refined classes and each divergent group's partition as
+/// indices into them; a class two groups refine to (same members, hence same
+/// signature) is shared.
+fn refine_divergent_groups<'a>(
+    all_members: &BTreeMap<&'a KernGroup, BTreeSet<&'a GlyphName>>,
+    divergent_glyphs: &HashSet<&'a GlyphName>,
+    kerned_maps: &[HashMap<&'a GlyphName, &'a KernGroup>],
+) -> (Vec<RefinedClass<'a>>, BTreeMap<&'a KernGroup, Vec<usize>>) {
+    let mut refined_classes: Vec<RefinedClass> = Vec::new();
+    let mut refined_by_group: BTreeMap<&KernGroup, Vec<usize>> = Default::default();
+    let mut ids_by_members: HashMap<BTreeSet<&GlyphName>, usize> = HashMap::new();
+    // Names claimed by output classes: every group name up front (a
+    // consistent group keeps its name; a divergent group's is reserved for
+    // its own refined classes), plus refined-class names as assigned.
+    let mut taken: HashSet<KernGroup> = all_members.keys().map(|group| (*group).clone()).collect();
+    for (group, members) in all_members {
+        if !members
+            .iter()
+            .any(|member| divergent_glyphs.contains(*member))
+        {
+            continue; // consistent: stays whole under its own name
+        }
+        let mut partition: BTreeMap<Vec<Option<&KernGroup>>, BTreeSet<&GlyphName>> =
+            Default::default();
+        for member in members {
+            let signature = kerned_maps
+                .iter()
+                .map(|map| map.get(member).copied())
+                .collect();
+            partition.entry(signature).or_default().insert(member);
+        }
+        let mut group_classes: Vec<(BTreeSet<&GlyphName>, Vec<Option<&KernGroup>>)> = partition
+            .into_iter()
+            .map(|(sig, members)| (members, sig))
+            .collect();
+        group_classes.sort();
+        // Naming (cosmetic; class names never reach the compiled font): the
+        // refined class of members the group holds in every source keeps the
+        // group's name -- failing that, the first new one does -- and the
+        // rest get numeric suffixes in member order.
+        let is_loyal =
+            |signature: &[Option<&KernGroup>]| signature.iter().all(|found| *found == Some(*group));
+        let mut base_name_free = !group_classes
+            .iter()
+            .any(|(_, signature)| is_loyal(signature));
+        let mut ids = Vec::new();
+        for (members, signature) in group_classes {
+            if let Some(&id) = ids_by_members.get(&members) {
+                ids.push(id); // shared with an earlier group's refinement
+                continue;
+            }
+            let name = if is_loyal(&signature) || base_name_free {
+                base_name_free = false;
+                (*group).clone()
+            } else {
+                synthesize_class_name(group, &taken)
+            };
+            taken.insert(name.clone());
+            ids_by_members.insert(members.clone(), refined_classes.len());
+            ids.push(refined_classes.len());
+            refined_classes.push(RefinedClass {
+                name,
+                members,
+                signature,
+            });
+        }
+        refined_by_group.insert(*group, ids);
+    }
+    (refined_classes, refined_by_group)
+}
+
+impl<'a> SideState<'a> {
+    fn new(sources: &[KernSource<'a>], side: Side) -> Self {
+        let kerned_maps = kerned_maps(sources, side);
+
+        let mut all_members: BTreeMap<&KernGroup, BTreeSet<&GlyphName>> = Default::default();
+        for source in sources {
+            for (glyph, group) in source.map_for(side) {
+                all_members.entry(group).or_default().insert(glyph);
+            }
+        }
+
+        let divergent_glyphs: HashSet<&GlyphName> = all_members
+            .values()
+            .flatten()
+            .filter(|glyph| is_divergent(sources, glyph, side))
+            .copied()
+            .collect();
+
+        let (refined_classes, refined_by_group) =
+            refine_divergent_groups(&all_members, &divergent_glyphs, &kerned_maps);
+
+        SideState {
+            all_members,
+            divergent_glyphs,
+            refined_classes,
+            refined_by_group,
+        }
+    }
+
+    /// Expand one side of a kern key into its pairing units.
+    ///
+    /// A glyph or a consistent class is a single unit. A divergent class
+    /// expands to its precomputed refined classes, each emitted as a class --
+    /// singletons included, so class-level kerns stay in class-based
+    /// (PairPos format 2) subtables the way the varLib.merge path compiles
+    /// them.
+    fn units_for(&self, side: &ir::KernSide) -> Vec<Unit<'_>> {
+        let group = match side {
+            ir::KernSide::Glyph(_) => {
+                return vec![Unit {
+                    names: Names::Uniform(side.clone()),
+                    emit: side.clone(),
+                }];
+            }
+            ir::KernSide::Group(group) => group,
+        };
+        match self.refined_by_group.get(group) {
+            None if self.all_members.contains_key(group) => vec![Unit {
+                names: Names::Uniform(side.clone()),
+                emit: side.clone(),
+            }],
+            // a group unknown to every source; the FE validates against this
+            None => vec![],
+            Some(ids) => ids
+                .iter()
+                .map(|&id| {
+                    let refined_class = &self.refined_classes[id];
+                    Unit {
+                        names: Names::PerSource(&refined_class.signature),
+                        emit: ir::KernSide::Group(refined_class.name.clone()),
+                    }
+                })
+                .collect(),
+        }
+    }
+}
+
+/// A fresh name for a refined class: the group's name plus the first free
+/// numeric suffix.
+fn synthesize_class_name(group: &KernGroup, taken: &HashSet<KernGroup>) -> KernGroup {
+    (1usize..)
+        .map(|n| match group {
+            KernGroup::Side1(name) => KernGroup::Side1(format!("{name}_{n}").into()),
+            KernGroup::Side2(name) => KernGroup::Side2(format!("{name}_{n}").into()),
+        })
+        .find(|name| !taken.contains(name))
+        .unwrap()
+}
+
+/// Resolve a refined pair to a value at every source location.
+fn resolve_units(sources: &[KernSource], unit1: &Unit, unit2: &Unit) -> KernAdjustments {
+    // the common case: one pair, resolved with each source's own cascade
+    if let (Names::Uniform(side1), Names::Uniform(side2)) = (&unit1.names, &unit2.names) {
+        return resolve_pair(sources, &(side1.clone(), side2.clone()));
+    }
+    sources
+        .iter()
+        .enumerate()
+        .map(|(idx, source)| {
+            let value = match (unit1.names.at(idx), unit2.names.at(idx)) {
+                (Some(side1), Some(side2)) => lookup_kerning_value(
+                    &(side1, side2),
+                    source.kerns,
+                    &source.side1,
+                    &source.side2,
+                ),
+                // no kerned group in that source: varLib.merger's implicit class 0
+                _ => 0.0.into(),
+            };
+            (source.location.clone(), value)
+        })
+        .collect()
+}
+
+/// The most divergent glyph names quoted in the reconciliation log record.
+const MAX_LOGGED_DIVERGENT_GLYPHS: usize = 10;
+
+/// Resolve every kern pair defined in any master to a value at every location,
+/// reconciling sources whose kerning groups disagree.
 ///
-/// The exception is a glyph-to-class pair that is present in only some
-/// masters: the cascade would backfill it, where missing, with the more
-/// general class-to-class value, and -- since kern rules are ordered
-/// most-specific-first and the first match wins -- that backfill shadows
-/// competing class-to-glyph exceptions on the cells they share, rendering
-/// "phantom" values there that the sources never resolve to. Such a pair
-/// is instead resolved cell by cell: when every member of the class lands
-/// on the same values, the compact glyph-to-class pair is kept, carrying
-/// those cell values; otherwise it is split into one glyph-glyph pair per
-/// member. See <https://github.com/googlefonts/fontc/issues/2035>; this
-/// mirrors the equivalent fix in ufo2ft's kernFeatureWriter
-/// (<https://github.com/googlefonts/ufo2ft/issues/988>).
+/// Sources in a designspace can partition glyphs into kerning groups
+/// differently. Each source's cascade is therefore resolved against its own
+/// groups (the missing-pair fill follows the UFO kerning value lookup
+/// algorithm:
+/// <https://unifiedfontobject.org/versions/ufo3/kerning.plist/#kerning-value-lookup-algorithm>),
+/// and the output classes are the *common refinement* of the per-source
+/// partitions: members that share a kerned group in every source stay
+/// together, the rest split into refined classes resolved at class level per
+/// source (see [`SideState`]). This is the partition varLib's merger computes when
+/// aligning the per-master ClassDefs, so class kerning compiles the way the
+/// merge path would. See <https://github.com/googlefonts/fontc/issues/339>;
+/// mirrors the equivalent reconciliation in ufo2ft
+/// (<https://github.com/googlefonts/ufo2ft/issues/992>).
+///
+/// A glyph-to-class kern is instead a per-glyph override: it is resolved cell
+/// by cell over the class's members and emitted per glyph, so a partial-master
+/// exception can't backfill the class-to-class value, which would shadow
+/// competing class-to-glyph exceptions. See
+/// <https://github.com/googlefonts/fontc/issues/2035> and
+/// <https://github.com/googlefonts/ufo2ft/issues/988>.
+///
+/// Returns the refined group partition (the output classes) alongside the
+/// resolved adjustments.
 fn build_variable_kern_adjustments(
     ir_groups: &KerningGroups,
-    glyph_order: &GlyphOrder,
     kern_by_pos: &HashMap<NormalizedLocation, KerningInstance>,
-) -> BTreeMap<ir::KernPair, KernAdjustments> {
-    let (side1_glyphs, side2_glyphs) = glyph_to_group_maps(ir_groups);
+) -> (
+    BTreeMap<KernGroup, BTreeSet<GlyphName>>,
+    BTreeMap<ir::KernPair, KernAdjustments>,
+) {
     // resolve at the locations kerning is defined at
-    let sources = ir_groups
+    let instances: Vec<&KerningInstance> = ir_groups
         .locations
         .iter()
         .filter_map(|pos| kern_by_pos.get(pos))
-        .collect::<Vec<_>>();
+        .collect();
+    let sources: Vec<KernSource> = instances.iter().map(|i| KernSource::new(i)).collect();
+
+    let side1 = SideState::new(&sources, Side::First);
+    let side2 = SideState::new(&sources, Side::Second);
+
+    let divergent_glyphs: BTreeSet<&GlyphName> = side1
+        .divergent_glyphs
+        .iter()
+        .chain(&side2.divergent_glyphs)
+        .copied()
+        .collect();
+    if !divergent_glyphs.is_empty() {
+        let mut shown = divergent_glyphs
+            .iter()
+            .take(MAX_LOGGED_DIVERGENT_GLYPHS)
+            .map(|glyph| glyph.as_str())
+            .collect::<Vec<_>>()
+            .join(", ");
+        if divergent_glyphs.len() > MAX_LOGGED_DIVERGENT_GLYPHS {
+            shown.push_str(&format!(
+                ", ... ({} more)",
+                divergent_glyphs.len() - MAX_LOGGED_DIVERGENT_GLYPHS
+            ));
+        }
+        log::info!(
+            "Reconciling kerning groups that differ across masters for {} glyph(s): {shown}",
+            divergent_glyphs.len(),
+        );
+    }
+
+    // the output classes: consistent groups keep their union membership, the
+    // refined classes replace the divergent groups
+    let mut refined_groups: BTreeMap<KernGroup, BTreeSet<GlyphName>> = Default::default();
+    for state in [&side1, &side2] {
+        for (group, members) in &state.all_members {
+            if !state.refined_by_group.contains_key(*group) {
+                refined_groups.insert(
+                    (*group).clone(),
+                    members.iter().map(|member| (*member).clone()).collect(),
+                );
+            }
+        }
+        for refined_class in &state.refined_classes {
+            refined_groups.insert(
+                refined_class.name.clone(),
+                refined_class
+                    .members
+                    .iter()
+                    .map(|member| (*member).clone())
+                    .collect(),
+            );
+        }
+    }
+
     // all pairs defined in at least one master
     let all_pairs = kern_by_pos
         .values()
@@ -246,69 +654,48 @@ fn build_variable_kern_adjustments(
         .cloned()
         .collect::<HashSet<_>>();
 
-    let resolve = |pair: &ir::KernPair| -> KernAdjustments {
-        sources
-            .iter()
-            .map(|instance| {
-                let value =
-                    lookup_kerning_value(pair, &instance.kerns, &side1_glyphs, &side2_glyphs);
-                (instance.location.clone(), value)
-            })
-            .collect()
-    };
-
     let mut adjustments: BTreeMap<ir::KernPair, KernAdjustments> = Default::default();
     for key in all_pairs {
-        // resolve glyph-to-class exceptions at the cell level (see the doc
-        // comment above)
-        if let (ir::KernSide::Glyph(first), ir::KernSide::Group(second_group)) = &key
-            && let Some(members) = ir_groups.groups.get(second_group)
-        {
-            // group second-side members by their per-location cell value vector
-            let mut by_value = BTreeMap::<_, Vec<_>>::new();
-            for member in members.iter().filter(|name| glyph_order.contains(*name)) {
-                let cell = (first.clone().into(), member.clone().into());
-                let vector = resolve(&cell);
-                by_value.entry(vector).or_default().push(member.clone());
-            }
-            if by_value.len() == 1 {
-                // no cell diverges: keep the compact glyph-to-class pair, but
-                // carrying the agreed *cell* value -- not the key-level value,
-                // which class-to-glyph exceptions covering every cell
-                // uniformly never resolve to.
-                let (vector, _members) = by_value.into_iter().next().unwrap();
-                insert_resolved(&mut adjustments, key, vector);
-            } else {
-                // cells diverge: replace the glyph-to-class pair with one
-                // glyph-glyph pair per second-side member, each carrying its
-                // own cell value vector. (With no members in the glyph order
-                // this emits nothing, dropping the pair like `exec` would.)
-                for (vector, members) in by_value {
-                    for member in members {
-                        let pair = (
-                            ir::KernSide::Glyph(first.clone()),
-                            ir::KernSide::Glyph(member),
-                        );
-                        insert_resolved(&mut adjustments, pair, vector.clone());
-                    }
-                }
+        // glyph-to-class: a per-glyph override, not divergence -- resolve each
+        // member's own cell with the cascade and emit it as its own pair (the
+        // builder enumerates mixed glyph/class pairs to per-glyph rules anyway)
+        if let (ir::KernSide::Glyph(first), ir::KernSide::Group(second_group)) = &key {
+            for member in side2.all_members.get(second_group).into_iter().flatten() {
+                let pair = (first.clone().into(), (*member).clone().into());
+                let values = resolve_pair(&sources, &pair);
+                insert_resolved(&mut adjustments, pair, values);
             }
             continue;
         }
-        let values = resolve(&key);
-        insert_resolved(&mut adjustments, key, values);
+        let class_to_class = matches!(&key, (ir::KernSide::Group(_), ir::KernSide::Group(_)));
+        for unit1 in side1.units_for(&key.0) {
+            for unit2 in side2.units_for(&key.1) {
+                let values = resolve_units(&sources, &unit1, &unit2);
+                // zero class-to-class pairs override nothing, even refined ones
+                if class_to_class && values.values().all(|value| value.0 == 0.0) {
+                    continue;
+                }
+                insert_resolved(
+                    &mut adjustments,
+                    (unit1.emit.clone(), unit2.emit.clone()),
+                    values,
+                );
+            }
+        }
     }
-    adjustments
+    (refined_groups, adjustments)
 }
 
 /// Insert a resolved pair; colliding pairs always carry equal values.
 ///
-/// Two keys can produce the same pair: the cell-level split of a
+/// Distinct keys can produce the same pair: the cell-level split of a
 /// glyph-to-class exception emits glyph-glyph pairs, and one of those may
-/// also be defined explicitly (encountered in either order). Both resolve
-/// the same cell against the same unmodified sources, so the values cannot
-/// differ and the overwrite is benign. The debug_assert cannot fire; it
-/// documents that invariant and is compiled out of release builds.
+/// also be defined explicitly or emitted by the split of another class key
+/// containing the same member; two group keys refining to a shared class
+/// likewise emit the same class pair. Colliding inserts resolve the same
+/// cell against the same unmodified sources, so the values cannot differ
+/// and the overwrite is benign. The debug_assert cannot fire; it documents
+/// that invariant and is compiled out of release builds.
 fn insert_resolved(
     adjustments: &mut BTreeMap<ir::KernPair, KernAdjustments>,
     pair: ir::KernPair,

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -2340,38 +2340,11 @@ mod tests {
     #[test]
     fn partial_master_kern_exception_is_resolved_per_cell() {
         let result = TestCompile::compile_source("PartialKernException.designspace");
-        let all_kerns = result.be_context.all_kerning_pairs.get();
 
-        // one compact "side1 side2: [value at wght 0, value at wght 1]" line
-        // per pair, sorted, compared exhaustively: pairs untouched by the
-        // cell-level resolution must come through unchanged.
-        let mut kerns: Vec<(KernPair, Vec<(f64, f64)>)> = all_kerns
-            .adjustments
-            .iter()
-            .map(|(pair, adj)| {
-                let mut values: Vec<(f64, f64)> = adj
-                    .iter()
-                    .map(|(loc, val)| (loc.iter().map(|(_, v)| v.to_f64()).next().unwrap(), val.0))
-                    .collect();
-                values.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
-                (pair.clone(), values)
-            })
-            .collect();
-        kerns.sort_by(|(a, _), (b, _)| a.cmp(b));
-        let kerns: Vec<String> = kerns
-            .iter()
-            .map(|((first, second), values)| {
-                let values = values
-                    .iter()
-                    .map(|(_, val)| val.to_string())
-                    .collect::<Vec<_>>()
-                    .join(", ");
-                format!("{first} {second}: [{values}]")
-            })
-            .collect();
-
+        // pairs untouched by the cell-level resolution must come through
+        // unchanged.
         assert_eq!(
-            kerns,
+            dump_kern_adjustments(&result),
             vec![
                 // Greek: the exception (iotadasiaoxia, @GRK_iotaLeft)=30 is present
                 // only in the default master and its cells diverge, so the
@@ -2388,24 +2361,567 @@ mod tests {
                 "qhwee-ethiopic ca-ethiopic: [40, 30]",
                 "qhwee-ethiopic cee-ethiopic: [30, 30]",
                 // Uniform override: the class-to-glyph exceptions cover *every*
-                // member of @uoRight equally (one per member, same value), so no
-                // cell diverges and the compact glyph-to-class pair is kept, not
-                // split. But it must carry the agreed cell value [30, 70], not
-                // the class-to-class value (50) the backfill produced where the
+                // member of @uoRight equally (one per member, same value), so
+                // both cells carry the agreed value [30, 70] -- not the
+                // class-to-class value (50) the backfill produced where the
                 // glyph-to-class exception is absent (which would shadow the
                 // class-to-glyph exceptions at wght 0 -- a phantom even though
-                // no two cells disagree).
-                "uoA @side2.uoRight: [30, 70]",
+                // no two cells disagree). Per-glyph pairs, one per member: a
+                // mixed glyph/class pair enumerates to those exact rules in the
+                // lookup builder anyway.
+                "uoA uoX: [30, 70]",
+                "uoA uoY: [30, 70]",
                 // The remaining pairs are untouched by the cell-level resolution;
                 // where a master omits one, the aligned value comes from the
                 // class-to-class backfill, which is correct for these kinds.
                 "@side1.GRK_iotaRight iotapsilioxia: [20, 30]",
-                "@side1.GRK_iotaRight @side2.GRK_iotaLeft: [60, 50]",
                 "@side1.ethi_qhee ca-ethiopic: [40, 50]",
-                "@side1.ethi_qhee @side2.ethi_ca: [30, 50]",
                 "@side1.uoLeft uoX: [30, 50]",
                 "@side1.uoLeft uoY: [30, 50]",
+                "@side1.GRK_iotaRight @side2.GRK_iotaLeft: [60, 50]",
+                "@side1.ethi_qhee @side2.ethi_ca: [30, 50]",
                 "@side1.uoLeft @side2.uoRight: [50, 50]",
+            ]
+        );
+    }
+
+    /// Dump the resolved variable kern pairs as "first second: [v0, .., vN]"
+    /// lines, values in source location order. Pairs are listed the way the
+    /// kern feature orders its rules, most specific kind first -- glyph-glyph,
+    /// glyph-class, class-glyph, class-class -- then by name.
+    fn dump_kern_adjustments(result: &TestCompile) -> Vec<String> {
+        let all_kerns = result.be_context.all_kerning_pairs.get();
+        let mut kerns: Vec<(KernPair, Vec<(f64, f64)>)> = all_kerns
+            .adjustments
+            .iter()
+            .map(|(pair, adj)| {
+                let mut values: Vec<(f64, f64)> = adj
+                    .iter()
+                    .map(|(loc, val)| (loc.iter().map(|(_, v)| v.to_f64()).next().unwrap(), val.0))
+                    .collect();
+                values.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
+                (pair.clone(), values)
+            })
+            .collect();
+        kerns.sort_by(|(a, _), (b, _)| {
+            (a.0.is_group(), a.1.is_group(), a).cmp(&(b.0.is_group(), b.1.is_group(), b))
+        });
+        kerns
+            .iter()
+            .map(|((first, second), values)| {
+                let values = values
+                    .iter()
+                    .map(|(_, val)| val.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                format!("{first} {second}: [{values}]")
+            })
+            .collect()
+    }
+
+    /// Dump the output kern classes as "@group = [member ..]" lines.
+    fn dump_kern_groups(result: &TestCompile) -> Vec<String> {
+        let all_kerns = result.be_context.all_kerning_pairs.get();
+        let glyph_order = result.fe_context.glyph_order.get();
+        all_kerns
+            .groups
+            .iter()
+            .map(|(group, glyphs)| {
+                let glyphs = glyphs
+                    .iter()
+                    .map(|gid| {
+                        glyph_order
+                            .glyph_name(gid.to_u32() as usize)
+                            .unwrap()
+                            .to_string()
+                    })
+                    .collect::<Vec<_>>()
+                    .join(" ");
+                format!("@{group} = [{glyphs}]")
+            })
+            .collect()
+    }
+
+    // Kern fixtures are generated, not checked in: masters share identical
+    // box glyphs and differ only in groups/kerning, so the semantic input
+    // sits right beside the assertions.
+
+    /// (group name, members)
+    type KernGroupsDsl<'a> = &'a [(&'a str, &'a [&'a str])];
+    /// (side1, [(side2, value)])
+    type KernPairsDsl<'a> = &'a [(&'a str, &'a [(&'a str, i32)])];
+
+    #[derive(Clone, Copy)]
+    struct KernMaster<'a> {
+        style: &'a str,
+        xvalue: u32,
+        groups: KernGroupsDsl<'a>,
+        /// None = kernless master (no kerning.plist at all)
+        kerning: Option<KernPairsDsl<'a>>,
+    }
+
+    fn kern_plist(body: String) -> String {
+        format!(
+            "<?xml version='1.0' encoding='UTF-8'?>\n\
+             <!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \
+             \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n\
+             <plist version=\"1.0\">\n{body}</plist>\n"
+        )
+    }
+
+    fn kern_groups_plist(groups: KernGroupsDsl) -> String {
+        let mut body = String::from("  <dict>\n");
+        for (name, members) in groups {
+            body.push_str(&format!("    <key>{name}</key>\n    <array>\n"));
+            for member in *members {
+                body.push_str(&format!("      <string>{member}</string>\n"));
+            }
+            body.push_str("    </array>\n");
+        }
+        body.push_str("  </dict>\n");
+        kern_plist(body)
+    }
+
+    fn kern_kerning_plist(pairs: KernPairsDsl) -> String {
+        let mut body = String::from("  <dict>\n");
+        for (side1, entries) in pairs {
+            body.push_str(&format!("    <key>{side1}</key>\n    <dict>\n"));
+            for (side2, value) in *entries {
+                body.push_str(&format!(
+                    "      <key>{side2}</key>\n      <integer>{value}</integer>\n"
+                ));
+            }
+            body.push_str("    </dict>\n");
+        }
+        body.push_str("  </dict>\n");
+        kern_plist(body)
+    }
+
+    fn kern_glif(name: &str, codepoint: Option<u32>) -> String {
+        let unicode = codepoint
+            .map(|cp| format!("  <unicode hex=\"{cp:04X}\"/>\n"))
+            .unwrap_or_default();
+        format!(
+            "<?xml version='1.0' encoding='UTF-8'?>\n\
+             <glyph name=\"{name}\" format=\"2\">\n\
+             \x20 <advance width=\"600\"/>\n\
+             {unicode}\
+             \x20 <outline>\n\
+             \x20   <contour>\n\
+             \x20     <point x=\"50\" y=\"0\" type=\"line\"/>\n\
+             \x20     <point x=\"550\" y=\"0\" type=\"line\"/>\n\
+             \x20     <point x=\"550\" y=\"700\" type=\"line\"/>\n\
+             \x20     <point x=\"50\" y=\"700\" type=\"line\"/>\n\
+             \x20   </contour>\n\
+             \x20 </outline>\n\
+             </glyph>\n"
+        )
+    }
+
+    /// Write a wght designspace whose masters share identical box glyphs and
+    /// differ only in kern groups/kerning; returns the designspace path.
+    fn write_kern_fixture(
+        dir: &Path,
+        family: &str,
+        glyphs: &[&str],
+        masters: &[KernMaster],
+    ) -> PathBuf {
+        for master in masters {
+            let ufo = dir.join(format!("{family}-{}.ufo", master.style));
+            let glyphs_dir = ufo.join("glyphs");
+            fs::create_dir_all(&glyphs_dir).unwrap();
+            fs::write(
+                ufo.join("metainfo.plist"),
+                kern_plist(
+                    "  <dict>\n\
+                     \x20   <key>creator</key>\n\
+                     \x20   <string>com.github.fonttools.ufoLib</string>\n\
+                     \x20   <key>formatVersion</key>\n\
+                     \x20   <integer>3</integer>\n\
+                     \x20 </dict>\n"
+                        .into(),
+                ),
+            )
+            .unwrap();
+            fs::write(
+                ufo.join("layercontents.plist"),
+                kern_plist(
+                    "  <array>\n\
+                     \x20   <array>\n\
+                     \x20     <string>public.default</string>\n\
+                     \x20     <string>glyphs</string>\n\
+                     \x20   </array>\n\
+                     \x20 </array>\n"
+                        .into(),
+                ),
+            )
+            .unwrap();
+            fs::write(
+                ufo.join("fontinfo.plist"),
+                kern_plist(format!(
+                    "  <dict>\n\
+                     \x20   <key>ascender</key>\n\
+                     \x20   <integer>800</integer>\n\
+                     \x20   <key>capHeight</key>\n\
+                     \x20   <integer>700</integer>\n\
+                     \x20   <key>descender</key>\n\
+                     \x20   <integer>-200</integer>\n\
+                     \x20   <key>familyName</key>\n\
+                     \x20   <string>{family}</string>\n\
+                     \x20   <key>styleName</key>\n\
+                     \x20   <string>{}</string>\n\
+                     \x20   <key>unitsPerEm</key>\n\
+                     \x20   <integer>1000</integer>\n\
+                     \x20   <key>xHeight</key>\n\
+                     \x20   <integer>500</integer>\n\
+                     \x20 </dict>\n",
+                    master.style
+                )),
+            )
+            .unwrap();
+            let mut order = String::from(
+                "  <dict>\n\
+                 \x20   <key>public.glyphOrder</key>\n\
+                 \x20   <array>\n\
+                 \x20     <string>.notdef</string>\n",
+            );
+            for glyph in glyphs {
+                order.push_str(&format!("      <string>{glyph}</string>\n"));
+            }
+            order.push_str("    </array>\n  </dict>\n");
+            fs::write(ufo.join("lib.plist"), kern_plist(order)).unwrap();
+            let mut contents = String::from(
+                "  <dict>\n    <key>.notdef</key>\n    <string>_notdef.glif</string>\n",
+            );
+            for glyph in glyphs {
+                contents.push_str(&format!(
+                    "    <key>{glyph}</key>\n    <string>{glyph}_.glif</string>\n"
+                ));
+            }
+            contents.push_str("  </dict>\n");
+            fs::write(glyphs_dir.join("contents.plist"), kern_plist(contents)).unwrap();
+            fs::write(glyphs_dir.join("_notdef.glif"), kern_glif(".notdef", None)).unwrap();
+            for glyph in glyphs {
+                let codepoint = glyph.chars().next().unwrap() as u32;
+                fs::write(
+                    glyphs_dir.join(format!("{glyph}_.glif")),
+                    kern_glif(glyph, Some(codepoint)),
+                )
+                .unwrap();
+            }
+            fs::write(ufo.join("groups.plist"), kern_groups_plist(master.groups)).unwrap();
+            if let Some(pairs) = master.kerning {
+                fs::write(ufo.join("kerning.plist"), kern_kerning_plist(pairs)).unwrap();
+            }
+        }
+        let mut sources = String::new();
+        for master in masters {
+            sources.push_str(&format!(
+                "    <source filename=\"{family}-{style}.ufo\" \
+                 familyname=\"{family}\" stylename=\"{style}\">\n\
+                 \x20     <location>\n\
+                 \x20       <dimension name=\"Weight\" xvalue=\"{x}\"/>\n\
+                 \x20     </location>\n\
+                 \x20   </source>\n",
+                style = master.style,
+                x = master.xvalue
+            ));
+        }
+        let designspace = dir.join(format!("{family}.designspace"));
+        fs::write(
+            &designspace,
+            format!(
+                "<?xml version='1.0' encoding='UTF-8'?>\n\
+                 <designspace format=\"5.0\">\n\
+                 \x20 <axes>\n\
+                 \x20   <axis tag=\"wght\" name=\"Weight\" minimum=\"0\" \
+                 maximum=\"1000\" default=\"0\"/>\n\
+                 \x20 </axes>\n\
+                 \x20 <sources>\n\
+                 {sources}\x20 </sources>\n\
+                 </designspace>\n"
+            ),
+        )
+        .unwrap();
+        designspace
+    }
+
+    const DIVERGENT_GLYPHS: &[&str] = &["A", "B", "C", "D", "E", "H", "T", "W", "X", "Y", "Z"];
+
+    const DIVERGENT_REGULAR: KernMaster = KernMaster {
+        style: "Regular",
+        xvalue: 0,
+        groups: &[
+            ("public.kern1.in_both", &["C", "D", "E"]),
+            ("public.kern2.in_both", &["X", "W", "Y"]),
+        ],
+        kerning: Some(&[
+            ("A", &[("public.kern2.in_both", 100)]),
+            (
+                "public.kern1.in_both",
+                &[("T", 200), ("public.kern2.in_both", 300)],
+            ),
+        ]),
+    };
+
+    const DIVERGENT_BOLD: KernMaster = KernMaster {
+        style: "Bold",
+        xvalue: 1000,
+        groups: &[
+            ("public.kern1.bold_only_e", &["E"]),
+            ("public.kern1.in_both", &["C", "D", "H"]),
+            ("public.kern2.bold_only_y", &["Y"]),
+            ("public.kern2.bold_only_z", &["Z"]),
+            ("public.kern2.in_both", &["X", "W"]),
+        ],
+        kerning: Some(&[
+            (
+                "A",
+                &[
+                    ("public.kern2.bold_only_y", -50),
+                    ("public.kern2.in_both", 100),
+                ],
+            ),
+            ("B", &[("public.kern2.bold_only_z", -30)]),
+            (
+                "public.kern1.bold_only_e",
+                &[("T", -60), ("public.kern2.bold_only_y", -10)],
+            ),
+            (
+                "public.kern1.in_both",
+                &[("T", 200), ("public.kern2.in_both", 300)],
+            ),
+        ]),
+    };
+
+    // Two masters can partition glyphs into kerning groups *differently*: a
+    // glyph in one group at the default master can be in another group (or no
+    // group, or a group that only exists in that master) elsewhere. Each
+    // master's kerning must be resolved against that master's own groups, and
+    // the output classes refined into the common per-master partition, so the
+    // variable pair carries the value the source actually resolves to at every
+    // location. fontc used to read only the default master's groups.plist, so
+    // a master-specific group was dropped ("not a valid group name; ignored")
+    // and a divergent glyph silently took the default master's grouping
+    // everywhere. This mirrors the equivalent fix in ufo2ft's
+    // kernFeatureWriter and the reconciliation in fontTools' varLib merger.
+    // See https://github.com/googlefonts/fontc/issues/339 and
+    // https://github.com/googlefonts/ufo2ft/issues/992.
+    #[test]
+    fn divergent_kern_groups_resolved_against_each_master() {
+        let _ = env_logger::builder().is_test(true).try_init();
+        let tmp = tempdir().unwrap();
+        let designspace = write_kern_fixture(
+            tmp.path(),
+            "DivergentKernGroups",
+            DIVERGENT_GLYPHS,
+            &[DIVERGENT_REGULAR, DIVERGENT_BOLD],
+        );
+        let result = TestCompile::compile_source(designspace.to_str().unwrap());
+        let kerns = dump_kern_adjustments(&result);
+
+        // Second side: Y moves out of @kern2.in_both into @kern2.bold_only_y.
+        // The refinement keeps {X, W} as @side2.in_both and splits Y into its
+        // own single-glyph class -- a class, not a bare glyph, so it stays in
+        // the class-based PairPos subtable the way the varLib.merge path
+        // compiles it. The glyph-to-class (A, @kern2.in_both) is a per-glyph
+        // exception and instead resolves member by member over the membership
+        // union: X and W carry [100, 100] while Y picks up the Bold
+        // (A, @kern2.bold_only_y) = -50. Z is grouped only at Bold; (B, Z)
+        // must surface that orphan as [0, -30].
+        //
+        // First side, the mirror case: E moves to @kern1.bold_only_e, and H
+        // joins @kern1.in_both only at Bold. {C, D} stays @side1.in_both; each
+        // refined class resolves at class level against each master's own
+        // groups, so (@side1.bold_only_e, T) picks up the Bold
+        // (@kern1.bold_only_e, T) = -60 and (@side1.in_both_1, T) is 0 at
+        // Regular, where H is in no kerned group.
+        //
+        // Both sides at once: (@kern1.in_both, @kern2.in_both) refines to the
+        // cross product of the per-side refined classes, minus
+        // (@side1.in_both_1, @side2.bold_only_y), which resolves to zero
+        // everywhere and a zero class-class pair overrides nothing.
+        // (@side1.bold_only_e, @side2.bold_only_y) resolves to [300, -10] via
+        // the Bold (@kern1.bold_only_e, @kern2.bold_only_y) exception --
+        // reached identically from both the (in_both, in_both) cross-product
+        // and the (bold_only_e, bold_only_y) key, a check on idempotent
+        // emission.
+        assert_eq!(
+            kerns,
+            vec![
+                "A W: [100, 100]".to_string(),
+                "A X: [100, 100]".to_string(),
+                "A Y: [100, -50]".to_string(),
+                "B Z: [0, -30]".to_string(),
+                "@side1.bold_only_e T: [200, -60]".to_string(),
+                "@side1.in_both T: [200, 200]".to_string(),
+                "@side1.in_both_1 T: [0, 200]".to_string(),
+                "@side1.bold_only_e @side2.bold_only_y: [300, -10]".to_string(),
+                "@side1.bold_only_e @side2.in_both: [300, 0]".to_string(),
+                "@side1.in_both @side2.bold_only_y: [300, 0]".to_string(),
+                "@side1.in_both @side2.in_both: [300, 300]".to_string(),
+                "@side1.in_both_1 @side2.in_both: [0, 300]".to_string(),
+            ]
+        );
+
+        assert_eq!(
+            dump_kern_groups(&result),
+            vec![
+                "@side1.bold_only_e = [E]".to_string(),
+                "@side1.in_both = [C D]".to_string(),
+                "@side1.in_both_1 = [H]".to_string(),
+                "@side2.bold_only_y = [Y]".to_string(),
+                "@side2.bold_only_z = [Z]".to_string(),
+                "@side2.in_both = [W X]".to_string(),
+            ]
+        );
+    }
+
+    // How the kernless-master skip
+    // (https://github.com/googlefonts/ufo2ft/issues/995) interacts with the
+    // group reconciliation above
+    // (https://github.com/googlefonts/ufo2ft/issues/992): a non-default
+    // *kernless* master with *divergent* kern groups is skipped before group
+    // reconciliation (its location never enters KerningGroups.locations, so
+    // no KernInstance is built for it), so its groups can neither zero the
+    // class kern nor make grouped glyphs look divergent. Mirrors ufo2ft's
+    // test_variable_kern_kernless_master_with_groups_matches_varlib.
+    //
+    // A kernless Medium master with deliberately divergent groups: X grouped
+    // with Y (excluding W), C isolated from D. The reconciled output must be
+    // byte-for-byte the two-master result. Parity with fontmake on the
+    // three-master build is confirmed identical via ttx_diff against
+    // ufo2ft 3.9.0, which fixes both issues.
+    const DIVERGENT_KERNLESS_MEDIUM: KernMaster = KernMaster {
+        style: "Medium",
+        xvalue: 500,
+        groups: &[
+            ("public.kern1.in_both", &["C"]),
+            ("public.kern1.medium_only_d", &["D"]),
+            ("public.kern2.in_both", &["X", "Y"]),
+            ("public.kern2.medium_only_w", &["W"]),
+        ],
+        kerning: None,
+    };
+
+    #[test]
+    fn kernless_master_divergent_groups_do_not_reach_reconciliation() {
+        let _ = env_logger::builder().is_test(true).try_init();
+        let tmp = tempdir().unwrap();
+        let two = write_kern_fixture(
+            &tmp.path().join("two"),
+            "DivergentKernGroups",
+            DIVERGENT_GLYPHS,
+            &[DIVERGENT_REGULAR, DIVERGENT_BOLD],
+        );
+        let three = write_kern_fixture(
+            &tmp.path().join("three"),
+            "DivergentKernGroups",
+            DIVERGENT_GLYPHS,
+            &[DIVERGENT_REGULAR, DIVERGENT_KERNLESS_MEDIUM, DIVERGENT_BOLD],
+        );
+        let two_master = TestCompile::compile_source(two.to_str().unwrap());
+        let with_kernless = TestCompile::compile_source(three.to_str().unwrap());
+        assert_eq!(
+            dump_kern_adjustments(&with_kernless),
+            dump_kern_adjustments(&two_master),
+            "kernless divergent-groups master must not change the reconciled adjustments"
+        );
+        assert_eq!(
+            dump_kern_groups(&with_kernless),
+            dump_kern_groups(&two_master),
+            "kernless divergent-groups master must not change the reconciled classes"
+        );
+    }
+
+    // The refinement must match the partition varLib's merger computes from
+    // the compiled per-master ClassDefs. P and Q are grouped together in
+    // every master, so they stay one class. U and V are grouped apart at
+    // Bold, but no kerning references either group: compiled ClassDefs only
+    // contain kerned glyphs, so varLib sees both as class 0 at Bold and keeps
+    // them in one class -- the refinement must too, ignoring the unkerned
+    // distinction. And the (@kern1.in_both, P) = 5 exception must stay a
+    // per-glyph pair, not smear over P's whole refined class.
+    // See https://github.com/googlefonts/fontc/issues/339 and
+    // https://github.com/googlefonts/ufo2ft/issues/992.
+    #[test]
+    fn regrouped_kern_groups_refine_by_kerned_signature() {
+        let _ = env_logger::builder().is_test(true).try_init();
+        let tmp = tempdir().unwrap();
+        let designspace = write_kern_fixture(
+            tmp.path(),
+            "RegroupedKernGroups",
+            &["C", "D", "G", "P", "Q", "U", "V", "W"],
+            &[
+                KernMaster {
+                    style: "Regular",
+                    xvalue: 0,
+                    groups: &[
+                        ("public.kern1.in_both", &["C", "D"]),
+                        ("public.kern2.in_both", &["P", "Q", "U", "V", "W"]),
+                        ("public.kern2.regular_only_g", &["G"]),
+                    ],
+                    kerning: Some(&[(
+                        "public.kern1.in_both",
+                        &[
+                            ("public.kern2.in_both", 100),
+                            ("public.kern2.regular_only_g", 0),
+                        ],
+                    )]),
+                },
+                KernMaster {
+                    style: "Bold",
+                    xvalue: 1000,
+                    groups: &[
+                        ("public.kern1.in_both", &["C", "D"]),
+                        ("public.kern2.bold_only_pq", &["P", "Q"]),
+                        ("public.kern2.bold_unkerned_u", &["U"]),
+                        ("public.kern2.bold_unkerned_v", &["V"]),
+                        ("public.kern2.in_both", &["W"]),
+                    ],
+                    kerning: Some(&[(
+                        "public.kern1.in_both",
+                        &[
+                            ("P", 5),
+                            ("public.kern2.bold_only_pq", -40),
+                            ("public.kern2.in_both", 150),
+                        ],
+                    )]),
+                },
+            ],
+        );
+        let result = TestCompile::compile_source(designspace.to_str().unwrap());
+
+        // W stays @side2.in_both; {P, Q} resolve the Bold
+        // (@kern1.in_both, @kern2.bold_only_pq) = -40 as one class, with the
+        // (@kern1.in_both, P) = 5 exception emitted as its own pair; {U, V}
+        // resolve to 0 at Bold as @side2.in_both_1.
+        //
+        // The Regular (@kern1.in_both, @kern2.regular_only_g) = 0 emits
+        // nothing: a zero class-to-class pair overrides nothing.
+        assert_eq!(
+            dump_kern_adjustments(&result),
+            vec![
+                "@side1.in_both P: [100, 5]".to_string(),
+                "@side1.in_both @side2.bold_only_pq: [100, -40]".to_string(),
+                "@side1.in_both @side2.in_both: [100, 150]".to_string(),
+                "@side1.in_both @side2.in_both_1: [100, 0]".to_string(),
+            ]
+        );
+
+        // bold_unkerned_u, bold_unkerned_v, and regular_only_g are refined but
+        // never referenced by an output pair; their refined classes sit unused
+        // in the class map and stay out of the font.
+        assert_eq!(
+            dump_kern_groups(&result),
+            vec![
+                "@side1.in_both = [C D]".to_string(),
+                "@side2.bold_only_pq = [P Q]".to_string(),
+                "@side2.bold_unkerned_u = [U]".to_string(),
+                "@side2.bold_unkerned_v = [V]".to_string(),
+                "@side2.in_both = [W]".to_string(),
+                "@side2.in_both_1 = [U V]".to_string(),
+                "@side2.regular_only_g = [G]".to_string(),
             ]
         );
     }

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -181,6 +181,14 @@ pub struct KerningInstance {
     /// Used for both LTR and RTL. The BE application differs but the concept
     /// is the same.
     pub kerns: BTreeMap<KernPair, OrderedFloat<f64>>,
+    /// This source's own kerning groups (group -> member glyphs), as defined
+    /// at this location.
+    ///
+    /// Sources in a designspace can partition glyphs into kerning groups
+    /// differently, so the value-lookup cascade for a pair must be resolved
+    /// against the groups of the source it came from, not a single merged map.
+    /// See <https://github.com/googlefonts/fontc/issues/339>.
+    pub groups: BTreeMap<KernGroup, BTreeSet<GlyphName>>,
 }
 
 /// A named set of glyphs with common kerning behaviour

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -1236,6 +1236,10 @@ impl Work<Context, WorkId, Error> for KerningInstanceWork {
                     *kerning.kerns.entry(participants).or_default() = value;
                 });
         }
+        // Glyphs kerning groups are per-glyph and so shared across all masters;
+        // every instance carries the same partition and the BE reconciliation is
+        // a no-op. See <https://github.com/googlefonts/fontc/issues/339>.
+        kerning.groups = groups.clone();
 
         context.kerning_at.set(kerning);
         Ok(())

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -1665,10 +1665,23 @@ fn kerning_groups_for(
 ) -> Result<BTreeMap<KernGroup, BTreeSet<GlyphName>>, Error> {
     let ufo_dir = designspace_dir.join(&source.filename);
     let data_request = norad::DataRequest::none().groups(true);
-    Ok(norad::Font::load_requested_data(&ufo_dir, data_request)
-        .map_err(|e| BadSource::custom(ufo_dir, e))?
-        .groups
-        .into_iter()
+    let font = norad::Font::load_requested_data(&ufo_dir, data_request)
+        .map_err(|e| BadSource::custom(ufo_dir, e))?;
+    Ok(kern_groups_from_norad(&font.groups, glyph_order))
+}
+
+/// Build the kern-group partition for a single source.
+///
+/// Keep only kern1/kern2 groups, prune members to the glyph order, and drop the
+/// empties. The membership is this source's alone; sources in a designspace can
+/// disagree on how glyphs are grouped, which the BE reconciles.
+/// See <https://github.com/googlefonts/fontc/issues/339>.
+fn kern_groups_from_norad(
+    groups: &norad::Groups,
+    glyph_order: &GlyphOrder,
+) -> BTreeMap<KernGroup, BTreeSet<GlyphName>> {
+    groups
+        .iter()
         .filter_map(|(group_name, entries)| {
             KernGroup::from_group_name(group_name.as_str())
                 .filter(|_| !entries.is_empty())
@@ -1676,27 +1689,22 @@ fn kerning_groups_for(
         })
         .filter_map(|(group_name, entries)| {
             let members: BTreeSet<_> = entries
-                .into_iter()
+                .iter()
                 .filter_map(|glyph_name| {
-                    let glyph_name = GlyphName::new(glyph_name);
+                    let glyph_name = GlyphName::new(glyph_name.as_str());
                     if glyph_order.contains(&glyph_name) {
                         Some(glyph_name)
                     } else {
                         debug!(
-                            "{} kerning group '{}' references non-existent glyph '{}'; ignoring",
-                            source.filename, group_name, glyph_name
+                            "kern group '{group_name}' references non-existent glyph '{glyph_name}'; ignoring"
                         );
                         None
                     }
                 })
                 .collect();
-            if !members.is_empty() {
-                Some((group_name, members))
-            } else {
-                None
-            }
+            (!members.is_empty()).then_some((group_name, members))
         })
-        .collect())
+        .collect()
 }
 
 /// UFO specific behaviour for kern groups
@@ -1777,10 +1785,13 @@ impl Work<Context, WorkId, Error> for KerningInstanceWork {
     }
 
     fn read_access(&self) -> Access<WorkId> {
+        // No KerningGroups dependency: each instance loads its own source's
+        // groups. Instances are still only spawned once KerningGroupWork
+        // completes -- workload.rs reacts to its success by creating one
+        // KernInstance work per participating location.
         AccessBuilder::new()
             .variant(WorkId::StaticMetadata)
             .variant(WorkId::GlyphOrder)
-            .variant(WorkId::KerningGroups)
             .build()
     }
 
@@ -1793,7 +1804,6 @@ impl Work<Context, WorkId, Error> for KerningInstanceWork {
         let designspace_dir = self.designspace_dir.as_ref();
         let static_metadata = context.static_metadata.get();
         let glyph_order = context.glyph_order.get();
-        let groups = context.kerning_groups.get();
         let master_locations =
             master_locations(&static_metadata.all_source_axes, &self.designspace.sources);
 
@@ -1809,19 +1819,17 @@ impl Work<Context, WorkId, Error> for KerningInstanceWork {
             .unwrap();
 
         let ufo_dir = designspace_dir.join(&source.filename);
-        // UFO2 kerning uses @MMK_L_/@MMK_R_ group names; norad's upconversion to
-        // public.kern1./kern2. only fires when groups are loaded alongside kerning.
-        // Reading metainfo.plist is cheap (~150 bytes) and avoids loading groups.plist
-        // on every UFO3 source.
-        let meta_path = ufo_dir.join("metainfo.plist");
-        let meta: norad::MetaInfo =
-            plist::from_file(&meta_path).map_err(|e| BadSource::custom(&meta_path, e))?;
-        let needs_upconversion = meta.format_version != norad::FormatVersion::V3;
-        let data_request = norad::DataRequest::none()
-            .kerning(true)
-            .groups(needs_upconversion);
+        // Load groups alongside kerning: norad's UFO2 @MMK_L_/@MMK_R_ ->
+        // public.kern1./kern2. upconversion only fires when both are present,
+        // and we need this source's own groups to resolve its kerning cascade.
+        let data_request = norad::DataRequest::none().kerning(true).groups(true);
         let font = norad::Font::load_requested_data(&ufo_dir, data_request)
             .map_err(|e| BadSource::custom(ufo_dir, e))?;
+
+        // This source's own kern-group partition. Kerning references are
+        // validated against it (and resolved against it in the BE), so a group
+        // unique to this source is kept rather than dropped against a merged map.
+        let source_groups = kern_groups_from_norad(&font.groups, glyph_order.as_ref());
 
         let resolve = |name: &norad::Name, group_prefix: &str| {
             if let Some(group_name) = KernGroup::from_group_name(name.as_str()) {
@@ -1829,7 +1837,7 @@ impl Work<Context, WorkId, Error> for KerningInstanceWork {
                     warn!("'{name}' should have prefix {group_prefix}; ignored");
                     return None;
                 }
-                if !groups.groups.contains_key(&group_name) {
+                if !source_groups.contains_key(&group_name) {
                     warn!("'{name}' is not a valid group name; ignored");
                     return None;
                 }
@@ -1868,6 +1876,7 @@ impl Work<Context, WorkId, Error> for KerningInstanceWork {
 
             *kerns.kerns.entry((side1, side2)).or_default() = adjustment.into();
         }
+        kerns.groups = source_groups;
 
         debug!("{:?} has {} kern entries", self.location, kerns.kerns.len());
         context.kerning_at.set(kerns);
@@ -2861,11 +2870,12 @@ mod tests {
         }
     }
 
-    // #636's user-visible fallout: kerning referencing this master's own name
-    // for a same-membership group is dropped instead of renamed. #339's group
-    // reconciliation will keep these kerns; flip this test then.
+    // #636 used to drop kerning referencing this master's own name for a
+    // same-membership group (#2063 pinned that); each source's kerning now
+    // resolves against its own groups, so the pair survives under the
+    // source's own name and the BE reconciles the naming across masters (#339)
     #[test]
-    fn kerning_against_renamed_group_is_dropped() {
+    fn kerning_against_renamed_group_is_kept() {
         let tmp = tempfile::tempdir().unwrap();
         for ufo in ["WghtVar-Regular.ufo", "WghtVar-Bold.ufo"] {
             copy_dir(&testdata_dir().join(ufo), &tmp.path().join(ufo));
@@ -2904,9 +2914,13 @@ mod tests {
             ));
         assert_eq!(
             bold.kerns.keys().cloned().collect::<Vec<_>>(),
-            vec![(KernSide::Glyph("bar".into()), KernSide::Glyph("bar".into()))],
-            "only the glyph-glyph pair should survive; if the group pair is now \
-             kept, #339's reconciliation landed and this test should assert that instead"
+            vec![
+                (KernSide::Glyph("bar".into()), KernSide::Glyph("bar".into())),
+                (
+                    KernSide::Group(KernGroup::Side1("the_WrOng_name".into())),
+                    KernSide::Glyph("bar".into())
+                ),
+            ],
         );
     }
 


### PR DESCRIPTION
Fixes #339 and ports googlefonts/ufo2ft#996 to fontc.

When masters partition glyphs into kerning groups differently, resolve each master's kerning against its own groups and refine the output classes into the coarsest common refinement of the per-master partitions (the same partition varLib.merger computes from the compiled per-master ClassDefs), so class kerning compiles the way fontmake would when building a VF from DS/UFOs sources with divergent kern groups.

Previously fontc read only the default master's groups.plist: a divergent glyph took the default's grouping everywhere (wrong kerning value), and a group existing only in a non-default master was dropped along with its kerning.

The first commit adds the (initially failing) tests; the fixtures are generated by the tests themselves, masters sharing identical box glyphs and differing only in groups/kerning.

The second commit carries each source's own groups into IR (`KerningInstance.groups`), and validates each source's kerning against its own groups.

The third rewrites `build_variable_kern_adjustments` with per-source resolution through the UFO value-lookup cascade, and refined classes grouping members by which group holds them in each source. Divergence is detected on the source-declared groups, but the refinement counts only groups that are referenced by each source's own kerning, matching what reaches compiled ClassDefs in varLib.merger. Glyph-to-class pairs continue to be resolved per cell (googlefonts/ufo2ft#988, googlefonts/ufo2ft#994 semantics).

ttx_diff vs fontmake with ufo2ft 3.9.0 is identical (normalized GPOS) on the test fixtures and on JosefinSlab, whose [shipped VF](https://github.com/google/fonts/blob/47831f08ec6d6d7ad6b465f23dc9f9a890a2a04b/ofl/josefinslab/JosefinSlab%5Bwght%5D.ttf) carries this bug live.

Also note that the merged `KerningGroups.groups` map is now **unread** in the BE. The `KerningGroups` artifact itself keeps an orchestration role: its locations record which sources participate in kerning (the ufo2ft#995 skip), the BE iterates exactly those, and the `KerningGroupWork`'s completion spawns the per-location KernInstance works. Retiring the merged map and renaming the now misleadingly-named work is a planned follow-up to keep this diff reviewable.

We should merge after #2059 and the ufo2ft 3.9.0 bump (#2062), in the same crater window. Against pinned ufo2ft 3.8.2 it would spray kern diffs across crater.

