### PR TITLE
 Support the ufo2ft featureWriters lib key to disable or force-append automatic featues

### DIFF
--- a/fea-rs/src/compile/feature_writer.rs
+++ b/fea-rs/src/compile/feature_writer.rs
@@ -59,6 +59,7 @@ pub struct FeatureBuilder<'a> {
     pub(crate) lig_carets: BTreeMap<GlyphId16, Vec<CaretValue>>,
     mark_filter_sets: &'a mut HashMap<GlyphSet, FilterSetId>,
     feature_variations: Option<RawFeatureVariations>,
+    append_features: HashSet<Tag>,
 }
 
 pub trait LookupSubtableBuilder: Sized {
@@ -145,6 +146,7 @@ impl<'a> FeatureBuilder<'a> {
             mark_filter_sets,
             feature_variations: Default::default(),
             lig_carets: Default::default(),
+            append_features: Default::default(),
         }
     }
 
@@ -229,6 +231,15 @@ impl<'a> FeatureBuilder<'a> {
         })
     }
 
+    /// Force a generated feature to be appended, ignoring any insertion marker.
+    ///
+    /// Generated lookups for `tag` will be placed after all user-defined
+    /// lookups even if the FEA contains a `# Automatic Code` marker for that
+    /// feature. This models a feature writer running in `append` mode.
+    pub fn force_append(&mut self, tag: Tag) {
+        self.append_features.insert(tag);
+    }
+
     fn get_filter_set_id(&mut self, cls: GlyphSet) -> FilterSetId {
         let next_id = self.mark_filter_sets.len();
         *self.mark_filter_sets.entry(cls).or_insert_with(|| {
@@ -246,6 +257,7 @@ impl<'a> FeatureBuilder<'a> {
             features,
             lig_carets,
             feature_variations,
+            append_features,
             ..
         } = self;
         ExternalFeatures {
@@ -254,6 +266,7 @@ impl<'a> FeatureBuilder<'a> {
             sub_lookups,
             feature_variations,
             lig_carets,
+            append_features,
         }
     }
 }
@@ -297,6 +310,9 @@ pub(crate) struct ExternalFeatures {
     pub(crate) features: BTreeMap<FeatureKey, FeatureLookups>,
     pub(crate) lig_carets: BTreeMap<GlyphId16, Vec<CaretValue>>,
     pub(crate) feature_variations: Option<RawFeatureVariations>,
+    /// Features whose generated lookups must ignore insertion markers and be
+    /// appended after all user-defined lookups (feature writer `append` mode).
+    pub(crate) append_features: HashSet<Tag>,
 }
 
 /// A position in a feature where generated code should be inserted.
@@ -323,6 +339,8 @@ struct MergeCtx<'a> {
     all_feats: &'a mut AllFeatures,
     // that were explicit
     insert_markers: &'a HashMap<Tag, InsertionPoint>,
+    // features forced to append, ignoring any insertion marker
+    append_features: HashSet<Tag>,
     ext_pos_lookups: BTreeMap<LookupId, PositionLookup>,
     ext_sub_lookups: BTreeMap<LookupId, SubstitutionLookup>,
     ext_features: BTreeMap<FeatureKey, FeatureLookups>,
@@ -510,11 +528,14 @@ impl MergeCtx<'_> {
     }
 
     fn do_curs(&mut self) {
-        let curs_pos = self
-            .insert_markers
-            .get(&CURS)
-            .copied()
-            .unwrap_or_else(|| self.insertion_point_for_append());
+        let curs_pos = if self.append_features.contains(&CURS) {
+            self.insertion_point_for_append()
+        } else {
+            self.insert_markers
+                .get(&CURS)
+                .copied()
+                .unwrap_or_else(|| self.insertion_point_for_append())
+        };
         self.finalize_lookups_for_feature(CURS, curs_pos);
     }
 
@@ -533,11 +554,18 @@ impl MergeCtx<'_> {
                     DIST => [Some(DIST), kern],
                     _ => [kern, dist],
                 });
