### PR TITLE
[ufo2fontir] Support uservalue in instance locations

### DIFF
--- a/resources/testdata/mapping_instance_uservalue.designspace
+++ b/resources/testdata/mapping_instance_uservalue.designspace
@@ -1,0 +1,27 @@
+<?xml version='1.0' encoding='utf-8'?>
+<designspace format="5.0">
+  <!-- an instance located by uservalue on a mapped axis, see fontc#1649 -->
+  <axes>
+    <axis tag="wght" name="weight" minimum="400" default="400" maximum="700">
+      <map input="400" output="0"/>
+      <map input="700" output="100"/>
+    </axis>
+    <axis tag="wdth" name="width" minimum="75" default="100" maximum="100"/>
+  </axes>
+  <sources>
+    <source filename="WghtVar-Regular.ufo" name="Regular">
+      <location>
+        <dimension name="weight" xvalue="0"/>
+        <dimension name="width" xvalue="100"/>
+      </location>
+    </source>
+  </sources>
+  <instances>
+    <!-- width omitted: takes the axis default -->
+    <instance stylename="Medium">
+      <location>
+        <dimension name="weight" uservalue="500"/>
+      </location>
+    </instance>
+  </instances>
+</designspace>

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -45,7 +45,9 @@ use write_fonts::{
     types::{NameId, Tag},
 };
 
-use crate::toir::{master_locations, to_design_location, to_ir_axes, to_ir_glyph};
+use crate::toir::{
+    master_locations, to_design_location, to_instance_design_location, to_ir_axes, to_ir_glyph,
+};
 
 const UFO_KERN1_PREFIX: &str = "public.kern1.";
 const UFO_KERN2_PREFIX: &str = "public.kern2.";
@@ -245,7 +247,7 @@ impl Source for DesignSpaceIrSource {
                 default_master_lib = Some(ufo.lib);
             }
 
