### PR TITLE
Migrate from env_logger to tracing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,9 @@ smol_str = { version = "0.3.0", features = ["serde"] }
 regex = "1.7.1"
 thiserror = "2.0"
 log = "0.4"
-env_logger = "0.11.0"
+tracing = "0.1"
+tracing-log = "0.2"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 parking_lot = "0.12.1"
 # "string" lets us pass a runtime-built version string to #[command(version = ...)]
 clap = { version = "4.0.32", features = ["derive", "string"] }

--- a/fea-rs/Cargo.toml
+++ b/fea-rs/Cargo.toml
@@ -27,7 +27,7 @@ indexmap.workspace = true
 thiserror.workspace = true
 ordered-float.workspace = true
 log.workspace = true
-env_logger.workspace = true
+tracing-subscriber.workspace = true
 
 [features]
 test = ["diff", "rayon", "serde", "serde_json", "clap"]

--- a/fea-rs/src/bin/compile.rs
+++ b/fea-rs/src/bin/compile.rs
@@ -24,7 +24,7 @@ fn main() {
 }
 
 fn run() -> Result<(), Error> {
-    env_logger::init();
+    tracing_subscriber::fmt().init();
     let args = Args::parse();
     let (fea, glyph_names) = args.get_inputs()?;
     if !fea.exists() {

--- a/fea-rs/src/bin/ttx_test.rs
+++ b/fea-rs/src/bin/ttx_test.rs
@@ -9,7 +9,7 @@ use fea_rs::util::ttx;
 static WIP_DIFF_DIR: &str = "./wip";
 
 fn main() {
-    env_logger::init();
+    tracing_subscriber::fmt().init();
     let args = Args::parse();
 
     let results = ttx::run_fonttools_tests(args.test_filter);

--- a/fea-rs/src/tests/compile.rs
+++ b/fea-rs/src/tests/compile.rs
@@ -21,14 +21,14 @@ static IMPORT_RESOLUTION_TEST: &str = "./test-data/include-resolution-tests/dir1
 // tests taken directly from fonttools; these require some special handling.
 #[test]
 fn fonttools_tests() -> Result<(), Report> {
-    let _ = env_logger::builder().is_test(true).try_init();
+    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
     test_utils::assert_has_ttx_executable();
     test_utils::run_fonttools_tests(None).into_error()
 }
 
 #[test]
 fn should_fail() -> Result<(), Report> {
-    let _ = env_logger::builder().is_test(true).try_init();
+    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
     let mut results = Vec::new();
     for (glyph_map, var_info, tests) in iter_test_groups(BAD_DIR) {
         results.extend(
@@ -42,7 +42,7 @@ fn should_fail() -> Result<(), Report> {
 
 #[test]
 fn import_resolution() {
-    let _ = env_logger::builder().is_test(true).try_init();
+    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
     let glyph_map = test_utils::fonttools_test_glyph_order();
     let path = PathBuf::from(IMPORT_RESOLUTION_TEST);
     match test_utils::run_test(path, &glyph_map, &Default::default()) {
@@ -53,7 +53,7 @@ fn import_resolution() {
 
 #[test]
 fn should_pass() -> Result<(), Report> {
-    let _ = env_logger::builder().is_test(true).try_init();
+    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
     let mut results = Vec::new();
 
     for (glyph_map, var_info, tests) in iter_test_groups(GOOD_DIR) {

--- a/fontbe/Cargo.toml
+++ b/fontbe/Cargo.toml
@@ -46,5 +46,5 @@ more-asserts.workspace = true
 temp-env.workspace = true
 rstest.workspace = true
 pretty_assertions.workspace = true
-env_logger.workspace = true
+tracing-subscriber.workspace = true
 otl-normalizer = { version = "0.3.0", path = "../otl-normalizer" }

--- a/fontbe/src/features.rs
+++ b/fontbe/src/features.rs
@@ -875,7 +875,7 @@ mod tests {
 
     #[test]
     fn resolve_kern() {
-        let _ = env_logger::builder().is_test(true).try_init();
+        let _ = tracing_subscriber::fmt().with_test_writer().try_init();
         let wght = Tag::new(b"wght");
         let static_metadata = weight_variable_static_metadata();
         let var_info = FeaVariationInfo::new(&static_metadata);

--- a/fontbe/src/features/kern.rs
+++ b/fontbe/src/features/kern.rs
@@ -2394,7 +2394,7 @@ mod tests {
     //https://github.com/googlefonts/ufo2ft/blob/01d3faee/tests/featureWriters/kernFeatureWriter_test.py#L1531
     #[test]
     fn kern_split_and_drop() {
-        let _ = env_logger::builder().is_test(true).try_init();
+        let _ = tracing_subscriber::fmt().with_test_writer().try_init();
         const ALPHA: char = 'α';
         const A_ORYA: char = '\u{B05}';
 

--- a/fontc/Cargo.toml
+++ b/fontc/Cargo.toml
@@ -36,9 +36,12 @@ bitflags.workspace = true
 serde.workspace = true
 serde_yaml.workspace = true
 
+chrono.workspace = true
 log.workspace = true
-env_logger.workspace = true
 thiserror.workspace = true
+tracing-log.workspace = true
+tracing-subscriber.workspace = true
+tracing.workspace = true
 
 indexmap.workspace = true
 regex.workspace = true

--- a/fontc/benches/compile.rs
+++ b/fontc/benches/compile.rs
@@ -35,7 +35,7 @@ const DEFAULT_FONT_SOURCES: &[FontSource<'static>] = &[
 ];
 
 fn compile_benchmark(c: &mut Criterion) {
-    env_logger::builder().is_test(true).try_init().ok();
+    let _ = tracing_subscriber::fmt().with_test_writer().try_init();
     let mut bench_group = c.benchmark_group("fontc-compile");
     // Criterion requires at least 10 samples. The compile time of fonts is large enough that 10
     // samples is enough to get an idea of acceptable performance.

--- a/fontc/src/args.rs
+++ b/fontc/src/args.rs
@@ -117,7 +117,7 @@ pub struct Args {
 
     /// Set the log level, either globally or per module. Defaults to warn.
     ///
-    /// See <https://docs.rs/env_logger/latest/env_logger/#enabling-logging> for format.
+    /// See <https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives> for format.
     #[arg(long)]
     pub log: Option<String>,
 }

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -414,7 +414,7 @@ mod tests {
     impl TestCompile {
         fn new(source_file: &str, adjust_options: impl Fn(Options) -> Options) -> TestCompile {
             let timer = JobTimer::new();
-            let _ = env_logger::builder().is_test(true).try_init();
+            let _ = tracing_subscriber::fmt().with_test_writer().try_init();
 
             let temp_dir = tempdir().unwrap();
             let options = adjust_options(Options::for_test(temp_dir.path()));
@@ -2711,7 +2711,7 @@ mod tests {
     // https://github.com/googlefonts/ufo2ft/issues/992.
     #[test]
     fn divergent_kern_groups_resolved_against_each_master() {
-        let _ = env_logger::builder().is_test(true).try_init();
+        let _ = tracing_subscriber::fmt().with_test_writer().try_init();
         let tmp = tempdir().unwrap();
         let designspace = write_kern_fixture(
             tmp.path(),
@@ -2808,7 +2808,7 @@ mod tests {
 
     #[test]
     fn kernless_master_divergent_groups_do_not_reach_reconciliation() {
-        let _ = env_logger::builder().is_test(true).try_init();
+        let _ = tracing_subscriber::fmt().with_test_writer().try_init();
         let tmp = tempdir().unwrap();
         let two = write_kern_fixture(
             &tmp.path().join("two"),
@@ -2848,7 +2848,7 @@ mod tests {
     // https://github.com/googlefonts/ufo2ft/issues/992.
     #[test]
     fn regrouped_kern_groups_refine_by_kerned_signature() {
-        let _ = env_logger::builder().is_test(true).try_init();
+        let _ = tracing_subscriber::fmt().with_test_writer().try_init();
         let tmp = tempdir().unwrap();
         let designspace = write_kern_fixture(
             tmp.path(),
@@ -4792,7 +4792,7 @@ mod tests {
 
     #[test]
     fn use_base_table_from_fea() {
-        let _ = env_logger::builder().is_test(true).try_init();
+        let _ = tracing_subscriber::fmt().with_test_writer().try_init();
         let result = TestCompile::compile_source("CustomBaseTableInFea.ufo");
         let font = result.font();
         let base = font.base().unwrap();
@@ -5542,7 +5542,7 @@ mod tests {
         // (in the lookup list) to be ordered like fontmake, which means sorted
         // by the glyphnames of the rules, not the GIDs.
 
-        let _ = env_logger::builder().is_test(true).try_init();
+        let _ = tracing_subscriber::fmt().with_test_writer().try_init();
         let result = TestCompile::compile_source("dspace_rules/Basic.designspace");
         let gsub = result.font().gsub().unwrap();
         let features = gsub.feature_list().unwrap();
@@ -5587,7 +5587,7 @@ mod tests {
         // do we put lookups in the right order?
         // - aalt goes at the front
         // - except for rvrn, which goes at the front-front
-        let _ = env_logger::builder().is_test(true).try_init();
+        let _ = tracing_subscriber::fmt().with_test_writer().try_init();
         let result = TestCompile::compile_source("dspace_rules/Basic.designspace");
         let gsub = result.font().gsub().unwrap();
         let feature_list = gsub.feature_list().unwrap();
@@ -5641,7 +5641,7 @@ mod tests {
     #[test]
     fn designspace_rvrn_feature_variation() {
         // do we create a feature variation record, pointing at the expected values?
-        let _ = env_logger::builder().is_test(true).try_init();
+        let _ = tracing_subscriber::fmt().with_test_writer().try_init();
         let result = TestCompile::compile_source("dspace_rules/Basic.designspace");
         let gsub = result.font().gsub().unwrap();
         let feature_list = gsub.feature_list().unwrap();
@@ -5666,7 +5666,7 @@ mod tests {
 
     #[test]
     fn glyphs_feature_variations() {
-        let _ = env_logger::builder().is_test(true).try_init();
+        let _ = tracing_subscriber::fmt().with_test_writer().try_init();
         let result = TestCompile::compile_source("glyphs3/LibreFranklin-bracketlayer.glyphs");
         let gsub = result.font().gsub().unwrap();
         let lookup_list = gsub.lookup_list().unwrap();
@@ -5694,7 +5694,7 @@ mod tests {
     #[test]
     fn glyphs_feature_variations_custom_feature() {
         // honor the 'Feature for Feature Variations' key
-        let _ = env_logger::builder().is_test(true).try_init();
+        let _ = tracing_subscriber::fmt().with_test_writer().try_init();
         let result = TestCompile::compile_source("glyphs2/WorkSans-minimal-bracketlayer.glyphs");
         let gsub = result.font().gsub().unwrap();
         let lookup_list = gsub.lookup_list().unwrap();
@@ -5710,7 +5710,7 @@ mod tests {
     #[test]
     fn glyphs_fea_include_file() {
         // ensure that we resolve inclue statements in glyphs sources
-        let _ = env_logger::builder().is_test(true).try_init();
+        let _ = tracing_subscriber::fmt().with_test_writer().try_init();
         let result = TestCompile::compile_source("glyphs_fea_include/glyphs_include.glyphs");
         let gsub = result.font().gsub().unwrap();
         let feature_list = gsub.feature_list().unwrap();

--- a/fontc/src/main.rs
+++ b/fontc/src/main.rs
@@ -1,13 +1,60 @@
 use std::io::Write;
 
 use clap::Parser;
+use tracing::{error, warn};
+use tracing_log::NormalizeEvent;
+use tracing_subscriber::{
+    EnvFilter,
+    fmt::{FmtContext, FormatEvent, FormatFields, format::Writer},
+    registry::LookupSpan,
+};
 
 mod args;
 
 use args::Args;
 use fontbe::orchestration::AnyWorkId;
 use fontc::{Error, JobTimer};
-use log::{error, warn};
+
+struct LogFormatter;
+
+impl<S, N> FormatEvent<S, N> for LogFormatter
+where
+    S: tracing::Subscriber + for<'a> LookupSpan<'a>,
+    N: for<'a> FormatFields<'a> + 'static,
+{
+    fn format_event(
+        &self,
+        ctx: &FmtContext<'_, S, N>,
+        mut writer: Writer<'_>,
+        event: &tracing::Event<'_>,
+    ) -> std::fmt::Result {
+        let normalized_meta = event.normalized_metadata();
+        let meta = normalized_meta.as_ref().unwrap_or_else(|| event.metadata());
+        let ts = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Micros, true);
+        let thread_id = std::thread::current().id();
+        let target = meta.target();
+        let level = meta.level();
+
+        if writer.has_ansi_escapes() {
+            let (style_start, style_end) = match *level {
+                tracing::Level::ERROR => ("\x1b[1;31m", "\x1b[0m"),
+                tracing::Level::WARN => ("\x1b[33m", "\x1b[0m"),
+                tracing::Level::INFO => ("\x1b[32m", "\x1b[0m"),
+                tracing::Level::DEBUG => ("\x1b[34m", "\x1b[0m"),
+                tracing::Level::TRACE => ("\x1b[36m", "\x1b[0m"),
+            };
+            write!(
+                writer,
+                "[{ts} {thread_id:?} {target} {style_start}{level}{style_end}] "
+            )?;
+        } else {
+            write!(writer, "[{ts} {thread_id:?} {target} {level}] ")?;
+        }
+
+        ctx.format_fields(writer.by_ref(), event)?;
+        writeln!(writer)
+    }
+}
 
 fn main() {
     let args = Args::parse();
@@ -18,7 +65,7 @@ fn main() {
         let mut error_displayed = false;
         let mut additional = "";
         if let Error::Backend(fontbe::error::Error::FeaCompileError(e)) = &e {
-            if log::log_enabled!(log::Level::Warn) {
+            if tracing::enabled!(tracing::Level::WARN) {
                 error!("{e}");
                 if let Some(diagnostic) = e.diagnostics() {
                     warn!("{}", diagnostic.display());
@@ -47,24 +94,19 @@ fn run(args: Args) -> Result<(), Error> {
         .queued()
         .run();
     // default to WARN; RUST_LOG or --log can still override
-    let mut log_cfg =
-        env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("warn"));
-    log_cfg.format(|buf, record| {
-        let ts = buf.timestamp_micros();
-        let style = buf.default_level_style(record.level());
-        writeln!(
-            buf,
-            "[{ts} {:?} {} {style}{}{style:#}] {}",
-            std::thread::current().id(),
-            record.target(),
-            record.level(),
-            record.args()
-        )
-    });
-    if let Some(log_filters) = &args.log {
-        log_cfg.parse_filters(log_filters);
-    }
-    log_cfg.init();
+    let filter = if let Some(log_filters) = &args.log {
+        EnvFilter::builder()
+            .with_default_directive(tracing::level_filters::LevelFilter::WARN.into())
+            .parse_lossy(log_filters)
+    } else {
+        EnvFilter::builder()
+            .with_default_directive(tracing::level_filters::LevelFilter::WARN.into())
+            .from_env_lossy()
+    };
+    tracing_subscriber::fmt()
+        .event_format(LogFormatter)
+        .with_env_filter(filter)
+        .init();
     timer.add(time.complete());
 
     let input = args.source()?;

--- a/fontc_crater/Cargo.toml
+++ b/fontc_crater/Cargo.toml
@@ -23,6 +23,6 @@ clap.workspace = true
 serde_yaml.workspace = true
 serde_json.workspace = true
 tempfile.workspace = true
-env_logger.workspace = true
+tracing-subscriber.workspace = true
 log.workspace = true
 

--- a/fontc_crater/src/main.rs
+++ b/fontc_crater/src/main.rs
@@ -26,7 +26,7 @@ use error::Error;
 use target::{BuildType, Target};
 
 fn main() {
-    env_logger::init();
+    tracing_subscriber::fmt().init();
     let args = Args::parse();
     if let Err(e) = run(&args) {
         eprintln!("{e}");

--- a/fontdrasil/Cargo.toml
+++ b/fontdrasil/Cargo.toml
@@ -16,7 +16,6 @@ smol_str.workspace = true
 serde.workspace = true
 write-fonts.workspace = true
 log.workspace = true
-env_logger.workspace = true
 thiserror.workspace = true
 kurbo.workspace = true
 
@@ -24,6 +23,7 @@ kurbo.workspace = true
 diff.workspace = true
 tempfile.workspace = true
 pretty_assertions.workspace = true
+tracing-subscriber.workspace = true
 
 [lints.clippy]
 unwrap_used = "deny"

--- a/fontdrasil/src/util.rs
+++ b/fontdrasil/src/util.rs
@@ -135,7 +135,7 @@ mod tests {
 
     #[test]
     fn composite_cycle() {
-        let _ = env_logger::builder().is_test(true).try_init();
+        let _ = tracing_subscriber::fmt().with_test_writer().try_init();
         let glyphs = GlyphSetBuilder::default()
             .add("A", &["B"])
             .add("B", &["A"])
@@ -148,7 +148,7 @@ mod tests {
 
     #[test]
     fn composite_not_a_cycle() {
-        let _ = env_logger::builder().is_test(true).try_init();
+        let _ = tracing_subscriber::fmt().with_test_writer().try_init();
         let glyphs = GlyphSetBuilder::default()
             .add("A", &[])
             .add("B", &["A", "D"])

--- a/fontir/Cargo.toml
+++ b/fontir/Cargo.toml
@@ -24,7 +24,6 @@ ordered-float.workspace = true
 indexmap.workspace = true
 
 log.workspace = true
-env_logger.workspace = true
 
 write-fonts.workspace = true  # for pens
 
@@ -42,8 +41,9 @@ parking_lot.workspace = true
 parking_lot = { version = "0.12.3", features = ["nightly"] }
 
 [dev-dependencies]
-diff.workspace = true
-tempfile.workspace = true
-pretty_assertions.workspace = true
 bincode.workspace = true
+diff.workspace = true
+pretty_assertions.workspace = true
 rstest.workspace = true
+tempfile.workspace = true
+tracing-subscriber.workspace = true

--- a/fontir/src/glyph.rs
+++ b/fontir/src/glyph.rs
@@ -2008,7 +2008,7 @@ mod tests {
 
     #[test]
     fn non_export_component_has_intermediate_layer() {
-        let _ = env_logger::builder().is_test(true).try_init();
+        let _ = tracing_subscriber::fmt().with_test_writer().try_init();
         // https://github.com/googlefonts/fontc/issues/1592
         let [loc1, intermediate, loc2] = make_wght_locations([0.0, 0.5, 1.0]);
 
@@ -2110,7 +2110,7 @@ mod tests {
     // this tests that we also interpolate the component transform.
     #[test]
     fn nested_composite_with_intermediate_layer_not_present_in_component() {
-        let _ = env_logger::builder().is_test(true).try_init();
+        let _ = tracing_subscriber::fmt().with_test_writer().try_init();
         let [loc1, intermediate, loc2] = make_wght_locations([0.0, 0.5, 1.0]);
 
         let mut composite = TestGlyph::new("a");
@@ -2163,7 +2163,7 @@ mod tests {
     fn composite_with_intermediate_component_layer_and_another_nested_compoonent_without_intermediates()
      {
         // based on ecaron in Savate.glyphs
-        let _ = env_logger::builder().is_test(true).try_init();
+        let _ = tracing_subscriber::fmt().with_test_writer().try_init();
 
         let [loc1, intermediate, loc2] = make_wght_locations([0.0, 0.5, 1.0]);
         let mut ecaron = TestGlyph::new("ecaron");

--- a/fontir/src/ir/erase_open_corners.rs
+++ b/fontir/src/ir/erase_open_corners.rs
@@ -875,7 +875,7 @@ mod tests {
     // hit (in this case fonttools returns the hit with the lowest `t0`)
     #[test]
     fn seg_seg_intersect_order() {
-        let _ = env_logger::builder().is_test(true).try_init();
+        let _ = tracing_subscriber::fmt().with_test_writer().try_init();
         let seg1 = PathSeg::Cubic(CubicBez::new(
             (21.0, 34.0),
             (21.0, 33.0),
@@ -913,7 +913,7 @@ mod tests {
     // operation order of the divide/conquer calls in curve_curve_intersection_py
     #[test]
     fn curve_curve_intersect_order() {
-        let _ = env_logger::builder().is_test(true).try_init();
+        let _ = tracing_subscriber::fmt().with_test_writer().try_init();
         let seg1 = CubicBez::new(
             (336.0, 150.0),
             (340.0, 151.0),
@@ -936,7 +936,7 @@ mod tests {
 
     #[test]
     fn corner_with_t() {
-        let _ = env_logger::builder().is_test(true).try_init();
+        let _ = tracing_subscriber::fmt().with_test_writer().try_init();
         let mut path = BezPath::new();
         path.move_to((11.0, 4.0));
         path.line_to((17.0, 34.0));

--- a/fontra2fontir/Cargo.toml
+++ b/fontra2fontir/Cargo.toml
@@ -17,7 +17,6 @@ fontir = { version = "0.5.0", path = "../fontir" }
 write-fonts.workspace = true
 
 log.workspace = true
-env_logger.workspace = true
 
 thiserror.workspace = true
 

--- a/glyphs-reader/Cargo.toml
+++ b/glyphs-reader/Cargo.toml
@@ -24,7 +24,6 @@ thiserror.workspace = true
 icu_properties.workspace = true
 
 log.workspace = true
-env_logger.workspace = true
 
 regex.workspace = true
 
@@ -35,3 +34,4 @@ serde.workspace = true
 [dev-dependencies]
 pretty_assertions.workspace = true
 rstest.workspace = true
+tracing-subscriber.workspace = true

--- a/glyphs-reader/src/corner_components.rs
+++ b/glyphs-reader/src/corner_components.rs
@@ -586,7 +586,7 @@ mod tests {
     #[case::ax_curved_instroke2("ax_curved_instroke2")]
     // ported from glyphsLib: https://github.com/googlefonts/glyphsLib/blob/f90e4060ba/tests/corner_components_test.py#L14
     fn test_corner_components(#[case] glyph_name: &str) {
-        let _ = env_logger::builder().is_test(true).try_init();
+        let _ = tracing_subscriber::fmt().with_test_writer().try_init();
         // Skip glyphs with left_anchor as noted in the Python test
         if glyph_name.contains("left_anchor") {
             // In rstest we can't easily skip tests, so we just return early

--- a/glyphs-reader/src/font.rs
+++ b/glyphs-reader/src/font.rs
@@ -4392,7 +4392,7 @@ mod tests {
 
     fn assert_load_v2_matches_load_v3(name: &str, compare: LoadCompare) {
         let has_package = matches!(compare, LoadCompare::GlyphsAndPackage);
-        let _ = env_logger::builder().is_test(true).try_init();
+        let _ = tracing_subscriber::fmt().with_test_writer().try_init();
         let filename = format!("{name}.glyphs");
         let pkgname = format!("{name}.glyphspackage");
         let g2_file = glyphs2_dir().join(filename.clone());
@@ -4671,7 +4671,7 @@ mod tests {
 
     #[test]
     fn glyph_order_override_obeyed() {
-        let _ = env_logger::builder().is_test(true).try_init();
+        let _ = tracing_subscriber::fmt().with_test_writer().try_init();
         let font = Font::load(&glyphs3_dir().join("WghtVar_GlyphOrder.glyphs")).unwrap();
         assert_eq!(vec!["hyphen", "space", "exclam"], font.glyph_order);
     }
@@ -5925,7 +5925,7 @@ etc;
 
     #[test]
     fn user_to_design_with_no_axes() {
-        let _ = env_logger::builder().is_test(true).try_init();
+        let _ = tracing_subscriber::fmt().with_test_writer().try_init();
         let mut myfont = RawFont {
             font_master: vec![RawFontMaster {
                 custom_parameters: RawCustomParameters(vec![make_axis_location_params(&[(
@@ -5941,7 +5941,7 @@ etc;
 
     #[test]
     fn user_to_design_with_unknown_axis_location() {
-        let _ = env_logger::builder().is_test(true).try_init();
+        let _ = tracing_subscriber::fmt().with_test_writer().try_init();
         let mut myfont = RawFont {
             axes: vec![Axis {
                 name: "Weight".into(),

--- a/glyphs-reader/src/plist.rs
+++ b/glyphs-reader/src/plist.rs
@@ -1065,7 +1065,7 @@ mod tests {
     // in arrays the trailing comma is optional but supported
     #[test]
     fn array_optional_trailing_comma() {
-        let _ = env_logger::builder().is_test(true).try_init();
+        let _ = tracing_subscriber::fmt().with_test_writer().try_init();
         // we include a list that is not parsed in derive because that
         // takes a second codepath.
         let trailing = r#"

--- a/glyphs2fontir/Cargo.toml
+++ b/glyphs2fontir/Cargo.toml
@@ -17,7 +17,6 @@ glyphs-reader = { version = "0.5.0", path = "../glyphs-reader" }
 
 smol_str.workspace = true
 log.workspace = true
-env_logger.workspace = true
 
 thiserror.workspace = true
 
@@ -33,3 +32,4 @@ chrono.workspace = true
 diff.workspace = true
 tempfile.workspace = true
 pretty_assertions.workspace = true
+tracing-subscriber.workspace = true

--- a/glyphs2fontir/src/source.rs
+++ b/glyphs2fontir/src/source.rs
@@ -2289,7 +2289,7 @@ mod tests {
     }
 
     fn build_static_metadata(glyphs_file: PathBuf) -> (impl Source, Context) {
-        let _ = env_logger::builder().is_test(true).try_init();
+        let _ = tracing_subscriber::fmt().with_test_writer().try_init();
         let (source, context) = context_for(&glyphs_file);
         let task_context = context.copy_for_work(
             Access::None,
@@ -4245,7 +4245,7 @@ unitsPerEm = 1000;
 
     #[test]
     fn reads_feature_writers_from_font_user_data() {
-        let _ = env_logger::builder().is_test(true).try_init();
+        let _ = tracing_subscriber::fmt().with_test_writer().try_init();
         // NotoMusic-shaped config: curs+kern appended, mark skipped, no Gdef writer.
         let source = GlyphsIrSource::new_from_memory(
             r#"{
@@ -4320,7 +4320,7 @@ mode = skip;
     /// Exec the static metadata work over an in-memory glyphs source, returning
     /// the error it is expected to produce.
     fn feature_writers_error_from_glyphs_source(source: &str) -> Error {
-        let _ = env_logger::builder().is_test(true).try_init();
+        let _ = tracing_subscriber::fmt().with_test_writer().try_init();
         let source = GlyphsIrSource::new_from_memory(source).unwrap();
         let context = Context::new_root(Flags::default(), None);
         let task_context = context.copy_for_work(
@@ -4363,7 +4363,7 @@ ignoreMarks = 0;
     }
 
     fn feature_writers_from_glyphs_source(source: &str) -> Option<Vec<FeatureWriterSpec>> {
-        let _ = env_logger::builder().is_test(true).try_init();
+        let _ = tracing_subscriber::fmt().with_test_writer().try_init();
         let source = GlyphsIrSource::new_from_memory(source).unwrap();
         let context = Context::new_root(Flags::default(), None);
         let task_context = context.copy_for_work(

--- a/ufo2fontir/Cargo.toml
+++ b/ufo2fontir/Cargo.toml
@@ -22,7 +22,6 @@ serde_yaml.workspace = true
 smol_str.workspace = true
 
 log.workspace = true
-env_logger.workspace = true
 
 thiserror.workspace = true
 
@@ -42,3 +41,4 @@ diff.workspace = true
 tempfile.workspace = true
 pretty_assertions.workspace = true
 rstest.workspace = true
+tracing-subscriber.workspace = true

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -2405,7 +2405,7 @@ mod tests {
         flags: Flags,
         modify: F,
     ) -> (DesignSpaceIrSource, Context) {
-        let _ = env_logger::builder().is_test(true).try_init();
+        let _ = tracing_subscriber::fmt().with_test_writer().try_init();
         let mut source = load_designspace(name);
         modify(&mut source);
         let context = Context::new_root(flags, None);
@@ -3972,7 +3972,7 @@ mod tests {
 
     #[test]
     fn unsupported_feature_writer_option_is_error() {
-        let _ = env_logger::builder().is_test(true).try_init();
+        let _ = tracing_subscriber::fmt().with_test_writer().try_init();
         let entry = plist_dict! {
             "class" => "KernFeatureWriter",
             "options" => plist_dict! { "quantization" => 2i64 },


### PR DESCRIPTION
Use `tracing` instead of `env_logger`. The functionality is mostly the same, but the directives available for the `--log` flag are slightly different
- `--log debug|info|warn|error` still works
- Filtering and more advanced stuff has different syntax. See docs for [env_logger](https://docs.rs/env_logger/latest/env_logger/#filtering-results) and [tracing](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#example-syntax)
- Motivation: Enables #2077 for better performance traces.

# Before

<img width="1655" height="147" alt="image" src="https://github.com/user-attachments/assets/4282f15d-a64f-4ffc-b611-c04808b43c6b" />

# After

<img width="1648" height="140" alt="image" src="https://github.com/user-attachments/assets/2e00ba54-4c71-42f3-a5b5-27ee9cb93aae" />
