### PR TITLE
[kern] Retire the merged kerning-groups map 

### DIFF
--- a/fontbe/src/features/kern.rs
+++ b/fontbe/src/features/kern.rs
@@ -15,7 +15,7 @@ use fontdrasil::{
     types::GlyphName,
 };
 use fontir::{
-    ir::{self, GdefCategories, GlyphOrder, KernGroup, KerningGroups, KerningInstance},
+    ir::{self, GdefCategories, GlyphOrder, KernGroup, KerningInstance, KerningLocations},
     orchestration::WorkId as FeWorkId,
 };
 use icu_properties::props::BidiClass;
@@ -114,7 +114,7 @@ impl Work<Context, AnyWorkId, Error> for GatherIrKerningWork {
     /// Generate kerning data structures.
     fn exec(&self, context: &Context) -> Result<(), Error> {
         let glyph_order = context.ir.glyph_order.get();
-        let ir_groups = context.ir.kerning_groups.get();
+        let ir_groups = context.ir.kerning_locations.get();
         let ir_kerns = context.ir.kerning_at.all();
 
         // Add IR kerns to builder. IR kerns are split by location so put them back together again.
@@ -581,7 +581,7 @@ const MAX_LOGGED_DIVERGENT_GLYPHS: usize = 10;
 /// Returns the refined group partition (the output classes) alongside the
 /// resolved adjustments.
 fn build_variable_kern_adjustments(
-    ir_groups: &KerningGroups,
+    ir_groups: &KerningLocations,
     kern_by_pos: &HashMap<NormalizedLocation, KerningInstance>,
 ) -> (
     BTreeMap<KernGroup, BTreeSet<GlyphName>>,

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -568,7 +568,7 @@ mod tests {
             FeWorkIdentifier::GlyphOrder.into(),
             FeWorkIdentifier::PreliminaryGdefCategories.into(),
             FeWorkIdentifier::Features.into(),
-            FeWorkIdentifier::KerningGroups.into(),
+            FeWorkIdentifier::KerningLocations.into(),
             FeWorkIdentifier::KernInstance(NormalizedLocation::for_pos(&[("wght", 0.0)])).into(),
             FeWorkIdentifier::KernInstance(NormalizedLocation::for_pos(&[("wght", 1.0)])).into(),
             BeWorkIdentifier::Features.into(),
@@ -2208,7 +2208,7 @@ mod tests {
     fn assert_simple_kerning(source: &str) {
         let result = TestCompile::compile_source(source);
 
-        let kerning_groups = result.fe_context.kerning_groups.get();
+        let kerning_locations = result.fe_context.kerning_locations.get();
 
         let expected_groups = vec![
             (
@@ -2231,7 +2231,7 @@ mod tests {
 
         let wght = Tag::new(b"wght");
         let mut kerns: HashMap<KernPair, Vec<(String, f64)>> = HashMap::new();
-        for kern_loc in kerning_groups.locations.iter() {
+        for kern_loc in kerning_locations.locations.iter() {
             assert_eq!(
                 vec![wght],
                 kern_loc.axis_tags().cloned().collect::<Vec<_>>()
@@ -2785,7 +2785,7 @@ mod tests {
     // group reconciliation above
     // (https://github.com/googlefonts/ufo2ft/issues/992): a non-default
     // *kernless* master with *divergent* kern groups is skipped before group
-    // reconciliation (its location never enters KerningGroups.locations, so
+    // reconciliation (its location never enters KerningLocations, so
     // no KernInstance is built for it), so its groups can neither zero the
     // class kern nor make grouped glyphs look divergent. Mirrors ufo2ft's
     // test_variable_kern_kernless_master_with_groups_matches_varlib.

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -2210,16 +2210,24 @@ mod tests {
 
         let kerning_groups = result.fe_context.kerning_groups.get();
 
-        let mut groups: Vec<_> = kerning_groups
-            .groups
-            .iter()
-            .map(|(name, entries)| {
-                let mut entries: Vec<_> = entries.iter().map(|e| e.as_str()).collect();
-                entries.sort();
-                (name.to_owned(), entries)
-            })
-            .collect();
-        groups.sort();
+        let expected_groups = vec![
+            (
+                KernGroup::Side1("bracketleft_R".into()),
+                vec!["bracketleft"],
+            ),
+            (
+                KernGroup::Side1("bracketright_R".into()),
+                vec!["bracketright"],
+            ),
+            (
+                KernGroup::Side2("bracketleft_L".into()),
+                vec!["bracketleft"],
+            ),
+            (
+                KernGroup::Side2("bracketright_L".into()),
+                vec!["bracketright"],
+            ),
+        ];
 
         let wght = Tag::new(b"wght");
         let mut kerns: HashMap<KernPair, Vec<(String, f64)>> = HashMap::new();
@@ -2233,6 +2241,21 @@ mod tests {
                 .fe_context
                 .kerning_at
                 .get(&FeWorkIdentifier::KernInstance(kern_loc.clone()));
+
+            // groups are per-source; in these fixtures every master declares
+            // the same ones
+            let mut groups: Vec<_> = kerns_at
+                .groups
+                .iter()
+                .map(|(name, entries)| {
+                    let mut entries: Vec<_> = entries.iter().map(|e| e.as_str()).collect();
+                    entries.sort();
+                    (name.to_owned(), entries)
+                })
+                .collect();
+            groups.sort();
+            assert_eq!(groups, expected_groups, "groups at {kern_loc:?}");
+
             for (pair, adjustment) in kerns_at.kerns.iter() {
                 kerns.entry(pair.clone()).or_default().push((
                     format!(
@@ -2253,68 +2276,48 @@ mod tests {
         kerns.sort_by_key(|(left, right, _)| (left.clone(), right.clone()));
 
         assert_eq!(
-            (groups, kerns),
-            (
-                vec![
-                    (
-                        KernGroup::Side1("bracketleft_R".into()),
-                        vec!["bracketleft"],
-                    ),
-                    (
-                        KernGroup::Side1("bracketright_R".into()),
-                        vec!["bracketright"],
-                    ),
-                    (
-                        KernGroup::Side2("bracketleft_L".into()),
-                        vec!["bracketleft"],
-                    ),
-                    (
-                        KernGroup::Side2("bracketright_L".into()),
-                        vec!["bracketright"],
-                    ),
-                ],
-                vec![
-                    (
-                        KernSide::Glyph("bracketleft".into()),
-                        KernSide::Glyph("bracketright".into()),
-                        vec![
-                            ("wght 0".to_string(), -300.0),
-                            ("wght 1".to_string(), -150.0)
-                        ],
-                    ),
-                    (
-                        KernSide::Glyph("exclam".into()),
-                        KernSide::Glyph("exclam".into()),
-                        vec![
-                            ("wght 0".to_string(), -360.0),
-                            ("wght 1".to_string(), -100.0)
-                        ],
-                    ),
-                    (
-                        KernSide::Glyph("exclam".into()),
-                        KernSide::Glyph("hyphen".into()),
-                        vec![("wght 0".to_string(), 20.0),],
-                    ),
-                    (
-                        KernSide::Glyph("exclam".into()),
-                        KernSide::Group(KernGroup::Side2("bracketright_L".into())),
-                        vec![("wght 0".to_string(), -160.0),],
-                    ),
-                    (
-                        KernSide::Glyph("hyphen".into()),
-                        KernSide::Glyph("hyphen".into()),
-                        vec![
-                            ("wght 0".to_string(), -150.0),
-                            ("wght 1".to_string(), -50.0)
-                        ],
-                    ),
-                    (
-                        KernSide::Group(KernGroup::Side1("bracketleft_R".into())),
-                        KernSide::Glyph("exclam".into()),
-                        vec![("wght 0".to_string(), -165.0),],
-                    ),
-                ],
-            )
+            kerns,
+            vec![
+                (
+                    KernSide::Glyph("bracketleft".into()),
+                    KernSide::Glyph("bracketright".into()),
+                    vec![
+                        ("wght 0".to_string(), -300.0),
+                        ("wght 1".to_string(), -150.0)
+                    ],
+                ),
+                (
+                    KernSide::Glyph("exclam".into()),
+                    KernSide::Glyph("exclam".into()),
+                    vec![
+                        ("wght 0".to_string(), -360.0),
+                        ("wght 1".to_string(), -100.0)
+                    ],
+                ),
+                (
+                    KernSide::Glyph("exclam".into()),
+                    KernSide::Glyph("hyphen".into()),
+                    vec![("wght 0".to_string(), 20.0),],
+                ),
+                (
+                    KernSide::Glyph("exclam".into()),
+                    KernSide::Group(KernGroup::Side2("bracketright_L".into())),
+                    vec![("wght 0".to_string(), -160.0),],
+                ),
+                (
+                    KernSide::Glyph("hyphen".into()),
+                    KernSide::Glyph("hyphen".into()),
+                    vec![
+                        ("wght 0".to_string(), -150.0),
+                        ("wght 1".to_string(), -50.0)
+                    ],
+                ),
+                (
+                    KernSide::Group(KernGroup::Side1("bracketleft_R".into())),
+                    KernSide::Glyph("exclam".into()),
+                    vec![("wght 0".to_string(), -165.0),],
+                ),
+            ],
         );
     }
 

--- a/fontc/src/timing.rs
+++ b/fontc/src/timing.rs
@@ -221,7 +221,7 @@ fn short_name(id: &AnyWorkId) -> &'static str {
         AnyWorkId::Fe(FeWorkIdentifier::GlobalMetrics) => "metrics",
         AnyWorkId::Fe(FeWorkIdentifier::Glyph(..)) => "glyph",
         AnyWorkId::Fe(FeWorkIdentifier::GlyphOrder) => "glyphorder",
-        AnyWorkId::Fe(FeWorkIdentifier::KerningGroups) => "kerngrps",
+        AnyWorkId::Fe(FeWorkIdentifier::KerningLocations) => "kernlocs",
         AnyWorkId::Fe(FeWorkIdentifier::KernInstance(..)) => "kernat",
         AnyWorkId::Fe(FeWorkIdentifier::PaintGraph) => "colr",
         AnyWorkId::Fe(FeWorkIdentifier::PreliminaryGlyphOrder) => "pre-go",

--- a/fontc/src/workload.rs
+++ b/fontc/src/workload.rs
@@ -105,7 +105,7 @@ enum RecvType {
 fn priority(id: &AnyWorkId) -> u32 {
     match id {
         AnyWorkId::Fe(FeWorkIdentifier::Features) => 99,
-        AnyWorkId::Fe(FeWorkIdentifier::KerningGroups) => 99,
+        AnyWorkId::Fe(FeWorkIdentifier::KerningLocations) => 99,
         AnyWorkId::Fe(FeWorkIdentifier::KernInstance(..)) => 99,
         AnyWorkId::Fe(FeWorkIdentifier::GlyphOrder) => 99,
         AnyWorkId::Fe(FeWorkIdentifier::PreliminaryGlyphOrder) => 99,
@@ -152,7 +152,7 @@ impl Workload {
         workload.add(workload.source.create_static_metadata_work()?);
         workload.add(workload.source.create_global_metric_work()?);
         workload.add(workload.source.create_feature_ir_work()?);
-        workload.add_skippable_feature_work(workload.source.create_kerning_group_ir_work()?);
+        workload.add_skippable_feature_work(workload.source.create_kerning_locations_ir_work()?);
         workload
             .source
             .create_glyph_ir_work()?
@@ -424,8 +424,8 @@ impl Workload {
             gvar_job.read_access = gvar_deps.build().into();
         }
 
-        if let AnyWorkId::Fe(FeWorkIdentifier::KerningGroups) = success {
-            if let Some(groups) = fe_root.kerning_groups.try_get() {
+        if let AnyWorkId::Fe(FeWorkIdentifier::KerningLocations) = success {
+            if let Some(groups) = fe_root.kerning_locations.try_get() {
                 for location in groups.locations.iter() {
                     self.add(
                         self.source
@@ -440,7 +440,7 @@ impl Workload {
                 .expect("Gather IR Kerning has to be pending")
                 .read_access = AccessBuilder::<AnyWorkId>::new()
                 .variant(FeWorkIdentifier::GlyphOrder)
-                .variant(FeWorkIdentifier::KerningGroups)
+                .variant(FeWorkIdentifier::KerningLocations)
                 .variant(FeWorkIdentifier::KernInstance(NormalizedLocation::default()))
                 .build()
                 .into();

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -155,14 +155,16 @@ impl IntoIterator for GlyphOrder {
 /// In logical (reading) order
 pub type KernPair = (KernSide, KernSide);
 
-/// IR representation of kerning groups.
+/// IR record of which sources participate in kerning.
 ///
-/// In UFO terms, roughly [groups.plist](https://unifiedfontobject.org/versions/ufo3/groups.plist/)
-/// plus the set of locations that can have kerning.
+/// Kerning groups themselves are per-source data, carried on each
+/// [KerningInstance]: sources in a designspace can partition glyphs into
+/// groups differently, so there is no font-wide group map.
 #[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq, Eq)]
 pub struct KerningGroups {
-    pub groups: BTreeMap<KernGroup, BTreeSet<GlyphName>>,
-    /// The locations that have kerning defined.
+    /// The locations participating in the kerning variation model: every
+    /// source that kerns, plus the default, which anchors the model even
+    /// when kernless.
     ///
     /// Must be a subset of the master locations.
     pub locations: BTreeSet<NormalizedLocation>,

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -161,7 +161,7 @@ pub type KernPair = (KernSide, KernSide);
 /// [KerningInstance]: sources in a designspace can partition glyphs into
 /// groups differently, so there is no font-wide group map.
 #[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq, Eq)]
-pub struct KerningGroups {
+pub struct KerningLocations {
     /// The locations participating in the kerning variation model: every
     /// source that kerns, plus the default, which anchors the model even
     /// when kernless.
@@ -1658,7 +1658,7 @@ impl Persistable for FeaturesSource {
     }
 }
 
-impl Persistable for KerningGroups {
+impl Persistable for KerningLocations {
     fn read(from: &mut dyn Read) -> Self {
         serde_yaml::from_reader(from).unwrap()
     }

--- a/fontir/src/orchestration.rs
+++ b/fontir/src/orchestration.rs
@@ -320,7 +320,7 @@ pub enum WorkId {
     /// Computed after anchor propagation, entries updated based on anchor presence.
     GdefCategories,
     Features,
-    KerningGroups,
+    KerningLocations,
     KernInstance(NormalizedLocation),
     Anchor(GlyphName),
     /// CPAL data
@@ -347,7 +347,7 @@ impl Identifier for WorkId {
             WorkId::PreliminaryGdefCategories => "IrPreliminaryGdefCategories",
             WorkId::GdefCategories => "IrGdefCategories",
             WorkId::Features => "IrFeatures",
-            WorkId::KerningGroups => "IrKerningGroups",
+            WorkId::KerningLocations => "IrKerningLocations",
             WorkId::KernInstance(..) => "IrKernInstance",
             WorkId::Anchor(..) => "IrAnchor",
             WorkId::ColorPalettes => "IrPalettes",
@@ -430,7 +430,7 @@ pub struct Context {
     pub global_metrics: FeContextItem<ir::GlobalMetrics>,
     pub glyphs: FeContextMap<ir::Glyph>,
     pub features: FeContextItem<ir::FeaturesSource>,
-    pub kerning_groups: FeContextItem<ir::KerningGroups>,
+    pub kerning_locations: FeContextItem<ir::KerningLocations>,
     pub kerning_at: FeContextMap<ir::KerningInstance>,
     pub anchors: FeContextMap<ir::GlyphAnchors>,
     pub colors: FeContextItem<ir::ColorPalettes>,
@@ -458,7 +458,7 @@ impl Context {
             global_metrics: self.global_metrics.clone_with_acl(acl.clone()),
             glyphs: self.glyphs.clone_with_acl(acl.clone()),
             features: self.features.clone_with_acl(acl.clone()),
-            kerning_groups: self.kerning_groups.clone_with_acl(acl.clone()),
+            kerning_locations: self.kerning_locations.clone_with_acl(acl.clone()),
             kerning_at: self.kerning_at.clone_with_acl(acl.clone()),
             anchors: self.anchors.clone_with_acl(acl.clone()),
             colors: self.colors.clone_with_acl(acl.clone()),
@@ -504,8 +504,8 @@ impl Context {
             ),
             glyphs: ContextMap::new(acl.clone(), persistent_storage.clone()),
             features: ContextItem::new(WorkId::Features, acl.clone(), persistent_storage.clone()),
-            kerning_groups: ContextItem::new(
-                WorkId::KerningGroups,
+            kerning_locations: ContextItem::new(
+                WorkId::KerningLocations,
                 acl.clone(),
                 persistent_storage.clone(),
             ),

--- a/fontir/src/paths.rs
+++ b/fontir/src/paths.rs
@@ -48,7 +48,7 @@ impl Paths {
             WorkId::GlobalMetrics => dir.join("global_metrics.yml"),
             WorkId::Glyph(name) => Paths::glyph_ir_file(dir, name.as_str()),
             WorkId::Features => dir.join("features.yml"),
-            WorkId::KerningGroups => dir.join("kern_groups.yml"),
+            WorkId::KerningLocations => dir.join("kern_locations.yml"),
             WorkId::KernInstance(location) => Paths::kern_ir_file(dir, location),
             WorkId::ColorPalettes => dir.join("colors.yml"),
             WorkId::PaintGraph => dir.join("paint_graph.yml"),

--- a/fontir/src/source.rs
+++ b/fontir/src/source.rs
@@ -43,10 +43,10 @@ pub trait Source {
     /// When run work should update [crate::orchestration::Context] with [crate::ir::FeaturesSource].
     fn create_feature_ir_work(&self) -> Result<Box<IrWork>, Error>;
 
-    /// Create a function that could be called to produce kerning groups.
+    /// Create a function that could be called to produce the kerning locations.
     ///
-    /// When run work should update [crate::orchestration::Context] with [crate::ir::KerningGroups].
-    fn create_kerning_group_ir_work(&self) -> Result<Box<IrWork>, Error>;
+    /// When run work should update [crate::orchestration::Context] with [crate::ir::KerningLocations].
+    fn create_kerning_locations_ir_work(&self) -> Result<Box<IrWork>, Error>;
 
     /// Create a function that could be called to generate or identify kerning for a location.
     ///

--- a/fontra2fontir/src/source.rs
+++ b/fontra2fontir/src/source.rs
@@ -137,7 +137,7 @@ impl Source for FontraIrSource {
         todo!()
     }
 
-    fn create_kerning_group_ir_work(
+    fn create_kerning_locations_ir_work(
         &self,
     ) -> Result<Box<fontir::orchestration::IrWork>, fontir::error::Error> {
         todo!()

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -19,7 +19,7 @@ use fontir::{
     ir::{
         self, AnchorBuilder, ColorGlyphs, ColorPalettes, Condition, ConditionSet,
         DEFAULT_VENDOR_ID, GlobalMetric, GlobalMetrics, GlobalMetricsBuilder, GlyphAnchors,
-        GlyphInstance, GlyphOrder, KernGroup, KernSide, KerningGroups, KerningInstance,
+        GlyphInstance, GlyphOrder, KernGroup, KernSide, KerningInstance, KerningLocations,
         MetaTableValues, NameBuilder, NameKey, NamedInstance, Paint, PaintGlyph, PostscriptNames,
         PreliminaryGdefCategories, Rule, StaticMetadata, Substitution, VariableFeature,
     },
@@ -117,8 +117,8 @@ impl Source for GlyphsIrSource {
         }))
     }
 
-    fn create_kerning_group_ir_work(&self) -> Result<Box<IrWork>, Error> {
-        Ok(Box::new(KerningGroupWork(self.font_info.clone())))
+    fn create_kerning_locations_ir_work(&self) -> Result<Box<IrWork>, Error> {
+        Ok(Box::new(KerningLocationsWork(self.font_info.clone())))
     }
 
     fn create_kerning_instance_ir_work(
@@ -1034,7 +1034,7 @@ const SIDE1_PREFIX: &str = "@MMK_L_";
 const SIDE2_PREFIX: &str = "@MMK_R_";
 
 #[derive(Debug)]
-struct KerningGroupWork(Arc<FontInfo>);
+struct KerningLocationsWork(Arc<FontInfo>);
 
 #[derive(Debug)]
 struct KerningInstanceWork {
@@ -1071,9 +1071,9 @@ fn kern_participant(
     }
 }
 
-impl Work<Context, WorkId, Error> for KerningGroupWork {
+impl Work<Context, WorkId, Error> for KerningLocationsWork {
     fn id(&self) -> WorkId {
-        WorkId::KerningGroups
+        WorkId::KerningLocations
     }
 
     fn read_access(&self) -> Access<WorkId> {
@@ -1085,7 +1085,7 @@ impl Work<Context, WorkId, Error> for KerningGroupWork {
         let font_info = self.0.as_ref();
         let font = &font_info.font;
 
-        let mut groups = KerningGroups::default();
+        let mut kerning_locations = KerningLocations::default();
 
         // ufo2ft#995: keep the default master (it anchors the variation model)
         // and any master that actually kerns; drop non-default masters with no
@@ -1093,7 +1093,7 @@ impl Work<Context, WorkId, Error> for KerningGroupWork {
         // toward 0. Check both LTR and RTL kerning -- a master that kerns only
         // RTL is not kernless (fontc#1857 was exactly that miss).
         let default_master_id = font.default_master().id.clone();
-        groups.locations = font_info
+        kerning_locations.locations = font_info
             .master_positions
             .iter()
             .filter_map(|(master_id, pos)| {
@@ -1103,7 +1103,7 @@ impl Work<Context, WorkId, Error> for KerningGroupWork {
             })
             .collect();
 
-        context.kerning_groups.set(groups);
+        context.kerning_locations.set(kerning_locations);
         Ok(())
     }
 }
@@ -1210,9 +1210,9 @@ impl Work<Context, WorkId, Error> for KerningInstanceWork {
     }
 
     fn read_access(&self) -> Access<WorkId> {
-        // No KerningGroups dependency: instances share the partition
+        // No KerningLocations dependency: instances share the partition
         // derived once on FontInfo. Instances are still only spawned once
-        // KerningGroupWork completes -- workload.rs reacts to its success by
+        // KerningLocationsWork completes -- workload.rs reacts to its success by
         // creating one KernInstance work per participating location.
         AccessBuilder::new().variant(WorkId::GlyphOrder).build()
     }
@@ -2258,11 +2258,11 @@ mod tests {
             .glyph_order
             .set((*context.preliminary_glyph_order.get()).clone());
 
-        let work = source.create_kerning_group_ir_work().unwrap();
+        let work = source.create_kerning_locations_ir_work().unwrap();
         work.exec(&context.copy_for_work(work.read_access(), work.write_access()))
             .unwrap();
 
-        for location in context.kerning_groups.get().locations.iter() {
+        for location in context.kerning_locations.get().locations.iter() {
             let work = source
                 .create_kerning_instance_ir_work(location.clone())
                 .unwrap();
@@ -3100,12 +3100,12 @@ mod tests {
         // case, realigning fontc with ufo2ft main after ufo2ft#997. It does NOT
         // regress fontc#1857 (NotoSansHebrew): that font's masters all carry RTL
         // kerning, so they are not kernless -- see combine_ltr_and_rtl_kerning
-        // and the kerning_ltr/kerning_rtl check in KerningGroupWork.
+        // and the kerning_ltr/kerning_rtl check in KerningLocationsWork.
         let (_, context) = build_kerning(glyphs3_dir().join("KerningEmptyMaster.glyphs"));
 
-        let groups = context.kerning_groups.get();
+        let kerning = context.kerning_locations.get();
         assert_eq!(
-            groups.locations.len(),
+            kerning.locations.len(),
             1,
             "the empty non-default master should be skipped"
         );
@@ -3129,9 +3129,9 @@ mod tests {
         // non-default) has only RTL kerning here; a kernless check that looked at
         // kerning_ltr alone -- the original #1857 miss -- would wrongly skip it.
         let (_, context) = build_kerning(glyphs3_dir().join("KerningRtlOnlyMaster.glyphs"));
-        let groups = context.kerning_groups.get();
+        let kerning = context.kerning_locations.get();
         assert_eq!(
-            groups.locations.len(),
+            kerning.locations.len(),
             2,
             "the RTL-only non-default master must be kept"
         );

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -1087,39 +1087,6 @@ impl Work<Context, WorkId, Error> for KerningGroupWork {
 
         let mut groups = KerningGroups::default();
 
-        //https://github.com/googlefonts/glyphsLib/blob/682ff4b177/Lib/glyphsLib/builder/groups.py#L114
-        let rtl_glyphs = get_glyphs_with_rtl_kerning(font);
-        // build up the kern groups; a glyph may belong to a group on either or
-        // both 'side'.
-        for (name, glyph) in font
-            .glyphs
-            .iter()
-            // ignore non-export glyphs
-            .filter(|x| x.1.export)
-        {
-            let is_rtl = rtl_glyphs.contains(name.as_str());
-            // if there are bracket layers for this glyph, make sure the
-            // generated glyphs are assigned the same groups as the parent
-            let bracket_names = bracket_glyph_names(glyph, &font_info.axes)
-                .map(|(name, _)| name)
-                .collect::<Vec<_>>();
-            let right = glyph.right_kern.clone().map(KernGroup::Side1);
-            let left = glyph.left_kern.clone().map(KernGroup::Side2);
-            let (side1, side2) = if is_rtl {
-                (right.map(KernGroup::flip), left.map(KernGroup::flip))
-            } else {
-                (right, left)
-            };
-            for group in [side1, side2].into_iter().flatten() {
-                groups.groups.entry(group).or_default().extend(
-                    bracket_names
-                        .iter()
-                        .cloned()
-                        .chain(Some(name.clone().into())),
-                );
-            }
-        }
-
         // ufo2ft#995: keep the default master (it anchors the variation model)
         // and any master that actually kerns; drop non-default masters with no
         // kerning so the kern interpolates across them instead of being pinned
@@ -1139,6 +1106,54 @@ impl Work<Context, WorkId, Error> for KerningGroupWork {
         context.kerning_groups.set(groups);
         Ok(())
     }
+}
+
+impl FontInfo {
+    /// The kern-group partition, from the font's per-glyph kern attributes.
+    ///
+    /// Glyphs kerning groups are per-glyph properties, so unlike UFO sources
+    /// every instance shares one partition: it is derived once and cached.
+    fn kern_groups(&self) -> &BTreeMap<KernGroup, BTreeSet<GlyphName>> {
+        self.kern_groups.get_or_init(|| derive_kern_groups(self))
+    }
+}
+
+//https://github.com/googlefonts/glyphsLib/blob/682ff4b177/Lib/glyphsLib/builder/groups.py#L114
+fn derive_kern_groups(font_info: &FontInfo) -> BTreeMap<KernGroup, BTreeSet<GlyphName>> {
+    let font = &font_info.font;
+    let mut groups: BTreeMap<KernGroup, BTreeSet<GlyphName>> = Default::default();
+    let rtl_glyphs = get_glyphs_with_rtl_kerning(font);
+    // build up the kern groups; a glyph may belong to a group on either or
+    // both 'side'.
+    for (name, glyph) in font
+        .glyphs
+        .iter()
+        // ignore non-export glyphs
+        .filter(|x| x.1.export)
+    {
+        let is_rtl = rtl_glyphs.contains(name.as_str());
+        // if there are bracket layers for this glyph, make sure the
+        // generated glyphs are assigned the same groups as the parent
+        let bracket_names = bracket_glyph_names(glyph, &font_info.axes)
+            .map(|(name, _)| name)
+            .collect::<Vec<_>>();
+        let right = glyph.right_kern.clone().map(KernGroup::Side1);
+        let left = glyph.left_kern.clone().map(KernGroup::Side2);
+        let (side1, side2) = if is_rtl {
+            (right.map(KernGroup::flip), left.map(KernGroup::flip))
+        } else {
+            (right, left)
+        };
+        for group in [side1, side2].into_iter().flatten() {
+            groups.entry(group).or_default().extend(
+                bracket_names
+                    .iter()
+                    .cloned()
+                    .chain(Some(name.clone().into())),
+            );
+        }
+    }
+    groups
 }
 
 // https://github.com/googlefonts/glyphsLib/blob/682ff4b177115a/Lib/glyphsLib/builder/groups.py#L28
@@ -1162,7 +1177,6 @@ fn get_glyphs_with_rtl_kerning(font: &Font) -> HashSet<GlyphName> {
     for group in rtl_groups {
         rtl_glyphs.extend(
             groups
-                .groups
                 .get(&group)
                 .into_iter()
                 .flat_map(|x| x.iter().cloned()),
@@ -1173,8 +1187,8 @@ fn get_glyphs_with_rtl_kerning(font: &Font) -> HashSet<GlyphName> {
 }
 
 // we need to know the ltr groups in order to figure out the rtl glyphs
-fn just_ltr_groups(font: &Font) -> KerningGroups {
-    let mut groups = KerningGroups::default();
+fn just_ltr_groups(font: &Font) -> BTreeMap<KernGroup, BTreeSet<GlyphName>> {
+    let mut groups: BTreeMap<KernGroup, BTreeSet<GlyphName>> = Default::default();
     for (name, glyph) in font
         .glyphs
         .iter()
@@ -1184,11 +1198,7 @@ fn just_ltr_groups(font: &Font) -> KerningGroups {
         let right = glyph.right_kern.clone().map(KernGroup::Side1);
         let left = glyph.left_kern.clone().map(KernGroup::Side2);
         for group in [right, left].into_iter().flatten() {
-            groups
-                .groups
-                .entry(group)
-                .or_default()
-                .insert(name.clone().into());
+            groups.entry(group).or_default().insert(name.clone().into());
         }
     }
     groups
@@ -1200,16 +1210,16 @@ impl Work<Context, WorkId, Error> for KerningInstanceWork {
     }
 
     fn read_access(&self) -> Access<WorkId> {
-        AccessBuilder::new()
-            .variant(WorkId::GlyphOrder)
-            .variant(WorkId::KerningGroups)
-            .build()
+        // No KerningGroups dependency: instances share the partition
+        // derived once on FontInfo. Instances are still only spawned once
+        // KerningGroupWork completes -- workload.rs reacts to its success by
+        // creating one KernInstance work per participating location.
+        AccessBuilder::new().variant(WorkId::GlyphOrder).build()
     }
 
     fn exec(&self, context: &Context) -> Result<(), Error> {
         trace!("Generate IR for kerning at {:?}", self.location);
-        let kerning_groups = context.kerning_groups.get();
-        let groups = &kerning_groups.groups;
+        let groups = self.font_info.kern_groups();
         let arc_glyph_order = context.glyph_order.get();
         let glyph_order = arc_glyph_order.as_ref();
         let font_info = self.font_info.as_ref();
@@ -3017,9 +3027,15 @@ mod tests {
     fn expand_kerning_to_brackets() {
         // actual test:
         let (_, context) = build_kerning(glyphs2_dir().join("BracketTestFontKerning.glyphs"));
-        let groups = context.kerning_groups.get();
+        let light_location = NormalizedLocation::for_pos(&[("wdth", 0.0), ("wght", 0.0)]);
+        let all_kerns = context.kerning_at.all();
+        let light_kerns = &all_kerns
+            .iter()
+            .find(|thingie| thingie.1.location == light_location)
+            .unwrap()
+            .1;
         assert_eq!(
-            groups
+            light_kerns
                 .groups
                 .iter()
                 .map(|(name, glyphs)| (
@@ -3035,13 +3051,6 @@ mod tests {
                 ("side2.foo".to_string(), vec!["a", "a.BRACKET.varAlt01"]),
             ]
         );
-        let light_location = NormalizedLocation::for_pos(&[("wdth", 0.0), ("wght", 0.0)]);
-        let all_kerns = context.kerning_at.all();
-        let light_kerns = &all_kerns
-            .iter()
-            .find(|thingie| thingie.1.location == light_location)
-            .unwrap()
-            .1;
         assert_eq!(
             light_kerns.kerns,
             make_kerning(&[

--- a/glyphs2fontir/src/toir.rs
+++ b/glyphs2fontir/src/toir.rs
@@ -1,7 +1,8 @@
 use std::{
-    collections::{HashMap, HashSet, VecDeque},
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque},
     path::PathBuf,
     str::FromStr,
+    sync::OnceLock,
 };
 
 use indexmap::IndexMap;
@@ -305,6 +306,10 @@ pub(crate) struct FontInfo {
     pub axes: fontdrasil::types::Axes,
     /// Name of glyph : color glyphs split from it, if any
     pub color_glyphs: IndexMap<SmolStr, Vec<SmolStr>>,
+    /// The kern-group partition, lazily derived once by the
+    /// `FontInfo::kern_groups` accessor; per-glyph attributes make it
+    /// font-global, unlike UFO sources' per-master groups.
+    pub kern_groups: OnceLock<BTreeMap<ir::KernGroup, BTreeSet<GlyphName>>>,
 }
 
 impl TryFrom<Font> for FontInfo {
@@ -366,6 +371,7 @@ impl TryFrom<Font> for FontInfo {
             locations,
             axes,
             color_glyphs,
+            kern_groups: OnceLock::new(),
         })
     }
 }

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -1658,18 +1658,6 @@ impl Work<Context, WorkId, Error> for FeatureWork {
     }
 }
 
-fn kerning_groups_for(
-    designspace_dir: &Path,
-    glyph_order: &GlyphOrder,
-    source: &norad::designspace::Source,
-) -> Result<BTreeMap<KernGroup, BTreeSet<GlyphName>>, Error> {
-    let ufo_dir = designspace_dir.join(&source.filename);
-    let data_request = norad::DataRequest::none().groups(true);
-    let font = norad::Font::load_requested_data(&ufo_dir, data_request)
-        .map_err(|e| BadSource::custom(ufo_dir, e))?;
-    Ok(kern_groups_from_norad(&font.groups, glyph_order))
-}
-
 /// Build the kern-group partition for a single source.
 ///
 /// Keep only kern1/kern2 groups, prune members to the glyph order, and drop the
@@ -1730,30 +1718,19 @@ impl Work<Context, WorkId, Error> for KerningGroupWork {
     }
 
     fn read_access(&self) -> Access<WorkId> {
-        AccessBuilder::new()
-            .variant(WorkId::StaticMetadata)
-            .variant(WorkId::GlyphOrder)
-            .build()
+        AccessBuilder::new().variant(WorkId::StaticMetadata).build()
     }
 
     fn exec(&self, context: &Context) -> Result<(), Error> {
         debug!("Kerning groups for {:#?}", self.designspace_or_ufo);
 
         let designspace_dir = self.designspace_dir.as_ref();
-        let glyph_order = context.glyph_order.get();
         let static_metadata = context.static_metadata.get();
         let master_locations =
             master_locations(&static_metadata.all_source_axes, &self.designspace.sources);
-        let (default_master_idx, default_master) = default_master(&self.designspace)?;
+        let (default_master_idx, _) = default_master(&self.designspace)?;
 
-        // Step 1: find the groups
-
-        // Based on discussion on https://github.com/googlefonts/ufo2ft/pull/635, take the groups of
-        // the default master as the authoritative source on groups
-        let mut kerning_groups = KerningGroups {
-            groups: kerning_groups_for(designspace_dir, glyph_order.as_ref(), default_master)?,
-            ..Default::default()
-        };
+        let mut kerning_groups = KerningGroups::default();
 
         for (idx, source) in self
             .designspace
@@ -2770,30 +2747,6 @@ mod tests {
         );
     }
 
-    // The merged map is built from the default master alone; non-default
-    // masters' groups (e.g. Bold's renamed the_WrOng_name, #338) never appear.
-    #[test]
-    fn groups_come_from_default_master() {
-        let (_, context) = build_kerning("wght_var.designspace");
-        let kerning = context.kerning_groups.get();
-
-        let mut groups: Vec<_> = kerning
-            .groups
-            .iter()
-            .map(|(name, entries)| {
-                let mut entries: Vec<_> = entries.iter().map(|e| e.as_str()).collect();
-                entries.sort();
-                (name.clone(), entries)
-            })
-            .collect();
-        groups.sort();
-
-        assert_eq!(
-            groups,
-            vec![(KernGroup::Side1("correct_name".into()), vec!["bar", "plus"],),],
-        );
-    }
-
     #[test]
     fn non_default_kernless_source_skipped_from_variation() {
         // ufo2ft#995 port: KernlessMid has 3 masters; the middle Medium master
@@ -2817,10 +2770,14 @@ mod tests {
     #[test]
     fn ufo2_mmk_kerning_groups_upconverted() {
         let (_, context) = build_kerning("ufo2_kern.designspace");
-        let kerning = context.kerning_groups.get();
+
+        let location = NormalizedLocation::for_pos(&[("wght", 0.0)]);
+        let kern_instance = context
+            .kerning_at
+            .get(&fontir::orchestration::WorkId::KernInstance(location));
 
         // @MMK_L_A and @MMK_R_V should be upconverted to public.kern1.A / public.kern2.V
-        let mut groups: Vec<_> = kerning
+        let mut groups: Vec<_> = kern_instance
             .groups
             .iter()
             .map(|(name, entries)| {
@@ -2841,10 +2798,6 @@ mod tests {
         );
 
         // Verify the group-to-group kern pair is present in the kerning instance
-        let location = NormalizedLocation::for_pos(&[("wght", 0.0)]);
-        let kern_instance = context
-            .kerning_at
-            .get(&fontir::orchestration::WorkId::KernInstance(location));
         let group_pairs: Vec<_> = kern_instance
             .kerns
             .iter()

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -22,8 +22,8 @@ use fontir::{
     ir::{
         AnchorBuilder, Color, ColorGlyphs, ColorPalettes, Condition, ConditionSet,
         DEFAULT_VENDOR_ID, FeaturesSource, GlobalMetric, GlobalMetricsBuilder, GlyphOrder,
-        KernGroup, KernSide, KerningGroups, KerningInstance, MetaTableValues, NameBuilder, NameKey,
-        NamedInstance, Paint, PaintGlyph, PaintSolid, Panose, PostscriptNames,
+        KernGroup, KernSide, KerningInstance, KerningLocations, MetaTableValues, NameBuilder,
+        NameKey, NamedInstance, Paint, PaintGlyph, PaintSolid, Panose, PostscriptNames,
         PreliminaryGdefCategories, Rule, StaticMetadata, Substitution, VariableFeature,
     },
     orchestration::{Context, Flags, IrWork, WorkId},
@@ -326,8 +326,8 @@ impl Source for DesignSpaceIrSource {
         }))
     }
 
-    fn create_kerning_group_ir_work(&self) -> Result<Box<IrWork>, Error> {
-        Ok(Box::new(KerningGroupWork {
+    fn create_kerning_locations_ir_work(&self) -> Result<Box<IrWork>, Error> {
+        Ok(Box::new(KerningLocationsWork {
             designspace_or_ufo: self.designspace_or_ufo.clone(),
             designspace_dir: self.designspace_dir.clone(),
             designspace: self.designspace.clone(),
@@ -479,7 +479,7 @@ struct FeatureWork {
 }
 
 #[derive(Debug)]
-struct KerningGroupWork {
+struct KerningLocationsWork {
     designspace_or_ufo: Arc<PathBuf>,
     designspace_dir: Arc<PathBuf>,
     designspace: Arc<DesignSpaceDocument>,
@@ -1712,9 +1712,9 @@ impl KernGroupExt for KernGroup {
 }
 
 /// See <https://github.com/googlefonts/ufo2ft/blob/3e0563814cf541f7d8ca2bb7f6e446328e0e5e76/Lib/ufo2ft/featureWriters/kernFeatureWriter.py#L302-L357>
-impl Work<Context, WorkId, Error> for KerningGroupWork {
+impl Work<Context, WorkId, Error> for KerningLocationsWork {
     fn id(&self) -> WorkId {
-        WorkId::KerningGroups
+        WorkId::KerningLocations
     }
 
     fn read_access(&self) -> Access<WorkId> {
@@ -1730,7 +1730,7 @@ impl Work<Context, WorkId, Error> for KerningGroupWork {
             master_locations(&static_metadata.all_source_axes, &self.designspace.sources);
         let (default_master_idx, _) = default_master(&self.designspace)?;
 
-        let mut kerning_groups = KerningGroups::default();
+        let mut kerning_locations = KerningLocations::default();
 
         for (idx, source) in self
             .designspace
@@ -1747,10 +1747,10 @@ impl Work<Context, WorkId, Error> for KerningGroupWork {
                 continue;
             }
             let pos = master_locations.get(source.name.as_ref().unwrap()).unwrap();
-            kerning_groups.locations.insert(pos.clone());
+            kerning_locations.locations.insert(pos.clone());
         }
 
-        context.kerning_groups.set(kerning_groups);
+        context.kerning_locations.set(kerning_locations);
         Ok(())
     }
 }
@@ -1762,8 +1762,8 @@ impl Work<Context, WorkId, Error> for KerningInstanceWork {
     }
 
     fn read_access(&self) -> Access<WorkId> {
-        // No KerningGroups dependency: each instance loads its own source's
-        // groups. Instances are still only spawned once KerningGroupWork
+        // No KerningLocations dependency: each instance loads its own source's
+        // groups. Instances are still only spawned once KerningLocationsWork
         // completes -- workload.rs reacts to its success by creating one
         // KernInstance work per participating location.
         AccessBuilder::new()
@@ -2376,11 +2376,11 @@ mod tests {
             .glyph_order
             .set((*context.preliminary_glyph_order.get()).clone());
 
-        let work = source.create_kerning_group_ir_work().unwrap();
+        let work = source.create_kerning_locations_ir_work().unwrap();
         work.exec(&context.copy_for_work(work.read_access(), work.write_access()))
             .unwrap();
 
-        for location in context.kerning_groups.get().locations.iter() {
+        for location in context.kerning_locations.get().locations.iter() {
             let work = source
                 .create_kerning_instance_ir_work(location.clone())
                 .unwrap();
@@ -2755,9 +2755,9 @@ mod tests {
         // interpolating across. Regular (the default) and Bold kern, Medium does
         // not, so exactly those two locations survive.
         let (_, context) = build_kerning("KernlessMid.designspace");
-        let groups = context.kerning_groups.get();
+        let kerning = context.kerning_locations.get();
         assert_eq!(
-            groups.locations.len(),
+            kerning.locations.len(),
             2,
             "the kernless non-default Medium master should be skipped"
         );


### PR DESCRIPTION
Follow-up to #2065, which left the merged KerningGroups.groups map unread in the BE.

The first commit removes it: KerningGroups now only records the locations that participate in kerning, ufo2fontir stops loading the default master's groups, and glyphs2fontir derives its font-global partition once on FontInfo (shared by every kerning instance).

The second renames KerningGroups/KerningGroupWork to KerningLocations/KerningLocationsWork to match what is left.

Compiled output is byte-identical across both frontends.

Should be merged after #2065.
