### PR TITLE
Fix release binary archiving and bump to 1.0.0-rc.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,6 +99,10 @@ jobs:
     runs-on: ${{ matrix.platform.os }}
     env:
       TOOL: ${{ needs.detect.outputs.tool }}
+      # When --sdist is passed, maturin (observed with 1.15) builds the wheel
+      # from the extracted sdist in a temp dir; pin cargo's target dir to the
+      # workspace so the archive steps below can find the binaries.
+      CARGO_TARGET_DIR: ${{ github.workspace }}/target
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:

--- a/fontc/Cargo.toml
+++ b/fontc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fontc"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 build = "build.rs"
 edition = "2024"
 license = "MIT/Apache-2.0"

--- a/fontc_crater/Cargo.toml
+++ b/fontc_crater/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/googlefonts/fontc"
 readme = "README.md"
 
 [dependencies]
-fontc = { version = "1.0.0-rc.1", path = "../fontc" }
+fontc = { version = "1.0.0-rc.2", path = "../fontc" }
 
 google-fonts-sources = "0.11.1"
 maud = "0.27.0"


### PR DESCRIPTION
The `fontc-v1.0.0-rc.1` release run failed in the macOS build job (that's why I did a pre-release 😅 )

maturin 1.15 now builds the wheel from the extracted sdist in a temp directory when --sdist is passed, so the archive steps no longer found the binaries under the workspace `target/`. 

We can pin `CARGO_TARGET_DIR` to that to restore the old layout.

Nothing was published from the failed run (PyPI and GitHub release jobs were skipped), but the rc.1 tag was pushed, so this bumps to rc.2 rather than reusing the tag name.