### PR TITLE
bump write-fonts to 0.52.0 and skrifa to 0.46.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1726,9 +1726,9 @@ dependencies = [
 
 [[package]]
 name = "read-fonts"
-version = "0.42.1"
+version = "0.43.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c69341f5f744623061a258e9d06a0213783a89ec23b6efb88a1c0c4ed285559"
+checksum = "005c8acf251756c478b0bf402885bfd88a1476020c4c7e6060edc1aa68da38ea"
 dependencies = [
  "bytemuck",
  "font-types 0.12.4",
@@ -2019,9 +2019,9 @@ checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "skrifa"
-version = "0.45.1"
+version = "0.46.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5b090b1690f1c63a8659574ea987c557f1cc571e24dedcba89458f32d0ccb5"
+checksum = "d4febebda507fb889c545a37a135517769d1391941013561292897961d1887d6"
 dependencies = [
  "bytemuck",
  "read-fonts",
@@ -2753,9 +2753,9 @@ dependencies = [
 
 [[package]]
 name = "write-fonts"
-version = "0.51.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b082e0c3b0c5565b4f7bb1e0bbb4efbc8afc5a9441ade74fadc6502f9d406091"
+checksum = "843cebb7bd36359861dbce43d54ac8b33dfdf7b80a95913adc1ef7c7bb881e62"
 dependencies = [
  "font-types 0.12.4",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ icu_properties = "=2.1"
 smallvec = {version = "1.15", features = ["const_new"]}
 
 # fontations etc
-write-fonts = { version = "0.51.0", features = ["serde", "read", "tables"]  }
-skrifa = { version = "0.45.0", features = ["traversal"] }
+write-fonts = { version = "0.52.0", features = ["serde", "read", "tables"]  }
+skrifa = { version = "0.46.2", features = ["traversal"] }
 norad = { version = "0.18.4", default-features = false }
 
 # dev dependencies


### PR DESCRIPTION
Bump write-fonts to 0.52.0 and skrifa to 0.46.2 ahead of the 1.0 release. This unifies the graph on read-fonts 0.43.x / font-types 0.12.4 (same versions current harfrust (0.13.3) resolves to) so the published crates can be mixed with harfrust without duplicate font-types/read-fonts (as requested by @simoncozens).