### PR TITLE
notify-plugin: send client_payload as a JSON object

### DIFF
--- a/.github/workflows/notify-plugin.yml
+++ b/.github/workflows/notify-plugin.yml
@@ -69,8 +69,8 @@ jobs:
         run: |
           gh api repos/googlefonts/fontc-export-plugin/dispatches \
             --method POST \
-            --field event_type='fontc-release' \
-            --raw-field client_payload="{\"version\":\"${STEPS_VERSION_OUTPUTS_VERSION}\"}"
+            --raw-field event_type='fontc-release' \
+            --raw-field "client_payload[version]=${STEPS_VERSION_OUTPUTS_VERSION}"
 
       - name: Log notification
         if: steps.check.outputs.is_release == 'true'


### PR DESCRIPTION
The plugin notification failed on the 1.0.0 release with HTTP 422: `--raw-field client_payload="{...}"` sends the payload as a JSON-encoded *string*, but the repository_dispatch endpoint requires client_payload to be an actual object.

Use gh api's bracket syntax (`client_payload[version]=...`) instead, which builds the nested object. Request body verified with `gh api --verbose`:

```json
{
  "client_payload": {
    "version": "1.0.0"
  },
  "event_type": "fontc-release"
}
```

The 1.0.0 notification itself was already sent manually with the corrected invocation.

JMM