### PR TITLE
[fea-rs] Fix crasher when contextual input is empty

### DIFF
--- a/fea-rs/src/common.rs
+++ b/fea-rs/src/common.rs
@@ -83,6 +83,10 @@ impl GlyphOrClass {
         }
     }
 
+    pub(crate) fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     pub(crate) fn is_class(&self) -> bool {
         matches!(self, GlyphOrClass::Class(_))
     }

--- a/fea-rs/src/compile/compile_ctx.rs
+++ b/fea-rs/src/compile/compile_ctx.rs
@@ -952,10 +952,13 @@ impl<'a, F: FeatureProvider, V: VariationInfo> CompilationCtx<'a, F, V> {
         let target = input.target();
         let replacement = node.inline_rule().and_then(|r| r.replacements().next());
         //FIXME: warn if there are actual lookups here, we don't support that
-        if let Some((target, replacement)) =
+        if let Some((target_ids, replacement)) =
             self.validate_single_sub_inputs(&target, replacement.as_ref())
         {
-            let context = target
+            if self.report_empty_glyph_class(&target_ids, target.range()) {
+                return;
+            }
+            let context = target_ids
                 .iter()
                 .zip(replacement.into_iter_for_target())
                 .collect();
@@ -1265,15 +1268,18 @@ impl<'a, F: FeatureProvider, V: VariationInfo> CompilationCtx<'a, F, V> {
         let input = node.input();
         let mut found_empty = false;
         for (item, (glyphs, _)) in input.items().zip(context) {
-            if glyphs.is_empty() {
-                self.error(
-                    item.target().range(),
-                    "Empty glyph class in contextual rule",
-                );
-                found_empty = true;
-            }
+            found_empty |= self.report_empty_glyph_class(glyphs, item.target().range());
         }
         found_empty
+    }
+
+    /// Report `glyphs` if it is an empty class, returning whether it was.
+    fn report_empty_glyph_class(&mut self, glyphs: &GlyphOrClass, range: Range<usize>) -> bool {
+        if glyphs.is_empty() {
+            self.error(range, "Empty glyph class in contextual rule");
+            return true;
+        }
+        false
     }
 
     /// Resolve a value record, ignoring zero values

--- a/fea-rs/src/compile/compile_ctx.rs
+++ b/fea-rs/src/compile/compile_ctx.rs
@@ -931,6 +931,10 @@ impl<'a, F: FeatureProvider, V: VariationInfo> CompilationCtx<'a, F, V> {
             })
             .collect::<Vec<_>>();
 
+        if self.report_empty_contextual_input(node, &context) {
+            return;
+        }
+
         let lookup = self.ensure_current_lookup_type(Kind::GsubType6, node.range());
         lookup.add_contextual_rule(backtrack, context, lookahead);
     }
@@ -1220,7 +1224,10 @@ impl<'a, F: FeatureProvider, V: VariationInfo> CompilationCtx<'a, F, V> {
 
                 (glyphs, lookups)
             })
-            .collect();
+            .collect::<Vec<_>>();
+        if self.report_empty_contextual_input(node, &context) {
+            return;
+        }
         self.ensure_current_lookup_type(Kind::GposType8, node.range())
             .add_contextual_rule(backtrack, context, lookahead);
     }
@@ -1238,9 +1245,35 @@ impl<'a, F: FeatureProvider, V: VariationInfo> CompilationCtx<'a, F, V> {
             .input()
             .items()
             .map(|item| (self.resolve_glyph_or_class(&item.target()), Vec::new()))
-            .collect();
+            .collect::<Vec<_>>();
+        if self.report_empty_contextual_input(rule, &context) {
+            return;
+        }
         let lookup = self.ensure_current_lookup_type(kind, rule.range());
         lookup.add_contextual_rule(backtrack, context, lookahead);
+    }
+
+    /// Report any empty glyph class in a contextual rule's input sequence.
+    ///
+    /// Such a rule can never match, and cannot be built. Returns `true` if
+    /// anything was reported, in which case the rule must not be added.
+    fn report_empty_contextual_input(
+        &mut self,
+        node: &impl ContextualRuleNode,
+        context: &[(GlyphOrClass, Vec<LookupId>)],
+    ) -> bool {
+        let input = node.input();
+        let mut found_empty = false;
+        for (item, (glyphs, _)) in input.items().zip(context) {
+            if glyphs.is_empty() {
+                self.error(
+                    item.target().range(),
+                    "Empty glyph class in contextual rule",
+                );
+                found_empty = true;
+            }
+        }
+        found_empty
     }
 
     /// Resolve a value record, ignoring zero values