-            let location = to_design_location(&axis_tags_by_name, &source.location);
+            let location = to_design_location(&axis_tags_by_name, &source.location)?;
             for (glyph_name, glif_file) in glif_files(&ufo_dir, &mut layer_cache, source)? {
                 if !glif_file.exists() {
                     return Err(BadSource::new(glif_file, BadSourceKind::ExpectedFile).into());
@@ -521,12 +523,12 @@ fn default_master(
             (tag, UserCoord::new(a.default as f64).to_design(converter))
         })
         .collect();
-    designspace
-        .sources
-        .iter()
-        .enumerate()
-        .find(|(_, source)| to_design_location(&tags_by_name, &source.location) == default_location)
-        .ok_or(Error::NoDefaultMaster)
+    for (idx, source) in designspace.sources.iter().enumerate() {
+        if to_design_location(&tags_by_name, &source.location)? == default_location {
+            return Ok((idx, source));
+        }
+    }
+    Err(Error::NoDefaultMaster)
 }
 
 fn load_plist(ufo_dir: &Path, name: &str) -> Result<plist::Dictionary, BadSource> {
@@ -1058,7 +1060,7 @@ impl Work<Context, WorkId, Error> for StaticMetadataWork {
             .map(|inst| {
                 // TODO: Also support localised names, and names inferred from axis labels
                 // (also used to build STAT table)
-                NamedInstance {
+                Ok(NamedInstance {
                     name: inst.stylename.clone().unwrap_or_else(|| {
                         match inst
                             .name
@@ -1071,12 +1073,11 @@ impl Work<Context, WorkId, Error> for StaticMetadataWork {
                         }
                     }),
                     postscript_name: inst.postscriptfontname.clone(),
-                    location: to_design_location(&tags_by_name, &inst.location)
-                        .to_user(&axes)
-                        .unwrap(),
-                }
+                    location: to_instance_design_location(&axes, &tags_by_name, &inst.location)?
+                        .to_user(&axes)?,
+                })
             })
-            .collect();
+            .collect::<Result<Vec<_>, Error>>()?;
 
         let global_locations = master_locations(
             &axes,
@@ -1084,7 +1085,7 @@ impl Work<Context, WorkId, Error> for StaticMetadataWork {
                 .sources
                 .iter()
                 .filter(|s| !is_glyph_only(s)),
-        )
+        )?
         .into_values()
         .collect();
 
@@ -1515,7 +1516,7 @@ impl Work<Context, WorkId, Error> for GlobalMetricsWork {
         let designspace_dir = self.designspace_dir.as_ref();
         let font_infos = font_infos(designspace_dir, &self.designspace)?;
         let master_locations =
-            master_locations(&static_metadata.all_source_axes, &self.designspace.sources);
+            master_locations(&static_metadata.all_source_axes, &self.designspace.sources)?;
 
         let mut metrics = GlobalMetricsBuilder::new();
 
@@ -1816,7 +1817,7 @@ impl Work<Context, WorkId, Error> for KerningLocationsWork {
         let designspace_dir = self.designspace_dir.as_ref();
         let static_metadata = context.static_metadata.get();
         let master_locations =
-            master_locations(&static_metadata.all_source_axes, &self.designspace.sources);
+            master_locations(&static_metadata.all_source_axes, &self.designspace.sources)?;
         let (default_master_idx, _) = default_master(&self.designspace)?;
 
         let mut kerning_locations = KerningLocations::default();
@@ -1872,7 +1873,7 @@ impl Work<Context, WorkId, Error> for KerningInstanceWork {
         let static_metadata = context.static_metadata.get();
         let glyph_order = context.glyph_order.get();
         let master_locations =
-            master_locations(&static_metadata.all_source_axes, &self.designspace.sources);
+            master_locations(&static_metadata.all_source_axes, &self.designspace.sources)?;
 
         // We know all the groups, read all the kerning
         let source = self
@@ -2273,7 +2274,10 @@ mod tests {
     };
 
     use fontdrasil::{
-        coords::{DesignCoord, DesignLocation, NormalizedCoord, NormalizedLocation, UserCoord},
+        coords::{
+            DesignCoord, DesignLocation, NormalizedCoord, NormalizedLocation, UserCoord,
+            UserLocation,
+        },
         orchestration::{Access, AccessBuilder},
         types::GlyphName,
         variations::Tent,
@@ -2591,6 +2595,7 @@ mod tests {
                 &tags_by_name,
                 &default_master(&source.designspace).unwrap().1.location
             )
+            .unwrap()
         );
     }
 
@@ -3156,6 +3161,31 @@ mod tests {
                 GlyphName::from("manual-component"),
                 GlyphName::from("manualcomponent")
             )])),
+        );
+    }
+
+    // https://github.com/googlefonts/fontc/issues/1649
+    #[test]
+    fn static_metadata_instances_located_by_uservalue() {
+        let (_, context) =
+            build_static_metadata("mapping_instance_uservalue.designspace", Flags::default());
+        let static_metadata = context.static_metadata.get();
+
+        // uservalue 500 goes through the wght map (400..700 -> 0..100) and back;
+        // width is omitted from the location so it takes the axis default
+        assert_eq!(
+            static_metadata
+                .named_instances
+                .iter()
+                .map(|ni| (ni.name.as_str(), ni.location.clone()))
+                .collect::<Vec<_>>(),
+            vec![(
+                "Medium",
+                UserLocation::from(vec![
+                    (Tag::new(b"wght"), UserCoord::new(500.0)),
+                    (Tag::new(b"wdth"), UserCoord::new(100.0)),
+                ])
+            )]
         );
     }
 

--- a/ufo2fontir/src/toir.rs
+++ b/ufo2fontir/src/toir.rs
@@ -21,22 +21,86 @@ use crate::source::vertical_origin;
 /// See: <https://github.com/googlefonts/glyphsLib/blob/de5b4e34/Lib/glyphsLib/builder/constants.py#L27>
 const COMPONENT_INFO_KEY: &str = "com.schriftgestaltung.Glyphs.ComponentInfo";
 
