### PR TITLE
Manage github actions deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  # Actions are pinned to commit hashes (required by the unpinned-uses scan);
+  # dependabot updates both the hash and the trailing version comment.
+  # Cargo dependencies are deliberately NOT managed here: see #2094 for
+  # how the dependency graph is pinned and refreshed.
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: monthly
+    # Don't adopt a release until it has been public for a week: a compromised
+    # release is usually caught and yanked well inside that window.
+    cooldown:
+      default-days: 7

--- a/.github/workflows/notify-plugin.yml
+++ b/.github/workflows/notify-plugin.yml
@@ -2,10 +2,17 @@ name: Notify googlefonts/fontc-export-plugin of fontc release
 
 # Trigger when the release.yml workflow completes successfully.
 # https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflow_run
+#
+# workflow_run is safe here: this workflow checks out nothing, reuses no
+# artifacts from the triggering run, passes its inputs through env vars,
+# and only fires off Release, which itself only runs on pushed tags.
 on:
-  workflow_run:
+  workflow_run: # zizmor: ignore[dangerous-triggers]
     workflows: ["Release"]
     types: [completed]
+
+permissions:
+  contents: read
 
 jobs:
   notify-plugin:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,5 +1,10 @@
 name: ttx-diff CI/CD
 
+# The publish-pypi job overrides this with the id-token: write it needs
+# for trusted publishing.
+permissions:
+  contents: read
+
 on:
   push:
     branches:
@@ -28,10 +33,10 @@ jobs:
         # https://github.com/googlefonts/gftools/blob/d4c06f5d88e0a849fabf7089d80835a96dc42f30/pyproject.toml#L47-L49
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -48,10 +53,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.13"
 
@@ -78,10 +83,10 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/ttx-diff-v')
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.x"
 
@@ -90,7 +95,7 @@ jobs:
         run: pipx run build
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: python-packages
           path: ttx_diff/dist/
@@ -105,12 +110,12 @@ jobs:
 
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: python-packages
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: dist/

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,6 +19,9 @@ on:
 
 name: Continuous integration
 
+permissions:
+  contents: read
+
 # The check, clippy-lint, and test-stable-* jobs should typically be direct copies from
 # https://github.com/googlefonts/fontations/blob/main/.github/workflows/rust.yml.
 # other than the list of crates for cargo check no std
@@ -28,11 +31,12 @@ jobs:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
+          toolchain: stable
           components: rustfmt
 
       - name: rustfmt check
@@ -51,10 +55,11 @@ jobs:
     name: Clippy lints
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
+          toolchain: stable
           components: clippy
 
       - name: cargo clippy --all-features
@@ -73,10 +78,12 @@ jobs:
     name: fontbe tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        with:
+          toolchain: stable
 
       - name: cargo test fontbe
         run: cargo test -p fontbe --all-targets --all-features
@@ -91,10 +98,12 @@ jobs:
       #    default set of font sources.
       FONTC_BENCH_SRCS: ""
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        with:
+          toolchain: stable
 
       - name: cargo test fontc
         run: cargo test -p fontc --all-targets --all-features
@@ -103,10 +112,12 @@ jobs:
     name: tests other than fontbe,fontc
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        with:
+          toolchain: stable
 
       - name: cargo test fontdrasil
         run: cargo test -p fontdrasil --all-targets --all-features
@@ -127,10 +138,12 @@ jobs:
     name: cargo check no std
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        with:
+          toolchain: stable
 
       - name: cargo check fontdrasil
         run: cargo check --manifest-path=fontdrasil/Cargo.toml --no-default-features
@@ -154,9 +167,11 @@ jobs:
     name: resources/scripts/ots_test.sh
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - name: install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        with:
+          toolchain: stable
 
       - name: Run resources/scripts/ots_test.sh
         run:  resources/scripts/ots_test.sh
@@ -166,9 +181,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
-      - uses: actions/checkout@v6
-      - uses: getsentry/action-setup-venv@v3.2.0
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        with:
+          toolchain: stable
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: getsentry/action-setup-venv@5a80476d175edf56cb205b08bc58986fa99d1725 # v3.2.0
         id: venv
         with:
           python-version: 3.10.7
@@ -184,9 +201,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
-      - uses: actions/checkout@v6
-      - uses: getsentry/action-setup-venv@v3.2.0
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        with:
+          toolchain: stable
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: getsentry/action-setup-venv@5a80476d175edf56cb205b08bc58986fa99d1725 # v3.2.0
         id: venv
         with:
           python-version: 3.13
@@ -205,10 +224,12 @@ jobs:
     if: github.event.pull_request.head.repo.fork == false
     steps:
       - name: Check out fontc source repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Install the latest stable Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        with:
+          toolchain: stable
 
       - name: Build and install fontc (release mode)
         run: cd fontc && pwd && cargo install --path .
@@ -225,14 +246,14 @@ jobs:
           ttx --version
 
       - name: Check out GS source repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           repository: googlefonts/googlesans
           path: googlesans
           token: ${{ secrets.GS_READ_FONTC }}
 
       - name: Check out Oswald source repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           repository: googlefonts/OswaldFont
           path: oswald
@@ -255,7 +276,7 @@ jobs:
       - name: OTS tests, Oswald
         run: ots-9.1.0-Linux/ots-sanitize build/Oswald.ttf
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
         with:
           path: build/*.ttf
@@ -266,11 +287,12 @@ jobs:
     name: cargo check wasm
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
+          toolchain: stable
           target: wasm32-unknown-unknown
 
       # Not all libraries need to build here, only the ones needed for the core compiler
@@ -286,7 +308,7 @@ jobs:
 
     steps:
       - name: Check out fontc source repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: run tidy_glyphs.py
         run: python3 ./resources/scripts/tidy_glyphs.py just_check


### PR DESCRIPTION
Same treatment as googlefonts/fontations#2002: pin all remaining unpinned actions to commit SHAs, add the missing permissions blocks, and let dependabot bump the pins monthly.

The one local wrinkle: zizmor flags notify-plugin.yml's workflow_run trigger as a "fundamentally insecure workflow trigger", so it gets an inline ignore -- the justification is in a comment next to it.

Unblocks #2093; #2094 drops its own zizmor commit on rebase.