--- a/fea-rs/src/compile/lookups/contextual.rs
+++ b/fea-rs/src/compile/lookups/contextual.rs
@@ -333,10 +333,10 @@ impl ContextBuilder {
         self.rules.iter().any(ContextRule::is_chain_rule)
     }
 
-    fn has_glyph_classes_with_more_than_one_glyph(&self) -> bool {
+    fn has_non_singleton_glyph_classes(&self) -> bool {
         self.rules
             .iter()
-            .any(ContextRule::has_glyph_classes_with_more_than_one_glyph)
+            .any(ContextRule::has_non_singleton_glyph_classes)
     }
 
     /// If the input sequence can be represented as a class def, return it
@@ -355,7 +355,7 @@ impl ContextBuilder {
     }
 
     fn format_1_coverage(&self) -> Option<CoverageTableBuilder> {
-        if self.has_glyph_classes_with_more_than_one_glyph() {
+        if self.has_non_singleton_glyph_classes() {
             return None;
         }
         Some(
@@ -489,12 +489,16 @@ impl ContextRule {
         !self.backtrack.is_empty() || !self.lookahead.is_empty()
     }
 
-    fn has_glyph_classes_with_more_than_one_glyph(&self) -> bool {
+    /// `true` unless every item in this rule is exactly one glyph.
+    ///
+    /// Format 1 requires single glyphs throughout, so an empty class rules it
+    /// out just as a larger one does; hence `!= 1` and not `> 1`.
+    fn has_non_singleton_glyph_classes(&self) -> bool {
         self.backtrack
             .iter()
             .chain(self.lookahead.iter())
             .chain(self.context.iter().map(|(glyphs, _)| glyphs))
-            .any(|x| x.len() > 1)
+            .any(|x| x.len() != 1)
     }
 
     fn first_input_sequence_item(&self) -> &GlyphOrClass {

--- a/fea-rs/test-data/compile-tests/mini-latin/bad/empty_contextual_ignore_pos.ERR
+++ b/fea-rs/test-data/compile-tests/mini-latin/bad/empty_contextual_ignore_pos.ERR
@@ -1,0 +1,5 @@
+error: Empty glyph class in contextual rule
+in ./test-data/compile-tests/mini-latin/bad/empty_contextual_ignore_pos.fea at 3:15
+  | 
+3 |     ignore pos []' a;
+  |                ^^

--- a/fea-rs/test-data/compile-tests/mini-latin/bad/empty_contextual_ignore_pos.fea
+++ b/fea-rs/test-data/compile-tests/mini-latin/bad/empty_contextual_ignore_pos.fea
@@ -1,0 +1,5 @@
+# the `ignore pos` equivalent
+feature test {
+    ignore pos []' a;
+    pos a' a 5;
+} test;

--- a/fea-rs/test-data/compile-tests/mini-latin/bad/empty_contextual_ignore_sub.ERR
+++ b/fea-rs/test-data/compile-tests/mini-latin/bad/empty_contextual_ignore_sub.ERR
@@ -1,0 +1,5 @@
+error: Empty glyph class in contextual rule
+in ./test-data/compile-tests/mini-latin/bad/empty_contextual_ignore_sub.fea at 4:15
+  | 
+4 |     ignore sub []' a;
+  |                ^^

--- a/fea-rs/test-data/compile-tests/mini-latin/bad/empty_contextual_ignore_sub.fea
+++ b/fea-rs/test-data/compile-tests/mini-latin/bad/empty_contextual_ignore_sub.fea
@@ -1,0 +1,6 @@
+# an `ignore sub` rule builds the same contextual machinery, so an empty input
+# class panics there too
+feature test {
+    ignore sub []' a;
+    sub a' a by b;
+} test;

--- a/fea-rs/test-data/compile-tests/mini-latin/bad/empty_contextual_input_named.ERR
+++ b/fea-rs/test-data/compile-tests/mini-latin/bad/empty_contextual_input_named.ERR
@@ -1,0 +1,5 @@
+error: Empty glyph class in contextual rule
+in ./test-data/compile-tests/mini-latin/bad/empty_contextual_input_named.fea at 5:8
+  | 
+5 |     sub @EMPTY' a by b;
+  |         ^^^^^^

--- a/fea-rs/test-data/compile-tests/mini-latin/bad/empty_contextual_input_named.fea
+++ b/fea-rs/test-data/compile-tests/mini-latin/bad/empty_contextual_input_named.fea
@@ -1,0 +1,6 @@
+# the empty input class reached through a named glyph class
+@EMPTY = [];
+
+feature test {
+    sub @EMPTY' a by b;
+} test;

--- a/fea-rs/test-data/compile-tests/mini-latin/bad/empty_contextual_input_pos.ERR
+++ b/fea-rs/test-data/compile-tests/mini-latin/bad/empty_contextual_input_pos.ERR
@@ -1,0 +1,5 @@
+error: Empty glyph class in contextual rule
+in ./test-data/compile-tests/mini-latin/bad/empty_contextual_input_pos.fea at 3:8
+  | 
+3 |     pos []' a 5;
+  |         ^^

--- a/fea-rs/test-data/compile-tests/mini-latin/bad/empty_contextual_input_pos.fea
+++ b/fea-rs/test-data/compile-tests/mini-latin/bad/empty_contextual_input_pos.fea
@@ -1,0 +1,4 @@
+# the same shape in a contextual positioning rule
+feature test {
+    pos []' a 5;
+} test;

--- a/fea-rs/test-data/compile-tests/mini-latin/bad/empty_contextual_input_predicate.ERR
+++ b/fea-rs/test-data/compile-tests/mini-latin/bad/empty_contextual_input_predicate.ERR
@@ -1,0 +1,5 @@
+error: Empty glyph class in contextual rule
+in ./test-data/compile-tests/mini-latin/bad/empty_contextual_input_predicate.fea at 4:8
+  | 
+4 |     sub [$[name endswith ".zzz"]]' a by b;
+  |         ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/fea-rs/test-data/compile-tests/mini-latin/bad/empty_contextual_input_predicate.fea
+++ b/fea-rs/test-data/compile-tests/mini-latin/bad/empty_contextual_input_predicate.fea
@@ -1,0 +1,5 @@
+# the spelling that makes this reachable from a real Glyphs source: a predicate
+# that matches zero glyphs. No glyph in the mini-latin order ends in ".zzz".
+feature test {
+    sub [$[name endswith ".zzz"]]' a by b;
+} test;

--- a/fea-rs/test-data/compile-tests/mini-latin/bad/empty_contextual_input_second.ERR
+++ b/fea-rs/test-data/compile-tests/mini-latin/bad/empty_contextual_input_second.ERR
@@ -1,0 +1,5 @@
+error: Empty glyph class in contextual rule
+in ./test-data/compile-tests/mini-latin/bad/empty_contextual_input_second.fea at 4:10
+  | 
+4 |     sub a []' by b;
+  |           ^^

--- a/fea-rs/test-data/compile-tests/mini-latin/bad/empty_contextual_input_second.fea
+++ b/fea-rs/test-data/compile-tests/mini-latin/bad/empty_contextual_input_second.fea
@@ -1,0 +1,5 @@
+# as empty_contextual_input_sub, but the empty class is not the first item of
+# the input sequence
+feature test {
+    sub a []' by b;
+} test;

--- a/fea-rs/test-data/compile-tests/mini-latin/bad/empty_contextual_input_sub.ERR
+++ b/fea-rs/test-data/compile-tests/mini-latin/bad/empty_contextual_input_sub.ERR
@@ -1,0 +1,5 @@
+error: Empty glyph class in contextual rule
+in ./test-data/compile-tests/mini-latin/bad/empty_contextual_input_sub.fea at 6:8
+  | 
+6 |     sub []' a by b;
+  |         ^^

--- a/fea-rs/test-data/compile-tests/mini-latin/bad/empty_contextual_input_sub.fea
+++ b/fea-rs/test-data/compile-tests/mini-latin/bad/empty_contextual_input_sub.fea
@@ -1,0 +1,7 @@
+# an empty glyph class in the input sequence of a contextual substitution.
+# The rule can never match, but instead of a diagnostic it used to panic:
+# an empty class is not "more than one glyph", so format 1 was selected, and
+# format 1 requires every input item to be a single glyph.
+feature test {
+    sub []' a by b;
+} test;

--- a/fea-rs/test-data/compile-tests/mini-latin/bad/empty_reverse_sub_input.ERR
+++ b/fea-rs/test-data/compile-tests/mini-latin/bad/empty_reverse_sub_input.ERR
@@ -1,0 +1,5 @@
+error: Empty glyph class in contextual rule
+in ./test-data/compile-tests/mini-latin/bad/empty_reverse_sub_input.fea at 5:9
+  | 
+5 |     rsub []' by b;
+  |          ^^

--- a/fea-rs/test-data/compile-tests/mini-latin/bad/empty_reverse_sub_input.fea
+++ b/fea-rs/test-data/compile-tests/mini-latin/bad/empty_reverse_sub_input.fea
@@ -1,0 +1,6 @@
+# an empty glyph class as the input of a reverse chaining substitution.
+# Unlike the other contextual rules this never panicked; it compiled to
+# nothing at all, silently dropping the rule.
+feature test {
+    rsub []' by b;
+} test;

--- a/fea-rs/test-data/compile-tests/mini-latin/bad/empty_reverse_sub_named.ERR
+++ b/fea-rs/test-data/compile-tests/mini-latin/bad/empty_reverse_sub_named.ERR
@@ -1,0 +1,5 @@
+error: Empty glyph class in contextual rule
+in ./test-data/compile-tests/mini-latin/bad/empty_reverse_sub_named.fea at 5:9
+  | 
+5 |     rsub @EMPTY' by b;
+  |          ^^^^^^

--- a/fea-rs/test-data/compile-tests/mini-latin/bad/empty_reverse_sub_named.fea
+++ b/fea-rs/test-data/compile-tests/mini-latin/bad/empty_reverse_sub_named.fea
@@ -1,0 +1,6 @@
+# the empty reverse-sub input reached through a named glyph class
+@EMPTY = [];
+
+feature test {
+    rsub @EMPTY' by b;
+} test;

--- a/fea-rs/test-data/compile-tests/mini-latin/bad/empty_reverse_sub_predicate.ERR
+++ b/fea-rs/test-data/compile-tests/mini-latin/bad/empty_reverse_sub_predicate.ERR
@@ -1,0 +1,5 @@
+error: Empty glyph class in contextual rule
+in ./test-data/compile-tests/mini-latin/bad/empty_reverse_sub_predicate.fea at 3:9
+  | 
+3 |     rsub [$[name endswith ".zzz"]]' by b;
+  |          ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/fea-rs/test-data/compile-tests/mini-latin/bad/empty_reverse_sub_predicate.fea
+++ b/fea-rs/test-data/compile-tests/mini-latin/bad/empty_reverse_sub_predicate.fea
@@ -1,0 +1,4 @@
+# the empty reverse-sub input produced by a predicate that matches zero glyphs
+feature test {
+    rsub [$[name endswith ".zzz"]]' by b;
+} test;


### PR DESCRIPTION
Found while looking at the empty mark classes stuff.


JMM