### PR TITLE
Overlap detection & removal primitives

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ bitflags = "2.0"
 chrono = { version = "0.4.24", features = ["serde"] }
 indexmap = { version = "2.0", features = ["serde"] }
 kurbo = { version = "0.13.0", features = ["serde"] }
+linesweeper = "0.4.0"
 ordered-float = { version = "5.1.0", features = ["serde"] }
 smol_str = { version = "0.3.0", features = ["serde"] }
 regex = "1.7.1"

--- a/fontdrasil/Cargo.toml
+++ b/fontdrasil/Cargo.toml
@@ -11,6 +11,8 @@ categories = ["text-processing", "parsing", "graphics"]
 [features]
 
 [dependencies]
+linesweeper = "0.4.0"
+
 ordered-float.workspace = true
 smol_str.workspace = true
 serde.workspace = true

--- a/fontdrasil/Cargo.toml
+++ b/fontdrasil/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["text-processing", "parsing", "graphics"]
 [features]
 
 [dependencies]
-linesweeper = "0.4.0"
+linesweeper.workspace = true
 
 ordered-float.workspace = true
 smol_str.workspace = true

--- a/fontdrasil/src/lib.rs
+++ b/fontdrasil/src/lib.rs
@@ -4,6 +4,7 @@ pub mod agl;
 pub mod coords;
 pub mod error;
 pub mod orchestration;
+pub mod overlaps;
 pub mod paths;
 mod piecewise_linear_map;
 pub mod types;

--- a/fontdrasil/src/overlaps.rs
+++ b/fontdrasil/src/overlaps.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 /// An error from an overlap operation.
 #[derive(Debug, Error)]
 #[error(transparent)]
-pub struct OverlapError(#[from] linesweeper::Error);
+pub struct OverlapError(linesweeper::Error);
 
 /// Fill rule for interpreting which regions of a path are inside.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -16,11 +16,11 @@ pub enum FillRule {
     EvenOdd,
 }
 