+/// Convert a source location to design coordinates.
+///
+/// Source locations must use `xvalue`; `uservalue` is only meaningful for
+/// instances, see [`to_instance_design_location`].
 pub(crate) fn to_design_location(
     tags_by_name: &HashMap<&str, Tag>,
     loc: &[Dimension],
-) -> DesignLocation {
-    // TODO: what if Dimension uses uservalue? - new in DS5.0
+) -> Result<DesignLocation, Error> {
     loc.iter()
-        .filter_map(|d| match tags_by_name.get(d.name.as_str()) {
-            Some(tag) => Some((*tag, DesignCoord::new(d.xvalue.unwrap() as f64))),
-            // warn and skip dimensions with unknown axis names:
-            // https://github.com/fonttools/fonttools/blob/8e5c1bf7/Lib/fontTools/designspaceLib/__init__.py#L2424
-            None => {
+        .filter_map(|d| {
+            let Some(tag) = tags_by_name.get(d.name.as_str()) else {
+                // warn and skip dimensions with unknown axis names:
+                // https://github.com/fonttools/fonttools/blob/8e5c1bf7/Lib/fontTools/designspaceLib/__init__.py#L2424
                 log::warn!("Location with undefined axis: {:?}, skipping", d.name);
-                None
-            }
+                return None;
+            };
+            Some(match d.xvalue {
+                Some(x) => Ok((*tag, DesignCoord::new(x as f64))),
+                None => Err(Error::InvalidEntry(
+                    "source location",
+                    format!(
+                        "dimension {:?} has no xvalue{}",
+                        d.name,
+                        if d.uservalue.is_some() {
+                            " (uservalue is only supported for instances)"
+                        } else {
+                            ""
+                        }
+                    ),
+                )),
+            })
         })
         .collect()
+}
+
+/// Convert an instance location to design coordinates.
+///
+/// Mirrors fontTools' `InstanceDescriptor.getFullDesignLocation`: every axis
+/// starts at its default; each dimension then overrides its axis with the
+/// explicit design value (`xvalue`) if present, else the user value
+/// (`uservalue`) mapped forward through the axis map. A dimension with neither
+/// is an error, as in designspaceLib. Dimensions naming an unknown axis are
+/// skipped with a warning, matching [`to_design_location`].
+///
+/// <https://github.com/fonttools/fonttools/blob/8e5c1bf7/Lib/fontTools/designspaceLib/__init__.py#L819-L850>
+pub(crate) fn to_instance_design_location(
+    axes: &fontdrasil::types::Axes,
+    tags_by_name: &HashMap<&str, Tag>,
+    loc: &[Dimension],
+) -> Result<DesignLocation, Error> {
+    let mut result: DesignLocation = axes
+        .iter()
+        .map(|a| (a.tag, a.default.convert(&a.converter)))
+        .collect();
+    for d in loc {
+        let Some(tag) = tags_by_name.get(d.name.as_str()) else {
+            log::warn!("Location with undefined axis: {:?}, skipping", d.name);
+            continue;
+        };
+        let coord = match (d.xvalue, d.uservalue) {
+            (Some(x), _) => DesignCoord::new(x as f64),
+            (None, Some(u)) => {
+                let axis = axes
+                    .get(tag)
+                    .ok_or_else(|| Error::NoEntryInAxes(tag.to_string()))?;
+                UserCoord::new(u as f64).convert(&axis.converter)
+            }
+            (None, None) => {
+                return Err(Error::InvalidEntry(
+                    "instance location",
+                    format!(
+                        "dimension {:?} must have exactly one of xvalue or uservalue",
+                        d.name
+                    ),
+                ));
+            }
+        };
+        result.insert(*tag, coord);
+    }
+    Ok(result)
 }
 
 fn to_ir_contour(
@@ -160,17 +224,15 @@ fn to_ir_glyph_instance(
 pub fn master_locations<'a>(
     axes: &fontdrasil::types::Axes,
     sources: impl IntoIterator<Item = &'a designspace::Source>,
-) -> HashMap<String, NormalizedLocation> {
+) -> Result<HashMap<String, NormalizedLocation>, Error> {
     let tags_by_name: HashMap<_, _> = axes.iter().map(|a| (a.name.as_str(), a.tag)).collect();
     sources
         .into_iter()
         .map(|s| {
-            (
+            Ok((
                 s.name.clone().unwrap(),
-                to_design_location(&tags_by_name, &s.location)
-                    .to_normalized(axes)
-                    .unwrap(),
-            )
+                to_design_location(&tags_by_name, &s.location)?.to_normalized(axes)?,
+            ))
         })
         .collect()
 }
@@ -433,7 +495,7 @@ mod tests {
                 uservalue: None,
             },
         ];
-        let result = to_design_location(&tags_by_name, &loc);
+        let result = to_design_location(&tags_by_name, &loc).unwrap();
         assert_eq!(result.get(Tag::new(b"XROT")), Some(DesignCoord::new(10.0)));
         assert_eq!(result.get(Tag::new(b"YROT")), Some(DesignCoord::new(20.0)));
 
@@ -452,8 +514,88 @@ mod tests {
                 uservalue: None,
             },
         ];
-        let result = to_design_location(&tags_by_name, &loc_with_tags);
+        let result = to_design_location(&tags_by_name, &loc_with_tags).unwrap();
         assert_eq!(result.iter().count(), 0, "undefined axes should be skipped");
+    }
+
+    #[test]
+    fn to_design_location_rejects_missing_xvalue() {
+        let tags_by_name: HashMap<&str, Tag> = HashMap::from([("Weight", Tag::new(b"wght"))]);
+        // uservalue is only valid for instances
+        let loc = vec![Dimension {
+            name: "Weight".into(),
+            xvalue: None,
+            yvalue: None,
+            uservalue: Some(700.0),
+        }];
+        let err = to_design_location(&tags_by_name, &loc).unwrap_err();
+        assert!(
+            matches!(err, Error::InvalidEntry("source location", _)),
+            "{err:?}"
+        );
+    }
+
+    fn wght_axis_with_map() -> fontdrasil::types::Axes {
+        // user 300..700 maps to design 30..70, default 400 -> 40
+        fontdrasil::types::Axes::new(vec![fontdrasil::types::Axis {
+            name: "Weight".into(),
+            tag: Tag::new(b"wght"),
+            min: UserCoord::new(300.0),
+            default: UserCoord::new(400.0),
+            max: UserCoord::new(700.0),
+            hidden: false,
+            converter: CoordConverter::new(
+                vec![
+                    (UserCoord::new(300.0), DesignCoord::new(30.0)),
+                    (UserCoord::new(400.0), DesignCoord::new(40.0)),
+                    (UserCoord::new(700.0), DesignCoord::new(70.0)),
+                ],
+                1,
+            )
+            .unwrap(),
+            localized_names: Default::default(),
+        }])
+    }
+
+    fn dim(name: &str, xvalue: Option<f32>, uservalue: Option<f32>) -> Dimension {
+        Dimension {
+            name: name.into(),
+            xvalue,
+            yvalue: None,
+            uservalue,
+        }
+    }
+
+    // https://github.com/googlefonts/fontc/issues/1649
+    #[test]
+    fn instance_location_maps_uservalue_through_axis_map() {
+        let axes = wght_axis_with_map();
+        let tags_by_name = HashMap::from([("Weight", Tag::new(b"wght"))]);
+        let wght = Tag::new(b"wght");
+
+        // uservalue is mapped forward through the axis map
+        let loc =
+            to_instance_design_location(&axes, &tags_by_name, &[dim("Weight", None, Some(700.0))])
+                .unwrap();
+        assert_eq!(loc.get(wght), Some(DesignCoord::new(70.0)));
+
+        // xvalue is taken as-is
+        let loc =
+            to_instance_design_location(&axes, &tags_by_name, &[dim("Weight", Some(55.0), None)])
+                .unwrap();
+        assert_eq!(loc.get(wght), Some(DesignCoord::new(55.0)));
+
+        // an axis missing from the location gets the axis default (in design space)
+        let loc = to_instance_design_location(&axes, &tags_by_name, &[]).unwrap();
+        assert_eq!(loc.get(wght), Some(DesignCoord::new(40.0)));
+
+        // a dimension with neither value is an error, as in fontTools
+        let err = to_instance_design_location(&axes, &tags_by_name, &[dim("Weight", None, None)])
+            .unwrap_err();
+        assert!(
+            matches!(err, Error::InvalidEntry("instance location", _)),
+            "{err:?}"
+        );
     }
 
     /// Test parsing component anchors from glyphsLib's ComponentInfo in glyph lib.


### PR DESCRIPTION
DesignSpace 5 lets an instance give its location with uservalue instead of xvalue. We unwrapped xvalue unconditionally, so any such designspace panicked in StaticMetadataWork (MutatorSans has three of these instances).

Instance locations are now resolved the way fontTools' [InstanceDescriptor.getFullDesignLocation](https://github.com/fonttools/fonttools/blob/8e5c1bf7/Lib/fontTools/designspaceLib/__init__.py#L819-L850) does: for each dimension, xvalue if present, else uservalue mapped forward through the axis map; axes the location doesn't mention get the axis default. A dimension with neither attribute is an error, as it is in designspaceLib. Source locations still require xvalue, matching designspaceLib, which rejects uservalue on a source at read time.

While here, to_design_location and master_locations return Result instead of unwrapping, so those malformed dimensions are reported as errors rather than panics.

MutatorSans.designspace now builds.

Fixes #1649, fixes #813
