### PR TITLE
Handle SemVer pre-release tags in --version and the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -339,17 +339,19 @@ jobs:
       - name: Detect if tag is a pre-release
         id: before_release
         env:
-          # e.g. fontc-v0.1.0a1 or otl-normalizer-v1.2.0b2, but not fontc-v1.0.0
-          PRERELEASE_TAG_PATTERN: "(fontc|otl-normalizer)-v[[:digit:]]+\\.[[:digit:]]+\\.[[:digit:]]+([ab]|rc)[[:digit:]]+"
+          # A full release tag is exactly <tool>-v<MAJOR>.<MINOR>.<PATCH>, e.g.
+          # fontc-v1.0.0; anything else (fontc-v1.0.0-rc.1, ...) is a pre-release,
+          # so an unanticipated tag shape fails safe.
+          RELEASE_TAG_PATTERN: "^(fontc|otl-normalizer)-v[[:digit:]]+\\.[[:digit:]]+\\.[[:digit:]]+$"
         run: |
           # strip leading 'refs/tags/' to get the tag name
           TAG_NAME="${GITHUB_REF##*/}"
-          if egrep -q "$PRERELEASE_TAG_PATTERN" <<< "$TAG_NAME"; then
-            echo "Tag ${TAG_NAME} contains a pre-release suffix"
-            echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "Tag ${TAG_NAME} does not contain a pre-release suffix"
+          if egrep -q "$RELEASE_TAG_PATTERN" <<< "$TAG_NAME"; then
+            echo "Tag ${TAG_NAME} is a full release tag"
             echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Tag ${TAG_NAME} is not a plain <tool>-vX.Y.Z tag; marking as pre-release"
