### PR TITLE
fea-rs: accept bare defaults in variable metrics

### DIFF
--- a/fea-rs/src/compile/compile_ctx.rs
+++ b/fea-rs/src/compile/compile_ctx.rs
@@ -1338,20 +1338,22 @@ impl<'a, F: FeatureProvider, V: VariationInfo> CompilationCtx<'a, F, V> {
         let mut locations = HashMap::new();
         for metric_loc in metric.location_values() {
             let mut pos = NormalizedLocation::new();
-            for axis_value in metric_loc.location().items() {
-                let tag = axis_value.axis_tag().to_raw();
-                // All the tags are valid if we made it here, safe to unwrap
-                let (_, axis) = var_info.axis(tag).unwrap();
-                let coord = match axis_value.value().parse() {
-                    super::AxisLocation::Normalized(value) => NormalizedCoord::new(value),
-                    super::AxisLocation::User(value) => {
-                        UserCoord::new(value).to_normalized(&axis.converter)
-                    }
-                    super::AxisLocation::Design(value) => {
-                        DesignCoord::new(value).to_normalized(&axis.converter)
-                    }
-                };
-                pos.insert(tag, coord);
+            if let Some(location) = metric_loc.location() {
+                for axis_value in location.items() {
+                    let tag = axis_value.axis_tag().to_raw();
+                    // All the tags are valid if we made it here, safe to unwrap
+                    let (_, axis) = var_info.axis(tag).unwrap();
+                    let coord = match axis_value.value().parse() {
+                        super::AxisLocation::Normalized(value) => NormalizedCoord::new(value),
+                        super::AxisLocation::User(value) => {
+                            UserCoord::new(value).to_normalized(&axis.converter)
+                        }
+                        super::AxisLocation::Design(value) => {
+                            DesignCoord::new(value).to_normalized(&axis.converter)
+                        }
+                    };
+                    pos.insert(tag, coord);
+                }
             }
             locations.insert(pos, metric_loc.value().parse_signed());
         }

--- a/fea-rs/src/compile/validate.rs
+++ b/fea-rs/src/compile/validate.rs
@@ -1377,8 +1377,19 @@ impl<'a, V: VariationInfo> ValidationCtx<'a, V> {
             return;
         };
 
+        let mut bare_default_seen = false;
         for location_val in metric.location_values() {
-            for item in location_val.location().items() {
+            let Some(location) = location_val.location() else {
+                if bare_default_seen {
+                    self.error(
+                        location_val.range(),
+                        "duplicate value for the default location",
+                    );
+                }
+                bare_default_seen = true;
+                continue;
+            };
+            for item in location.items() {
                 let Some((_, axis)) = var_info.axis(item.axis_tag().to_raw()) else {
                     self.error(item.axis_tag().range(), "unknown axis");
                     continue;

--- a/fea-rs/src/parse/grammar/metrics.rs
+++ b/fea-rs/src/parse/grammar/metrics.rs
@@ -114,7 +114,7 @@ pub(crate) fn expect_metric(parser: &mut Parser, recovery: TokenSet) -> bool {
 /// (<https://glyphsapp.com/learn/tokens#g-number-values>)
 ///
 /// A variable metric has the syntax `(<location_value>+)`
-/// where `<location_value>` is `<location_spec>:<number>`
+/// where `<location_value>` is `<location_spec>:<number>` or a bare default `<number>`
 /// and a `<location_spec>` is `<axis_tag>=<number>,+`
 ///
 /// a number value has the syntax $ident or ${expr}
@@ -292,6 +292,10 @@ fn expect_variation_location_and_value(parser: &mut Parser, recovery: TokenSet) 
 }
 
 fn eat_variation_location_and_value(parser: &mut Parser, recovery: TokenSet) -> bool {
+    if parser.eat(Kind::Number) {
+        return true;
+    }
+
     if !parser.matches(0, TokenSet::TAG_LIKE) {
         return false;
     }

--- a/fea-rs/src/token_tree/typed.rs
+++ b/fea-rs/src/token_tree/typed.rs
@@ -1362,8 +1362,8 @@ impl VariableMetric {
 }
 
 impl LocationValue {
-    pub(crate) fn location(&self) -> LocationSpec {
-        self.iter().find_map(LocationSpec::cast).unwrap()
+    pub(crate) fn location(&self) -> Option<LocationSpec> {
+        self.iter().find_map(LocationSpec::cast)
     }
 
     pub(crate) fn value(&self) -> Number {

--- a/fea-rs/test-data/compile-tests/mini-latin/bad/variable_metrics_duplicate_default.ERR
+++ b/fea-rs/test-data/compile-tests/mini-latin/bad/variable_metrics_duplicate_default.ERR
@@ -1,0 +1,5 @@
+error: duplicate value for the default location
+in ./test-data/compile-tests/mini-latin/bad/variable_metrics_duplicate_default.fea at 2:16
+  | 
+2 |     pos p y (10 20 wght=900:30);
+  |                 ^^

--- a/fea-rs/test-data/compile-tests/mini-latin/bad/variable_metrics_duplicate_default.fea
+++ b/fea-rs/test-data/compile-tests/mini-latin/bad/variable_metrics_duplicate_default.fea
@@ -1,0 +1,3 @@
+feature kern {
+    pos p y (10 20 wght=900:30);
+} kern;

--- a/fea-rs/test-data/parse-tests/good/variable_metrics_default.PARSE_TREE
+++ b/fea-rs/test-data/parse-tests/good/variable_metrics_default.PARSE_TREE
@@ -1,0 +1,38 @@
+FILE@[0; 54)
+    FeatureNode@[0; 53)
+      FeatureKw@0 "feature"
+      WS@7 " "
+      Tag@8 "kern"
+      WS@12 " "
+      {@13 "{"
+      WS@14 "\n    "
+        GposType2@[19; 45)
+          PosKw@19 "pos"
+          WS@22 " "
+          GlyphName@23 "p"
+          WS@24 " "
+          GlyphName@25 "y"
+          WS@26 " "
+            ValueRecordNode@[27; 44)
+                VariableMetricNode@[27; 44)
+                  (@27 "("
+                    LocationValueNode@[28; 31)
+                      NUM@28 "-12"
+                  WS@31 " "
+                    LocationValueNode@[32; 43)
+                        LocationSpecNode@[32; 40)
+                            LocationSpecItemNode@[32; 40)
+                              Tag@32 "wght"
+                              =@36 "="
+                                AxisLocationNode@[37; 40)
+                                  NUM@37 "900"
+                      :@40 ":"
+                      NUM@41 "22"
+                  )@43 ")"
+          ;@44 ";"
+      WS@45 "\n"
+      }@46 "}"
+      WS@47 " "
+      Tag@48 "kern"
+      ;@52 ";"
+  WS@53 "\n"

--- a/fea-rs/test-data/parse-tests/good/variable_metrics_default.fea
+++ b/fea-rs/test-data/parse-tests/good/variable_metrics_default.fea
@@ -1,0 +1,3 @@
+feature kern {
+    pos p y (-12 wght=900:22);
+} kern;

--- a/fontbe/src/features.rs
+++ b/fontbe/src/features.rs
@@ -896,7 +896,7 @@ mod tests {
 
     #[test]
     fn variable_metric_bare_default_matches_explicit_default() {
-        fn compile_layout_tables(fea: &str) -> (Vec<u8>, Vec<u8>) {
+        fn compile_layout_tables(fea: &str) -> Result<(Vec<u8>, Vec<u8>), DiagnosticSet> {
             let ast = parse_fea(fea);
             let static_metadata = weight_variable_static_metadata();
             let var_info = FeaVariationInfo::new(&static_metadata);
@@ -905,28 +905,34 @@ mod tests {
             let diagnostics = fea_rs::compile::validate(&ast, &glyph_map, Some(&var_info));
             assert!(!diagnostics.has_errors(), "{diagnostics:?}");
 
-            let (compilation, _) =
-                fea_rs::compile::compile::<_, fea_rs::compile::NopFeatureProvider>(
-                    &ast,
-                    &glyph_map,
-                    Some(&var_info),
-                    None,
-                    Default::default(),
-                )
-                .unwrap();
-            (
+            let (compilation, _) = fea_rs::compile::compile::<
+                _,
+                fea_rs::compile::NopFeatureProvider,
+            >(
+                &ast, &glyph_map, Some(&var_info), None, Default::default()
+            )?;
+            Ok((
                 write_fonts::dump_table(compilation.gpos.as_ref().unwrap()).unwrap(),
                 write_fonts::dump_table(compilation.gdef.as_ref().unwrap()).unwrap(),
-            )
+            ))
         }
 
         let bare_default =
-            compile_layout_tables("feature kern {\n    pos p y (-12 wght=700:22);\n} kern;\n");
+            compile_layout_tables("feature kern {\n    pos p y (-12 wght=700:22);\n} kern;\n")
+                .unwrap();
         let explicit_default = compile_layout_tables(
             "feature kern {\n    pos p y (wght=400:-12 wght=700:22);\n} kern;\n",
-        );
+        )
+        .unwrap();
 
         assert_eq!(bare_default, explicit_default);
+        // Both `10` and `wght=400:20` target the default; reject rather than choose one.
+        assert!(
+            compile_layout_tables(
+                "feature kern {\n    pos p y (10 wght=400:20 wght=700:30);\n} kern;\n",
+            )
+            .is_err()
+        );
     }
 
     fn parse_fea(fea: &str) -> ParseTree {

--- a/fontbe/src/features.rs
+++ b/fontbe/src/features.rs
@@ -894,6 +894,41 @@ mod tests {
         assert_eq!((15, vec![10, 20]), (default, region_values));
     }
 
+    #[test]
+    fn variable_metric_bare_default_matches_explicit_default() {
+        fn compile_layout_tables(fea: &str) -> (Vec<u8>, Vec<u8>) {
+            let ast = parse_fea(fea);
+            let static_metadata = weight_variable_static_metadata();
+            let var_info = FeaVariationInfo::new(&static_metadata);
+            let glyph_map = fea_rs::GlyphMap::new([".notdef", "p", "y"]).unwrap();
+
+            let diagnostics = fea_rs::compile::validate(&ast, &glyph_map, Some(&var_info));
+            assert!(!diagnostics.has_errors(), "{diagnostics:?}");
+
+            let (compilation, _) =
+                fea_rs::compile::compile::<_, fea_rs::compile::NopFeatureProvider>(
+                    &ast,
+                    &glyph_map,
+                    Some(&var_info),
+                    None,
+                    Default::default(),
+                )
+                .unwrap();
+            (
+                write_fonts::dump_table(compilation.gpos.as_ref().unwrap()).unwrap(),
+                write_fonts::dump_table(compilation.gdef.as_ref().unwrap()).unwrap(),
+            )
+        }
+
+        let bare_default =
+            compile_layout_tables("feature kern {\n    pos p y (-12 wght=700:22);\n} kern;\n");
+        let explicit_default = compile_layout_tables(
+            "feature kern {\n    pos p y (wght=400:-12 wght=700:22);\n} kern;\n",
+        );
+
+        assert_eq!(bare_default, explicit_default);
+    }
+
     fn parse_fea(fea: &str) -> ParseTree {
         fea_rs::parse::parse_string(fea.to_string()).0
     }

--- a/fontdrasil/src/variations.rs
+++ b/fontdrasil/src/variations.rs
@@ -379,14 +379,14 @@ impl VariationModel {
         let seqs = if seqs.keys().all(|loc| loc.has_exact_axes(self.axis_order())) {
             Cow::Borrowed(seqs)
         } else {
-            let normalized = seqs
-                .iter()
-                .map(|(k, v)| {
-                    let mut k = k.to_owned();
-                    k.fit_to_axes(self.axis_order());
-                    (k, v.clone())
-                })
-                .collect();
+            let mut normalized = HashMap::with_capacity(seqs.len());
+            for (location, value) in seqs {
+                let mut location = location.to_owned();
+                location.fit_to_axes(self.axis_order());
+                if normalized.insert(location.clone(), value.clone()).is_some() {
+                    return Err(DeltaError::DuplicateLocation(location));
+                }
+            }
             Cow::Owned(normalized)
         };
 
@@ -448,6 +448,8 @@ impl VariationModel {
 pub enum DeltaError {
     #[error("The default must have a point sequence")]
     DefaultUndefined,
+    #[error("Multiple values have the same normalized location {0:?}")]
+    DuplicateLocation(NormalizedLocation),
     #[error("Every point sequence must have the same length")]
     InconsistentNumbersOfPoints,
     #[error("{0:?} is not present in the variation model")]
@@ -1571,6 +1573,28 @@ mod tests {
             ],
             model.influence
         );
+    }
+
+    #[test]
+    fn reject_locations_that_collide_after_fitting_to_axes() {
+        let default = NormalizedLocation::for_pos(&[("wght", 0.0)]);
+        let redundant_default = NormalizedLocation::for_pos(&[("wght", 0.0), ("wdth", 0.0)]);
+        let max = NormalizedLocation::for_pos(&[("wght", 1.0)]);
+        let model = VariationModel::new(
+            HashSet::from([default.clone(), max.clone()]),
+            axis_order(&["wght"]),
+        );
+        let point_seqs = HashMap::from([
+            (default.clone(), vec![10.0]),
+            (redundant_default, vec![20.0]),
+            (max, vec![30.0]),
+        ]);
+
+        // Dropping the non-model `wdth` axis makes the two defaults collide.
+        assert!(matches!(
+            model.deltas(&point_seqs),
+            Err(DeltaError::DuplicateLocation(location)) if location == default
+        ));
     }
 
     /// An extrapolating model still takes its reach from the masters, not from [-1, 1].


### PR DESCRIPTION
Match fontTools' variable-scalar shorthand by allowing one bare value to supply the default location. Reject duplicate bare defaults and test that the shorthand compiles identically to spelling out the default location.

https://github.com/fonttools/fonttools/pull/4024

For example, with a `wght` default of 400, `(-12 wght=700:22)` is equivalent to `(wght=400:-12 wght=700:22)`.

/cc @khaledhosny 