### PR TITLE
feature-gate fontra support behind an off-by-default 'fontra' feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ $ cargo run -p fontc -- resources/testdata/wght_var.designspace
 # Build a .glyphs file
 $ cargo run -p fontc -- resources/testdata/glyphs3/WghtVar.glyphs
 
-# Build a .fontra file
-$ cargo run -p fontc -- resources/testdata/fontra/minimal.fontra
+# Build a .fontra file; fontra support is experimental and incomplete
+$ cargo run -p fontc --features fontra -- resources/testdata/fontra/minimal.fontra
 ```
 
 ### Emit IR

--- a/fontc/Cargo.toml
+++ b/fontc/Cargo.toml
@@ -22,13 +22,15 @@ harness = false
 [features]
 default = ["cli", "rayon"]
 cli = ["clap"]
+# .fontra source support; experimental and incomplete, hence off by default
+fontra = ["dep:fontra2fontir"]
 
 [dependencies]
 fontdrasil = { version = "0.4.0", path = "../fontdrasil" }
 fontbe = { version = "0.5.0", path = "../fontbe" }
 fontir = { version = "0.5.0", path = "../fontir" }
 glyphs2fontir = { version = "0.6.0", path = "../glyphs2fontir" }
-fontra2fontir = { version = "0.4.0", path = "../fontra2fontir" }
+fontra2fontir = { version = "0.4.0", path = "../fontra2fontir", optional = true }
 ufo2fontir = { version = "0.4.0", path = "../ufo2fontir" }
 
 bitflags.workspace = true

--- a/fontc/src/error.rs
+++ b/fontc/src/error.rs
@@ -16,6 +16,8 @@ pub enum Error {
     StdioWriteFail(#[source] io::Error),
     #[error("Unrecognized source {0}")]
     UnrecognizedSource(PathBuf),
+    #[error("Cannot compile {0}: fontra support is not enabled, rebuild with --features fontra")]
+    FontraNotEnabled(PathBuf),
     #[error(transparent)]
     YamlSerError(#[from] serde_yaml::Error),
     #[error(transparent)]

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -10,6 +10,7 @@ mod workload;
 pub use error::Error;
 
 pub use fontir::orchestration::Flags; // Re-export for library users
+#[cfg(feature = "fontra")]
 use fontra2fontir::source::FontraIrSource;
 use glyphs2fontir::source::GlyphsIrSource;
 use ufo2fontir::source::DesignSpaceIrSource;
@@ -35,6 +36,7 @@ use log::debug;
 pub enum Input {
     DesignSpacePath(PathBuf),
     GlyphsPath(PathBuf),
+    #[cfg(feature = "fontra")]
     FontraPath(PathBuf),
     GlyphsMemory(String),
 }
@@ -53,7 +55,10 @@ impl Input {
             "ufo" => Ok(Input::DesignSpacePath(path.to_path_buf())),
             "glyphs" => Ok(Input::GlyphsPath(path.to_path_buf())),
             "glyphspackage" => Ok(Input::GlyphsPath(path.to_path_buf())),
+            #[cfg(feature = "fontra")]
             "fontra" => Ok(Input::FontraPath(path.to_path_buf())),
+            #[cfg(not(feature = "fontra"))]
+            "fontra" => Err(Error::FontraNotEnabled(path.to_path_buf())),
             _ => Err(Error::UnrecognizedSource(path.to_path_buf())),
         }
     }
@@ -69,6 +74,7 @@ impl Input {
         match self {
             Input::DesignSpacePath(path) => Ok(Box::new(DesignSpaceIrSource::new(path)?)),
             Input::GlyphsPath(path) => Ok(Box::new(GlyphsIrSource::new(path)?)),
+            #[cfg(feature = "fontra")]
             Input::FontraPath(path) => Ok(Box::new(FontraIrSource::new(path)?)),
             Input::GlyphsMemory(source) => Ok(Box::new(GlyphsIrSource::new_from_memory(source)?)),
         }


### PR DESCRIPTION
.fontra input is experimental and still hits a `todo!()` in fontra2fontir, so I think it's best not to build it by default, especially in light of the upcoming fontc 1.0

Without the feature a .fontra path will now report a clean error instead of panicking.