### PR TITLE
Make public error enums non-exhaustive

### DIFF
--- a/fea-rs/src/compile/error.rs
+++ b/fea-rs/src/compile/error.rs
@@ -60,6 +60,7 @@ pub enum GlyphOrderError {
 /// An error reported by the compiler
 #[derive(Debug, thiserror::Error)]
 #[allow(missing_docs)]
+#[non_exhaustive]
 pub enum CompilerError {
     #[error(transparent)]
     SourceLoad(#[from] SourceLoadError),

--- a/fontbe/src/error.rs
+++ b/fontbe/src/error.rs
@@ -22,6 +22,7 @@ use write_fonts::{
 };
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum Error {
     #[error("IO failure")]
     IoError(#[from] io::Error),
@@ -109,6 +110,7 @@ pub enum Error {
 }
 
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum GlyphProblem {
     InconsistentComponents,
     InconsistentPathElements,

--- a/fontc/src/error.rs
+++ b/fontc/src/error.rs
@@ -3,6 +3,7 @@ use std::{io, path::PathBuf};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum Error {
     #[error("'{0}' exists but is not a directory")]
     ExpectedDirectory(PathBuf),

--- a/fontdrasil/src/error.rs
+++ b/fontdrasil/src/error.rs
@@ -4,6 +4,7 @@ use crate::coords::{Coord, UserSpace};
 use crate::types::Tag;
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum Error {
     #[error("Default index {0} is out of bounds for design coordinates of length {1}")]
     DefaultOutOfBounds(usize, usize),

--- a/fontdrasil/src/variations.rs
+++ b/fontdrasil/src/variations.rs
@@ -21,6 +21,7 @@ use write_fonts::{
 };
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum VariationModelError {
     #[error("{axis_names:?} in {location:?} have no assigned order")]
     AxesWithoutAssignedOrder {
@@ -445,6 +446,7 @@ impl VariationModel {
 }
 
 #[derive(Error, Debug)]
+#[non_exhaustive]
 pub enum DeltaError {
     #[error("The default must have a point sequence")]
     DefaultUndefined,

--- a/fontir/src/error.rs
+++ b/fontir/src/error.rs
@@ -13,6 +13,7 @@ use write_fonts::types::{InvalidTag, Tag};
 use crate::ir::GlobalMetric;
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum Error {
     /// A source file was not understood
     #[error(transparent)]
@@ -111,6 +112,7 @@ pub struct BadSource {
 
 /// Conditions under which we can fail to read a source file
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum BadSourceKind {
     ExpectedDirectory,
     ExpectedFile,
@@ -133,6 +135,7 @@ pub struct BadGlyph {
 }
 
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum BadGlyphKind {
     NoInstances,
     DuplicateLocation(NormalizedLocation),
@@ -160,6 +163,7 @@ pub struct BadAnchor {
 
 /// Reasons an anchor can be malformed
 #[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
 pub enum BadAnchorReason {
     NoDefault,
     // top_0 looks like a ligature base, but 0 is an invalid index
@@ -172,6 +176,7 @@ pub enum BadAnchorReason {
 
 /// An async work error, hence one that must be Send
 #[derive(Debug, Error, PartialEq)]
+#[non_exhaustive]
 pub enum PathConversionError {
     #[error("has {num_offcurve} consecutive offcurve points {points:?}")]
     TooManyOffcurvePoints {

--- a/glyphs-reader/src/error.rs
+++ b/glyphs-reader/src/error.rs
@@ -6,6 +6,7 @@ use thiserror::Error;
 use crate::{corner_components::BadCornerComponent, smart_components::BadSmartComponent};
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum Error {
     #[error("IO failure")]
     IoError(#[from] io::Error),

--- a/glyphs-reader/src/glyphdata.rs
+++ b/glyphs-reader/src/glyphdata.rs
@@ -291,6 +291,7 @@ pub struct QueryResult {
 }
 
 #[derive(Clone, Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum GlyphDataError {
     #[error("Couldn't read user file at '{path}': '{reason}'")]
     UserFile {

--- a/otl-normalizer/src/error.rs
+++ b/otl-normalizer/src/error.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use write_fonts::{read::ReadError, types::Tag};
 
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum Error {
     #[error("could not read path '{path}': '{inner}'")]
     Load {


### PR DESCRIPTION
Fixes #2091.

Marks all 15 public error enums across the workspace [`#[non_exhaustive]`](https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute), so error variants added after 1.0 land in minor releases instead of breaking SemVer (adding fields to existing struct-like variants stays breaking). No call-site changes were needed.

My agent did a full API sweep (walked through the `pub use` chains in rustdoc JSON, and cross-checked by compiling exhaustive-match probes against all 9 lib crates) and found exactly these:

- `fontc::Error`
- `fontdrasil::error::Error`, `fontdrasil::variations::{VariationModelError, DeltaError}`
- `fontir::error::{Error, BadSourceKind, BadGlyphKind, BadAnchorReason, PathConversionError}`
- `fontbe::error::{Error, GlyphProblem}`
- `glyphs_reader::error::Error`, `glyphs_reader::glyphdata::GlyphDataError`
- `fea_rs::compile::error::CompilerError`
- `otl_normalizer::Error`

fea-rs already marked 3 of 4 public error enums (`UfoGlyphOrderError`, `FontGlyphOrderError`, `GlyphOrderError`) as non_exhaustive, `CompilerError` was the odd one out.

ufo2fontir, glyphs2fontir and ascii_plist_derive expose no public enums.

Downstream code that builds these errors via `?`/`From` is untouched, since the attribute only restricts matching.

JMM