-        let marker = features_we_are_writing
-            .into_iter()
-            .flatten()
-            .find_map(|k| self.insert_markers.get(&k).copied())
-            .unwrap_or_else(|| self.insertion_point_for_append());
+        // kern and dist are set together by the caller; if either is forced to
+        // append, ignore both markers.
+        let marker = if self.append_features.contains(&KERN) || self.append_features.contains(&DIST)
+        {
+            self.insertion_point_for_append()
+        } else {
+            features_we_are_writing
+                .into_iter()
+                .flatten()
+                .find_map(|k| self.insert_markers.get(&k).copied())
+                .unwrap_or_else(|| self.insertion_point_for_append())
+        };
 
         let lookups = self.take_lookups_for_features(&[KERN, DIST]);
         if !lookups.is_empty() {
@@ -561,13 +589,16 @@ impl MergeCtx<'_> {
 
         const ORDER: [Tag; 4] = [ABVM, BLWM, MARK, MKMK];
         let mut inserts = [None; 4];
+        // append-forced tags neither take a marker nor participate in the
+        // priority cascade below; they fall through to append placement.
+        let is_append = ORDER.map(|tag| self.append_features.contains(&tag));
         let features_we_write = self
             .ext_features
             .keys()
             .map(|ft| ft.feature)
             .collect::<HashSet<_>>();
         for (i, tag) in ORDER.iter().enumerate() {
-            if features_we_write.contains(tag) {
+            if features_we_write.contains(tag) && !is_append[i] {
                 inserts[i] = self.insert_markers.get(tag).copied();
             }
         }
@@ -579,7 +610,7 @@ impl MergeCtx<'_> {
                 for j in 0..i {
                     let j = i - j - 1; // we want to go in reverse order,
                     // prepending each time
-                    if inserts[j].is_none() {
+                    if inserts[j].is_none() && !is_append[j] {
                         inserts[j] = Some(InsertionPoint {
                             lookup_id: insert.lookup_id,
                             priority: insert.priority - 1,
@@ -652,6 +683,7 @@ impl ExternalFeatures {
             ext_features: self.features.clone(),
             feature_variations: self.feature_variations.clone(),
             insert_markers: markers,
+            append_features: self.append_features.clone(),
             processed_lookups: Default::default(),
             append_priority: 1_000_000_000,
         };
@@ -738,6 +770,7 @@ mod tests {
             features,
             lig_carets: Default::default(),
             feature_variations: Default::default(),
+            append_features: Default::default(),
         };
 
         let mut all_features = AllFeatures::default();
@@ -787,6 +820,7 @@ mod tests {
             features,
             lig_carets: Default::default(),
             feature_variations: Default::default(),
+            append_features: Default::default(),
         };
 
         let markers = make_markers_with_order([]);
@@ -842,6 +876,7 @@ mod tests {
             features,
             lig_carets: Default::default(),
             feature_variations: Default::default(),
+            append_features: Default::default(),
         }
     }
 
@@ -959,5 +994,75 @@ mod tests {
         let mut all_feats = AllFeatures::default();
         external.merge_into(&mut all, &mut all_feats, &markers);
         assert_eq!(all_feats.feature_order_for_test(), [CURS, ABVM]);
+    }
+
+    #[test]
+    fn appended_kern_ignores_marker() {
+        // the user has some hand-written lookups...
+        let mut all = AllLookups::default();
+        all.splice_gpos(
+            0,
+            (0..4).map(|_| PositionLookup::Single(Default::default())),
+        );
+
+        let mut external = mock_external_features(&[KERN]);
+        // ...and kern has an explicit insertion marker near the front...
+        let markers = HashMap::from([(
+            KERN,
+            InsertionPoint {
+                lookup_id: LookupId::Gpos(1),
+                priority: 100,
+            },
+        )]);
+        // ...but forcing append makes the generated lookups ignore the marker
+        // and land after all user lookups.
+        external.append_features = HashSet::from([KERN]);
+
+        let mut all_feats = AllFeatures::default();
+        external.merge_into(&mut all, &mut all_feats, &markers);
+
+        let kern = all_feats
+            .features
+            .get(&FeatureKey::new(KERN, LANG_DFLT, SCRIPT_DFLT))
+            .unwrap();
+        // id 4 is past the four user lookups, not the marker position (id 1)
+        assert_eq!(
+            kern.iter_ids().map(LookupId::to_raw).collect::<Vec<_>>(),
+            [4]
+        );
+    }
+
+    #[test]
+    fn appended_curs_before_kern() {
+        // markers would order these [KERN, CURS]...
+        let mut external = mock_external_features(&[KERN, CURS]);
+        let markers = make_markers_with_order([KERN, CURS]);
+        // ...but forcing both to append ignores the markers, so the default
+        // writer order (curs before kern) wins.
+        external.append_features = HashSet::from([CURS, KERN]);
+        let mut all = AllLookups::default();
+        let mut all_feats = AllFeatures::default();
+        external.merge_into(&mut all, &mut all_feats, &markers);
+        assert_eq!(all_feats.feature_order_for_test(), [CURS, KERN]);
+    }
+
+    #[test]
+    fn appended_mark_excluded_from_cascade() {
+        // mkmk has a marker; normally it drags abvm & blwm in front of it.
+        // abvm is forced to append so it must not be dragged forward, but blwm
+        // (not appended) still cascades ahead of mkmk.
+        //
+        // This mixed state is unreachable through the featureWriters config
+        // (ufo2ft's mark writer applies one mode to all four tags); it pins the
+        // per-tag contract of the public force_append API, and is the only
+        // configuration that can observe the cascade exclusion: with all four
+        // tags appended every insert slot stays empty and the cascade no-ops.
+        let mut external = mock_external_features(&[ABVM, BLWM, MKMK]);
+        let markers = make_markers_with_order([MKMK]);
+        external.append_features = HashSet::from([ABVM]);
+        let mut all = AllLookups::default();
+        let mut all_feats = AllFeatures::default();
+        external.merge_into(&mut all, &mut all_feats, &markers);
+        assert_eq!(all_feats.feature_order_for_test(), [BLWM, MKMK, ABVM]);
     }
 }

--- a/fea-rs/src/compile/feature_writer.rs
+++ b/fea-rs/src/compile/feature_writer.rs
@@ -527,15 +527,26 @@ impl MergeCtx<'_> {
         }
     }
 
+    /// The insertion position for a group of features' generated lookups.
+    ///
+    /// An append-forced feature ignores insertion markers entirely; otherwise
+    /// the first marker among `features` wins, and everything else falls
+    /// through to append placement.
+    fn insert_pos_for_features(&mut self, features: &[Tag]) -> InsertionPoint {
+        if features
+            .iter()
+            .any(|tag| self.append_features.contains(tag))
+        {
+            return self.insertion_point_for_append();
+        }
+        features
+            .iter()
+            .find_map(|tag| self.insert_markers.get(tag).copied())
+            .unwrap_or_else(|| self.insertion_point_for_append())
+    }
+
     fn do_curs(&mut self) {
-        let curs_pos = if self.append_features.contains(&CURS) {
-            self.insertion_point_for_append()
-        } else {
-            self.insert_markers
-                .get(&CURS)
-                .copied()
-                .unwrap_or_else(|| self.insertion_point_for_append())
-        };
+        let curs_pos = self.insert_pos_for_features(&[CURS]);
         self.finalize_lookups_for_feature(CURS, curs_pos);
     }
 
@@ -554,18 +565,11 @@ impl MergeCtx<'_> {
                     DIST => [Some(DIST), kern],
                     _ => [kern, dist],
                 });
-        // kern and dist are set together by the caller; if either is forced to
-        // append, ignore both markers.
-        let marker = if self.append_features.contains(&KERN) || self.append_features.contains(&DIST)
-        {
-            self.insertion_point_for_append()
-        } else {
-            features_we_are_writing
-                .into_iter()
-                .flatten()
-                .find_map(|k| self.insert_markers.get(&k).copied())
-                .unwrap_or_else(|| self.insertion_point_for_append())
-        };
+        // kern and dist are set together by the caller, so a forced append on
+        // either applies to whichever of them we write.
+        let features_we_are_writing: Vec<_> =
+            features_we_are_writing.into_iter().flatten().collect();
+        let marker = self.insert_pos_for_features(&features_we_are_writing);
 
         let lookups = self.take_lookups_for_features(&[KERN, DIST]);
         if !lookups.is_empty() {

--- a/fontbe/src/features.rs
+++ b/fontbe/src/features.rs
@@ -25,8 +25,8 @@ use fea_rs::{
 
 use fontir::{
     ir::{
-        FeatureGenerationPlan, FeatureGenerationSettings, FeatureWriterMode, FeaturesSource,
-        GdefCategories, GlyphOrder, StaticMetadata, resolve_feature_generation,
+        self, FeatureGenerationPlan, FeatureGenerationSettings, FeatureWriterMode, FeaturesSource,
+        GdefCategories, GlyphOrder, StaticMetadata,
     },
     orchestration::WorkId as FeWorkId,
 };
@@ -622,7 +622,7 @@ impl Work<Context, AnyWorkId, Error> for FeatureCompilationWork {
 
         // Resolve the plan once for this work unit; separate work units (kern,
         // marks) resolve their own, since the work graph precludes threading one.
-        let plan = resolve_feature_generation(&static_metadata.misc.feature_generation);
+        let plan = ir::resolve_feature_generation(&static_metadata.misc.feature_generation);
         let mut result = self.compile(
             &static_metadata,
             &glyph_order,
@@ -759,9 +759,9 @@ fn settings_tags(settings: &FeatureGenerationSettings, all: &[Tag]) -> Vec<Tag> 
 fn append_forced_tags(plan: &FeatureGenerationPlan) -> Vec<Tag> {
     let mut tags = Vec::new();
     for (settings, all) in [
-        (&plan.curs, &[CURS][..]),
-        (&plan.kern, &[KERN, DIST][..]),
-        (&plan.mark, &[MARK, MKMK, ABVM, BLWM][..]),
+        (&plan.curs, [CURS].as_slice()),
+        (&plan.kern, [KERN, DIST].as_slice()),
+        (&plan.mark, [MARK, MKMK, ABVM, BLWM].as_slice()),
     ] {
         let Some(settings) = settings else { continue };
         if settings.mode == FeatureWriterMode::Append {
@@ -977,11 +977,11 @@ mod tests {
     #[test]
     fn append_forced_tags_only_for_append_writers() {
         // key absent -> everything enabled in skip mode -> nothing appended.
-        let plan = resolve_feature_generation(&None);
+        let plan = ir::resolve_feature_generation(&None);
         assert!(append_forced_tags(&plan).is_empty());
 
         // kern in append mode -> its tags are forced; disabled writers contribute none.
-        let plan = resolve_feature_generation(&Some(vec![
+        let plan = ir::resolve_feature_generation(&Some(vec![
             fontir::ir::FeatureWriterSpec {
                 writer: fontir::ir::KnownFeatureWriter::Kern,
                 mode: FeatureWriterMode::Append,

--- a/fontbe/src/features.rs
+++ b/fontbe/src/features.rs
@@ -24,7 +24,10 @@ use fea_rs::{
 };
 
 use fontir::{
-    ir::{FeaturesSource, GdefCategories, GlyphOrder, StaticMetadata},
+    ir::{
+        FeatureWriterMode, FeatureWriterPlan, FeatureWriterSettings, FeaturesSource,
+        GdefCategories, GlyphOrder, StaticMetadata, resolve_feature_writers,
+    },
     orchestration::WorkId as FeWorkId,
 };
 
@@ -63,6 +66,14 @@ pub use marks::create_mark_work;
 
 const DFLT_SCRIPT: Tag = Tag::new(b"DFLT");
 const DFLT_LANG: Tag = Tag::new(b"dflt");
+
+const CURS: Tag = Tag::new(b"curs");
+const KERN: Tag = Tag::new(b"kern");
+const DIST: Tag = Tag::new(b"dist");
+const MARK: Tag = Tag::new(b"mark");
+const MKMK: Tag = Tag::new(b"mkmk");
+const ABVM: Tag = Tag::new(b"abvm");
+const BLWM: Tag = Tag::new(b"blwm");
 
 #[derive(Debug)]
 pub struct FeatureFirstPassWork {}
@@ -250,6 +261,8 @@ struct FeatureWriter<'a> {
     kerning: &'a FeaRsKerns,
     marks: &'a FeaRsMarks,
     feature_variations: Option<FeatureVariationsProvider>,
+    // tags whose generated lookups must be appended after all user lookups
+    append_features: Vec<Tag>,
 }
 
 impl<'a> FeatureWriter<'a> {
@@ -257,11 +270,13 @@ impl<'a> FeatureWriter<'a> {
         kerning: &'a FeaRsKerns,
         marks: &'a FeaRsMarks,
         feature_variations: Option<FeatureVariationsProvider>,
+        append_features: Vec<Tag>,
     ) -> Self {
         FeatureWriter {
             marks,
             kerning,
             feature_variations,
+            append_features,
         }
     }
 
@@ -299,6 +314,11 @@ impl FeatureProvider for FeatureWriter<'_> {
         self.add_kerning_features(builder);
         self.add_marks(builder);
         self.add_feature_variations(builder);
+        // writers running in `append` mode ignore insertion markers; their
+        // lookups land after all user-defined ones.
+        for tag in &self.append_features {
+            builder.force_append(*tag);
+        }
     }
 }
 
@@ -388,6 +408,7 @@ impl FeatureCompilationWork {
         Box::new(FeatureCompilationWork {})
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn compile(
         &self,
         static_metadata: &StaticMetadata,
@@ -395,6 +416,7 @@ impl FeatureCompilationWork {
         ast: &FeaFirstPassOutput,
         kerns: &FeaRsKerns,
         marks: &FeaRsMarks,
+        plan: &FeatureWriterPlan,
         compile_debg: bool,
     ) -> Result<Compilation, Error> {
         let feature_variations = static_metadata
@@ -409,7 +431,8 @@ impl FeatureCompilationWork {
             })
             .transpose()?;
         let var_info = FeaVariationInfo::new(static_metadata);
-        let feature_writer = FeatureWriter::new(kerns, marks, feature_variations);
+        let feature_writer =
+            FeatureWriter::new(kerns, marks, feature_variations, append_forced_tags(plan));
         // we've already validated the AST, so we only need to compile
         match fea_rs::compile::compile(
             &ast.ast,
@@ -597,15 +620,19 @@ impl Work<Context, AnyWorkId, Error> for FeatureCompilationWork {
         let kerns = context.fea_rs_kerns.get();
         let marks = context.fea_rs_marks.get();
 
+        // Resolve the plan once for this work unit; separate work units (kern,
+        // marks) resolve their own, since the work graph precludes threading one.
+        let plan = resolve_feature_writers(&static_metadata.misc.feature_writers);
         let mut result = self.compile(
             &static_metadata,
             &glyph_order,
             &ast,
             kerns.as_ref(),
             marks.as_ref(),
+            &plan,
             context.compile_debg,
         )?;
-        if result.gdef_classes.is_none() && !gdef_categories.categories.is_empty() {
+        if plan.gdef && result.gdef_classes.is_none() && !gdef_categories.categories.is_empty() {
             // the FEA did not contain an explicit GDEF block with glyph categories,
             // so let's use the ones from the source, if present (i.e. from
             // `public.openTypeCatgories` or computed from GlyphData.xml
@@ -717,13 +744,55 @@ fn get_script_language_systems(ast: &ParseTree) -> HashMap<UnicodeShortName, Vec
     unic_script_to_languages
 }
 
-/// Return the set of features from the list that we need to generate.
+/// The effective tags a writer generates, applying its `features` subset option.
+fn settings_tags(settings: &FeatureWriterSettings, all: &[Tag]) -> Vec<Tag> {
+    match &settings.features {
+        Some(subset) => all.iter().copied().filter(|t| subset.contains(t)).collect(),
+        None => all.to_vec(),
+    }
+}
+
+/// Tags whose generated lookups must be appended (insertion markers ignored).
 ///
-/// This ignores features that already exist in the FEA, and for which there
-/// is no insertion mark.
-fn feature_writer_todo_list(features: &[Tag], ast: &ParseTree) -> HashSet<Tag> {
+/// A tag is force-appended exactly when its writer is enabled in `append` mode;
+/// this is independent of the FEA, so it needs no AST.
+fn append_forced_tags(plan: &FeatureWriterPlan) -> Vec<Tag> {
+    let mut tags = Vec::new();
+    for (settings, all) in [
+        (&plan.curs, &[CURS][..]),
+        (&plan.kern, &[KERN, DIST][..]),
+        (&plan.mark, &[MARK, MKMK, ABVM, BLWM][..]),
+    ] {
+        let Some(settings) = settings else { continue };
+        if settings.mode == FeatureWriterMode::Append {
+            tags.extend(settings_tags(settings, all));
+        }
+    }
+    tags
+}
+
+/// Decide which of a writer's `tags` to generate and whether each is appended.
+///
+/// `settings` is `None` when the writer is disabled, in which case nothing
+/// generates. In `Skip` mode a tag whose feature is manually declared in the FEA
+/// without an insertion marker is dropped (fontc's historical behavior); `Append`
+/// mode ignores markers and keeps every tag. The returned value maps each retained
+/// tag to whether its lookups must be appended after all user lookups.
+fn feature_writer_todo_list(
+    tags: &[Tag],
+    settings: Option<&FeatureWriterSettings>,
+    ast: &ParseTree,
+) -> BTreeMap<Tag, bool> {
     use fea_rs::typed;
-    let mut result = features.iter().copied().collect::<HashSet<_>>();
+    let Some(settings) = settings else {
+        return BTreeMap::new();
+    };
+    let wanted = settings_tags(settings, tags);
+    if settings.mode == FeatureWriterMode::Append {
+        return wanted.into_iter().map(|tag| (tag, true)).collect();
+    }
+
+    let wanted_set = wanted.iter().copied().collect::<HashSet<_>>();
     let mut existing_features = HashMap::new();
     for feature in ast
         .typed_root()
@@ -731,10 +800,14 @@ fn feature_writer_todo_list(features: &[Tag], ast: &ParseTree) -> HashSet<Tag> {
         .filter_map(typed::Feature::cast)
     {
         let tag = feature.tag().to_raw();
-        if result.contains(&tag) {
+        if wanted_set.contains(&tag) {
             *existing_features.entry(tag).or_insert(false) |= feature.has_insert_marker();
         }
     }
+    let mut result = wanted
+        .into_iter()
+        .map(|tag| (tag, false))
+        .collect::<BTreeMap<_, _>>();
     for (tag, has_marker) in existing_features {
         if !has_marker {
             log::warn!(
@@ -817,5 +890,112 @@ mod tests {
         assert!(!regions.iter().any(|(r, _)| is_default(r)));
         let region_values: Vec<_> = regions.into_iter().map(|(_, v)| v + default).collect();
         assert_eq!((15, vec![10, 20]), (default, region_values));
+    }
+
+    fn parse_fea(fea: &str) -> ParseTree {
+        fea_rs::parse::parse_string(fea.to_string()).0
+    }
+
+    fn settings(mode: FeatureWriterMode) -> FeatureWriterSettings {
+        FeatureWriterSettings {
+            mode,
+            features: None,
+        }
+    }
+
+    // a manual kern block, optionally with an insertion marker
+    fn manual_kern_fea(marker: bool) -> String {
+        let marker = if marker { "# Automatic Code\n" } else { "" };
+        format!("languagesystem DFLT dflt;\nfeature kern {{\n{marker}    pos A B -40;\n}} kern;\n")
+    }
+
+    #[test]
+    fn todo_disabled_generates_nothing() {
+        let ast = parse_fea("languagesystem DFLT dflt;");
+        let todo = feature_writer_todo_list(&[KERN, DIST], None, &ast);
+        assert!(todo.is_empty());
+    }
+
+    #[test]
+    fn todo_skip_no_user_block() {
+        let ast = parse_fea("languagesystem DFLT dflt;");
+        let todo = feature_writer_todo_list(
+            &[KERN, DIST],
+            Some(&settings(FeatureWriterMode::Skip)),
+            &ast,
+        );
+        assert_eq!(todo, BTreeMap::from([(KERN, false), (DIST, false)]));
+    }
+
+    #[test]
+    fn todo_skip_manual_block_without_marker_drops_tag() {
+        let ast = parse_fea(&manual_kern_fea(false));
+        let todo = feature_writer_todo_list(
+            &[KERN, DIST],
+            Some(&settings(FeatureWriterMode::Skip)),
+            &ast,
+        );
+        // kern is manually declared with no marker, so it drops; dist stays.
+        assert_eq!(todo, BTreeMap::from([(DIST, false)]));
+    }
+
+    #[test]
+    fn todo_skip_manual_block_with_marker_keeps_tag() {
+        let ast = parse_fea(&manual_kern_fea(true));
+        let todo = feature_writer_todo_list(
+            &[KERN, DIST],
+            Some(&settings(FeatureWriterMode::Skip)),
+            &ast,
+        );
+        // the insertion marker means kern still generates, landing at the marker.
+        assert_eq!(todo, BTreeMap::from([(KERN, false), (DIST, false)]));
+    }
+
+    #[test]
+    fn todo_append_ignores_markerless_manual_block() {
+        let ast = parse_fea(&manual_kern_fea(false));
+        let todo = feature_writer_todo_list(
+            &[KERN, DIST],
+            Some(&settings(FeatureWriterMode::Append)),
+            &ast,
+        );
+        // append mode ignores markers: every tag stays and is force-appended.
+        assert_eq!(todo, BTreeMap::from([(KERN, true), (DIST, true)]));
+    }
+
+    #[test]
+    fn todo_respects_features_subset() {
+        let ast = parse_fea("languagesystem DFLT dflt;");
+        let settings = FeatureWriterSettings {
+            mode: FeatureWriterMode::Skip,
+            features: Some(vec![KERN]),
+        };
+        let todo = feature_writer_todo_list(&[KERN, DIST], Some(&settings), &ast);
+        assert_eq!(todo, BTreeMap::from([(KERN, false)]));
+    }
+
+    #[test]
+    fn append_forced_tags_only_for_append_writers() {
+        // key absent -> everything enabled in skip mode -> nothing appended.
+        let plan = resolve_feature_writers(&None);
+        assert!(append_forced_tags(&plan).is_empty());
+
+        // kern in append mode -> its tags are forced; disabled writers contribute none.
+        let plan = resolve_feature_writers(&Some(vec![
+            fontir::ir::FeatureWriterSpec {
+                writer: fontir::ir::KnownFeatureWriter::Kern,
+                mode: FeatureWriterMode::Append,
+                features: None,
+            },
+            fontir::ir::FeatureWriterSpec {
+                writer: fontir::ir::KnownFeatureWriter::Curs,
+                mode: FeatureWriterMode::Skip,
+                features: None,
+            },
+        ]));
+        let tags = append_forced_tags(&plan)
+            .into_iter()
+            .collect::<HashSet<_>>();
+        assert_eq!(tags, HashSet::from([KERN, DIST]));
     }
 }

--- a/fontbe/src/features.rs
+++ b/fontbe/src/features.rs
@@ -25,8 +25,8 @@ use fea_rs::{
 
 use fontir::{
     ir::{
-        FeatureWriterMode, FeatureWriterPlan, FeatureWriterSettings, FeaturesSource,
-        GdefCategories, GlyphOrder, StaticMetadata, resolve_feature_writers,
+        FeatureGenerationPlan, FeatureGenerationSettings, FeatureWriterMode, FeaturesSource,
+        GdefCategories, GlyphOrder, StaticMetadata, resolve_feature_generation,
     },
     orchestration::WorkId as FeWorkId,
 };
@@ -416,7 +416,7 @@ impl FeatureCompilationWork {
         ast: &FeaFirstPassOutput,
         kerns: &FeaRsKerns,
         marks: &FeaRsMarks,
-        plan: &FeatureWriterPlan,
+        plan: &FeatureGenerationPlan,
         compile_debg: bool,
     ) -> Result<Compilation, Error> {
         let feature_variations = static_metadata
@@ -622,7 +622,7 @@ impl Work<Context, AnyWorkId, Error> for FeatureCompilationWork {
 
         // Resolve the plan once for this work unit; separate work units (kern,
         // marks) resolve their own, since the work graph precludes threading one.
-        let plan = resolve_feature_writers(&static_metadata.misc.feature_writers);
+        let plan = resolve_feature_generation(&static_metadata.misc.feature_generation);
         let mut result = self.compile(
             &static_metadata,
             &glyph_order,
@@ -745,7 +745,7 @@ fn get_script_language_systems(ast: &ParseTree) -> HashMap<UnicodeShortName, Vec
 }
 
 /// The effective tags a writer generates, applying its `features` subset option.
-fn settings_tags(settings: &FeatureWriterSettings, all: &[Tag]) -> Vec<Tag> {
+fn settings_tags(settings: &FeatureGenerationSettings, all: &[Tag]) -> Vec<Tag> {
     match &settings.features {
         Some(subset) => all.iter().copied().filter(|t| subset.contains(t)).collect(),
         None => all.to_vec(),
@@ -756,7 +756,7 @@ fn settings_tags(settings: &FeatureWriterSettings, all: &[Tag]) -> Vec<Tag> {
 ///
 /// A tag is force-appended exactly when its writer is enabled in `append` mode;
 /// this is independent of the FEA, so it needs no AST.
-fn append_forced_tags(plan: &FeatureWriterPlan) -> Vec<Tag> {
+fn append_forced_tags(plan: &FeatureGenerationPlan) -> Vec<Tag> {
     let mut tags = Vec::new();
     for (settings, all) in [
         (&plan.curs, &[CURS][..]),
@@ -780,7 +780,7 @@ fn append_forced_tags(plan: &FeatureWriterPlan) -> Vec<Tag> {
 /// tag to whether its lookups must be appended after all user lookups.
 fn feature_writer_todo_list(
     tags: &[Tag],
-    settings: Option<&FeatureWriterSettings>,
+    settings: Option<&FeatureGenerationSettings>,
     ast: &ParseTree,
 ) -> BTreeMap<Tag, bool> {
     use fea_rs::typed;
@@ -896,8 +896,8 @@ mod tests {
         fea_rs::parse::parse_string(fea.to_string()).0
     }
 
-    fn settings(mode: FeatureWriterMode) -> FeatureWriterSettings {
-        FeatureWriterSettings {
+    fn settings(mode: FeatureWriterMode) -> FeatureGenerationSettings {
+        FeatureGenerationSettings {
             mode,
             features: None,
         }
@@ -966,7 +966,7 @@ mod tests {
     #[test]
     fn todo_respects_features_subset() {
         let ast = parse_fea("languagesystem DFLT dflt;");
-        let settings = FeatureWriterSettings {
+        let settings = FeatureGenerationSettings {
             mode: FeatureWriterMode::Skip,
             features: Some(vec![KERN]),
         };
@@ -977,11 +977,11 @@ mod tests {
     #[test]
     fn append_forced_tags_only_for_append_writers() {
         // key absent -> everything enabled in skip mode -> nothing appended.
-        let plan = resolve_feature_writers(&None);
+        let plan = resolve_feature_generation(&None);
         assert!(append_forced_tags(&plan).is_empty());
 
         // kern in append mode -> its tags are forced; disabled writers contribute none.
-        let plan = resolve_feature_writers(&Some(vec![
+        let plan = resolve_feature_generation(&Some(vec![
             fontir::ir::FeatureWriterSpec {
                 writer: fontir::ir::KnownFeatureWriter::Kern,
                 mode: FeatureWriterMode::Append,

--- a/fontbe/src/features/kern.rs
+++ b/fontbe/src/features/kern.rs
@@ -15,7 +15,10 @@ use fontdrasil::{
     types::GlyphName,
 };
 use fontir::{
-    ir::{self, GdefCategories, GlyphOrder, KernGroup, KerningInstance, KerningLocations},
+    ir::{
+        self, GdefCategories, GlyphOrder, KernGroup, KerningInstance, KerningLocations,
+        StaticMetadata, resolve_feature_writers,
+    },
     orchestration::WorkId as FeWorkId,
 };
 use icu_properties::props::BidiClass;
@@ -829,6 +832,7 @@ impl Work<Context, AnyWorkId, Error> for KerningGatherWork {
         let ast = context.fea_ast.get();
         let glyph_order = context.ir.glyph_order.get();
         let gdef_categories = context.ir.gdef_categories.get();
+        let static_metadata = context.ir.static_metadata.get();
         let mut pairs: Vec<_> = arc_fragments
             .iter()
             .flat_map(|(_, fragment)| fragment.kerns.iter())
@@ -858,6 +862,7 @@ impl Work<Context, AnyWorkId, Error> for KerningGatherWork {
             &ast,
             &gdef_categories,
             &glyph_order,
+            &static_metadata,
             char_map,
             non_spacing_glyphs,
         )?;
@@ -874,10 +879,12 @@ fn finalize_kerning(
     ast: &FeaFirstPassOutput,
     gdef_categories: &GdefCategories,
     glyph_order: &GlyphOrder,
+    static_metadata: &StaticMetadata,
     char_map: HashMap<u32, GlyphId16>,
     non_spacing_glyphs: HashSet<GlyphId16>,
 ) -> Result<FeaRsKerns, Error> {
-    let todo = super::feature_writer_todo_list(&[KERN, DIST], &ast.ast);
+    let plan = resolve_feature_writers(&static_metadata.misc.feature_writers);
+    let todo = super::feature_writer_todo_list(&[KERN, DIST], plan.kern.as_ref(), &ast.ast);
     if pairs.is_empty() || todo.is_empty() {
         log::info!("no kerning work to do");
         return Ok(Default::default());
@@ -906,10 +913,10 @@ fn finalize_kerning(
     let (lookups_by_script, lookups) = split_lookups_by_script(lookups);
 
     let kern_features = todo
-        .contains(&KERN)
+        .contains_key(&KERN)
         .then(|| assign_lookups_to_scripts(lookups_by_script.clone(), &ast.ast, KERN));
     let dist_features = todo
-        .contains(&DIST)
+        .contains_key(&DIST)
         .then(|| assign_lookups_to_scripts(lookups_by_script, &ast.ast, DIST));
     let features = kern_features
         .into_iter()
@@ -1729,6 +1736,7 @@ mod tests {
                 &layout_output.first_pass_fea,
                 &layout_output.gdef_categories,
                 &self.glyph_order,
+                &layout_output.static_metadata,
                 self.charmap,
                 self.non_spacing,
             )

--- a/fontbe/src/features/kern.rs
+++ b/fontbe/src/features/kern.rs
@@ -17,7 +17,7 @@ use fontdrasil::{
 use fontir::{
     ir::{
         self, GdefCategories, GlyphOrder, KernGroup, KerningInstance, KerningLocations,
-        StaticMetadata, resolve_feature_generation,
+        StaticMetadata,
     },
     orchestration::WorkId as FeWorkId,
 };
@@ -883,7 +883,7 @@ fn finalize_kerning(
     char_map: HashMap<u32, GlyphId16>,
     non_spacing_glyphs: HashSet<GlyphId16>,
 ) -> Result<FeaRsKerns, Error> {
-    let plan = resolve_feature_generation(&static_metadata.misc.feature_generation);
+    let plan = ir::resolve_feature_generation(&static_metadata.misc.feature_generation);
     let todo = super::feature_writer_todo_list(&[KERN, DIST], plan.kern.as_ref(), &ast.ast);
     if pairs.is_empty() || todo.is_empty() {
         log::info!("no kerning work to do");

--- a/fontbe/src/features/kern.rs
+++ b/fontbe/src/features/kern.rs
@@ -17,7 +17,7 @@ use fontdrasil::{
 use fontir::{
     ir::{
         self, GdefCategories, GlyphOrder, KernGroup, KerningInstance, KerningLocations,
-        StaticMetadata, resolve_feature_writers,
+        StaticMetadata, resolve_feature_generation,
     },
     orchestration::WorkId as FeWorkId,
 };
@@ -883,7 +883,7 @@ fn finalize_kerning(
     char_map: HashMap<u32, GlyphId16>,
     non_spacing_glyphs: HashSet<GlyphId16>,
 ) -> Result<FeaRsKerns, Error> {
-    let plan = resolve_feature_writers(&static_metadata.misc.feature_writers);
+    let plan = resolve_feature_generation(&static_metadata.misc.feature_generation);
     let todo = super::feature_writer_todo_list(&[KERN, DIST], plan.kern.as_ref(), &ast.ast);
     if pairs.is_empty() || todo.is_empty() {
         log::info!("no kerning work to do");

--- a/fontbe/src/features/marks.rs
+++ b/fontbe/src/features/marks.rs
@@ -37,7 +37,7 @@ use crate::{
 use fontir::{
     ir::{
         self, Anchor, AnchorKind, FeatureGenerationPlan, GdefCategories, GlyphAnchors, GlyphOrder,
-        StaticMetadata, resolve_feature_generation,
+        StaticMetadata,
     },
     orchestration::WorkId as FeWorkId,
 };
@@ -210,7 +210,7 @@ impl<'a> MarkLookupBuilder<'a> {
         fea_first_pass: &'a FeaFirstPassOutput,
         char_map: HashMap<u32, GlyphId16>,
     ) -> Result<Self, Error> {
-        let plan = resolve_feature_generation(&static_metadata.misc.feature_generation);
+        let plan = ir::resolve_feature_generation(&static_metadata.misc.feature_generation);
         let gdef_classes = super::get_gdef_classes(gdef_categories, fea_first_pass, glyph_order);
         // ligature carets are part of the GDEF table, which the Gdef writer owns.
         let lig_carets = if plan.gdef {

--- a/fontbe/src/features/marks.rs
+++ b/fontbe/src/features/marks.rs
@@ -35,7 +35,10 @@ use crate::{
     },
 };
 use fontir::{
-    ir::{self, Anchor, AnchorKind, GdefCategories, GlyphAnchors, GlyphOrder, StaticMetadata},
+    ir::{
+        self, Anchor, AnchorKind, FeatureWriterPlan, GdefCategories, GlyphAnchors, GlyphOrder,
+        StaticMetadata, resolve_feature_writers,
+    },
     orchestration::WorkId as FeWorkId,
 };
 
@@ -71,6 +74,9 @@ struct MarkLookupBuilder<'a> {
     mark_glyphs: BTreeSet<GlyphId16>,
     lig_carets: BTreeMap<GlyphId16, Vec<CaretValueBuilder>>,
     char_map: HashMap<u32, GlyphId16>,
+    // marks.rs fuses ufo2ft's Mark and Curs writers, so we carry the whole plan
+    // and gate mark/curs (and GDEF ligature carets) independently.
+    plan: FeatureWriterPlan,
 }
 
 /// Abstract over the difference in anchor shape between mark2lig and mark2base/mark2mark
@@ -204,8 +210,14 @@ impl<'a> MarkLookupBuilder<'a> {
         fea_first_pass: &'a FeaFirstPassOutput,
         char_map: HashMap<u32, GlyphId16>,
     ) -> Result<Self, Error> {
+        let plan = resolve_feature_writers(&static_metadata.misc.feature_writers);
         let gdef_classes = super::get_gdef_classes(gdef_categories, fea_first_pass, glyph_order);
-        let lig_carets = get_ligature_carets(glyph_order, static_metadata, &anchors)?;
+        // ligature carets are part of the GDEF table, which the Gdef writer owns.
+        let lig_carets = if plan.gdef {
+            get_ligature_carets(glyph_order, static_metadata, &anchors)?
+        } else {
+            Default::default()
+        };
         // first we want to narrow our input down to only anchors that are participating.
         // in pythonland this is https://github.com/googlefonts/ufo2ft/blob/8e9e6eb66a/Lib/ufo2ft/featureWriters/markFeatureWriter.py#L380
         let mut pruned = BTreeMap::new();
@@ -278,6 +290,7 @@ impl<'a> MarkLookupBuilder<'a> {
             mark_glyphs,
             lig_carets,
             char_map,
+            plan,
         })
     }
 
@@ -289,8 +302,16 @@ impl<'a> MarkLookupBuilder<'a> {
 
         let (abvm_glyphs, non_abvm_glyphs) = self.split_mark_and_abvm_blwm_glyphs()?;
 
-        let todo = super::feature_writer_todo_list(
-            &[MARK, MKMK, ABVM, BLWM, CURS],
+        // the Mark writer covers mark/mkmk/abvm/blwm; Curs is a separate writer,
+        // so gate them from their own plan entries.
+        let mark_todo = super::feature_writer_todo_list(
+            &[MARK, MKMK, ABVM, BLWM],
+            self.plan.mark.as_ref(),
+            &self.fea_first_pass.ast,
+        );
+        let curs_todo = super::feature_writer_todo_list(
+            &[CURS],
+            self.plan.curs.as_ref(),
             &self.fea_first_pass.ast,
         );
 
@@ -301,22 +322,22 @@ impl<'a> MarkLookupBuilder<'a> {
             &non_abvm_glyphs,
             |_| true,
         )?;
-        if !todo.contains(&MARK) {
+        if !mark_todo.contains_key(&MARK) {
             mark_mkmk.mark_base.clear();
             mark_mkmk.mark_lig.clear();
         }
-        if !todo.contains(&MKMK) {
+        if !mark_todo.contains_key(&MKMK) {
             mark_mkmk.mark_mark.clear();
         }
 
-        let curs = todo
-            .contains(&CURS)
+        let curs = curs_todo
+            .contains_key(&CURS)
             .then(|| self.make_cursive_lookups())
             .transpose()?
             .unwrap_or_default();
         let (abvm, blwm) = if !abvm_glyphs.is_empty() {
-            let abvm = todo
-                .contains(&ABVM)
+            let abvm = mark_todo
+                .contains_key(&ABVM)
                 .then(|| {
                     self.make_lookups(
                         &mark_base_groups,
@@ -327,8 +348,8 @@ impl<'a> MarkLookupBuilder<'a> {
                     )
                 })
                 .transpose()?;
-            let blwm = todo
-                .contains(&BLWM)
+            let blwm = mark_todo
+                .contains_key(&BLWM)
                 .then(|| {
                     self.make_lookups(
                         &mark_base_groups,
@@ -1063,7 +1084,9 @@ mod tests {
         coords::{Coord, CoordConverter, NormalizedLocation},
         types::Axis,
     };
-    use fontir::ir::{GdefCategories, NamedInstance};
+    use fontir::ir::{
+        FeatureWriterMode, FeatureWriterSpec, GdefCategories, KnownFeatureWriter, NamedInstance,
+    };
     use kurbo::Point;
 
     use write_fonts::{
@@ -1119,6 +1142,7 @@ mod tests {
         categories: BTreeMap<GlyphName, GlyphClassDef>,
         char_map: HashMap<u32, GlyphName>,
         user_fea: &'static str,
+        feature_writers: Option<Vec<FeatureWriterSpec>>,
     }
 
     struct AnchorBuilder<const N: usize> {
@@ -1204,6 +1228,7 @@ mod tests {
                 anchors: Default::default(),
                 categories: Default::default(),
                 char_map: Default::default(),
+                feature_writers: None,
             }
         }
 
@@ -1212,6 +1237,12 @@ mod tests {
         /// By default we use a single 'languagesytem DFLT dflt' statement.
         fn set_user_fea(&mut self, fea: &'static str) -> &mut Self {
             self.user_fea = fea;
+            self
+        }
+
+        /// Set the `featureWriters` config (`None` = key absent = defaults).
+        fn set_feature_writers(&mut self, specs: Option<Vec<FeatureWriterSpec>>) -> &mut Self {
+            self.feature_writers = specs;
             self
         }
 
@@ -1279,6 +1310,7 @@ mod tests {
                 .with_categories(categories)
                 .with_user_fea(self.user_fea)
                 .with_glyph_order(self.anchors.keys().cloned().collect())
+                .with_feature_writers(self.feature_writers.clone())
                 .build()
         }
 
@@ -2033,6 +2065,60 @@ mod tests {
               entry: @(x: -11, y: 33)
               exit: @(x: -11, y: 44)
             "#
+        );
+    }
+
+    fn spec(writer: KnownFeatureWriter) -> FeatureWriterSpec {
+        FeatureWriterSpec {
+            writer,
+            mode: FeatureWriterMode::Skip,
+            features: None,
+        }
+    }
+
+    // marks.rs fuses ufo2ft's Mark and Curs writers; a config that lists Mark but
+    // not Curs must suppress the curs feature while still running the mark writer.
+    #[test]
+    fn curs_gated_independently_of_mark() {
+        let mut input = MarksInput::default();
+        input.add_glyph("a", None, |anchors| {
+            anchors.add("entry", [(10., 10.)]).add("exit", [(10., 60.)]);
+        });
+
+        // Mark writer only: no curs, even though the anchors are present.
+        let out = input
+            .set_feature_writers(Some(vec![spec(KnownFeatureWriter::Mark)]))
+            .get_normalized_output();
+        assert!(
+            !out.contains("curs"),
+            "curs should be gated off, got:\n{out}"
+        );
+
+        // Curs writer only: curs is generated.
+        let out = input
+            .set_feature_writers(Some(vec![spec(KnownFeatureWriter::Curs)]))
+            .get_normalized_output();
+        assert!(
+            out.contains("curs"),
+            "curs should be generated, got:\n{out}"
+        );
+    }
+
+    // Ligature carets live in the GDEF table, which the Gdef writer owns; a config
+    // without a Gdef writer must not emit them.
+    #[test]
+    fn gdef_writer_disabled_skips_lig_carets() {
+        let out = MarksInput::default()
+            .set_feature_writers(Some(vec![spec(KnownFeatureWriter::Mark)]))
+            .add_glyph("f_i", None, |anchors| {
+                anchors.add("caret_1", [(100, 0)]);
+            })
+            .compile();
+
+        assert!(
+            out.gdef.is_none(),
+            "expected no GDEF table when the Gdef writer is disabled, got {:?}",
+            out.gdef
         );
     }
 }

--- a/fontbe/src/features/marks.rs
+++ b/fontbe/src/features/marks.rs
@@ -36,8 +36,8 @@ use crate::{
 };
 use fontir::{
     ir::{
-        self, Anchor, AnchorKind, FeatureWriterPlan, GdefCategories, GlyphAnchors, GlyphOrder,
-        StaticMetadata, resolve_feature_writers,
+        self, Anchor, AnchorKind, FeatureGenerationPlan, GdefCategories, GlyphAnchors, GlyphOrder,
+        StaticMetadata, resolve_feature_generation,
     },
     orchestration::WorkId as FeWorkId,
 };
@@ -76,7 +76,7 @@ struct MarkLookupBuilder<'a> {
     char_map: HashMap<u32, GlyphId16>,
     // marks.rs fuses ufo2ft's Mark and Curs writers, so we carry the whole plan
     // and gate mark/curs (and GDEF ligature carets) independently.
-    plan: FeatureWriterPlan,
+    plan: FeatureGenerationPlan,
 }
 
 /// Abstract over the difference in anchor shape between mark2lig and mark2base/mark2mark
@@ -210,7 +210,7 @@ impl<'a> MarkLookupBuilder<'a> {
         fea_first_pass: &'a FeaFirstPassOutput,
         char_map: HashMap<u32, GlyphId16>,
     ) -> Result<Self, Error> {
-        let plan = resolve_feature_writers(&static_metadata.misc.feature_writers);
+        let plan = resolve_feature_generation(&static_metadata.misc.feature_generation);
         let gdef_classes = super::get_gdef_classes(gdef_categories, fea_first_pass, glyph_order);
         // ligature carets are part of the GDEF table, which the Gdef writer owns.
         let lig_carets = if plan.gdef {
@@ -1142,7 +1142,7 @@ mod tests {
         categories: BTreeMap<GlyphName, GlyphClassDef>,
         char_map: HashMap<u32, GlyphName>,
         user_fea: &'static str,
-        feature_writers: Option<Vec<FeatureWriterSpec>>,
+        feature_generation: Option<Vec<FeatureWriterSpec>>,
     }
 
     struct AnchorBuilder<const N: usize> {
@@ -1228,7 +1228,7 @@ mod tests {
                 anchors: Default::default(),
                 categories: Default::default(),
                 char_map: Default::default(),
-                feature_writers: None,
+                feature_generation: None,
             }
         }
 
@@ -1241,8 +1241,8 @@ mod tests {
         }
 
         /// Set the `featureWriters` config (`None` = key absent = defaults).
-        fn set_feature_writers(&mut self, specs: Option<Vec<FeatureWriterSpec>>) -> &mut Self {
-            self.feature_writers = specs;
+        fn set_feature_generation(&mut self, specs: Option<Vec<FeatureWriterSpec>>) -> &mut Self {
+            self.feature_generation = specs;
             self
         }
 
@@ -1310,7 +1310,7 @@ mod tests {
                 .with_categories(categories)
                 .with_user_fea(self.user_fea)
                 .with_glyph_order(self.anchors.keys().cloned().collect())
-                .with_feature_writers(self.feature_writers.clone())
+                .with_feature_generation(self.feature_generation.clone())
                 .build()
         }
 
@@ -2087,7 +2087,7 @@ mod tests {
 
         // Mark writer only: no curs, even though the anchors are present.
         let out = input
-            .set_feature_writers(Some(vec![spec(KnownFeatureWriter::Mark)]))
+            .set_feature_generation(Some(vec![spec(KnownFeatureWriter::Mark)]))
             .get_normalized_output();
         assert!(
             !out.contains("curs"),
@@ -2096,7 +2096,7 @@ mod tests {
 
         // Curs writer only: curs is generated.
         let out = input
-            .set_feature_writers(Some(vec![spec(KnownFeatureWriter::Curs)]))
+            .set_feature_generation(Some(vec![spec(KnownFeatureWriter::Curs)]))
             .get_normalized_output();
         assert!(
             out.contains("curs"),
@@ -2109,7 +2109,7 @@ mod tests {
     #[test]
     fn gdef_writer_disabled_skips_lig_carets() {
         let out = MarksInput::default()
-            .set_feature_writers(Some(vec![spec(KnownFeatureWriter::Mark)]))
+            .set_feature_generation(Some(vec![spec(KnownFeatureWriter::Mark)]))
             .add_glyph("f_i", None, |anchors| {
                 anchors.add("caret_1", [(100, 0)]);
             })

--- a/fontbe/src/features/test_helpers.rs
+++ b/fontbe/src/features/test_helpers.rs
@@ -18,7 +18,7 @@ pub(crate) struct LayoutOutputBuilder {
     glyph_locations: HashSet<NormalizedLocation>,
     user_fea: Arc<str>,
     glyph_order: GlyphOrder,
-    feature_writers: Option<Vec<FeatureWriterSpec>>,
+    feature_generation: Option<Vec<FeatureWriterSpec>>,
 }
 
 /// A helper for compiling layout tables (including with user-provided features)
@@ -64,11 +64,11 @@ impl LayoutOutputBuilder {
         self
     }
 
-    pub(crate) fn with_feature_writers(
+    pub(crate) fn with_feature_generation(
         &mut self,
-        feature_writers: Option<Vec<FeatureWriterSpec>>,
+        feature_generation: Option<Vec<FeatureWriterSpec>>,
     ) -> &mut Self {
-        self.feature_writers = feature_writers;
+        self.feature_generation = feature_generation;
         self
     }
 
@@ -85,7 +85,7 @@ impl LayoutOutputBuilder {
             false,
         )
         .unwrap();
-        static_metadata.misc.feature_writers = self.feature_writers.clone();
+        static_metadata.misc.feature_generation = self.feature_generation.clone();
 
         let gdef_categories = self.categories.clone().unwrap_or_default();
 
@@ -140,7 +140,7 @@ impl Default for LayoutOutputBuilder {
             glyph_locations: Default::default(),
             user_fea: "languagesystem DFLT dflt;".into(),
             glyph_order: Default::default(),
-            feature_writers: None,
+            feature_generation: None,
         }
     }
 }

--- a/fontbe/src/features/test_helpers.rs
+++ b/fontbe/src/features/test_helpers.rs
@@ -4,7 +4,7 @@ use std::{collections::HashSet, path::Path, sync::Arc};
 
 use fea_rs::compile::{Compilation, FeatureProvider};
 use fontdrasil::{coords::NormalizedLocation, types::Axes};
-use fontir::ir::{GdefCategories, GlyphOrder, NamedInstance, StaticMetadata};
+use fontir::ir::{FeatureWriterSpec, GdefCategories, GlyphOrder, NamedInstance, StaticMetadata};
 
 use crate::orchestration::FeaFirstPassOutput;
 
@@ -18,6 +18,7 @@ pub(crate) struct LayoutOutputBuilder {
     glyph_locations: HashSet<NormalizedLocation>,
     user_fea: Arc<str>,
     glyph_order: GlyphOrder,
+    feature_writers: Option<Vec<FeatureWriterSpec>>,
 }
 
 /// A helper for compiling layout tables (including with user-provided features)
@@ -63,8 +64,16 @@ impl LayoutOutputBuilder {
         self
     }
 
+    pub(crate) fn with_feature_writers(
+        &mut self,
+        feature_writers: Option<Vec<FeatureWriterSpec>>,
+    ) -> &mut Self {
+        self.feature_writers = feature_writers;
+        self
+    }
+
     pub(crate) fn build(&self) -> LayoutOutput {
-        let static_metadata = StaticMetadata::new(
+        let mut static_metadata = StaticMetadata::new(
             1000,
             Default::default(),
             self.axes.clone().into_inner(),
@@ -76,6 +85,7 @@ impl LayoutOutputBuilder {
             false,
         )
         .unwrap();
+        static_metadata.misc.feature_writers = self.feature_writers.clone();
 
         let gdef_categories = self.categories.clone().unwrap_or_default();
 
@@ -130,6 +140,7 @@ impl Default for LayoutOutputBuilder {
             glyph_locations: Default::default(),
             user_fea: "languagesystem DFLT dflt;".into(),
             glyph_order: Default::default(),
+            feature_writers: None,
         }
     }
 }

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -6226,4 +6226,94 @@ mod tests {
         assert_eq!(250, os2.us_win_descent());
         assert_eq!(700, os2.us_weight_class());
     }
+
+    fn gpos_feature_tags(font: &FontRef) -> Vec<Tag> {
+        let gpos = font.gpos().unwrap();
+        let feature_list = gpos.feature_list().unwrap();
+        feature_list
+            .feature_records()
+            .iter()
+            .map(|r| r.feature_tag())
+            .collect()
+    }
+
+    // The FeatureWriters*.glyphs fixtures below share the same glyph content (an
+    // A/V kern pair, a base+combining-mark pair, and a glyph with a ligature
+    // caret) and differ only in the featureWriters userData key. This keyless
+    // control proves the fixture *does* produce kern, mark, GDEF glyph classes
+    // and a ligature caret list, so the suppression asserted by the other tests
+    // is not vacuous.
+    #[test]
+    fn feature_writers_absent_generates_defaults() {
+        let compile = TestCompile::compile_source("glyphs3/FeatureWritersDefault.glyphs");
+        let font = compile.font();
+        let tags = gpos_feature_tags(&font);
+        assert!(tags.contains(&Tag::new(b"kern")), "{tags:?}");
+        assert!(tags.contains(&Tag::new(b"mark")), "{tags:?}");
+
+        let gdef = font.gdef().unwrap();
+        let classdef = gdef.glyph_class_def().unwrap().unwrap();
+        let gravecomb = compile.get_gid("gravecomb");
+        assert_eq!(
+            classdef.get(gravecomb),
+            GlyphClassDef::Mark as u16,
+            "the combining mark should get GDEF class Mark"
+        );
+        assert!(
+            gdef.lig_caret_list().is_some(),
+            "GdefFeatureWriter should emit a ligature caret list"
+        );
+    }
+
+    // An empty featureWriters list disables every automatic feature: no kern,
+    // no mark, no GDEF.
+    #[test]
+    fn feature_writers_empty_list_disables_everything() {
+        let compile = TestCompile::compile_source("glyphs3/FeatureWritersEmpty.glyphs");
+        let font = compile.font();
+        assert!(font.gpos().is_err(), "expected no GPOS");
+        assert!(font.gdef().is_err(), "expected no GDEF");
+    }
+
+    // NotoMusic shape read from .glyphs font userData: Curs(append), Kern(append),
+    // Mark(skip), Gdef omitted. The cursive feature is generated from the font's
+    // entry/exit anchors alongside kern.
+    #[test]
+    fn feature_writers_curs_from_glyphs_user_data() {
+        let compile = TestCompile::compile_source("glyphs3/FeatureWritersCurs.glyphs");
+        let font = compile.font();
+        let tags = gpos_feature_tags(&font);
+        assert!(tags.contains(&Tag::new(b"curs")), "{tags:?}");
+        assert!(tags.contains(&Tag::new(b"kern")), "{tags:?}");
+    }
+
+    // OpenSans shape: KernFeatureWriter(append) with a manual `feature kern`
+    // block that has no insertion marker (the key lives in the default master
+    // UFO lib). In skip mode fontc drops the source-derived kern; append keeps
+    // it and lands its lookup after the manual one. Here the manual block emits
+    // lookup 0 (bar/plus) and the generated kern emits lookup 1 (bar/bar).
+    #[test]
+    fn feature_writers_kern_append_keeps_source_kerning() {
+        let compile = TestCompile::compile_source("fw_append.designspace");
+        let font = compile.font();
+        let gpos = font.gpos().unwrap();
+        assert_eq!(
+            gpos.lookup_list().unwrap().lookup_count(),
+            2,
+            "manual plus appended source kern lookups"
+        );
+        let feature_list = gpos.feature_list().unwrap();
+        let appended = feature_list.feature_records().iter().any(|r| {
+            r.feature_tag() == Tag::new(b"kern")
+                && r.feature(feature_list.offset_data())
+                    .unwrap()
+                    .lookup_list_indices()
+                    .iter()
+                    .any(|i| i.get() == 1)
+        });
+        assert!(
+            appended,
+            "the source-derived kern lookup should be appended to the kern feature"
+        );
+    }
 }

--- a/fontir/src/error.rs
+++ b/fontir/src/error.rs
@@ -95,6 +95,8 @@ pub enum Error {
     MetricDeltaError(GlobalMetric, #[source] DeltaError),
     #[error("Coordinate conversion error: {0}")]
     CoordinateConversionError(#[from] fontdrasil::error::Error),
+    #[error("Unsupported featureWriters configuration: {0}")]
+    UnsupportedFeatureWriters(String),
 }
 
 /// An error related to loading source input files

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -31,10 +31,16 @@ use crate::{
 
 // just public so we publish the docs
 mod erase_open_corners;
+mod feature_writers;
 mod path_builder;
 mod static_metadata;
 
 pub use erase_open_corners::erase_open_corners;
+pub use feature_writers::{
+    FEATURE_WRITERS_LIB_KEY, FeatureWriterMode, FeatureWriterOptionValue, FeatureWriterPlan,
+    FeatureWriterSettings, FeatureWriterSpec, KnownFeatureWriter, reject_duplicate_writers,
+    resolve_feature_writers, validate_feature_writer,
+};
 pub use path_builder::GlyphPathBuilder;
 pub use static_metadata::{
     Condition, ConditionSet, GdefCategories, MetaTableValues, MiscMetadata, NameKey, NamedInstance,

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -37,9 +37,9 @@ mod static_metadata;
 
 pub use erase_open_corners::erase_open_corners;
 pub use feature_writers::{
-    FEATURE_WRITERS_LIB_KEY, FeatureWriterMode, FeatureWriterOptionValue, FeatureWriterPlan,
-    FeatureWriterSettings, FeatureWriterSpec, KnownFeatureWriter, reject_duplicate_writers,
-    resolve_feature_writers, validate_feature_writer,
+    FEATURE_WRITERS_LIB_KEY, FeatureGenerationPlan, FeatureGenerationSettings, FeatureWriterMode,
+    FeatureWriterOptionValue, FeatureWriterSpec, KnownFeatureWriter, reject_duplicate_writers,
+    resolve_feature_generation, validate_feature_writer,
 };
 pub use path_builder::GlyphPathBuilder;
 pub use static_metadata::{

--- a/fontir/src/ir/feature_writers.rs
+++ b/fontir/src/ir/feature_writers.rs
@@ -294,9 +294,9 @@ fn parse_features(
     Some(tags)
 }
 
-/// Per-writer settings in the resolved [`FeatureWriterPlan`].
+/// Per-writer settings in the resolved [`FeatureGenerationPlan`].
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct FeatureWriterSettings {
+pub struct FeatureGenerationSettings {
     pub mode: FeatureWriterMode,
     /// Restrict generation to this subset of the writer's tags; `None` = all.
     pub features: Option<Vec<Tag>>,
@@ -308,43 +308,43 @@ pub struct FeatureWriterSettings {
 /// be generated. Note ufo2ft's Mark writer covers mark/mkmk/abvm/blwm while Curs
 /// is a separate writer, so `curs` is gated independently.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct FeatureWriterPlan {
-    pub curs: Option<FeatureWriterSettings>,
-    pub kern: Option<FeatureWriterSettings>,
-    pub mark: Option<FeatureWriterSettings>,
+pub struct FeatureGenerationPlan {
+    pub curs: Option<FeatureGenerationSettings>,
+    pub kern: Option<FeatureGenerationSettings>,
+    pub mark: Option<FeatureGenerationSettings>,
     pub gdef: bool,
 }
 
 impl FeatureWriterSpec {
-    fn settings(&self) -> FeatureWriterSettings {
-        FeatureWriterSettings {
+    fn settings(&self) -> FeatureGenerationSettings {
+        FeatureGenerationSettings {
             mode: self.mode,
             features: self.features.clone(),
         }
     }
 }
 
-/// Resolve the `feature_writers` config into a per-writer plan.
+/// Resolve the featureWriters config into a per-writer plan.
 ///
 /// `None` (key absent) enables everything in [`Skip`] mode -- the compiler's
 /// historical behavior. `Some(list)` fully replaces the defaults: only listed
 /// writers are enabled; an empty list disables all automatic features.
 ///
 /// [`Skip`]: FeatureWriterMode::Skip
-pub fn resolve_feature_writers(specs: &Option<Vec<FeatureWriterSpec>>) -> FeatureWriterPlan {
+pub fn resolve_feature_generation(specs: &Option<Vec<FeatureWriterSpec>>) -> FeatureGenerationPlan {
     let Some(specs) = specs else {
-        let enabled = FeatureWriterSettings {
+        let enabled = FeatureGenerationSettings {
             mode: FeatureWriterMode::Skip,
             features: None,
         };
-        return FeatureWriterPlan {
+        return FeatureGenerationPlan {
             curs: Some(enabled.clone()),
             kern: Some(enabled.clone()),
             mark: Some(enabled),
             gdef: true,
         };
     };
-    let mut plan = FeatureWriterPlan {
+    let mut plan = FeatureGenerationPlan {
         curs: None,
         kern: None,
         mark: None,
@@ -732,7 +732,7 @@ mod tests {
 
     #[test]
     fn resolve_absent_enables_everything_in_skip() {
-        let plan = resolve_feature_writers(&None);
+        let plan = resolve_feature_generation(&None);
         assert_eq!(plan.curs.as_ref().unwrap().mode, FeatureWriterMode::Skip);
         assert_eq!(plan.kern.as_ref().unwrap().mode, FeatureWriterMode::Skip);
         assert_eq!(plan.mark.as_ref().unwrap().mode, FeatureWriterMode::Skip);
@@ -746,7 +746,7 @@ mod tests {
             mode: FeatureWriterMode::Append,
             features: None,
         }]);
-        let plan = resolve_feature_writers(&specs);
+        let plan = resolve_feature_generation(&specs);
         assert_eq!(plan.kern.as_ref().unwrap().mode, FeatureWriterMode::Append);
         assert!(plan.curs.is_none());
         assert!(plan.mark.is_none());
@@ -755,7 +755,7 @@ mod tests {
 
     #[test]
     fn resolve_empty_disables_everything() {
-        let plan = resolve_feature_writers(&Some(vec![]));
+        let plan = resolve_feature_generation(&Some(vec![]));
         assert!(plan.curs.is_none());
         assert!(plan.kern.is_none());
         assert!(plan.mark.is_none());

--- a/fontir/src/ir/feature_writers.rs
+++ b/fontir/src/ir/feature_writers.rs
@@ -110,7 +110,7 @@ impl FeatureWriterOptionValue {
 /// A built-in writer is recognised under every spelling ufo2ft can import: the
 /// bare class name (resolved in the default `ufo2ft.featureWriters` package),
 /// the class qualified by its defining submodule, and glyphsLib's legacy
-/// `ContextualMarkFeatureWriter` alias (see [`GLYPHSLIB_MARK_MODULE`]).
+/// `ContextualMarkFeatureWriter` alias (see `GLYPHSLIB_MARK_MODULE`).
 ///
 /// Mirrors ufo2ft's `loadFeatureWriters(..., ignoreErrors=True)`:
 /// - malformed or unrecognised entries (unknown module/class combination, unknown

--- a/fontir/src/ir/feature_writers.rs
+++ b/fontir/src/ir/feature_writers.rs
@@ -1,0 +1,764 @@
+//! Configuration for the `com.github.googlei18n.ufo2ft.featureWriters` lib key.
+//!
+//! ufo2ft lets sources override which automatic feature writers run (kern, mark,
+//! curs, GDEF) and in what mode. fontc plays the combined fontmake+ufo2ft role, so
+//! it reads the same key and mirrors ufo2ft's semantics. The frontends translate
+//! their own plist types into the plist-agnostic [`FeatureWriterOptionValue`] and
+//! feed each entry to [`validate_feature_writer`], which holds the shared
+//! string-matching and error policy.
+
+use log::warn;
+use serde::{Deserialize, Serialize};
+use write_fonts::types::Tag;
+
+use crate::error::Error;
+
+/// The lib/userData key carrying the feature-writer configuration.
+pub const FEATURE_WRITERS_LIB_KEY: &str = "com.github.googlei18n.ufo2ft.featureWriters";
+
+const DEFAULT_MODULE: &str = "ufo2ft.featureWriters";
+/// The legacy kern writer; ufo2ft honours it but fontc can't match its
+/// direction-based lookup grouping, so it's a hard error (see [`validate_feature_writer`]).
+const KERN2_MODULE: &str = "ufo2ft.featureWriters.kernFeatureWriter2";
+/// glyphsLib's mark writer module. Its `ContextualMarkFeatureWriter` has been an
+/// empty compatibility subclass of ufo2ft's `MarkFeatureWriter` since glyphsLib 6.10
+/// (contextual-anchor handling moved into ufo2ft's regular writer), so entries naming
+/// it map to [`KnownFeatureWriter::Mark`]. Sources converted by older glyphsLib still
+/// carry this spelling (e.g. KumbhSans).
+const GLYPHSLIB_MARK_MODULE: &str = "glyphsLib.featureWriters.markFeatureWriter";
+
+const CURS: Tag = Tag::new(b"curs");
+const KERN: Tag = Tag::new(b"kern");
+const DIST: Tag = Tag::new(b"dist");
+const MARK: Tag = Tag::new(b"mark");
+const MKMK: Tag = Tag::new(b"mkmk");
+const ABVM: Tag = Tag::new(b"abvm");
+const BLWM: Tag = Tag::new(b"blwm");
+
+/// Whether a writer respects existing manual feature blocks or is appended after them.
+#[derive(Serialize, Deserialize, Default, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FeatureWriterMode {
+    /// Skip generating a tag when the source has a manual block for it without an
+    /// insertion marker; this is fontc's historical behavior.
+    #[default]
+    Skip,
+    /// Ignore insertion markers; generated lookups land after all user lookups.
+    Append,
+}
+
+/// The feature writers fontc knows how to emulate.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KnownFeatureWriter {
+    Curs,
+    Kern,
+    Mark,
+    Gdef,
+}
+
+impl KnownFeatureWriter {
+    /// The feature tags a writer generates. Empty for `Gdef`, which writes a table.
+    fn tags(self) -> &'static [Tag] {
+        match self {
+            KnownFeatureWriter::Curs => &[CURS],
+            KnownFeatureWriter::Kern => &[KERN, DIST],
+            KnownFeatureWriter::Mark => &[MARK, MKMK, ABVM, BLWM],
+            KnownFeatureWriter::Gdef => &[],
+        }
+    }
+}
+
+/// A single validated entry from the `featureWriters` list.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct FeatureWriterSpec {
+    pub writer: KnownFeatureWriter,
+    pub mode: FeatureWriterMode,
+    /// The `features` option: restrict generation to this subset of the writer's
+    /// tags. `None` means all of the writer's tags.
+    pub features: Option<Vec<Tag>>,
+}
+
+/// A plist-agnostic option value.
+///
+/// Each frontend maps its own plist scalar types onto this so that
+/// [`validate_feature_writer`] can be shared. Anything we don't recognise (a
+/// nested dict, a non-string array element, ...) becomes [`Other`], which the
+/// validator treats as a malformed option and drops.
+///
+/// [`Other`]: FeatureWriterOptionValue::Other
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FeatureWriterOptionValue {
+    Boolean(bool),
+    Integer(i64),
+    String(String),
+    /// An array of strings (used by the `features` option).
+    Array(Vec<String>),
+    /// A value whose type we don't handle.
+    Other,
+}
+
+impl FeatureWriterOptionValue {
+    fn as_str(&self) -> Option<&str> {
+        match self {
+            FeatureWriterOptionValue::String(s) => Some(s),
+            _ => None,
+        }
+    }
+}
+
+/// Validate one `featureWriters` list entry against the shared error policy.
+///
+/// A built-in writer is recognised under every spelling ufo2ft can import: the
+/// bare class name (resolved in the default `ufo2ft.featureWriters` package),
+/// the class qualified by its defining submodule, and glyphsLib's legacy
+/// `ContextualMarkFeatureWriter` alias (see [`GLYPHSLIB_MARK_MODULE`]).
+///
+/// Mirrors ufo2ft's `loadFeatureWriters(..., ignoreErrors=True)`:
+/// - malformed or unrecognised entries (unknown module/class combination, unknown
+///   option key, wrong option type, invalid mode, invalid `features` subset) log a
+///   warning and are dropped (`Ok(None)`), matching fontmake's silent feature loss;
+/// - a recognised writer carrying a recognised option that ufo2ft would honour
+///   but fontc can't match (`ignoreMarks=false`, `quantization != 1`,
+///   `groupMarkClasses=true`, a valid Gdef `features` subset), and the legacy
+///   `kernFeatureWriter2`, are hard errors -- refusing beats silent divergence.
+///
+/// Drop wins over the hard error: ufo2ft binds all constructor kwargs at once, so
+/// a malformation (e.g. an unknown option) drops the whole entry before any
+/// honoured option takes effect. We therefore scan the entire entry and only
+/// raise a deferred hard error if nothing else dropped it.
+pub fn validate_feature_writer(
+    class: &str,
+    module: Option<&str>,
+    options: &[(String, FeatureWriterOptionValue)],
+) -> Result<Option<FeatureWriterSpec>, Error> {
+    let module = module.unwrap_or(DEFAULT_MODULE);
+    // Recognised-but-unimplemented; deferred so a malformed option still drops the
+    // entry the way fontmake would (rather than us failing a build it completes).
+    let mut hard_error: Option<String> = None;
+    let writer = if module == KERN2_MODULE && class == "KernFeatureWriter" {
+        hard_error = Some("legacy kernFeatureWriter2 is not supported".into());
+        // Recognise the kern option names while scanning.
+        KnownFeatureWriter::Kern
+    } else {
+        // Accept the (module, class) pairs ufo2ft can import: each built-in class
+        // is re-exported from the ufo2ft.featureWriters package and defined in its
+        // own submodule. Anything else fails ufo2ft's import and is dropped.
+        match (module, class) {
+            (DEFAULT_MODULE | "ufo2ft.featureWriters.cursFeatureWriter", "CursFeatureWriter") => {
+                KnownFeatureWriter::Curs
+            }
+            (DEFAULT_MODULE | "ufo2ft.featureWriters.kernFeatureWriter", "KernFeatureWriter") => {
+                KnownFeatureWriter::Kern
+            }
+            (DEFAULT_MODULE | "ufo2ft.featureWriters.markFeatureWriter", "MarkFeatureWriter")
+            | (GLYPHSLIB_MARK_MODULE, "MarkFeatureWriter" | "ContextualMarkFeatureWriter") => {
+                KnownFeatureWriter::Mark
+            }
+            (DEFAULT_MODULE | "ufo2ft.featureWriters.gdefFeatureWriter", "GdefFeatureWriter") => {
+                KnownFeatureWriter::Gdef
+            }
+            _ => {
+                warn!("featureWriters: unknown writer '{module}.{class}'; dropping entry");
+                return Ok(None);
+            }
+        }
+    };
+
+    let mut mode = FeatureWriterMode::Skip;
+    let mut features = None;
+    for (key, value) in options {
+        match key.as_str() {
+            "mode" => {
+                let Some(parsed) = value.as_str().and_then(parse_mode) else {
+                    warn!("featureWriters: invalid mode {value:?}; dropping entry");
+                    return Ok(None);
+                };
+                mode = parsed;
+            }
+            "features" => {
+                if writer == KnownFeatureWriter::Gdef {
+                    // ufo2ft's GdefFeatureWriter takes a GlyphClassDefs/LigatureCarets
+                    // subset, which fontc doesn't implement: honouring the entry
+                    // without the subset would silently emit a different GDEF, and
+                    // dropping it would silently emit none. A valid subset is a hard
+                    // error; anything else fails ufo2ft's own validation and drops.
+                    if is_valid_gdef_features(value) {
+                        hard_error = Some(format!("GdefFeatureWriter features={value:?}"));
+                        continue;
+                    }
+                    warn!("featureWriters: invalid features {value:?}; dropping entry");
+                    return Ok(None);
+                }
+                let Some(parsed) = parse_features(writer, value) else {
+                    warn!("featureWriters: invalid features {value:?}; dropping entry");
+                    return Ok(None);
+                };
+                features = Some(parsed);
+            }
+            "ignoreMarks" if writer == KnownFeatureWriter::Kern => match value {
+                FeatureWriterOptionValue::Boolean(true) => (),
+                FeatureWriterOptionValue::Boolean(false) => {
+                    hard_error = Some("KernFeatureWriter ignoreMarks=false".into());
+                }
+                _ => {
+                    warn!("featureWriters: invalid ignoreMarks {value:?}; dropping entry");
+                    return Ok(None);
+                }
+            },
+            "quantization"
+                if writer == KnownFeatureWriter::Kern || writer == KnownFeatureWriter::Mark =>
+            {
+                match value {
+                    FeatureWriterOptionValue::Integer(1) => (),
+                    FeatureWriterOptionValue::Integer(other) => {
+                        hard_error = Some(format!("{class} quantization={other}"));
+                    }
+                    _ => {
+                        warn!("featureWriters: invalid quantization {value:?}; dropping entry");
+                        return Ok(None);
+                    }
+                }
+            }
+            "groupMarkClasses" if writer == KnownFeatureWriter::Mark => match value {
+                FeatureWriterOptionValue::Boolean(false) => (),
+                FeatureWriterOptionValue::Boolean(true) => {
+                    hard_error = Some("MarkFeatureWriter groupMarkClasses=true".into());
+                }
+                _ => {
+                    warn!("featureWriters: invalid groupMarkClasses {value:?}; dropping entry");
+                    return Ok(None);
+                }
+            },
+            other => {
+                warn!("featureWriters: unknown option '{other}' on {class}; dropping entry");
+                return Ok(None);
+            }
+        }
+    }
+
+    if let Some(reason) = hard_error {
+        return Err(Error::UnsupportedFeatureWriters(reason));
+    }
+    Ok(Some(FeatureWriterSpec {
+        writer,
+        mode,
+        features,
+    }))
+}
+
+fn parse_mode(raw: &str) -> Option<FeatureWriterMode> {
+    match raw {
+        "skip" => Some(FeatureWriterMode::Skip),
+        "append" => Some(FeatureWriterMode::Append),
+        _ => None,
+    }
+}
+
+/// The values ufo2ft's `GdefFeatureWriter` accepts for its `features` option.
+///
+/// Unlike the other writers these are not feature tags: they select which parts
+/// of the GDEF table to generate.
+const GDEF_WRITER_FEATURES: [&str; 2] = ["GlyphClassDefs", "LigatureCarets"];
+
+/// Whether a Gdef `features` value would pass ufo2ft's own validation
+/// (a non-empty subset of [`GDEF_WRITER_FEATURES`]).
+fn is_valid_gdef_features(value: &FeatureWriterOptionValue) -> bool {
+    let FeatureWriterOptionValue::Array(raw) = value else {
+        return false;
+    };
+    !raw.is_empty()
+        && raw
+            .iter()
+            .all(|v| GDEF_WRITER_FEATURES.contains(&v.as_str()))
+}
+
+/// Parse the `features` option: a non-empty subset of the writer's tags.
+fn parse_features(
+    writer: KnownFeatureWriter,
+    value: &FeatureWriterOptionValue,
+) -> Option<Vec<Tag>> {
+    let FeatureWriterOptionValue::Array(raw) = value else {
+        return None;
+    };
+    if raw.is_empty() {
+        return None;
+    }
+    let allowed = writer.tags();
+    let mut tags = Vec::with_capacity(raw.len());
+    for tag in raw {
+        let tag = Tag::new_checked(tag.as_bytes()).ok()?;
+        if !allowed.contains(&tag) {
+            return None;
+        }
+        tags.push(tag);
+    }
+    Some(tags)
+}
+
+/// Per-writer settings in the resolved [`FeatureWriterPlan`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FeatureWriterSettings {
+    pub mode: FeatureWriterMode,
+    /// Restrict generation to this subset of the writer's tags; `None` = all.
+    pub features: Option<Vec<Tag>>,
+}
+
+/// The `featureWriters` config resolved into a per-writer plan.
+///
+/// `None` for a writer means it is disabled and its features must not
+/// be generated. Note ufo2ft's Mark writer covers mark/mkmk/abvm/blwm while Curs
+/// is a separate writer, so `curs` is gated independently.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FeatureWriterPlan {
+    pub curs: Option<FeatureWriterSettings>,
+    pub kern: Option<FeatureWriterSettings>,
+    pub mark: Option<FeatureWriterSettings>,
+    pub gdef: bool,
+}
+
+impl FeatureWriterSpec {
+    fn settings(&self) -> FeatureWriterSettings {
+        FeatureWriterSettings {
+            mode: self.mode,
+            features: self.features.clone(),
+        }
+    }
+}
+
+/// Resolve the `feature_writers` config into a per-writer plan.
+///
+/// `None` (key absent) enables everything in [`Skip`] mode -- the compiler's
+/// historical behavior. `Some(list)` fully replaces the defaults: only listed
+/// writers are enabled; an empty list disables all automatic features.
+///
+/// [`Skip`]: FeatureWriterMode::Skip
+pub fn resolve_feature_writers(specs: &Option<Vec<FeatureWriterSpec>>) -> FeatureWriterPlan {
+    let Some(specs) = specs else {
+        let enabled = FeatureWriterSettings {
+            mode: FeatureWriterMode::Skip,
+            features: None,
+        };
+        return FeatureWriterPlan {
+            curs: Some(enabled.clone()),
+            kern: Some(enabled.clone()),
+            mark: Some(enabled),
+            gdef: true,
+        };
+    };
+    let mut plan = FeatureWriterPlan {
+        curs: None,
+        kern: None,
+        mark: None,
+        gdef: false,
+    };
+    // Duplicate writers are rejected at parse time ([`reject_duplicate_writers`]),
+    // so each slot is assigned at most once.
+    for spec in specs {
+        match spec.writer {
+            KnownFeatureWriter::Curs => plan.curs = Some(spec.settings()),
+            KnownFeatureWriter::Kern => plan.kern = Some(spec.settings()),
+            KnownFeatureWriter::Mark => plan.mark = Some(spec.settings()),
+            KnownFeatureWriter::Gdef => plan.gdef = true,
+        }
+    }
+    plan
+}
+
+/// Reject a config that lists the same writer more than once.
+///
+/// ufo2ft instantiates and runs every entry in order, so repeated writers can be
+/// meaningful there (e.g. two Mark writers with disjoint `features` subsets);
+/// fontc resolves one settings slot per writer and would silently keep only the
+/// last. Refusing beats silently changing what the config means.
+pub fn reject_duplicate_writers(specs: &[FeatureWriterSpec]) -> Result<(), Error> {
+    let mut seen = Vec::with_capacity(specs.len());
+    for spec in specs {
+        if seen.contains(&spec.writer) {
+            return Err(Error::UnsupportedFeatureWriters(format!(
+                "featureWriters lists the {:?} writer more than once",
+                spec.writer
+            )));
+        }
+        seen.push(spec.writer);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn opt(key: &str, value: FeatureWriterOptionValue) -> (String, FeatureWriterOptionValue) {
+        (key.to_string(), value)
+    }
+
+    #[test]
+    fn recognised_writer_default_options() {
+        let spec = validate_feature_writer("KernFeatureWriter", None, &[])
+            .unwrap()
+            .unwrap();
+        assert_eq!(spec.writer, KnownFeatureWriter::Kern);
+        assert_eq!(spec.mode, FeatureWriterMode::Skip);
+        assert_eq!(spec.features, None);
+    }
+
+    #[test]
+    fn append_mode() {
+        let spec = validate_feature_writer(
+            "CursFeatureWriter",
+            Some(DEFAULT_MODULE),
+            &[opt(
+                "mode",
+                FeatureWriterOptionValue::String("append".into()),
+            )],
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(spec.mode, FeatureWriterMode::Append);
+    }
+
+    #[test]
+    fn unknown_class_is_dropped() {
+        assert_eq!(
+            validate_feature_writer("NopeWriter", None, &[]).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn unknown_module_is_dropped() {
+        assert_eq!(
+            validate_feature_writer("KernFeatureWriter", Some("some.other.module"), &[]).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn module_qualified_builtin_is_accepted() {
+        // ufo2ft imports the class from its defining submodule just as happily as
+        // from the package root, so both spellings must resolve.
+        for (class, module, expected) in [
+            (
+                "CursFeatureWriter",
+                "ufo2ft.featureWriters.cursFeatureWriter",
+                KnownFeatureWriter::Curs,
+            ),
+            (
+                "KernFeatureWriter",
+                "ufo2ft.featureWriters.kernFeatureWriter",
+                KnownFeatureWriter::Kern,
+            ),
+            (
+                "MarkFeatureWriter",
+                "ufo2ft.featureWriters.markFeatureWriter",
+                KnownFeatureWriter::Mark,
+            ),
+            (
+                "GdefFeatureWriter",
+                "ufo2ft.featureWriters.gdefFeatureWriter",
+                KnownFeatureWriter::Gdef,
+            ),
+        ] {
+            let spec = validate_feature_writer(class, Some(module), &[])
+                .unwrap()
+                .unwrap();
+            assert_eq!(spec.writer, expected, "{module}.{class}");
+        }
+    }
+
+    #[test]
+    fn mismatched_module_and_class_is_dropped() {
+        // ufo2ft's getattr on the submodule would fail, dropping the entry.
+        assert_eq!(
+            validate_feature_writer(
+                "MarkFeatureWriter",
+                Some("ufo2ft.featureWriters.kernFeatureWriter"),
+                &[]
+            )
+            .unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn glyphslib_contextual_mark_alias_maps_to_mark() {
+        let spec = validate_feature_writer(
+            "ContextualMarkFeatureWriter",
+            Some(GLYPHSLIB_MARK_MODULE),
+            &[],
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(spec.writer, KnownFeatureWriter::Mark);
+        // The re-exported regular writer resolves from the same module too.
+        let spec = validate_feature_writer("MarkFeatureWriter", Some(GLYPHSLIB_MARK_MODULE), &[])
+            .unwrap()
+            .unwrap();
+        assert_eq!(spec.writer, KnownFeatureWriter::Mark);
+    }
+
+    #[test]
+    fn contextual_mark_alias_requires_its_module() {
+        // The alias is not importable from the default ufo2ft package, nor from the
+        // glyphsLib.featureWriters package root (whose __init__ exports nothing).
+        assert_eq!(
+            validate_feature_writer("ContextualMarkFeatureWriter", None, &[]).unwrap(),
+            None
+        );
+        assert_eq!(
+            validate_feature_writer(
+                "ContextualMarkFeatureWriter",
+                Some("glyphsLib.featureWriters"),
+                &[]
+            )
+            .unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn invalid_mode_is_dropped() {
+        assert_eq!(
+            validate_feature_writer(
+                "KernFeatureWriter",
+                None,
+                &[opt("mode", FeatureWriterOptionValue::String("nope".into()))]
+            )
+            .unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn unknown_option_is_dropped() {
+        assert_eq!(
+            validate_feature_writer(
+                "KernFeatureWriter",
+                None,
+                &[opt("bogus", FeatureWriterOptionValue::Boolean(true))]
+            )
+            .unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn default_option_values_are_noops() {
+        // ignoreMarks=true, quantization=1 are the defaults; accepted.
+        let spec = validate_feature_writer(
+            "KernFeatureWriter",
+            None,
+            &[
+                opt("ignoreMarks", FeatureWriterOptionValue::Boolean(true)),
+                opt("quantization", FeatureWriterOptionValue::Integer(1)),
+            ],
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(spec.writer, KnownFeatureWriter::Kern);
+    }
+
+    #[test]
+    fn non_default_option_is_hard_error() {
+        assert!(
+            validate_feature_writer(
+                "KernFeatureWriter",
+                None,
+                &[opt("quantization", FeatureWriterOptionValue::Integer(2))]
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn drop_wins_over_hard_error() {
+        // quantization=2 would be a hard error, but the unknown option drops the
+        // whole entry first -- just as ufo2ft binds all kwargs at once.
+        assert_eq!(
+            validate_feature_writer(
+                "KernFeatureWriter",
+                None,
+                &[
+                    opt("quantization", FeatureWriterOptionValue::Integer(2)),
+                    opt("bogus", FeatureWriterOptionValue::Boolean(true)),
+                ]
+            )
+            .unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn kern2_is_hard_error() {
+        assert!(validate_feature_writer("KernFeatureWriter", Some(KERN2_MODULE), &[]).is_err());
+    }
+
+    #[test]
+    fn kern2_with_wrong_class_is_dropped() {
+        // ufo2ft's import of a class the kern2 module doesn't define fails, so the
+        // entry drops before the writer could be honoured; no hard error.
+        assert_eq!(
+            validate_feature_writer("MarkFeatureWriter", Some(KERN2_MODULE), &[]).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn kern2_dropped_by_malformed_option() {
+        // Even the kern2 hard error yields to a malformed option.
+        assert_eq!(
+            validate_feature_writer(
+                "KernFeatureWriter",
+                Some(KERN2_MODULE),
+                &[opt("bogus", FeatureWriterOptionValue::Boolean(true))]
+            )
+            .unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn features_subset_is_honoured() {
+        let spec = validate_feature_writer(
+            "KernFeatureWriter",
+            None,
+            &[opt(
+                "features",
+                FeatureWriterOptionValue::Array(vec!["kern".into()]),
+            )],
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(spec.features, Some(vec![KERN]));
+    }
+
+    #[test]
+    fn features_not_a_subset_is_dropped() {
+        // curs is not one of the kern writer's tags.
+        assert_eq!(
+            validate_feature_writer(
+                "KernFeatureWriter",
+                None,
+                &[opt(
+                    "features",
+                    FeatureWriterOptionValue::Array(vec!["curs".into()])
+                )]
+            )
+            .unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn gdef_features_valid_subset_is_error() {
+        // ufo2ft would honour a GlyphClassDefs/LigatureCarets subset and emit a
+        // partial GDEF; fontc doesn't implement that, so it must refuse rather
+        // than silently emit a different (or no) GDEF.
+        for subset in [
+            vec!["GlyphClassDefs".to_string()],
+            vec!["LigatureCarets".to_string()],
+            vec!["GlyphClassDefs".to_string(), "LigatureCarets".to_string()],
+        ] {
+            let result = validate_feature_writer(
+                "GdefFeatureWriter",
+                None,
+                &[opt("features", FeatureWriterOptionValue::Array(subset))],
+            );
+            assert!(matches!(result, Err(Error::UnsupportedFeatureWriters(_))));
+        }
+    }
+
+    #[test]
+    fn gdef_features_invalid_subset_is_dropped() {
+        // A value ufo2ft's own validation would reject (ValueError -> dropped
+        // under ignoreErrors=True).
+        assert_eq!(
+            validate_feature_writer(
+                "GdefFeatureWriter",
+                None,
+                &[opt(
+                    "features",
+                    FeatureWriterOptionValue::Array(vec!["kern".into()])
+                )]
+            )
+            .unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn gdef_features_drop_wins_over_error() {
+        // An unknown option drops the whole entry in ufo2ft before the features
+        // kwarg could take effect, so the deferred hard error must not fire.
+        assert_eq!(
+            validate_feature_writer(
+                "GdefFeatureWriter",
+                None,
+                &[
+                    opt(
+                        "features",
+                        FeatureWriterOptionValue::Array(vec!["GlyphClassDefs".into()])
+                    ),
+                    opt("nonsense", FeatureWriterOptionValue::Boolean(true)),
+                ]
+            )
+            .unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn duplicate_writers_are_rejected() {
+        let kern = FeatureWriterSpec {
+            writer: KnownFeatureWriter::Kern,
+            mode: FeatureWriterMode::Skip,
+            features: None,
+        };
+        let mark = FeatureWriterSpec {
+            writer: KnownFeatureWriter::Mark,
+            ..kern.clone()
+        };
+        assert!(reject_duplicate_writers(&[kern.clone(), mark.clone()]).is_ok());
+        // Same writer twice is an error even when the settings differ: ufo2ft
+        // would run both entries, fontc would silently keep only the last.
+        let kern_append = FeatureWriterSpec {
+            mode: FeatureWriterMode::Append,
+            ..kern.clone()
+        };
+        assert!(matches!(
+            reject_duplicate_writers(&[kern, kern_append]),
+            Err(Error::UnsupportedFeatureWriters(_))
+        ));
+    }
+
+    #[test]
+    fn resolve_absent_enables_everything_in_skip() {
+        let plan = resolve_feature_writers(&None);
+        assert_eq!(plan.curs.as_ref().unwrap().mode, FeatureWriterMode::Skip);
+        assert_eq!(plan.kern.as_ref().unwrap().mode, FeatureWriterMode::Skip);
+        assert_eq!(plan.mark.as_ref().unwrap().mode, FeatureWriterMode::Skip);
+        assert!(plan.gdef);
+    }
+
+    #[test]
+    fn resolve_selective() {
+        let specs = Some(vec![FeatureWriterSpec {
+            writer: KnownFeatureWriter::Kern,
+            mode: FeatureWriterMode::Append,
+            features: None,
+        }]);
+        let plan = resolve_feature_writers(&specs);
+        assert_eq!(plan.kern.as_ref().unwrap().mode, FeatureWriterMode::Append);
+        assert!(plan.curs.is_none());
+        assert!(plan.mark.is_none());
+        assert!(!plan.gdef);
+    }
+
+    #[test]
+    fn resolve_empty_disables_everything() {
+        let plan = resolve_feature_writers(&Some(vec![]));
+        assert!(plan.curs.is_none());
+        assert!(plan.kern.is_none());
+        assert!(plan.mark.is_none());
+        assert!(!plan.gdef);
+    }
+}

--- a/fontir/src/ir/static_metadata.rs
+++ b/fontir/src/ir/static_metadata.rs
@@ -229,7 +229,7 @@ pub struct MiscMetadata {
     ///
     /// `None` means the key was absent (use the built-in defaults); `Some` fully
     /// replaces the defaults (an empty list disables all automatic features).
-    pub feature_writers: Option<Vec<FeatureWriterSpec>>,
+    pub feature_generation: Option<Vec<FeatureWriterSpec>>,
 }
 
 /// Records that will go in the '[meta]' table.
@@ -503,7 +503,7 @@ impl StaticMetadata {
                 us_weight_class: None,
                 us_width_class: None,
                 gasp: Vec::new(),
-                feature_writers: None,
+                feature_generation: None,
             },
             variations: None,
         })
@@ -664,7 +664,7 @@ mod tests {
                 us_weight_class: None,
                 us_width_class: None,
                 gasp: Vec::new(),
-                feature_writers: Some(vec![FeatureWriterSpec {
+                feature_generation: Some(vec![FeatureWriterSpec {
                     writer: KnownFeatureWriter::Kern,
                     mode: FeatureWriterMode::Append,
                     features: None,

--- a/fontir/src/ir/static_metadata.rs
+++ b/fontir/src/ir/static_metadata.rs
@@ -21,6 +21,7 @@ use fontdrasil::{
     variations::{VariationModel, VariationModelError},
 };
 
+use super::feature_writers::FeatureWriterSpec;
 use crate::orchestration::Persistable;
 
 /// Glyph names mapped to postscript names
@@ -223,6 +224,12 @@ pub struct MiscMetadata {
 
     // <https://learn.microsoft.com/en-us/typography/opentype/spec/gasp>
     pub gasp: Vec<GaspRange>,
+
+    /// The `com.github.googlei18n.ufo2ft.featureWriters` config.
+    ///
+    /// `None` means the key was absent (use the built-in defaults); `Some` fully
+    /// replaces the defaults (an empty list disables all automatic features).
+    pub feature_writers: Option<Vec<FeatureWriterSpec>>,
 }
 
 /// Records that will go in the '[meta]' table.
@@ -496,6 +503,7 @@ impl StaticMetadata {
                 us_weight_class: None,
                 us_width_class: None,
                 gasp: Vec::new(),
+                feature_writers: None,
             },
             variations: None,
         })
@@ -590,6 +598,8 @@ impl Persistable for PreliminaryGdefCategories {
 mod tests {
     use fontdrasil::coords::UserCoord;
 
+    use crate::ir::{FeatureWriterMode, KnownFeatureWriter};
+
     use super::*;
 
     fn test_static_metadata() -> StaticMetadata {
@@ -654,6 +664,11 @@ mod tests {
                 us_weight_class: None,
                 us_width_class: None,
                 gasp: Vec::new(),
+                feature_writers: Some(vec![FeatureWriterSpec {
+                    writer: KnownFeatureWriter::Kern,
+                    mode: FeatureWriterMode::Append,
+                    features: None,
+                }]),
             },
             number_values: Default::default(),
             variations: None,

--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -88,6 +88,7 @@ pub struct Font {
     pub kerning_rtl: Kerning,
 
     pub custom_parameters: CustomParameters,
+    pub user_data: BTreeMap<SmolStr, Plist>,
 }
 
 /// Custom parameter options that can be set on a glyphs font
@@ -854,6 +855,7 @@ struct RawFont {
     kerning_RTL: Kerning,
     custom_parameters: RawCustomParameters,
     numbers: Vec<NumberName>,
+    user_data: BTreeMap<SmolStr, Plist>,
 }
 
 #[derive(Default, Debug, PartialEq, FromPlist)]
@@ -3791,6 +3793,7 @@ impl TryFrom<RawFont> for Font {
             kerning_ltr: from.kerning_LTR,
             kerning_rtl: from.kerning_RTL,
             custom_parameters,
+            user_data: from.user_data,
         })
     }
 }
@@ -6555,6 +6558,44 @@ name = _corner.hi;
                         .collect::<Vec<_>>()
                 ))
                 .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn retains_font_level_user_data() {
+        // Font-level userData is retained verbatim; glyphs2fontir interprets the
+        // featureWriters key from it.
+        let font = Font::load_from_string(
+            r#"{
+.formatVersion = 3;
+fontMaster = (
+{
+id = "m01";
+}
+);
+unitsPerEm = 1000;
+userData = {
+com.github.googlei18n.ufo2ft.featureWriters = (
+{
+class = KernFeatureWriter;
+options = {
+mode = append;
+};
+}
+);
+};
+}"#,
+        )
+        .unwrap();
+        let writers = font
+            .user_data
+            .get("com.github.googlei18n.ufo2ft.featureWriters")
+            .and_then(Plist::as_array)
+            .expect("featureWriters retained as an array");
+        assert_eq!(writers.len(), 1);
+        assert_eq!(
+            writers[0].get("class").and_then(Plist::as_str),
+            Some("KernFeatureWriter")
         );
     }
 }

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -571,7 +571,7 @@ impl Work<Context, WorkId, Error> for StaticMetadataWork {
         )
         .map_err(Error::VariationModelError)?;
         static_metadata.misc.selection_flags = selection_flags;
-        static_metadata.misc.feature_writers = feature_writers_from_user_data(&font.user_data)?;
+        static_metadata.misc.feature_generation = feature_writers_from_user_data(&font.user_data)?;
         static_metadata.variations = variations;
         // treat  empty string or all spaces as equivalent to no value; it means
         // 'null', per the spec
@@ -4296,7 +4296,7 @@ mode = skip;
             .exec(&task_context)
             .unwrap();
         assert_eq!(
-            context.static_metadata.get().misc.feature_writers,
+            context.static_metadata.get().misc.feature_generation,
             Some(vec![
                 FeatureWriterSpec {
                     writer: KnownFeatureWriter::Curs,
@@ -4379,7 +4379,12 @@ ignoreMarks = 0;
             .unwrap()
             .exec(&task_context)
             .unwrap();
-        context.static_metadata.get().misc.feature_writers.clone()
+        context
+            .static_metadata
+            .get()
+            .misc
+            .feature_generation
+            .clone()
     }
 
     #[test]

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -18,10 +18,12 @@ use fontir::{
     feature_variations::{NBox, overlay_feature_variations},
     ir::{
         self, AnchorBuilder, ColorGlyphs, ColorPalettes, Condition, ConditionSet,
-        DEFAULT_VENDOR_ID, GlobalMetric, GlobalMetrics, GlobalMetricsBuilder, GlyphAnchors,
-        GlyphInstance, GlyphOrder, KernGroup, KernSide, KerningInstance, KerningLocations,
-        MetaTableValues, NameBuilder, NameKey, NamedInstance, Paint, PaintGlyph, PostscriptNames,
-        PreliminaryGdefCategories, Rule, StaticMetadata, Substitution, VariableFeature,
+        DEFAULT_VENDOR_ID, FEATURE_WRITERS_LIB_KEY, FeatureWriterOptionValue, FeatureWriterSpec,
+        GlobalMetric, GlobalMetrics, GlobalMetricsBuilder, GlyphAnchors, GlyphInstance, GlyphOrder,
+        KernGroup, KernSide, KerningInstance, KerningLocations, MetaTableValues, NameBuilder,
+        NameKey, NamedInstance, Paint, PaintGlyph, PostscriptNames, PreliminaryGdefCategories,
+        Rule, StaticMetadata, Substitution, VariableFeature, reject_duplicate_writers,
+        validate_feature_writer,
     },
     orchestration::{Context, Flags, IrWork, WorkId},
     source::Source,
@@ -328,6 +330,89 @@ fn names(font: &Font, flags: SelectionFlags) -> HashMap<NameKey, String> {
     names
 }
 
+/// Read the `com.github.googlei18n.ufo2ft.featureWriters` config from font userData.
+///
+/// glyphsLib round-trips the key at the font level, so this mirrors ufo2fontir's
+/// designspace-lib read but against the glyphs plist types. `None` means the key is
+/// absent (use the defaults); `Some` (including an empty list, or one where every
+/// entry was dropped) fully replaces them. Malformed entries warn and drop; a
+/// malformed key or module and duplicate writers are hard errors.
+fn feature_writers_from_user_data(
+    user_data: &BTreeMap<SmolStr, Plist>,
+) -> Result<Option<Vec<FeatureWriterSpec>>, Error> {
+    let Some(value) = user_data.get(FEATURE_WRITERS_LIB_KEY) else {
+        return Ok(None);
+    };
+    let Some(entries) = value.as_array() else {
+        // ufo2ft iterates whatever it finds and drops every element, silently
+        // building a font with no automatic features. A non-list value is always
+        // an authoring mistake; refusing loudly beats shipping a featureless font.
+        return Err(Error::UnsupportedFeatureWriters(
+            "featureWriters userData key is not a list".into(),
+        ));
+    };
+    let mut specs = Vec::new();
+    for entry in entries {
+        let Some(dict) = entry.as_dict() else {
+            warn!("featureWriters entry is not a dict; dropping");
+            continue;
+        };
+        let Some(class) = dict.get("class").and_then(Plist::as_str) else {
+            warn!("featureWriters entry has no 'class'; dropping");
+            continue;
+        };
+        let module = match dict.get("module") {
+            None => None,
+            Some(value) => match value.as_str() {
+                Some(module) => Some(module),
+                // ufo2ft would fail the import and drop the entry; a non-string
+                // module is always an authoring mistake, so refuse loudly.
+                None => {
+                    return Err(Error::UnsupportedFeatureWriters(
+                        "featureWriters 'module' is not a string".into(),
+                    ));
+                }
+            },
+        };
+        let options = match dict.get("options") {
+            None => Vec::new(),
+            Some(Plist::Dictionary(opts)) => opts
+                .iter()
+                .map(|(k, v)| (k.to_string(), plist_to_feature_writer_option(k, v)))
+                .collect(),
+            Some(_) => {
+                warn!("featureWriters 'options' is not a dict; dropping");
+                continue;
+            }
+        };
+        if let Some(spec) = validate_feature_writer(class, module, &options)? {
+            specs.push(spec);
+        }
+    }
+    reject_duplicate_writers(&specs)?;
+    Ok(Some(specs))
+}
+
+fn plist_to_feature_writer_option(key: &str, value: &Plist) -> FeatureWriterOptionValue {
+    match value {
+        // glyphs plist has no boolean type: booleans round-trip as integers. The
+        // bool-valued options must map back to Boolean so the shared validator can
+        // hard-error on their non-default values instead of silently dropping them.
+        Plist::Integer(i @ (0 | 1)) if matches!(key, "ignoreMarks" | "groupMarkClasses") => {
+            FeatureWriterOptionValue::Boolean(*i == 1)
+        }
+        Plist::Integer(i) => FeatureWriterOptionValue::Integer(*i),
+        Plist::String(s) => FeatureWriterOptionValue::String(s.clone()),
+        Plist::Array(items) => items
+            .iter()
+            .map(|v| v.as_str().map(str::to_string))
+            .collect::<Option<Vec<_>>>()
+            .map(FeatureWriterOptionValue::Array)
+            .unwrap_or(FeatureWriterOptionValue::Other),
+        _ => FeatureWriterOptionValue::Other,
+    }
+}
+
 #[derive(Debug)]
 struct StaticMetadataWork(GlyphsIrSource);
 
@@ -486,6 +571,7 @@ impl Work<Context, WorkId, Error> for StaticMetadataWork {
         )
         .map_err(Error::VariationModelError)?;
         static_metadata.misc.selection_flags = selection_flags;
+        static_metadata.misc.feature_writers = feature_writers_from_user_data(&font.user_data)?;
         static_metadata.variations = variations;
         // treat  empty string or all spaces as equivalent to no value; it means
         // 'null', per the spec
@@ -1970,7 +2056,10 @@ mod tests {
     };
     use fontir::{
         error::Error,
-        ir::{AnchorKind, Color, GlobalMetricsInstance, Glyph, GlyphOrder, NameKey},
+        ir::{
+            AnchorKind, Color, FeatureWriterMode, GlobalMetricsInstance, Glyph, GlyphOrder,
+            KnownFeatureWriter, NameKey,
+        },
         orchestration::{Context, Flags, WorkId},
         source::Source,
     };
@@ -4152,5 +4241,156 @@ unitsPerEm = 1000;
                 .contains(Flags::DECOMPOSE_TRANSFORMED_COMPONENTS),
             "decomposeTransformedComponents in userData should set DECOMPOSE_TRANSFORMED_COMPONENTS flag"
         );
+    }
+
+    #[test]
+    fn reads_feature_writers_from_font_user_data() {
+        let _ = env_logger::builder().is_test(true).try_init();
+        // NotoMusic-shaped config: curs+kern appended, mark skipped, no Gdef writer.
+        let source = GlyphsIrSource::new_from_memory(
+            r#"{
+.formatVersion = 3;
+fontMaster = (
+{
+id = "m01";
+}
+);
+unitsPerEm = 1000;
+userData = {
+com.github.googlei18n.ufo2ft.featureWriters = (
+{
+class = CursFeatureWriter;
+options = {
+mode = append;
+};
+},
+{
+class = KernFeatureWriter;
+options = {
+mode = append;
+};
+},
+{
+class = MarkFeatureWriter;
+options = {
+mode = skip;
+};
+}
+);
+};
+}"#,
+        )
+        .unwrap();
+        let context = Context::new_root(Flags::default(), None);
+        let task_context = context.copy_for_work(
+            Access::None,
+            AccessBuilder::new()
+                .variant(WorkId::StaticMetadata)
+                .variant(WorkId::PreliminaryGlyphOrder)
+                .variant(WorkId::PreliminaryGdefCategories)
+                .build(),
+        );
+        source
+            .create_static_metadata_work()
+            .unwrap()
+            .exec(&task_context)
+            .unwrap();
+        assert_eq!(
+            context.static_metadata.get().misc.feature_writers,
+            Some(vec![
+                FeatureWriterSpec {
+                    writer: KnownFeatureWriter::Curs,
+                    mode: FeatureWriterMode::Append,
+                    features: None,
+                },
+                FeatureWriterSpec {
+                    writer: KnownFeatureWriter::Kern,
+                    mode: FeatureWriterMode::Append,
+                    features: None,
+                },
+                FeatureWriterSpec {
+                    writer: KnownFeatureWriter::Mark,
+                    mode: FeatureWriterMode::Skip,
+                    features: None,
+                },
+            ])
+        );
+    }
+
+    /// Exec the static metadata work over an in-memory glyphs source, returning
+    /// the error it is expected to produce.
+    fn feature_writers_error_from_glyphs_source(source: &str) -> Error {
+        let _ = env_logger::builder().is_test(true).try_init();
+        let source = GlyphsIrSource::new_from_memory(source).unwrap();
+        let context = Context::new_root(Flags::default(), None);
+        let task_context = context.copy_for_work(
+            Access::None,
+            AccessBuilder::new()
+                .variant(WorkId::StaticMetadata)
+                .variant(WorkId::PreliminaryGlyphOrder)
+                .variant(WorkId::PreliminaryGdefCategories)
+                .build(),
+        );
+        source
+            .create_static_metadata_work()
+            .unwrap()
+            .exec(&task_context)
+            .unwrap_err()
+    }
+
+    #[test]
+    fn unsupported_feature_writer_option_is_error() {
+        // glyphs stores the bool as an integer; ignoreMarks=false is honoured by
+        // ufo2ft but fontc can't match it, so it must be a hard error not a drop.
+        let error = feature_writers_error_from_glyphs_source(
+            r#"{
+.formatVersion = 3;
+fontMaster = ( { id = "m01"; } );
+unitsPerEm = 1000;
+userData = {
+com.github.googlei18n.ufo2ft.featureWriters = (
+{
+class = KernFeatureWriter;
+options = {
+ignoreMarks = 0;
+};
+}
+);
+};
+}"#,
+        );
+        assert!(matches!(error, Error::UnsupportedFeatureWriters(_)));
+    }
+
+    fn feature_writers_from_glyphs_source(source: &str) -> Option<Vec<FeatureWriterSpec>> {
+        let _ = env_logger::builder().is_test(true).try_init();
+        let source = GlyphsIrSource::new_from_memory(source).unwrap();
+        let context = Context::new_root(Flags::default(), None);
+        let task_context = context.copy_for_work(
+            Access::None,
+            AccessBuilder::new()
+                .variant(WorkId::StaticMetadata)
+                .variant(WorkId::PreliminaryGlyphOrder)
+                .variant(WorkId::PreliminaryGdefCategories)
+                .build(),
+        );
+        source
+            .create_static_metadata_work()
+            .unwrap()
+            .exec(&task_context)
+            .unwrap();
+        context.static_metadata.get().misc.feature_writers.clone()
+    }
+
+    #[test]
+    fn absent_feature_writers_key_is_none_from_user_data() {
+        let writers = feature_writers_from_glyphs_source(
+            r#"{
+.formatVersion = 3;
+fontMaster = ( { id = "m01"; } );
+unitsPerEm = 1000;
+}"#,
+        );
+        assert_eq!(writers, None);
     }
 }

--- a/resources/testdata/FeatureWriters.ufo/fontinfo.plist
+++ b/resources/testdata/FeatureWriters.ufo/fontinfo.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>familyName</key>
+    <string>FeatureWriters</string>
+    <key>unitsPerEm</key>
+    <integer>1000</integer>
+  </dict>
+</plist>

--- a/resources/testdata/FeatureWriters.ufo/glyphs/contents.plist
+++ b/resources/testdata/FeatureWriters.ufo/glyphs/contents.plist
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+  </dict>
+</plist>

--- a/resources/testdata/FeatureWriters.ufo/layercontents.plist
+++ b/resources/testdata/FeatureWriters.ufo/layercontents.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <array>
+    <array>
+      <string>public.default</string>
+      <string>glyphs</string>
+    </array>
+  </array>
+</plist>

--- a/resources/testdata/FeatureWriters.ufo/lib.plist
+++ b/resources/testdata/FeatureWriters.ufo/lib.plist
@@ -1,0 +1,18 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.github.googlei18n.ufo2ft.featureWriters</key>
+    <array>
+      <dict>
+        <key>class</key>
+        <string>KernFeatureWriter</string>
+        <key>options</key>
+        <dict>
+          <key>mode</key>
+          <string>skip</string>
+        </dict>
+      </dict>
+    </array>
+  </dict>
+</plist>

--- a/resources/testdata/FeatureWriters.ufo/metainfo.plist
+++ b/resources/testdata/FeatureWriters.ufo/metainfo.plist
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>formatVersion</key>
+    <integer>3</integer>
+  </dict>
+</plist>

--- a/resources/testdata/FeatureWritersAppend-Regular.ufo/features.fea
+++ b/resources/testdata/FeatureWritersAppend-Regular.ufo/features.fea
@@ -1,0 +1,6 @@
+languagesystem DFLT dflt;
+languagesystem latn dflt;
+
+feature kern {
+    position bar plus -100;
+} kern;

--- a/resources/testdata/FeatureWritersAppend-Regular.ufo/fontinfo.plist
+++ b/resources/testdata/FeatureWritersAppend-Regular.ufo/fontinfo.plist
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>unitsPerEm</key>
+    <integer>1000</integer>
+    <key>ascender</key>
+    <integer>800</integer>
+    <key>descender</key>
+    <integer>-200</integer>
+    <key>familyName</key>
+    <string>FeatureWriters Append</string>
+    <key>styleName</key>
+    <string>Regular</string>
+  </dict>
+</plist>

--- a/resources/testdata/FeatureWritersAppend-Regular.ufo/glyphs/bar.glif
+++ b/resources/testdata/FeatureWritersAppend-Regular.ufo/glyphs/bar.glif
@@ -1,0 +1,5 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="bar" format="2">
+  <advance width="517"/>
+  <unicode hex="007C"/>
+</glyph>

--- a/resources/testdata/FeatureWritersAppend-Regular.ufo/glyphs/contents.plist
+++ b/resources/testdata/FeatureWritersAppend-Regular.ufo/glyphs/contents.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>bar</key>
+    <string>bar.glif</string>
+    <key>plus</key>
+    <string>plus.glif</string>
+  </dict>
+</plist>

--- a/resources/testdata/FeatureWritersAppend-Regular.ufo/glyphs/plus.glif
+++ b/resources/testdata/FeatureWritersAppend-Regular.ufo/glyphs/plus.glif
@@ -1,0 +1,5 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="plus" format="2">
+  <advance width="557"/>
+  <unicode hex="002B"/>
+</glyph>

--- a/resources/testdata/FeatureWritersAppend-Regular.ufo/kerning.plist
+++ b/resources/testdata/FeatureWritersAppend-Regular.ufo/kerning.plist
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>bar</key>
+    <dict>
+      <key>bar</key>
+      <integer>-70</integer>
+    </dict>
+  </dict>
+</plist>

--- a/resources/testdata/FeatureWritersAppend-Regular.ufo/layercontents.plist
+++ b/resources/testdata/FeatureWritersAppend-Regular.ufo/layercontents.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <array>
+    <array>
+      <string>public.default</string>
+      <string>glyphs</string>
+    </array>
+  </array>
+</plist>

--- a/resources/testdata/FeatureWritersAppend-Regular.ufo/lib.plist
+++ b/resources/testdata/FeatureWritersAppend-Regular.ufo/lib.plist
@@ -1,0 +1,25 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>public.glyphOrder</key>
+    <array>
+      <string>bar</string>
+      <string>plus</string>
+    </array>
+    <key>com.github.googlei18n.ufo2ft.featureWriters</key>
+    <array>
+      <dict>
+        <key>class</key>
+        <string>KernFeatureWriter</string>
+        <key>module</key>
+        <string>ufo2ft.featureWriters.kernFeatureWriter</string>
+        <key>options</key>
+        <dict>
+          <key>mode</key>
+          <string>append</string>
+        </dict>
+      </dict>
+    </array>
+  </dict>
+</plist>

--- a/resources/testdata/FeatureWritersAppend-Regular.ufo/metainfo.plist
+++ b/resources/testdata/FeatureWritersAppend-Regular.ufo/metainfo.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>creator</key>
+    <string>com.github.fonttools.ufoLib</string>
+    <key>formatVersion</key>
+    <integer>3</integer>
+  </dict>
+</plist>

--- a/resources/testdata/fw_append.designspace
+++ b/resources/testdata/fw_append.designspace
@@ -1,0 +1,18 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- featureWriters KernFeatureWriter mode=append, key in the default master UFO lib -->
+<designspace format="4.1">
+  <axes>
+    <axis tag="wght" name="Weight" minimum="400" maximum="400" default="400"/>
+  </axes>
+  <sources>
+    <source filename="FeatureWritersAppend-Regular.ufo" name="FeatureWriters Append Regular" familyname="FeatureWriters Append" stylename="Regular">
+      <lib copy="1"/>
+      <groups copy="1"/>
+      <features copy="1"/>
+      <info copy="1"/>
+      <location>
+        <dimension name="Weight" xvalue="400"/>
+      </location>
+    </source>
+  </sources>
+</designspace>

--- a/resources/testdata/glyphs3/FeatureWritersCurs.glyphs
+++ b/resources/testdata/glyphs3/FeatureWritersCurs.glyphs
@@ -1,0 +1,62 @@
+{
+.appVersion = "3260";
+.formatVersion = 3;
+familyName = FeatureWritersCurs;
+fontMaster = (
+{
+id = m01;
+name = Regular;
+}
+);
+glyphs = (
+{
+glyphname = A;
+layers = (
+{
+anchors = (
+{
+name = entry;
+pos = (50,0);
+},
+{
+name = exit;
+pos = (450,0);
+}
+);
+layerId = m01;
+width = 500;
+}
+);
+}
+);
+kerningLTR = {
+m01 = {
+A = {
+A = -50;
+};
+};
+};
+unitsPerEm = 1000;
+userData = {
+com.github.googlei18n.ufo2ft.featureWriters = (
+{
+class = CursFeatureWriter;
+options = {
+mode = append;
+};
+},
+{
+class = KernFeatureWriter;
+options = {
+mode = append;
+};
+},
+{
+class = MarkFeatureWriter;
+options = {
+mode = skip;
+};
+}
+);
+};
+}

--- a/resources/testdata/glyphs3/FeatureWritersDefault.glyphs
+++ b/resources/testdata/glyphs3/FeatureWritersDefault.glyphs
@@ -1,0 +1,67 @@
+{
+.appVersion = "3260";
+.formatVersion = 3;
+familyName = FeatureWritersDefault;
+fontMaster = (
+{
+id = m01;
+name = Regular;
+}
+);
+glyphs = (
+{
+glyphname = A;
+layers = (
+{
+anchors = (
+{
+name = top;
+pos = (250,700);
+}
+);
+layerId = m01;
+width = 500;
+}
+);
+},
+{
+glyphname = gravecomb;
+unicode = 768;
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (250,0);
+}
+);
+layerId = m01;
+width = 0;
+}
+);
+},
+{
+glyphname = f_f;
+layers = (
+{
+anchors = (
+{
+name = caret_1;
+pos = (300,0);
+}
+);
+layerId = m01;
+width = 600;
+}
+);
+}
+);
+kerningLTR = {
+m01 = {
+A = {
+A = -50;
+};
+};
+};
+unitsPerEm = 1000;
+}

--- a/resources/testdata/glyphs3/FeatureWritersEmpty.glyphs
+++ b/resources/testdata/glyphs3/FeatureWritersEmpty.glyphs
@@ -1,0 +1,71 @@
+{
+.appVersion = "3260";
+.formatVersion = 3;
+familyName = FeatureWritersEmpty;
+fontMaster = (
+{
+id = m01;
+name = Regular;
+}
+);
+glyphs = (
+{
+glyphname = A;
+layers = (
+{
+anchors = (
+{
+name = top;
+pos = (250,700);
+}
+);
+layerId = m01;
+width = 500;
+}
+);
+},
+{
+glyphname = gravecomb;
+unicode = 768;
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (250,0);
+}
+);
+layerId = m01;
+width = 0;
+}
+);
+},
+{
+glyphname = f_f;
+layers = (
+{
+anchors = (
+{
+name = caret_1;
+pos = (300,0);
+}
+);
+layerId = m01;
+width = 600;
+}
+);
+}
+);
+kerningLTR = {
+m01 = {
+A = {
+A = -50;
+};
+};
+};
+unitsPerEm = 1000;
+userData = {
+com.github.googlei18n.ufo2ft.featureWriters = (
+);
+};
+}

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -21,10 +21,12 @@ use fontir::{
     error::{BadSource, BadSourceKind, Error},
     ir::{
         AnchorBuilder, Color, ColorGlyphs, ColorPalettes, Condition, ConditionSet,
-        DEFAULT_VENDOR_ID, FeaturesSource, GlobalMetric, GlobalMetricsBuilder, GlyphOrder,
-        KernGroup, KernSide, KerningInstance, KerningLocations, MetaTableValues, NameBuilder,
-        NameKey, NamedInstance, Paint, PaintGlyph, PaintSolid, Panose, PostscriptNames,
-        PreliminaryGdefCategories, Rule, StaticMetadata, Substitution, VariableFeature,
+        DEFAULT_VENDOR_ID, FEATURE_WRITERS_LIB_KEY, FeatureWriterOptionValue, FeatureWriterSpec,
+        FeaturesSource, GlobalMetric, GlobalMetricsBuilder, GlyphOrder, KernGroup, KernSide,
+        KerningInstance, KerningLocations, MetaTableValues, NameBuilder, NameKey, NamedInstance,
+        Paint, PaintGlyph, PaintSolid, Panose, PostscriptNames, PreliminaryGdefCategories, Rule,
+        StaticMetadata, Substitution, VariableFeature, reject_duplicate_writers,
+        validate_feature_writer,
     },
     orchestration::{Context, Flags, IrWork, WorkId},
     source::Source,
@@ -612,6 +614,87 @@ fn glyph_categories(
     Ok(categories)
 }
 
+/// Read the `com.github.googlei18n.ufo2ft.featureWriters` config from a lib dict.
+///
+/// The default master's UFO lib is already merged into `designspace.lib`, so this
+/// single lookup implements fontmake's precedence (designspace lib beats the
+/// default-master UFO lib). `None` means the key is absent (use the defaults);
+/// `Some` (including an empty list, or one where every entry was dropped) fully
+/// replaces them. Malformed entries warn and drop, mirroring fontmake; a
+/// malformed key or module and duplicate writers are hard errors.
+fn feature_writers_from_lib(lib: &Dictionary) -> Result<Option<Vec<FeatureWriterSpec>>, Error> {
+    let Some(value) = lib.get(FEATURE_WRITERS_LIB_KEY) else {
+        return Ok(None);
+    };
+    let Some(entries) = value.as_array() else {
+        // ufo2ft iterates whatever it finds and drops every element, silently
+        // building a font with no automatic features. A non-list value is always
+        // an authoring mistake; refusing loudly beats shipping a featureless font.
+        return Err(Error::UnsupportedFeatureWriters(
+            "featureWriters lib key is not a list".into(),
+        ));
+    };
+    let mut specs = Vec::new();
+    for entry in entries {
+        let Some(dict) = entry.as_dictionary() else {
+            warn!("featureWriters entry is not a dict; dropping");
+            continue;
+        };
+        let Some(class) = dict.get("class").and_then(Value::as_string) else {
+            warn!("featureWriters entry has no 'class'; dropping");
+            continue;
+        };
+        let module = match dict.get("module") {
+            None => None,
+            Some(value) => match value.as_string() {
+                Some(module) => Some(module),
+                // ufo2ft would fail the import and drop the entry; a non-string
+                // module is always an authoring mistake, so refuse loudly.
+                None => {
+                    return Err(Error::UnsupportedFeatureWriters(
+                        "featureWriters 'module' is not a string".into(),
+                    ));
+                }
+            },
+        };
+        let options = match dict.get("options") {
+            None => Vec::new(),
+            Some(Value::Dictionary(opts)) => opts
+                .iter()
+                .map(|(k, v)| (k.clone(), plist_to_feature_writer_option(v)))
+                .collect(),
+            Some(_) => {
+                warn!("featureWriters 'options' is not a dict; dropping");
+                continue;
+            }
+        };
+        if let Some(spec) = validate_feature_writer(class, module, &options)? {
+            specs.push(spec);
+        }
+    }
+    reject_duplicate_writers(&specs)?;
+    Ok(Some(specs))
+}
+
+fn plist_to_feature_writer_option(value: &Value) -> FeatureWriterOptionValue {
+    if let Some(b) = value.as_boolean() {
+        FeatureWriterOptionValue::Boolean(b)
+    } else if let Some(i) = value.as_signed_integer() {
+        FeatureWriterOptionValue::Integer(i)
+    } else if let Some(s) = value.as_string() {
+        FeatureWriterOptionValue::String(s.to_string())
+    } else if let Some(items) = value.as_array() {
+        items
+            .iter()
+            .map(|v| v.as_string().map(str::to_string))
+            .collect::<Option<Vec<_>>>()
+            .map(FeatureWriterOptionValue::Array)
+            .unwrap_or(FeatureWriterOptionValue::Other)
+    } else {
+        FeatureWriterOptionValue::Other
+    }
+}
+
 /// Generate preliminary GDEF categories from GlyphData.xml for UFO sources
 /// without explicit `public.openTypeCategories`.
 ///
@@ -1176,6 +1259,8 @@ impl Work<Context, WorkId, Error> for StaticMetadataWork {
         static_metadata.misc.meta_table = lib_plist
             .get("public.openTypeMeta")
             .and_then(parse_meta_table_values);
+
+        static_metadata.misc.feature_writers = feature_writers_from_lib(&self.designspace.lib)?;
 
         if let Some(gasp_records) = font_info_at_default.open_type_gasp_range_records.as_ref() {
             static_metadata.misc.gasp = gasp_records
@@ -2187,8 +2272,8 @@ mod tests {
     };
     use fontir::{
         ir::{
-            AnchorKind, GlobalMetricsInstance, GlyphOrder, NameKey, PostscriptNames,
-            test_helpers::Round2,
+            AnchorKind, FeatureWriterMode, FeatureWriterSpec, GlobalMetricsInstance, GlyphOrder,
+            KnownFeatureWriter, NameKey, PostscriptNames, test_helpers::Round2,
         },
         orchestration::{Context, Flags, WorkId},
         source::Source,
@@ -3767,5 +3852,142 @@ mod tests {
         // wght_var has glyphs "bar" and "plus" -- neither is a mark or ligature,
         // so categories will be empty but infer_from_anchors is still true
         assert!(cats.categories.is_empty());
+    }
+
+    fn feature_writers_of(
+        source_name: &str,
+        entries: Vec<Value>,
+    ) -> Option<Vec<FeatureWriterSpec>> {
+        let (_, context) = build_static_metadata_with(source_name, Flags::default(), |source| {
+            let ds = Arc::get_mut(&mut source.designspace).unwrap();
+            ds.lib
+                .insert(FEATURE_WRITERS_LIB_KEY.into(), Value::Array(entries));
+        });
+        context.static_metadata.get().misc.feature_writers.clone()
+    }
+
+    #[test]
+    fn reads_feature_writers_from_designspace_lib() {
+        let entry = plist_dict! {
+            "class" => "KernFeatureWriter",
+            "options" => plist_dict! { "mode" => "skip" },
+        };
+        let writers = feature_writers_of("wght_var.designspace", vec![entry.into()]).unwrap();
+        assert_eq!(
+            writers,
+            vec![FeatureWriterSpec {
+                writer: KnownFeatureWriter::Kern,
+                mode: FeatureWriterMode::Skip,
+                features: None,
+            }]
+        );
+    }
+
+    #[test]
+    fn malformed_feature_writer_entry_is_dropped() {
+        // The unknown class drops with a warning; the valid entry still applies.
+        let bad = plist_dict! { "class" => "BogusWriter" };
+        let good = plist_dict! { "class" => "CursFeatureWriter" };
+        let writers =
+            feature_writers_of("wght_var.designspace", vec![bad.into(), good.into()]).unwrap();
+        assert_eq!(
+            writers,
+            vec![FeatureWriterSpec {
+                writer: KnownFeatureWriter::Curs,
+                mode: FeatureWriterMode::Skip,
+                features: None,
+            }]
+        );
+    }
+
+    #[test]
+    fn empty_feature_writers_list_is_some_empty() {
+        assert_eq!(
+            feature_writers_of("wght_var.designspace", vec![]),
+            Some(vec![])
+        );
+    }
+
+    /// Build static metadata with the featureWriters lib key set to `value`,
+    /// returning the work result so error cases can be asserted.
+    fn static_metadata_with_feature_writers(value: Value) -> Result<(), Error> {
+        let mut source = load_designspace("wght_var.designspace");
+        let ds = Arc::get_mut(&mut source.designspace).unwrap();
+        ds.lib.insert(FEATURE_WRITERS_LIB_KEY.into(), value);
+        let context = Context::new_root(Flags::default(), None);
+        let task_context = context.copy_for_work(
+            Access::None,
+            AccessBuilder::new()
+                .variant(WorkId::StaticMetadata)
+                .variant(WorkId::PreliminaryGlyphOrder)
+                .variant(WorkId::PreliminaryGdefCategories)
+                .build(),
+        );
+        source
+            .create_static_metadata_work()
+            .unwrap()
+            .exec(&task_context)
+    }
+
+    #[test]
+    fn non_list_feature_writers_is_error() {
+        // ufo2ft would iterate-and-drop, silently building a featureless font;
+        // fontc refuses instead. Never a fallback to the built-in defaults.
+        let result = static_metadata_with_feature_writers(Value::String("nonsense".into()));
+        assert!(matches!(result, Err(Error::UnsupportedFeatureWriters(_))));
+    }
+
+    #[test]
+    fn non_string_feature_writer_module_is_error() {
+        // ufo2ft would fail the import and drop the entry; fontc refuses.
+        let entry = plist_dict! {
+            "class" => "KernFeatureWriter",
+            "module" => 123i64,
+        };
+        let result = static_metadata_with_feature_writers(Value::Array(vec![entry.into()]));
+        assert!(matches!(result, Err(Error::UnsupportedFeatureWriters(_))));
+    }
+
+    #[test]
+    fn duplicate_feature_writers_is_error() {
+        // ufo2ft runs every entry in order; fontc keeps one settings slot per
+        // writer, so it refuses rather than silently keeping only the last.
+        let first = plist_dict! { "class" => "KernFeatureWriter" };
+        let second = plist_dict! { "class" => "KernFeatureWriter" };
+        let result =
+            static_metadata_with_feature_writers(Value::Array(vec![first.into(), second.into()]));
+        assert!(matches!(result, Err(Error::UnsupportedFeatureWriters(_))));
+    }
+
+    #[test]
+    fn absent_feature_writers_key_is_none() {
+        let (_, context) = build_static_metadata("wght_var.designspace", Flags::default());
+        assert_eq!(context.static_metadata.get().misc.feature_writers, None);
+    }
+
+    #[test]
+    fn unsupported_feature_writer_option_is_error() {
+        let _ = env_logger::builder().is_test(true).try_init();
+        let entry = plist_dict! {
+            "class" => "KernFeatureWriter",
+            "options" => plist_dict! { "quantization" => 2i64 },
+        };
+        let result = static_metadata_with_feature_writers(Value::Array(vec![entry.into()]));
+        assert!(matches!(result, Err(Error::UnsupportedFeatureWriters(_))));
+    }
+
+    #[test]
+    fn reads_feature_writers_from_ufo_lib() {
+        // The default master's UFO lib is merged into the designspace lib, so a
+        // key set only in a raw .ufo's lib.plist is still read.
+        let (_, context) = build_static_metadata("FeatureWriters.ufo", Flags::default());
+        assert_eq!(
+            context.static_metadata.get().misc.feature_writers,
+            Some(vec![FeatureWriterSpec {
+                writer: KnownFeatureWriter::Kern,
+                mode: FeatureWriterMode::Skip,
+                features: None,
+            }])
+        );
     }
 }

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -1260,7 +1260,7 @@ impl Work<Context, WorkId, Error> for StaticMetadataWork {
             .get("public.openTypeMeta")
             .and_then(parse_meta_table_values);
 
-        static_metadata.misc.feature_writers = feature_writers_from_lib(&self.designspace.lib)?;
+        static_metadata.misc.feature_generation = feature_writers_from_lib(&self.designspace.lib)?;
 
         if let Some(gasp_records) = font_info_at_default.open_type_gasp_range_records.as_ref() {
             static_metadata.misc.gasp = gasp_records
@@ -3863,7 +3863,12 @@ mod tests {
             ds.lib
                 .insert(FEATURE_WRITERS_LIB_KEY.into(), Value::Array(entries));
         });
-        context.static_metadata.get().misc.feature_writers.clone()
+        context
+            .static_metadata
+            .get()
+            .misc
+            .feature_generation
+            .clone()
     }
 
     #[test]
@@ -3962,7 +3967,7 @@ mod tests {
     #[test]
     fn absent_feature_writers_key_is_none() {
         let (_, context) = build_static_metadata("wght_var.designspace", Flags::default());
-        assert_eq!(context.static_metadata.get().misc.feature_writers, None);
+        assert_eq!(context.static_metadata.get().misc.feature_generation, None);
     }
 
     #[test]
@@ -3982,7 +3987,7 @@ mod tests {
         // key set only in a raw .ufo's lib.plist is still read.
         let (_, context) = build_static_metadata("FeatureWriters.ufo", Flags::default());
         assert_eq!(
-            context.static_metadata.get().misc.feature_writers,
+            context.static_metadata.get().misc.feature_generation,
             Some(vec![FeatureWriterSpec {
                 writer: KnownFeatureWriter::Kern,
                 mode: FeatureWriterMode::Skip,


### PR DESCRIPTION
Adds support for the `com.github.googlei18n.ufo2ft.featureWriters` lib key (UFO/designspace lib and Glyphs font-level userData), so sources can disable individual automatic feature writers or request "append" placement instead of the default "skip" (or insert at marker) behavior.

fontc already implemented "skip" mode; this adds "append" (fea-rs learns forced append placement for generated features) and wires the key through fontir/ufo2fontir/glyphs2fontir to fontbe. Key absent means the default writer list, key present is a full replacement, an empty list disables all automatic features.

The plumbing: each frontend parses the key (the designspace lib, already merged with the default master's lib.plist, or the Glyphs font-level userData) into validated `FeatureWriterSpec` entries on `StaticMetadata.misc`, so validation fires once at IR-build time and the config rides the cached IR. Backends resolve that into a `FeatureWriterPlan`: one settings slot (`mode` + `features` subset) per writer, `None` meaning disabled, plus a bool for Gdef.
The plan is consulted at the generation sites: `feature_writer_todo_list `decides per tag whether to generate and whether to append; append-forced tags reach fea-rs through the new `FeatureBuilder::force_append` method, and the Gdef flag gates both the GDEF class-def overwrite and ligature caret generation.

Validation mirrors ufo2ft's current default `loadFeatureWriters(ignoreErrors=True)`: entries ufo2ft would fail to import (e.g. unknown writers, wrong module/class pairs) are warned and dropped, while recognized options that fontc currently doesn't implement (`ignoreMarks=false`, `quantization != 1`, `groupMarkClasses=true`, a valid GdefFeatureWriter `features=` subset, or the old `kernFeatureWriter2`) are hard errors. So we deliberately refuse rather than silently build something different, although some of these (quantization, kern2's lookup organization) could be worth implementing or decide to relaxe later.

The glyphsLib's legacy `ContextualMarkFeatureWriter` alias is accepted as a plain Mark writer, since glyphsLib >= 6.10 defines it as a shim subclass of ufo2ft's MarkFeatureWriter (when the latter gained contextual anchors support; btw, contextual anchor generation itself is tracked separately #551).

You'll note that in a few places fontc is deliberately stricter than ufo2ft: a non-list key value, a non-string module, and a writer listed more than once are hard errors where ufo2ft silently builds without the affected writers (or, for duplicates, runs every entry in order). AFAIK none of these appear in any crater source.

Also one known limitation: custom writer order is not honored for "append" placement (generated features keep the default curs -> kern -> marks merge order).

I verified ttx-diff identical to fontmake on Agdasima, NotoMusic, KumbhSans, Lunasima, Gulzar, NotoSansTakri, AkayaKanadaka and OpenSans' GPOS/GDEF tables.

I verified this with ttx_diff against fontmake: Agdasima, NotoMusic, KumbhSans, Gulzar, NotoSansTakri and AkayaKanadaka are identical; OpenSans Roman and Italic have identical GPOS/GDEF (pre-existing unrelated diffs untouched); Lunasima is identical except a pre-existing unrelated head flags diff (bit 8).

Fixes #1868, fixes #1045, fixes #1842, fixes #1843 (the latter three are older reports/manifestations of the ignored key).

PS: The stutter is mandatory: GitHub requires "full syntax for each issue" (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)... a parser that can close an issue but not cross a comma.


EDIT: I changed some names after review feedback in be9cf0e7: FeatureWriterPlan -> FeatureGenerationPlan, FeatureWriterSettings -> FeatureGenerationSettings, resolve_feature_writers -> resolve_feature_generation, and the misc.feature_writers field -> feature_generation.