### PR TITLE
[fea-rs] Fix panic with empty mark classes

### DIFF
--- a/fea-rs/src/common.rs
+++ b/fea-rs/src/common.rs
@@ -42,6 +42,16 @@ pub(crate) struct MarkClass {
     pub(crate) members: Vec<(GlyphClass, Option<AnchorBuilder>)>,
 }
 
+impl MarkClass {
+    /// `true` if no member of this class contributes any glyphs.
+    ///
+    /// Such a class never registers its name with the GPOS mark builders, so
+    /// attaching to it would panic; see `CompilationCtx::define_mark_class`.
+    pub(crate) fn is_empty(&self) -> bool {
+        self.members.iter().all(|(glyphs, _)| glyphs.is_empty())
+    }
+}
+
 impl From<u16> for GlyphIdent {
     fn from(src: u16) -> GlyphIdent {
         GlyphIdent::Cid(src)

--- a/fea-rs/src/common/glyph_class.rs
+++ b/fea-rs/src/common/glyph_class.rs
@@ -50,6 +50,10 @@ impl GlyphClass {
     pub(crate) fn len(&self) -> usize {
         self.0.len()
     }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
 }
 
 impl std::iter::FromIterator<GlyphId16> for GlyphClass {

--- a/fea-rs/src/compile/compile_ctx.rs
+++ b/fea-rs/src/compile/compile_ctx.rs
@@ -1030,6 +1030,10 @@ impl<'a, F: FeatureProvider, V: VariationInfo> CompilationCtx<'a, F, V> {
             let class_name = mark_class_node.text().to_owned();
             let mark_class = self.mark_classes.get(&class_name).unwrap();
 
+            if mark_class.is_empty() {
+                continue;
+            }
+
             // access the lookup through the field, so the borrow checker
             // doesn't think we're borrowing all of self
             //TODO: we do validation here because our validation pass isn't smart
@@ -1092,6 +1096,10 @@ impl<'a, F: FeatureProvider, V: VariationInfo> CompilationCtx<'a, F, V> {
                 let class_name = mark_class_node.text();
                 let mark_class = self.mark_classes.get(class_name).unwrap();
 
+                if mark_class.is_empty() {
+                    continue;
+                }
+
                 // access the lookup through the field, so the borrow checker
                 // doesn't think we're borrowing all of self
                 //TODO: we do validation here because our validation pass isn't smart
@@ -1138,6 +1146,10 @@ impl<'a, F: FeatureProvider, V: VariationInfo> CompilationCtx<'a, F, V> {
             let mark_class_node = mark.mark_class_name().expect("checked in validation");
             let class_name = mark_class_node.text();
             let mark_class = self.mark_classes.get(mark_class_node.text()).unwrap();
+
+            if mark_class.is_empty() {
+                continue;
+            }
 
             //TODO: we do validation here because our validation pass isn't smart
             //enough. We need to not just validate a rule, but every rule in a lookup.
@@ -1429,7 +1441,14 @@ impl<'a, F: FeatureProvider, V: VariationInfo> CompilationCtx<'a, F, V> {
 
     fn define_mark_class(&mut self, class_decl: typed::MarkClassDef) {
         let class_items = class_decl.glyph_class();
-        let class_items = self.resolve_glyph_or_class(&class_items).into();
+        let class_items: GlyphClass = self.resolve_glyph_or_class(&class_items).into();
+
+        if class_items.is_empty() {
+            self.error(
+                class_decl.glyph_class().range(),
+                "Empty glyph class in mark class definition",
+            );
+        }
 
         let anchor = self.resolve_anchor(&class_decl.anchor());
         let class_name = class_decl.mark_class_name();

--- a/fea-rs/test-data/compile-tests/mini-latin/bad/empty_mark_class_literal.ERR
+++ b/fea-rs/test-data/compile-tests/mini-latin/bad/empty_mark_class_literal.ERR
@@ -1,0 +1,5 @@
+error: Empty glyph class in mark class definition
+in ./test-data/compile-tests/mini-latin/bad/empty_mark_class_literal.fea at 4:10
+  | 
+4 | markClass [] <anchor 0 0> @TOP;
+  |           ^^

--- a/fea-rs/test-data/compile-tests/mini-latin/bad/empty_mark_class_literal.fea
+++ b/fea-rs/test-data/compile-tests/mini-latin/bad/empty_mark_class_literal.fea
@@ -1,0 +1,8 @@
+# an empty glyph class literal in a markClass definition. Nobody writes this
+# by hand, but it is the simplest spelling of the bug, and it used to panic in
+# the GPOS builders instead of producing a diagnostic.
+markClass [] <anchor 0 0> @TOP;
+
+feature test {
+    pos base a <anchor 100 0> mark @TOP;
+} test;

--- a/fea-rs/test-data/compile-tests/mini-latin/bad/empty_mark_class_mark_to_ligature.ERR
+++ b/fea-rs/test-data/compile-tests/mini-latin/bad/empty_mark_class_mark_to_ligature.ERR
@@ -1,0 +1,5 @@
+error: Empty glyph class in mark class definition
+in ./test-data/compile-tests/mini-latin/bad/empty_mark_class_mark_to_ligature.fea at 2:10
+  | 
+2 | markClass [] <anchor 0 0> @TOP;
+  |           ^^

--- a/fea-rs/test-data/compile-tests/mini-latin/bad/empty_mark_class_mark_to_ligature.fea
+++ b/fea-rs/test-data/compile-tests/mini-latin/bad/empty_mark_class_mark_to_ligature.fea
@@ -1,0 +1,7 @@
+# the same empty class, attached in a mark-to-ligature rule
+markClass [] <anchor 0 0> @TOP;
+
+feature test {
+    pos ligature f_i <anchor 100 0> mark @TOP
+        ligComponent <anchor 200 0> mark @TOP;
+} test;

--- a/fea-rs/test-data/compile-tests/mini-latin/bad/empty_mark_class_mark_to_mark.ERR
+++ b/fea-rs/test-data/compile-tests/mini-latin/bad/empty_mark_class_mark_to_mark.ERR
@@ -1,0 +1,5 @@
+error: Empty glyph class in mark class definition
+in ./test-data/compile-tests/mini-latin/bad/empty_mark_class_mark_to_mark.fea at 2:10
+  | 
+2 | markClass [] <anchor 0 0> @TOP;
+  |           ^^

--- a/fea-rs/test-data/compile-tests/mini-latin/bad/empty_mark_class_mark_to_mark.fea
+++ b/fea-rs/test-data/compile-tests/mini-latin/bad/empty_mark_class_mark_to_mark.fea
@@ -1,0 +1,6 @@
+# the same empty class, attached in a mark-to-mark rule
+markClass [] <anchor 0 0> @TOP;
+
+feature test {
+    pos mark acutecomb <anchor 100 0> mark @TOP;
+} test;

--- a/fea-rs/test-data/compile-tests/mini-latin/bad/empty_mark_class_named.ERR
+++ b/fea-rs/test-data/compile-tests/mini-latin/bad/empty_mark_class_named.ERR
@@ -1,0 +1,5 @@
+error: Empty glyph class in mark class definition
+in ./test-data/compile-tests/mini-latin/bad/empty_mark_class_named.fea at 5:10
+  | 
+5 | markClass @EMPTY <anchor 0 0> @TOP;
+  |           ^^^^^^

--- a/fea-rs/test-data/compile-tests/mini-latin/bad/empty_mark_class_named.fea
+++ b/fea-rs/test-data/compile-tests/mini-latin/bad/empty_mark_class_named.fea
@@ -1,0 +1,9 @@
+# an empty class reached through a named glyph class. The validation pass
+# tracks named classes by name only, so this spelling can only be caught once
+# the class contents have been resolved.
+@EMPTY = [];
+markClass @EMPTY <anchor 0 0> @TOP;
+
+feature test {
+    pos base a <anchor 100 0> mark @TOP;
+} test;

--- a/fea-rs/test-data/compile-tests/mini-latin/bad/empty_mark_class_nested.ERR
+++ b/fea-rs/test-data/compile-tests/mini-latin/bad/empty_mark_class_nested.ERR
@@ -1,0 +1,5 @@
+error: Empty glyph class in mark class definition
+in ./test-data/compile-tests/mini-latin/bad/empty_mark_class_nested.fea at 4:10
+  | 
+4 | markClass @ALSO_EMPTY <anchor 0 0> @TOP;
+  |           ^^^^^^^^^^^

--- a/fea-rs/test-data/compile-tests/mini-latin/bad/empty_mark_class_nested.fea
+++ b/fea-rs/test-data/compile-tests/mini-latin/bad/empty_mark_class_nested.fea
@@ -1,0 +1,8 @@
+# as empty_mark_class_named, but the emptiness is one level further down.
+@EMPTY = [];
+@ALSO_EMPTY = [@EMPTY];
+markClass @ALSO_EMPTY <anchor 0 0> @TOP;
+
+feature test {
+    pos base a <anchor 100 0> mark @TOP;
+} test;

--- a/fea-rs/test-data/compile-tests/mini-latin/bad/empty_mark_class_predicate.ERR
+++ b/fea-rs/test-data/compile-tests/mini-latin/bad/empty_mark_class_predicate.ERR
@@ -1,0 +1,5 @@
+error: Empty glyph class in mark class definition
+in ./test-data/compile-tests/mini-latin/bad/empty_mark_class_predicate.fea at 5:10
+  | 
+5 | markClass [$[name endswith ".zzz"]] <anchor 0 0> @TOP;
+  |           ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/fea-rs/test-data/compile-tests/mini-latin/bad/empty_mark_class_predicate.fea
+++ b/fea-rs/test-data/compile-tests/mini-latin/bad/empty_mark_class_predicate.fea
@@ -1,0 +1,9 @@
+# a Glyphs.app predicate that matches zero glyphs. This is the spelling that
+# matters: no glyph in the mini-latin order ends in ".zzz", so the predicate
+# expands to an empty class, exactly as a renamed or removed suffix in a real
+# Glyphs source would.
+markClass [$[name endswith ".zzz"]] <anchor 0 0> @TOP;
+
+feature test {
+    pos base a <anchor 100 0> mark @TOP;
+} test;

--- a/fea-rs/test-data/compile-tests/mini-latin/bad/empty_mark_class_unused.ERR
+++ b/fea-rs/test-data/compile-tests/mini-latin/bad/empty_mark_class_unused.ERR
@@ -1,0 +1,5 @@
+error: Empty glyph class in mark class definition
+in ./test-data/compile-tests/mini-latin/bad/empty_mark_class_unused.fea at 4:10
+  | 
+4 | markClass [] <anchor 0 0> @TOP;
+  |           ^^

--- a/fea-rs/test-data/compile-tests/mini-latin/bad/empty_mark_class_unused.fea
+++ b/fea-rs/test-data/compile-tests/mini-latin/bad/empty_mark_class_unused.fea
@@ -1,0 +1,8 @@
+# an empty mark class that is never attached to anything. This cannot panic,
+# since no builder is ever reached, but feaLib rejects it at parse time and we
+# report it too: the definition is wrong whether or not anyone uses it.
+markClass [] <anchor 0 0> @TOP;
+
+feature test {
+    sub a by b;
+} test;

--- a/fea-rs/test-data/compile-tests/mini-latin/bad/empty_mark_class_with_good_class.ERR
+++ b/fea-rs/test-data/compile-tests/mini-latin/bad/empty_mark_class_with_good_class.ERR
@@ -1,0 +1,5 @@
+error: Empty glyph class in mark class definition
+in ./test-data/compile-tests/mini-latin/bad/empty_mark_class_with_good_class.fea at 3:10
+  | 
+3 | markClass [] <anchor 0 0> @TOP;
+  |           ^^

--- a/fea-rs/test-data/compile-tests/mini-latin/bad/empty_mark_class_with_good_class.fea
+++ b/fea-rs/test-data/compile-tests/mini-latin/bad/empty_mark_class_with_good_class.fea
@@ -1,0 +1,10 @@
+# an empty mark class alongside a well-formed one, both used by the same rule.
+# The good class must not mask the error in the empty one.
+markClass [] <anchor 0 0> @TOP;
+markClass [brevecomb] <anchor 0 0> @BOTTOM;
+
+feature test {
+    pos base a
+        <anchor 100 0> mark @TOP
+        <anchor 100 -200> mark @BOTTOM;
+} test;


### PR DESCRIPTION
This bug has been sitting there for a while, but is more relevant now because an empty glyphs.app predicate can create an empty mark class.

There's a similar issue with contextual lookups; I'll have a separate fix for that.


JMM