### PR TITLE
Bump fontc version to 1.0.0-rc.1

### DIFF
--- a/fontc/Cargo.toml
+++ b/fontc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fontc"
-version = "0.6.0"
+version = "1.0.0-rc.1"
 build = "build.rs"
 edition = "2024"
 license = "MIT/Apache-2.0"

--- a/fontc_crater/Cargo.toml
+++ b/fontc_crater/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/googlefonts/fontc"
 readme = "README.md"
 
 [dependencies]
-fontc = { version = "0.6.0", path = "../fontc" }
+fontc = { version = "1.0.0-rc.1", path = "../fontc" }
 
 google-fonts-sources = "0.11.1"
 maud = "0.27.0"


### PR DESCRIPTION
I want to validate the release pipeline end to end by bumping fontc to 1.0.0-rc.1 (a pre-release) before committing to the final 1.0.
So I will push a fontc-v1.0.0-rc.1 tag after merging this PR and that should trigger the PyPI wheel building and GitHub prerelease.

I won't publish 1.0.0-rc.1 to crates.io nor bump the library crate versions, this release candidate only exercises the fontc release.

A workspace-wide 1.0 bump will come after it checks out.