-impl From<FillRule> for LsFillRule {
-    fn from(fill_rule: FillRule) -> Self {
-        match fill_rule {
-            FillRule::NonZero => Self::NonZero,
-            FillRule::EvenOdd => Self::EvenOdd,
+impl FillRule {
+    fn to_linesweeper(self) -> LsFillRule {
+        match self {
+            FillRule::NonZero => LsFillRule::NonZero,
+            FillRule::EvenOdd => LsFillRule::EvenOdd,
         }
     }
 }
@@ -40,12 +40,17 @@ pub fn remove_overlaps(
     // TODO: if linesweeper gave us an owned iterator, we could just have this method return a
     //       Contour iterator instead of a Vec<BezPath>, and then re-use it in has_overlaps without
     //       incurring allocation overhead
-    let beziers =
-        linesweeper::binary_op(bez_path, &BezPath::new(), fill_rule.into(), BinaryOp::Union)?
-            .contours()
-            .cloned()
-            .map(|contour| contour.path)
-            .collect::<Vec<_>>();
+    let beziers = linesweeper::binary_op(
+        bez_path,
+        &BezPath::new(),
+        fill_rule.to_linesweeper(),
+        BinaryOp::Union,
+    )
+    .map_err(OverlapError)?
+    .contours()
+    .cloned()
+    .map(|contour| contour.path)
+    .collect::<Vec<_>>();
     Ok(beziers)
 }
 
@@ -60,15 +65,17 @@ pub fn has_overlaps(bez_path: &BezPath) -> Result<bool, OverlapError> {
     let non_zero_beziers = linesweeper::binary_op(
         bez_path,
         &BezPath::new(),
-        FillRule::NonZero.into(),
+        LsFillRule::NonZero,
         BinaryOp::Union,
-    )?;
+    )
+    .map_err(OverlapError)?;
     let even_odd_beziers = linesweeper::binary_op(
         bez_path,
         &BezPath::new(),
-        FillRule::EvenOdd.into(),
+        LsFillRule::EvenOdd,
         BinaryOp::Union,
-    )?;
+    )
+    .map_err(OverlapError)?;
 
     // TODO: Could Contours implement PartialEq?
     //       Ok(non_zero_beziers != even_odd_beziers)

--- a/fontdrasil/src/overlaps.rs
+++ b/fontdrasil/src/overlaps.rs
@@ -56,7 +56,7 @@ pub fn has_overlaps(bez_path: &BezPath) -> Result<bool, linesweeper::Error> {
 
 #[cfg(test)]
 mod tests {
-    #![expect(clippy::indexing_slicing)]
+    #![expect(clippy::indexing_slicing, clippy::expect_used)]
     use super::*;
     use kurbo::{PathEl, Point};
 
@@ -73,5 +73,38 @@ mod tests {
 
         let ab = combine_paths(&[a, b]);
         assert_eq!(ab, BezPath::from_vec(full_path));
+    }
+
+    #[test]
+    fn detects_overlaps() {
+        // Artist's rendition:
+        //      ┌────────┐
+        //      │        │
+        //  ┌───┼────┐   │
+        //  │ A │    │ B │
+        //  │   └────┼───┘
+        //  │        │
+        //  └────────┘
+        let square_a = BezPath::from_vec(vec![
+            PathEl::MoveTo(Point::new(0.0, 0.0)),
+            PathEl::LineTo(Point::new(10.0, 0.0)),
+            PathEl::LineTo(Point::new(10.0, 10.0)),
+            PathEl::LineTo(Point::new(0.0, 10.0)),
+            PathEl::LineTo(Point::new(0.0, 0.0)),
+            PathEl::ClosePath,
+        ]);
+        let square_b = BezPath::from_vec(vec![
+            PathEl::MoveTo(Point::new(5.0, 5.0)),
+            PathEl::LineTo(Point::new(15.0, 5.0)),
+            PathEl::LineTo(Point::new(15.0, 15.0)),
+            PathEl::LineTo(Point::new(5.0, 15.0)),
+            PathEl::LineTo(Point::new(5.0, 5.0)),
+            PathEl::ClosePath,
+        ]);
+
+        let combined = combine_paths([&square_a, &square_b]);
+
+        let res = has_overlaps(&combined).expect("linesweeper should detect overlaps");
+        assert!(res, "overlaps should have been found");
     }
 }

--- a/fontdrasil/src/overlaps.rs
+++ b/fontdrasil/src/overlaps.rs
@@ -1,5 +1,11 @@
 use kurbo::BezPath;
 use linesweeper::{BinaryOp, FillRule};
+use thiserror::Error;
+
+/// An error from an overlap operation.
+#[derive(Debug, Error)]
+#[error(transparent)]
+pub struct OverlapError(#[from] linesweeper::Error);
 
 /// Combines one or more [`BezPath`]s into a single one by concatenating their elements.
 pub fn combine_paths<'a>(bez_paths: impl IntoIterator<Item = &'a BezPath>) -> BezPath {
@@ -12,7 +18,7 @@ pub fn combine_paths<'a>(bez_paths: impl IntoIterator<Item = &'a BezPath>) -> Be
 pub fn remove_overlaps(
     bez_path: &BezPath,
     fill_rule: FillRule,
-) -> Result<Vec<BezPath>, linesweeper::Error> {
+) -> Result<Vec<BezPath>, OverlapError> {
     // TODO: if linesweeper gave us an owned iterator, we could just have this method return a
     //       Contour iterator instead of a Vec<BezPath>, and then re-use it in has_overlaps without
     //       incurring allocation overhead
@@ -31,7 +37,7 @@ pub fn remove_overlaps(
 /// algorithms handle overlapping areas differently.
 ///
 /// If you have multiple beziers, you will need to [combine them](combine_paths) first.
-pub fn has_overlaps(bez_path: &BezPath) -> Result<bool, linesweeper::Error> {
+pub fn has_overlaps(bez_path: &BezPath) -> Result<bool, OverlapError> {
     let non_zero_beziers = linesweeper::binary_op(
         bez_path,
         &BezPath::new(),

--- a/fontdrasil/src/overlaps.rs
+++ b/fontdrasil/src/overlaps.rs
@@ -60,6 +60,17 @@ mod tests {
     use super::*;
     use kurbo::{PathEl, Point};
 
+    fn square(x0: f64, y0: f64, x1: f64, y1: f64) -> BezPath {
+        BezPath::from_vec(vec![
+            PathEl::MoveTo(Point::new(x0, y0)),
+            PathEl::LineTo(Point::new(x1, y0)),
+            PathEl::LineTo(Point::new(x1, y1)),
+            PathEl::LineTo(Point::new(x0, y1)),
+            PathEl::LineTo(Point::new(x0, y0)),
+            PathEl::ClosePath,
+        ])
+    }
+
     fn overlapping_squares() -> (BezPath, BezPath) {
         // Artist's rendition:
         //      ┌────────┐
@@ -69,23 +80,7 @@ mod tests {
         //  │   └────┼───┘
         //  │        │
         //  └────────┘
-        let square_a = BezPath::from_vec(vec![
-            PathEl::MoveTo(Point::new(0.0, 0.0)),
-            PathEl::LineTo(Point::new(10.0, 0.0)),
-            PathEl::LineTo(Point::new(10.0, 10.0)),
-            PathEl::LineTo(Point::new(0.0, 10.0)),
-            PathEl::LineTo(Point::new(0.0, 0.0)),
-            PathEl::ClosePath,
-        ]);
-        let square_b = BezPath::from_vec(vec![
-            PathEl::MoveTo(Point::new(5.0, 5.0)),
-            PathEl::LineTo(Point::new(15.0, 5.0)),
-            PathEl::LineTo(Point::new(15.0, 15.0)),
-            PathEl::LineTo(Point::new(5.0, 15.0)),
-            PathEl::LineTo(Point::new(5.0, 5.0)),
-            PathEl::ClosePath,
-        ]);
-        (square_a, square_b)
+        (square(0.0, 0.0, 10.0, 10.0), square(5.0, 5.0, 15.0, 15.0))
     }
 
     #[test]
@@ -147,5 +142,46 @@ mod tests {
 
         let res = has_overlaps(&combined).expect("linesweeper should detect overlaps");
         assert!(res, "overlaps should have been found");
+    }
+
+    #[test]
+    fn no_overlaps_in_disjoint_squares() {
+        //  ┌────────┐          ┌────────┐
+        //  │   A    │          │   B    │
+        //  └────────┘          └────────┘
+        let square_a = square(0.0, 0.0, 10.0, 10.0);
+        let far_square = square(20.0, 20.0, 30.0, 30.0);
+        let combined = combine_paths([&square_a, &far_square]);
+
+        let res = has_overlaps(&combined).expect("linesweeper should not error");
+        assert!(!res, "disjoint contours are not overlapping");
+    }
+
+    #[test]
+    fn no_overlaps_in_square_with_counter() {
+        // 'O'-style glyph: outer contour with an opposite-winding inner counter
+        //  ┌──────────────┐
+        //  │    outer     │
+        //  │  ┌────────┐  │
+        //  │  │counter │  │
+        //  │  └────────┘  │
+        //  └──────────────┘
+        let outer = square(0.0, 0.0, 10.0, 10.0);
+        let counter = square(2.0, 2.0, 8.0, 8.0).reverse_subpaths();
+        let combined = combine_paths([&outer, &counter]);
+
+        let res = has_overlaps(&combined).expect("linesweeper should not error");
+        assert!(!res, "a counter is not an overlap");
+    }
+
+    #[test]
+    fn detects_duplicate_contours() {
+        // identical contour twice: even-odd cancels them out, non-zero keeps one,
+        // so the two results differ in length
+        let square_a = square(0.0, 0.0, 10.0, 10.0);
+        let combined = combine_paths([&square_a, &square_a]);
+
+        let res = has_overlaps(&combined).expect("linesweeper should not error");
+        assert!(res, "duplicate contours are overlapping");
     }
 }

--- a/fontdrasil/src/overlaps.rs
+++ b/fontdrasil/src/overlaps.rs
@@ -58,7 +58,7 @@ pub fn has_overlaps(bez_path: &BezPath) -> Result<bool, linesweeper::Error> {
 mod tests {
     #![expect(clippy::indexing_slicing, clippy::expect_used)]
     use super::*;
-    use kurbo::{PathEl, Point};
+    use kurbo::{Circle, PathEl, Point, Shape};
 
     fn square(x0: f64, y0: f64, x1: f64, y1: f64) -> BezPath {
         BezPath::from_vec(vec![
@@ -69,6 +69,12 @@ mod tests {
             PathEl::LineTo(Point::new(x0, y0)),
             PathEl::ClosePath,
         ])
+    }
+
+    fn curve_count(path: &BezPath) -> usize {
+        path.iter()
+            .filter(|element| matches!(element, PathEl::CurveTo(..)))
+            .count()
     }
 
     fn overlapping_squares() -> (BezPath, BezPath) {
@@ -183,5 +189,72 @@ mod tests {
 
         let res = has_overlaps(&combined).expect("linesweeper should not error");
         assert!(res, "duplicate contours are overlapping");
+    }
+
+    #[test]
+    fn remove_overlaps_preserves_curves() {
+        let circle_a = Circle::new((0.0, 0.0), 100.0).to_path(0.01);
+        let input_curve_count = curve_count(&circle_a);
+        assert!(
+            input_curve_count > 0,
+            "the input circle should contain curves"
+        );
+
+        let result = remove_overlaps(&circle_a, FillRule::NonZero)
+            .expect("linesweeper should process a circle");
+        let [result] = result.as_slice() else {
+            panic!("a circle should remain a single contour");
+        };
+        assert_eq!(curve_count(result), input_curve_count);
+
+        //    .-"-.-"-.           .-"""""-.
+        //   ( A ( ) B )    ->   (  A ~ B  )
+        //    `-.-`-.-'           `-.....-'
+        let circle_b = Circle::new((80.0, 0.0), 100.0).to_path(0.01);
+        let combined = combine_paths([&circle_a, &circle_b]);
+        let input_curve_count = curve_count(&combined);
+        let result = remove_overlaps(&combined, FillRule::NonZero)
+            .expect("linesweeper should union overlapping circles");
+        let [result] = result.as_slice() else {
+            panic!("overlapping circles should produce a single contour");
+        };
+        assert!(
+            curve_count(result) >= input_curve_count - 2,
+            "unioning circles should preserve their curves"
+        );
+    }
+
+    #[test]
+    fn remove_overlaps_removes_all_overlaps() {
+        // removal must be complete: recombining its output and running detection
+        // on it should find nothing left to remove
+        let (square_a, square_b) = overlapping_squares();
+        let far_square = square(20.0, 20.0, 30.0, 30.0);
+        let counter = square(2.0, 2.0, 8.0, 8.0).reverse_subpaths();
+        let third_square = square(2.5, -5.0, 12.5, 5.0);
+        let circle_a = Circle::new((0.0, 0.0), 100.0).to_path(0.01);
+        let circle_b = Circle::new((80.0, 0.0), 100.0).to_path(0.01);
+        let fixtures = [
+            ("overlapping squares", combine_paths([&square_a, &square_b])),
+            ("disjoint squares", combine_paths([&square_a, &far_square])),
+            ("square with counter", combine_paths([&square_a, &counter])),
+            ("duplicate contours", combine_paths([&square_a, &square_a])),
+            ("single circle", circle_a.clone()),
+            ("overlapping circles", combine_paths([&circle_a, &circle_b])),
+            (
+                "triple overlap",
+                combine_paths([&square_a, &square_b, &third_square]),
+            ),
+        ];
+
+        for (name, input) in fixtures {
+            let result = remove_overlaps(&input, FillRule::NonZero)
+                .expect("linesweeper should remove overlaps");
+            let combined = combine_paths(&result);
+            let has_overlaps =
+                has_overlaps(&combined).expect("linesweeper should inspect the result");
+
+            assert!(!has_overlaps, "{name} still has overlaps after removal");
+        }
     }
 }

--- a/fontdrasil/src/overlaps.rs
+++ b/fontdrasil/src/overlaps.rs
@@ -1,0 +1,44 @@
+use kurbo::BezPath;
+use linesweeper::{BinaryOp, FillRule};
+
+pub fn combine_paths<'a>(bez_paths: impl IntoIterator<Item = &'a BezPath>) -> BezPath {
+    bez_paths.into_iter().flat_map(|path| path.iter()).collect()
+}
+
+pub fn remove_overlaps(
+    bez_path: &BezPath,
+    fill_rule: FillRule,
+) -> Result<Vec<BezPath>, linesweeper::Error> {
+    // TODO: if linesweeper gave us an owned iterator, we could just have this method return a
+    //       Contour iterator instead of a Vec<BezPath>, and then re-use it in has_overlaps without
+    //       incurring allocation overhead
+    let beziers = linesweeper::binary_op(bez_path, &BezPath::new(), fill_rule, BinaryOp::Union)?
+        .contours()
+        .cloned()
+        .map(|contour| contour.path)
+        .collect::<Vec<_>>();
+    Ok(beziers)
+}
+
+pub fn has_overlaps(bez_path: &BezPath) -> Result<bool, linesweeper::Error> {
+    let non_zero_beziers = linesweeper::binary_op(
+        bez_path,
+        &BezPath::new(),
+        FillRule::NonZero,
+        BinaryOp::Union,
+    )?;
+    let even_odd_beziers = linesweeper::binary_op(
+        bez_path,
+        &BezPath::new(),
+        FillRule::EvenOdd,
+        BinaryOp::Union,
+    )?;
+
+    // TODO: Could Contours implement PartialEq?
+    //       Ok(non_zero_beziers != even_odd_beziers)
+    let has_overlaps = Iterator::ne(
+        non_zero_beziers.contours().map(|nzc| &nzc.path),
+        even_odd_beziers.contours().map(|eoc| &eoc.path),
+    );
+    Ok(has_overlaps)
+}

--- a/fontdrasil/src/overlaps.rs
+++ b/fontdrasil/src/overlaps.rs
@@ -60,23 +60,7 @@ mod tests {
     use super::*;
     use kurbo::{PathEl, Point};
 
-    #[test]
-    fn combine_combines() {
-        let full_path = vec![
-            PathEl::MoveTo(Point::new(5., 5.)),
-            PathEl::LineTo(Point::new(15.0, 15.0)),
-            PathEl::MoveTo(Point::new(10., 10.)),
-            PathEl::LineTo(Point::new(15.0, 15.0)),
-        ];
-        let a = BezPath::from_iter(full_path[..2].iter().copied());
-        let b = BezPath::from_iter(full_path[2..].iter().copied());
-
-        let ab = combine_paths(&[a, b]);
-        assert_eq!(ab, BezPath::from_vec(full_path));
-    }
-
-    #[test]
-    fn detects_overlaps() {
+    fn overlapping_squares() -> (BezPath, BezPath) {
         // Artist's rendition:
         //      ┌────────┐
         //      │        │
@@ -101,7 +85,64 @@ mod tests {
             PathEl::LineTo(Point::new(5.0, 5.0)),
             PathEl::ClosePath,
         ]);
+        (square_a, square_b)
+    }
 
+    #[test]
+    fn combine_combines() {
+        let full_path = vec![
+            PathEl::MoveTo(Point::new(5., 5.)),
+            PathEl::LineTo(Point::new(15.0, 15.0)),
+            PathEl::MoveTo(Point::new(10., 10.)),
+            PathEl::LineTo(Point::new(15.0, 15.0)),
+        ];
+        let a = BezPath::from_iter(full_path[..2].iter().copied());
+        let b = BezPath::from_iter(full_path[2..].iter().copied());
+
+        let ab = combine_paths(&[a, b]);
+        assert_eq!(ab, BezPath::from_vec(full_path));
+    }
+
+    #[test]
+    fn merges_paths() {
+        let (square_a, square_b) = overlapping_squares();
+        let combined = combine_paths([&square_a, &square_b]);
+
+        let beziers = remove_overlaps(&combined, FillRule::NonZero)
+            .expect("linesweeper should remove overlaps");
+        let [bezier] = beziers.as_slice() else {
+            panic!(
+                "removing overlaps from two squares with non-zero fill should produce a single BezPath"
+            );
+        };
+
+        // Artist's rendition:
+        //      ┌────────┐
+        //      │        │
+        //  ┌───┘        │
+        //  │   A <3 B   │
+        //  │        ┌───┘
+        //  │        │
+        //  └────────┘
+        let expected = BezPath::from_vec(vec![
+            PathEl::MoveTo(Point::new(0.0, 10.0)),
+            PathEl::LineTo(Point::new(0.0, 0.0)),
+            PathEl::LineTo(Point::new(10.0, 0.0)),
+            PathEl::LineTo(Point::new(10.0, 5.0)),
+            PathEl::LineTo(Point::new(15.0, 5.0)),
+            PathEl::LineTo(Point::new(15.0, 15.0)),
+            PathEl::LineTo(Point::new(5.0, 15.0)),
+            PathEl::LineTo(Point::new(5.0, 10.0)),
+            PathEl::LineTo(Point::new(0.0, 10.0)),
+            PathEl::ClosePath,
+        ]);
+
+        assert_eq!(bezier, &expected);
+    }
+
+    #[test]
+    fn detects_overlaps() {
+        let (square_a, square_b) = overlapping_squares();
         let combined = combine_paths([&square_a, &square_b]);
 
         let res = has_overlaps(&combined).expect("linesweeper should detect overlaps");

--- a/fontdrasil/src/overlaps.rs
+++ b/fontdrasil/src/overlaps.rs
@@ -53,3 +53,25 @@ pub fn has_overlaps(bez_path: &BezPath) -> Result<bool, linesweeper::Error> {
     );
     Ok(has_overlaps)
 }
+
+#[cfg(test)]
+mod tests {
+    #![expect(clippy::indexing_slicing)]
+    use super::*;
+    use kurbo::{PathEl, Point};
+
+    #[test]
+    fn combine_combines() {
+        let full_path = vec![
+            PathEl::MoveTo(Point::new(5., 5.)),
+            PathEl::LineTo(Point::new(15.0, 15.0)),
+            PathEl::MoveTo(Point::new(10., 10.)),
+            PathEl::LineTo(Point::new(15.0, 15.0)),
+        ];
+        let a = BezPath::from_iter(full_path[..2].iter().copied());
+        let b = BezPath::from_iter(full_path[2..].iter().copied());
+
+        let ab = combine_paths(&[a, b]);
+        assert_eq!(ab, BezPath::from_vec(full_path));
+    }
+}

--- a/fontdrasil/src/overlaps.rs
+++ b/fontdrasil/src/overlaps.rs
@@ -1,11 +1,29 @@
 use kurbo::BezPath;
-use linesweeper::{BinaryOp, FillRule};
+use linesweeper::{BinaryOp, FillRule as LsFillRule};
 use thiserror::Error;
 
 /// An error from an overlap operation.
 #[derive(Debug, Error)]
 #[error(transparent)]
 pub struct OverlapError(#[from] linesweeper::Error);
+
+/// Fill rule for interpreting which regions of a path are inside.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FillRule {
+    /// Non-zero winding rule.
+    NonZero,
+    /// Even-odd winding rule.
+    EvenOdd,
+}
+
+impl From<FillRule> for LsFillRule {
+    fn from(fill_rule: FillRule) -> Self {
+        match fill_rule {
+            FillRule::NonZero => Self::NonZero,
+            FillRule::EvenOdd => Self::EvenOdd,
+        }
+    }
+}
 
 /// Combines one or more [`BezPath`]s into a single one by concatenating their elements.
 pub fn combine_paths<'a>(bez_paths: impl IntoIterator<Item = &'a BezPath>) -> BezPath {
@@ -22,11 +40,12 @@ pub fn remove_overlaps(
     // TODO: if linesweeper gave us an owned iterator, we could just have this method return a
     //       Contour iterator instead of a Vec<BezPath>, and then re-use it in has_overlaps without
     //       incurring allocation overhead
-    let beziers = linesweeper::binary_op(bez_path, &BezPath::new(), fill_rule, BinaryOp::Union)?
-        .contours()
-        .cloned()
-        .map(|contour| contour.path)
-        .collect::<Vec<_>>();
+    let beziers =
+        linesweeper::binary_op(bez_path, &BezPath::new(), fill_rule.into(), BinaryOp::Union)?
+            .contours()
+            .cloned()
+            .map(|contour| contour.path)
+            .collect::<Vec<_>>();
     Ok(beziers)
 }
 
@@ -41,13 +60,13 @@ pub fn has_overlaps(bez_path: &BezPath) -> Result<bool, OverlapError> {
     let non_zero_beziers = linesweeper::binary_op(
         bez_path,
         &BezPath::new(),
-        FillRule::NonZero,
+        FillRule::NonZero.into(),
         BinaryOp::Union,
     )?;
     let even_odd_beziers = linesweeper::binary_op(
         bez_path,
         &BezPath::new(),
-        FillRule::EvenOdd,
+        FillRule::EvenOdd.into(),
         BinaryOp::Union,
     )?;
 

--- a/fontdrasil/src/overlaps.rs
+++ b/fontdrasil/src/overlaps.rs
@@ -1,10 +1,14 @@
 use kurbo::BezPath;
 use linesweeper::{BinaryOp, FillRule};
 
+/// Combines one or more [`BezPath`]s into a single one by concatenating their elements.
 pub fn combine_paths<'a>(bez_paths: impl IntoIterator<Item = &'a BezPath>) -> BezPath {
     bez_paths.into_iter().flat_map(|path| path.iter()).collect()
 }
 
+/// Removes overlaps from a single [`BezPath`] using the given [`FillRule`].
+///
+/// If you have multiple beziers, you will need to [combine them](combine_paths) first.
 pub fn remove_overlaps(
     bez_path: &BezPath,
     fill_rule: FillRule,
@@ -20,6 +24,13 @@ pub fn remove_overlaps(
     Ok(beziers)
 }
 
+/// Checks if the given [`BezPath`] overlaps itself.
+///
+/// This is done by removing overlaps with [non-zero](FillRule::NonZero) and
+/// [even-odd](FillRule::EvenOdd) fill rules and seeing if the results are different, as these two
+/// algorithms handle overlapping areas differently.
+///
+/// If you have multiple beziers, you will need to [combine them](combine_paths) first.
 pub fn has_overlaps(bez_path: &BezPath) -> Result<bool, linesweeper::Error> {
     let non_zero_beziers = linesweeper::binary_op(
         bez_path,


### PR DESCRIPTION
This PR adds functions to concatenate `BezPath`s, as well as functions that use [`linesweeper`](https://radicle.network/nodes/rosa.radicle.network/rad%3Az2jbcL8tV3Fqqqk1yPyGkDTjgaTfH) to perform overlap removal & detection. In future PRs these can then be used to do overlap removal for statics (#717) and automatically set the overlap bit (#2061).

Outstanding questions:
1. Do we want to expose `linesweeper` types internally within the fontc crates? Currently `linesweeper::Error` is exposed.
2. Do we need to specify an epsilon value ourselves? `linesweeper` uses `1e-6` by default.
3. Is this code living in the right place? I can foresee `fontir` needing the overlap removal method and `fontbe` needing overlap detection, so my rationale was that the logic should go in the "general utilities & types" crate.
4. What sort of QA do we want around this code to be satisfied that it's doing the right thing? Tests are pretty minimal right now while this is a proof of concept, but when it comes to actually setting the overlap bit and such we probably want to be a lot more rigorous

For the TODOs in code that talk about potential linesweeper features, I have opened [an issue](https://radicle.network/nodes/rosa.radicle.network/rad%3Az2jbcL8tV3Fqqqk1yPyGkDTjgaTfH/issues/53ddb00297b3ca82056f3c588d66f1bac3efba52) and [a PR](https://radicle.network/nodes/rosa.radicle.network/rad%3Az2jbcL8tV3Fqqqk1yPyGkDTjgaTfH/patches/d4a09be08f0cd74d5f5c30f7c62a333d1135e122).