### PR TITLE
Fixup how we init tracing_subscriber

### DIFF
--- a/fea-rs/src/bin/compile.rs
+++ b/fea-rs/src/bin/compile.rs
@@ -24,7 +24,7 @@ fn main() {
 }
 
 fn run() -> Result<(), Error> {
-    tracing_subscriber::fmt().init();
+    tracing_subscriber::fmt::init();
     let args = Args::parse();
     let (fea, glyph_names) = args.get_inputs()?;
     if !fea.exists() {

--- a/fea-rs/src/bin/ttx_test.rs
+++ b/fea-rs/src/bin/ttx_test.rs
@@ -9,7 +9,7 @@ use fea_rs::util::ttx;
 static WIP_DIFF_DIR: &str = "./wip";
 
 fn main() {
-    tracing_subscriber::fmt().init();
+    tracing_subscriber::fmt::init();
     let args = Args::parse();
 
     let results = ttx::run_fonttools_tests(args.test_filter);

--- a/fontc_crater/src/main.rs
+++ b/fontc_crater/src/main.rs
@@ -26,7 +26,8 @@ use error::Error;
 use target::{BuildType, Target};
 
 fn main() {
-    tracing_subscriber::fmt().init();
+    // note: the free fn, not `fmt().init()`; only this one reads RUST_LOG
+    tracing_subscriber::fmt::init();
     let args = Args::parse();
     if let Err(e) = run(&args) {
         eprintln!("{e}");


### PR DESCRIPTION
Funny gotcha in this crate, but ::fmt()::init() creates a builder and then inits it without looking at the environment; and ::fmt::init() calls a free fn in the fmt module that _does_ look at the environment. (I was seeing an issue where doing `RUST_LOG=debug cargo run fontc_crater --etc --etc` wasn't showing me the expected log messages)


JMM