+            echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
           fi
           # Create descriptive release title with tool name
           # e.g. fontc-v0.3.2 -> fontc 0.3.2, otl-normalizer-v0.0.1 -> otl-normalizer 0.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,15 +100,18 @@ jobs:
     env:
       TOOL: ${{ needs.detect.outputs.tool }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.13"
           architecture: ${{ matrix.platform.python-architecture }}
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
+          toolchain: stable
           targets: ${{ matrix.platform.target }}
 
       # Install gnu-tar because BSD tar is buggy
@@ -121,7 +124,7 @@ jobs:
 
       - name: Build wheel (macOS universal2) and sdist
         if: matrix.platform.target == 'x86_64-apple-darwin'
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           target: universal2-apple-darwin
           args: --release -o dist --sdist
@@ -129,7 +132,7 @@ jobs:
 
       - name: Build wheel (without sdist)
         if: matrix.platform.target != 'x86_64-apple-darwin'
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           target: ${{matrix.platform.target}}
           args: --release -o dist
@@ -170,13 +173,13 @@ jobs:
           cd -
 
       - name: Upload wheel artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: wheels-${{ env.TOOL }}-${{ matrix.platform.target }}
           path: ${{ needs.detect.outputs.working-directory }}/dist
 
       - name: Upload binary artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: binaries-${{ env.TOOL }}-${{ matrix.platform.target }}
           path: |
@@ -198,10 +201,12 @@ jobs:
           - target: "aarch64-unknown-linux-gnu"
             manylinux: "2014"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
 
       - name: Build Wheels
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           target: ${{ matrix.platform.target }}
           manylinux: ${{ matrix.platform.manylinux }}
@@ -220,13 +225,13 @@ jobs:
         run: tar czvf target/release/${TOOL}-${{ matrix.platform.target }}.tar.gz -C target/${{ matrix.platform.target }}/release ${TOOL}
 
       - name: Upload wheel artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: wheels-${{ env.TOOL }}-${{ matrix.platform.target }}
           path: ${{ needs.detect.outputs.working-directory }}/dist
 
       - name: Upload binary artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: binaries-${{ env.TOOL }}-${{ matrix.platform.target }}
           path: target/release/${{ env.TOOL }}-${{ matrix.platform.target }}.tar.gz
@@ -252,10 +257,12 @@ jobs:
     steps:
       # checkout@v3 doesn't work inside the manylinux container:
       # https://github.com/actions/checkout/issues/1487
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
 
       - name: Build Wheels
-        uses: PyO3/maturin-action@v1
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           target: ${{ matrix.platform.target }}
           manylinux: ${{ matrix.platform.compatibility }}
@@ -267,13 +274,13 @@ jobs:
         run: tar czvf target/release/${TOOL}-${{ matrix.platform.target }}.tar.gz -C target/${{ matrix.platform.target }}/release ${TOOL}
 
       - name: Upload wheel artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: wheels-${{ env.TOOL }}-${{ matrix.platform.target }}
           path: ${{ needs.detect.outputs.working-directory }}/dist
 
       - name: Upload binary artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: binaries-${{ env.TOOL }}-${{ matrix.platform.target }}
           path: target/release/${{ env.TOOL }}-${{ matrix.platform.target }}.tar.gz
@@ -289,14 +296,14 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: wheels-${{ needs.detect.outputs.tool }}-*
           # so that all artifacts are downloaded in the same directory specified by 'path'
           merge-multiple: true
           path: dist
 
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           skip-existing: true
 
@@ -311,12 +318,12 @@ jobs:
     env:
       TOOL: ${{ needs.detect.outputs.tool }}
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: binaries-${{ needs.detect.outputs.tool }}-*
           merge-multiple: true
 
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: wheels-${{ needs.detect.outputs.tool }}-*
           merge-multiple: true
@@ -366,7 +373,7 @@ jobs:
           fi
 
       - name: Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           name: ${{ steps.before_release.outputs.release_title }}
           files: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,21 +155,22 @@ jobs:
         if: matrix.platform.os != 'windows-latest'
         run: |
           cd target/${{ matrix.platform.target }}/release
-          tar czvf ../../../${{ env.TOOL }}-${{ matrix.platform.target }}.tar.gz ${{ env.TOOL }}
+          tar czvf ../../../${TOOL}-${{ matrix.platform.target }}.tar.gz ${TOOL}
           cd -
 
       - name: Archive binary (windows)
         if: matrix.platform.os == 'windows-latest'
+        shell: bash
         run: |
           cd target/${{ matrix.platform.target }}/release
-          7z a ../../../${{ env.TOOL }}-${{ matrix.platform.target }}.zip ${{ env.TOOL }}.exe
+          7z a ../../../${TOOL}-${{ matrix.platform.target }}.zip ${TOOL}.exe
           cd -
 
       - name: Archive binary (macOS aarch64)
         if: matrix.platform.os == 'macos-latest'
         run: |
           cd target/aarch64-apple-darwin/release
-          tar czvf ../../../${{ env.TOOL }}-aarch64-apple-darwin.tar.gz ${{ env.TOOL }}
+          tar czvf ../../../${TOOL}-aarch64-apple-darwin.tar.gz ${TOOL}
           cd -
 
       - name: Upload wheel artifacts

--- a/fontc/src/version.rs
+++ b/fontc/src/version.rs
@@ -5,6 +5,9 @@
 //! It's `git describe` rendered as SemVer: a build past a release tag is a dev
 //! pre-release of the *next* patch, e.g. `0.6.1-dev.394+gd62ba016.dirty` (394
 //! commits past `fontc-v0.6.0`, dirty tree); on the tag itself, just `0.6.0`.
+//! Past a pre-release tag like `fontc-v1.0.0-rc.1` the pre-release identifiers
+//! extend instead (`1.0.0-rc.1.dev.394+g...`), sorting after the tag and
+//! before the final it precedes.
 //!
 //! Two details are deliberate, both for ordering (see the sort test below):
 //! bumping to `0.6.1` rather than `0.6.0-dev.N`, since a pre-release sorts
@@ -34,7 +37,18 @@ pub(crate) fn version_string(describe: &str, crate_version: &str) -> String {
         && !distance.is_empty()
         && distance.bytes().all(|b| b.is_ascii_digit())
     {
-        let mut version = format!("{}-dev.{distance}+g{sha}", bump_patch(tag));
+        // Past a plain release tag, a dev build is a pre-release of the *next*
+        // patch (`0.6.0` -> `0.6.1-dev.N`): a `-dev` suffix on the tag's own
+        // version would sort below the release it follows. Past a pre-release
+        // tag, the identifiers extend instead (`1.0.0-rc.1` -> `1.0.0-rc.1.dev.N`),
+        // which SemVer §11 orders after the tag and before the final; a patch
+        // bump there would wrongly sort above the unreleased final.
+        let base = if tag.contains('-') {
+            format!("{tag}.dev")
+        } else {
+            format!("{}-dev", bump_patch(tag))
+        };
+        let mut version = format!("{base}.{distance}+g{sha}");
         if dirty {
             version.push_str(".dirty");
         }
@@ -52,10 +66,10 @@ pub(crate) fn version_string(describe: &str, crate_version: &str) -> String {
 /// bumps the patch (`0.6.0` -> `0.6.1`), or returns `tag` unchanged if it isn't
 /// `MAJOR.MINOR.PATCH`.
 ///
-/// Assumes plain `MAJOR.MINOR.PATCH` release tags, the only kind fontc cuts
-/// today. A pre-release tag like `0.6.0-rc.1` would wrongly become `0.6.1`,
-/// sorting *above* the eventual `0.6.0` -- that path is currently unreachable,
-/// and should be handled if/when fontc starts tagging pre-releases.
+/// Only plain `MAJOR.MINOR.PATCH` tags reach this: `version_string` routes
+/// pre-release tags to the identifier-extension path instead. Should one slip
+/// through anyway, its pre-release part is dropped before bumping (defensive;
+/// pinned by the `patch_bump` test).
 fn bump_patch(tag: &str) -> String {
     let release = tag.split('-').next().unwrap_or(tag);
     let parts: Vec<&str> = release.split('.').collect();

--- a/fontc/src/version.rs
+++ b/fontc/src/version.rs
@@ -92,6 +92,33 @@ mod tests {
     }
 
     #[test]
+    fn past_a_prerelease_tag() {
+        // Past a pre-release tag the identifiers extend (`rc.1` -> `rc.1.dev.5`),
+        // sorting after the tag and before the final. A patch bump here would
+        // produce `1.0.1-dev.5`, wrongly sorting above the unreleased `1.0.0`.
+        assert_eq!(
+            version_string("fontc-v1.0.0-rc.1-5-gabc1234", "1.0.0-rc.1"),
+            "1.0.0-rc.1.dev.5+gabc1234"
+        );
+        assert_eq!(
+            version_string("fontc-v1.0.0-rc.1-5-gabc1234-dirty", "1.0.0-rc.1"),
+            "1.0.0-rc.1.dev.5+gabc1234.dirty"
+        );
+    }
+
+    #[test]
+    fn on_a_prerelease_tag() {
+        assert_eq!(
+            version_string("fontc-v1.0.0-rc.1", "1.0.0-rc.1"),
+            "1.0.0-rc.1"
+        );
+        assert_eq!(
+            version_string("fontc-v1.0.0-rc.1-dirty", "1.0.0-rc.1"),
+            "1.0.0-rc.1+dirty"
+        );
+    }
+
+    #[test]
     fn without_git() {
         // `cargo install`, source tarball, shallow clone with no reachable tag.
         // The describe is empty or a vergen sentinel; fall back to crate version.
@@ -107,10 +134,14 @@ mod tests {
     // strings *themselves* against the SemVer crate -- an independent oracle --
     // so we're checking our own format, not git's.
     const EMITTED: &[&str] = &[
-        "0.6.1-dev.394+gd62ba016",       // past a release tag
-        "0.6.1-dev.394+gd62ba016.dirty", // ...from a dirty tree
-        "0.6.0",                         // exactly on a release tag
-        "0.6.0+dirty",                   // ...from a dirty tree
+        "0.6.1-dev.394+gd62ba016",         // past a release tag
+        "0.6.1-dev.394+gd62ba016.dirty",   // ...from a dirty tree
+        "0.6.0",                           // exactly on a release tag
+        "0.6.0+dirty",                     // ...from a dirty tree
+        "1.0.0-rc.1.dev.5+gabc1234",       // past a pre-release tag
+        "1.0.0-rc.1.dev.5+gabc1234.dirty", // ...from a dirty tree
+        "1.0.0-rc.1",                      // exactly on a pre-release tag
+        "1.0.0-rc.1+dirty",                // ...from a dirty tree
     ];
 
     /// Each string we emit parses under the SemVer 2.0.0 grammar and round-trips.
@@ -160,6 +191,15 @@ mod tests {
             snapshot.cmp_precedence(&v("0.6.1-dev.394+gd62ba016.dirty")),
             Ordering::Equal
         );
+
+        // A dev build past a pre-release tag extends its identifiers, so it
+        // sits above that pre-release and below both the next pre-release and
+        // the final (SemVer §11: with an equal prefix, the larger set of
+        // pre-release fields has higher precedence).
+        let rc_dev = v("1.0.0-rc.1.dev.5+gabc1234");
+        assert_eq!(v("1.0.0-rc.1").cmp_precedence(&rc_dev), Ordering::Less);
+        assert_eq!(rc_dev.cmp_precedence(&v("1.0.0-rc.2")), Ordering::Less);
+        assert_eq!(rc_dev.cmp_precedence(&v("1.0.0")), Ordering::Less);
     }
 
     #[test]


### PR DESCRIPTION
While trying to tag a `fontc-v1.0.0-rc.1` pre-release, I noticed that the two places that interpret tags were mishandling them.

The git-describe based `--version` bumped the patch digit for dev builds past `fontc-v1.0.0-rc.1` to `1.0.1-dev.N`, which would have sorted above the unreleased 1.0.0 final.
Also, the pre-release detection in release.yml only caught Python-style PEP 440 suffixes, so a SemVer-style `rc` tag would have been published as a full release.

The version.rs now correctly extends the pre-release identifiers (e.g. `1.0.0-rc.1.dev.N+gsha`) so they sort after the tag and before the final. See Semver $11.4 (https://semver.org/):

> A larger set of pre-release fields has a higher precedence than a smaller set, if all of the preceding identifiers are equal.

And the release workflow recognizes a full release only for a plain `<tool>-vX.Y.Z` tag, any other shape fails safe to pre-release.

Note that maturin already normalizes the Cargo version for PyPI (1.0.0-rc.1 -> 1.0.0rc1), so wheels are unaffected.

