### PR TITLE
Fea test variable syntax

### DIFF
--- a/fea-rs/src/compile/compile_ctx.rs
+++ b/fea-rs/src/compile/compile_ctx.rs
@@ -24,7 +24,9 @@ use write_fonts::{
             ConditionFormat1, ConditionSet, FeatureVariations, LookupFlag,
             builders::{CaretValueBuilder as CaretValue, DeviceOrDeltas, Metric},
         },
-        variations::{common_builder::RemapVarStore, ivs_builder::VariationStoreBuilder},
+        variations::{
+            VariationRegion, common_builder::RemapVarStore, ivs_builder::VariationStoreBuilder,
+        },
     },
     types::{NameId, Tag},
 };
@@ -1409,10 +1411,7 @@ impl<'a, F: FeatureProvider, V: VariationInfo> CompilationCtx<'a, F, V> {
             locations.insert(pos, metric_loc.value().parse_signed());
         }
         match var_info.resolve_variable_metric(&locations) {
-            Ok((default, deltas)) => Metric {
-                default,
-                device_or_deltas: DeviceOrDeltas::Deltas(deltas),
-            },
+            Ok((default, deltas)) => metric_from_deltas(default, deltas),
             Err(e) => {
                 self.error(metric.range(), format!("failed to compute deltas: '{e}'"));
                 Default::default()
@@ -1451,10 +1450,7 @@ impl<'a, F: FeatureProvider, V: VariationInfo> CompilationCtx<'a, F, V> {
         let locations = var_info.resolve_variable_metric(&locations);
 
         match locations {
-            Ok((default, deltas)) => Metric {
-                default,
-                device_or_deltas: DeviceOrDeltas::Deltas(deltas),
-            },
+            Ok((default, deltas)) => metric_from_deltas(default, deltas),
             Err(e) => {
                 self.error(
                     number_value.range(),
@@ -2451,6 +2447,22 @@ fn get_reasonable_length_span(node: &NodeOrToken) -> Range<usize> {
             let end = range.end.min(range.start + MAX_SPAN_LEN_FOR_NODES);
             range.start..end
         }
+    }
+}
+
+/// A variable scalar whose value is the same at every master is just a scalar.
+///
+/// Matches feaLib's `VariableScalar.does_vary`:
+/// <https://github.com/fonttools/fonttools/blob/34be2443a/Lib/fontTools/feaLib/variableScalar.py#L58-L61>
+fn metric_from_deltas(default: i16, deltas: Vec<(VariationRegion, i16)>) -> Metric {
+    let device_or_deltas = if deltas.iter().all(|(_, delta)| *delta == 0) {
+        DeviceOrDeltas::None
+    } else {
+        DeviceOrDeltas::Deltas(deltas)
+    };
+    Metric {
+        default,
+        device_or_deltas,
     }
 }
 

--- a/fea-rs/src/compile/variations.rs
+++ b/fea-rs/src/compile/variations.rs
@@ -210,7 +210,7 @@ impl MockVariationInfo {
 
 #[cfg(any(test, feature = "test", feature = "cli"))]
 impl VariationInfo for MockVariationInfo {
-    type Error = NopError;
+    type Error = fontdrasil::variations::DeltaError;
 
     fn axis(&self, axis_tag: Tag) -> Option<(usize, &Axis)> {
         self.axes.iter().enumerate().find_map(|(i, axis)| {
@@ -224,9 +224,14 @@ impl VariationInfo for MockVariationInfo {
 
     fn resolve_variable_metric(
         &self,
-        _locations: &HashMap<NormalizedLocation, i16>,
+        locations: &HashMap<NormalizedLocation, i16>,
     ) -> Result<(i16, Vec<(VariationRegion, i16)>), Self::Error> {
-        Ok(Default::default())
+        let axes = fontdrasil::types::Axes::new(self.axes.clone());
+        let model = fontdrasil::variations::VariationModel::new(
+            locations.keys().cloned().collect(),
+            axes.axis_order(),
+        );
+        fontdrasil::variations::resolve_variable_metric(&model, &axes, locations)
     }
 
     fn axis_count(&self) -> u16 {
@@ -236,7 +241,7 @@ impl VariationInfo for MockVariationInfo {
     fn resolve_glyphs_number_value(
         &self,
         _: &str,
-    ) -> Result<HashMap<NormalizedLocation, f64>, NopError> {
+    ) -> Result<HashMap<NormalizedLocation, f64>, Self::Error> {
         Ok(Default::default())
     }
 }

--- a/fea-rs/src/util/ttx.rs
+++ b/fea-rs/src/util/ttx.rs
@@ -38,11 +38,6 @@ static IGNORED_TESTS: &[&str] = &[
     //
     // includes syntax that is (i think) useless, and should at least be a warning
     "GSUB_8.fea",
-    // # tests of variable syntax extension #
-    "variable_bug2772.fea",
-    "variable_scalar_anchor.fea",
-    "variable_scalar_valuerecord.fea",
-    "variable_mark_anchor.fea",
     // ## new in fonttools 4.62.1, not yet supported or compare failures ##
     // inline alternate subst in contextual rules (see #1925)
     "contextual_merge_alternate.fea",


### PR DESCRIPTION
based on #2107, this makes our MockVariationStore compute real variable metrics, based on the same logic we use in fontc.

This lets us run some fonttools tests we'd been ignoring previously, and _that_ uncovered a bug, fixed in the second commit.