### PR TITLE
bump workspace crate versions for the 1.0.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "ascii_plist_derive"
-version = "0.2.0"
+version = "1.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -670,7 +670,7 @@ checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fea-rs"
-version = "0.22.0"
+version = "1.0.0"
 dependencies = [
  "ansi_term",
  "clap",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "fontbe"
-version = "0.5.0"
+version = "1.0.0"
 dependencies = [
  "chrono",
  "diff",
@@ -772,7 +772,7 @@ dependencies = [
 
 [[package]]
 name = "fontc"
-version = "1.0.0-rc.2"
+version = "1.0.0"
 dependencies = [
  "bitflags 2.13.1",
  "chrono",
@@ -831,7 +831,7 @@ dependencies = [
 
 [[package]]
 name = "fontdrasil"
-version = "0.4.0"
+version = "1.0.0"
 dependencies = [
  "diff",
  "kurbo",
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "fontir"
-version = "0.5.0"
+version = "1.0.0"
 dependencies = [
  "bincode",
  "bitflags 2.13.1",
@@ -875,7 +875,7 @@ dependencies = [
 
 [[package]]
 name = "fontra2fontir"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "diff",
  "fontdrasil",
@@ -966,7 +966,7 @@ checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "glyphs-reader"
-version = "0.5.0"
+version = "1.0.0"
 dependencies = [
  "ascii_plist_derive",
  "chrono",
@@ -989,7 +989,7 @@ dependencies = [
 
 [[package]]
 name = "glyphs2fontir"
-version = "0.6.0"
+version = "1.0.0"
 dependencies = [
  "chrono",
  "diff",
@@ -1475,7 +1475,7 @@ dependencies = [
 
 [[package]]
 name = "otl-normalizer"
-version = "0.3.0"
+version = "1.0.0"
 dependencies = [
  "clap",
  "fea-rs",
@@ -2352,7 +2352,7 @@ dependencies = [
 
 [[package]]
 name = "ufo2fontir"
-version = "0.4.0"
+version = "1.0.0"
 dependencies = [
  "chrono",
  "diff",

--- a/fea-rs/Cargo.toml
+++ b/fea-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fea-rs"
-version = "0.22.0"
+version = "1.0.0"
 license = "MIT/Apache-2.0"
 authors = ["Colin Rofls <colin@cmyr.net>"]
 description = "Tools for working with Adobe OpenType Feature files."
@@ -12,7 +12,7 @@ edition = "2024"
 exclude = ["test-data"]
 
 [dependencies]
-fontdrasil = { version = "0.4.0", path = "../fontdrasil" }
+fontdrasil = { version = "1.0.0", path = "../fontdrasil" }
 ansi_term = "0.12.1"
 serde_json = {version = "1.0.87", optional = true }
 

--- a/fontbe/Cargo.toml
+++ b/fontbe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fontbe"
-version = "0.5.0"
+version = "1.0.0"
 edition = "2024"
 license = "MIT/Apache-2.0"
 description = "the backend for fontc, a font compiler."
@@ -11,9 +11,9 @@ categories = ["text-processing", "parsing", "graphics"]
 [features]
 
 [dependencies]
-fontdrasil = { version = "0.4.0", path = "../fontdrasil" }
-fontir = { version = "0.5.0", path = "../fontir" }
-fea-rs = { version = "0.22.0", path = "../fea-rs" }
+fontdrasil = { version = "1.0.0", path = "../fontdrasil" }
+fontir = { version = "1.0.0", path = "../fontir" }
+fea-rs = { version = "1.0.0", path = "../fea-rs" }
 tinystr = "0.8.0"
 
 icu_properties.workspace = true
@@ -46,4 +46,4 @@ temp-env.workspace = true
 rstest.workspace = true
 pretty_assertions.workspace = true
 tracing-subscriber.workspace = true
-otl-normalizer = { version = "0.3.0", path = "../otl-normalizer" }
+otl-normalizer = { version = "1.0.0", path = "../otl-normalizer" }

--- a/fontc/Cargo.toml
+++ b/fontc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fontc"
-version = "1.0.0-rc.2"
+version = "1.0.0"
 build = "build.rs"
 edition = "2024"
 license = "MIT/Apache-2.0"
@@ -24,12 +24,12 @@ default = ["cli", "rayon"]
 cli = ["clap"]
 
 [dependencies]
-fontdrasil = { version = "0.4.0", path = "../fontdrasil" }
-fontbe = { version = "0.5.0", path = "../fontbe" }
-fontir = { version = "0.5.0", path = "../fontir" }
-glyphs2fontir = { version = "0.6.0", path = "../glyphs2fontir" }
-fontra2fontir = { version = "0.4.0", path = "../fontra2fontir" }
-ufo2fontir = { version = "0.4.0", path = "../ufo2fontir" }
+fontdrasil = { version = "1.0.0", path = "../fontdrasil" }
+fontbe = { version = "1.0.0", path = "../fontbe" }
+fontir = { version = "1.0.0", path = "../fontir" }
+glyphs2fontir = { version = "1.0.0", path = "../glyphs2fontir" }
+fontra2fontir = { version = "0.5.0", path = "../fontra2fontir" }
+ufo2fontir = { version = "1.0.0", path = "../ufo2fontir" }
 
 bitflags.workspace = true
 

--- a/fontc_crater/Cargo.toml
+++ b/fontc_crater/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/googlefonts/fontc"
 readme = "README.md"
 
 [dependencies]
-fontc = { version = "1.0.0-rc.2", path = "../fontc" }
+fontc = { version = "1.0.0", path = "../fontc" }
 
 google-fonts-sources = "0.11.1"
 maud = "0.27.0"

--- a/fontdrasil/Cargo.toml
+++ b/fontdrasil/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fontdrasil"
-version = "0.4.0"
+version = "1.0.0"
 edition = "2024"
 license = "MIT/Apache-2.0"
 description = "Common types and utilites used by fontc, a font compiler."

--- a/fontir/Cargo.toml
+++ b/fontir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fontir"
-version = "0.5.0"
+version = "1.0.0"
 edition = "2024"
 license = "MIT/Apache-2.0"
 description = "Intermediate Representation used by fontc, a font compiler."
@@ -11,7 +11,7 @@ categories = ["text-processing", "parsing", "graphics"]
 [features]
 
 [dependencies]
-fontdrasil = { version = "0.4.0", path = "../fontdrasil" }
+fontdrasil = { version = "1.0.0", path = "../fontdrasil" }
 
 bitflags.workspace = true
 serde.workspace = true

--- a/fontra2fontir/Cargo.toml
+++ b/fontra2fontir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fontra2fontir"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 license = "MIT/Apache-2.0"
 description = "Converts fontra.xyz/ files to font ir for compilation."
@@ -11,8 +11,8 @@ categories = ["text-processing", "parsing", "graphics"]
 [features]
 
 [dependencies]
-fontdrasil = { version = "0.4.0", path = "../fontdrasil" }
-fontir = { version = "0.5.0", path = "../fontir" }
+fontdrasil = { version = "1.0.0", path = "../fontdrasil" }
+fontir = { version = "1.0.0", path = "../fontir" }
 
 write-fonts.workspace = true
 

--- a/glyphs-reader/Cargo.toml
+++ b/glyphs-reader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glyphs-reader"
-version = "0.5.0"
+version = "1.0.0"
 license = "MIT/Apache-2.0"
 authors = ["Raph Levien <raph.levien@gmail.com>"]
 repository = "https://github.com/googlefonts/fontc"
@@ -12,8 +12,8 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ascii_plist_derive = { version = "0.2.0", path = "ascii_plist_derive" }
-fontdrasil = { version = "0.4.0", path = "../fontdrasil" }
+ascii_plist_derive = { version = "1.0.0", path = "ascii_plist_derive" }
+fontdrasil = { version = "1.0.0", path = "../fontdrasil" }
 quick-xml = "0.41"
 write-fonts.workspace = true
 ordered-float.workspace = true

--- a/glyphs-reader/ascii_plist_derive/Cargo.toml
+++ b/glyphs-reader/ascii_plist_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ascii_plist_derive"
-version = "0.2.0"
+version = "1.0.0"
 authors = ["Raph Levien <raph.levien@gmail.com>"]
 edition = "2024"
 repository = "https://github.com/googlefonts/fontc"

--- a/glyphs2fontir/Cargo.toml
+++ b/glyphs2fontir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glyphs2fontir"
-version = "0.6.0"
+version = "1.0.0"
 edition = "2024"
 license = "MIT/Apache-2.0"
 description = "Converts www.glyphsapp.com files to font ir for compilation."
@@ -11,9 +11,9 @@ categories = ["text-processing", "parsing", "graphics"]
 [features]
 
 [dependencies]
-fontdrasil = { version = "0.4.0", path = "../fontdrasil" }
-fontir = { version = "0.5.0", path = "../fontir" }
-glyphs-reader = { version = "0.5.0", path = "../glyphs-reader" }
+fontdrasil = { version = "1.0.0", path = "../fontdrasil" }
+fontir = { version = "1.0.0", path = "../fontir" }
+glyphs-reader = { version = "1.0.0", path = "../glyphs-reader" }
 
 smol_str.workspace = true
 log.workspace = true

--- a/otl-normalizer/Cargo.toml
+++ b/otl-normalizer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "otl-normalizer"
-version = "0.3.0"
+version = "1.0.0"
 edition = "2024"
 license = "MIT/Apache-2.0"
 description = "a normalized text representation of OpenType layout subtables"
@@ -9,7 +9,7 @@ readme = "README.md"
 
 
 [dependencies]
-fontdrasil = { version = "0.4.0", path = "../fontdrasil" }
+fontdrasil = { version = "1.0.0", path = "../fontdrasil" }
 clap.workspace = true
 thiserror.workspace = true
 smol_str.workspace = true
@@ -17,7 +17,7 @@ write-fonts.workspace = true
 indexmap.workspace = true
 
 [dev-dependencies]
-fea-rs = { version = "0.22.0", path = "../fea-rs" }
+fea-rs = { version = "1.0.0", path = "../fea-rs" }
 
 # Support for `cargo binstall otl-normalizer`.
 # The default Github download URL template used by cargo-binstall doesn't work

--- a/ufo2fontir/Cargo.toml
+++ b/ufo2fontir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ufo2fontir"
-version = "0.4.0"
+version = "1.0.0"
 edition = "2024"
 license = "MIT/Apache-2.0"
 description = "Converts UFO or UFO+designspace to font ir for compilation."
@@ -11,10 +11,10 @@ categories = ["text-processing", "parsing", "graphics"]
 [features]
 
 [dependencies]
-fea-rs = { version = "0.22.0", path = "../fea-rs" }
-fontdrasil = { version = "0.4.0", path = "../fontdrasil" }
-fontir = { version = "0.5.0", path = "../fontir" }
-glyphs-reader = { version = "0.5.0", path = "../glyphs-reader" }
+fea-rs = { version = "1.0.0", path = "../fea-rs" }
+fontdrasil = { version = "1.0.0", path = "../fontdrasil" }
+fontir = { version = "1.0.0", path = "../fontir" }
+glyphs-reader = { version = "1.0.0", path = "../glyphs-reader" }
 
 kurbo.workspace = true
 serde.workspace = true


### PR DESCRIPTION
- fontc 1.0.0-rc.2 -> 1.0.0;
- fontdrasil, fontir, fontbe, glyphs-reader, ascii_plist_derive, glyphs2fontir, ufo2fontir, fea-rs and otl-normalizer all -> 1.0.0;
- fontra2fontir (incomplete backend) -> 0.5.0 only;
- fontc_crater stays unpublished at 0.2.0.