### PR TITLE
[clippy] Fix chunks_exact lint

### DIFF
--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -1941,10 +1941,10 @@ impl GlyphInstance {
         let components = self
             .components
             .iter()
-            .zip(values.chunks_exact(6))
+            .zip(values.as_chunks::<6>().0)
             .map(|(comp, coeffs)| Component {
                 base: comp.base.clone(),
-                transform: Affine::new(coeffs.try_into().unwrap()),
+                transform: Affine::new(*coeffs),
                 anchor: comp.anchor.clone(),
             })
             .collect();

--- a/glyphs-reader/src/plist.rs
+++ b/glyphs-reader/src/plist.rs
@@ -451,12 +451,13 @@ impl<'a> Token<'a> {
                         .iter()
                         .position(|b| *b == b'>')
                         .ok_or(Error::UnclosedData)?;
-                let chunks = s.as_bytes()[data_start..data_end].chunks_exact(2);
-                if !chunks.remainder().is_empty() {
+                let (chunks, remainder) = s.as_bytes()[data_start..data_end].as_chunks::<2>();
+                if !remainder.is_empty() {
                     return Err(Error::BadData);
                 }
                 let data = chunks
-                    .map(|x| byte_from_hex(x.try_into().unwrap()))
+                    .iter()
+                    .map(|x| byte_from_hex(*x))
                     .collect::<Result<_, _>>()?;
                 Ok((Token::Data(data), data_end + 1))
             }


### PR DESCRIPTION
new with Rust 1.98
https://rust-lang.github.io/rust-clippy/rust-1.98.0/index.html#chunks_exact_to_as_chunks

JMM