### PR TITLE
[ufo2fontir] Skip named instances outside the axis ranges

### DIFF
--- a/resources/testdata/instance_out_of_range.designspace
+++ b/resources/testdata/instance_out_of_range.designspace
@@ -1,0 +1,26 @@
+<?xml version='1.0' encoding='utf-8'?>
+<designspace format="5.0">
+  <!-- a named instance outside the axis range, which fontmake drops -->
+  <axes>
+    <axis tag="wght" name="weight" minimum="400" default="400" maximum="700"/>
+  </axes>
+  <sources>
+    <source filename="WghtVar-Regular.ufo" name="Regular">
+      <location>
+        <dimension name="weight" xvalue="400"/>
+      </location>
+    </source>
+  </sources>
+  <instances>
+    <instance stylename="Regular">
+      <location>
+        <dimension name="weight" xvalue="400"/>
+      </location>
+    </instance>
+    <instance stylename="Extrapolated">
+      <location>
+        <dimension name="weight" xvalue="2000"/>
+      </location>
+    </instance>
+  </instances>
+</designspace>

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -1054,35 +1054,32 @@ impl Work<Context, WorkId, Error> for StaticMetadataWork {
             .get(&NameKey::new_bmp_only(NameId::FAMILY_NAME))
             .map(|name| name.clone() + " ")
             .unwrap_or_default();
-        let named_instances: Vec<NamedInstance> = self
-            .designspace
-            .instances
-            .iter()
-            .map(|inst| {
-                // TODO: Also support localised names, and names inferred from axis labels
-                // (also used to build STAT table)
-                Ok(NamedInstance {
-                    name: inst.stylename.clone().unwrap_or_else(|| {
-                        match inst
-                            .name
-                            .as_ref()
-                            .unwrap()
-                            .strip_prefix(family_prefix.as_str())
-                        {
-                            Some(tail) => tail.to_string(),
-                            None => inst.name.clone().unwrap(),
-                        }
-                    }),
-                    postscript_name: inst.postscriptfontname.clone(),
-                    location: to_instance_design_location(&axes, &tags_by_name, &inst.location)?
-                        .to_user(&axes)?,
-                })
-            })
-            .collect::<Result<Vec<_>, Error>>()?
-            .into_iter()
+        let mut named_instances = Vec::with_capacity(self.designspace.instances.len());
+        for inst in &self.designspace.instances {
+            let location = to_instance_design_location(&axes, &tags_by_name, &inst.location)?
+                .to_user(&axes)?;
             // fontmake silently drops instances outside the axis ranges; do the same
-            .filter(|inst| within_axis_ranges(&axes, &inst.location))
-            .collect();
+            if !within_axis_ranges(&axes, &location) {
+                continue;
+            }
+            // TODO: Also support localised names, and names inferred from axis labels
+            // (also used to build STAT table)
+            named_instances.push(NamedInstance {
+                name: inst.stylename.clone().unwrap_or_else(|| {
+                    match inst
+                        .name
+                        .as_ref()
+                        .unwrap()
+                        .strip_prefix(family_prefix.as_str())
+                    {
+                        Some(tail) => tail.to_string(),
+                        None => inst.name.clone().unwrap(),
+                    }
+                }),
+                postscript_name: inst.postscriptfontname.clone(),
+                location,
+            });
+        }
 
         let global_locations = master_locations(
             &axes,

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -47,6 +47,7 @@ use write_fonts::{
 
 use crate::toir::{
     master_locations, to_design_location, to_instance_design_location, to_ir_axes, to_ir_glyph,
+    within_axis_ranges,
 };
 
 const UFO_KERN1_PREFIX: &str = "public.kern1.";
@@ -1053,7 +1054,7 @@ impl Work<Context, WorkId, Error> for StaticMetadataWork {
             .get(&NameKey::new_bmp_only(NameId::FAMILY_NAME))
             .map(|name| name.clone() + " ")
             .unwrap_or_default();
-        let named_instances = self
+        let named_instances: Vec<NamedInstance> = self
             .designspace
             .instances
             .iter()
@@ -1077,7 +1078,11 @@ impl Work<Context, WorkId, Error> for StaticMetadataWork {
                         .to_user(&axes)?,
                 })
             })
-            .collect::<Result<Vec<_>, Error>>()?;
+            .collect::<Result<Vec<_>, Error>>()?
+            .into_iter()
+            // fontmake silently drops instances outside the axis ranges; do the same
+            .filter(|inst| within_axis_ranges(&axes, &inst.location))
+            .collect();
 
         let global_locations = master_locations(
             &axes,
@@ -3186,6 +3191,23 @@ mod tests {
                     (Tag::new(b"wdth"), UserCoord::new(100.0)),
                 ])
             )]
+        );
+    }
+
+    #[test]
+    fn static_metadata_skips_instances_outside_axis_range() {
+        let (_, context) =
+            build_static_metadata("instance_out_of_range.designspace", Flags::default());
+        let static_metadata = context.static_metadata.get();
+
+        // "Extrapolated" sits at wght=2000 on a 400..700 axis and is dropped, as in fontmake
+        assert_eq!(
+            static_metadata
+                .named_instances
+                .iter()
+                .map(|ni| ni.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["Regular"]
         );
     }
 

--- a/ufo2fontir/src/toir.rs
+++ b/ufo2fontir/src/toir.rs
@@ -103,6 +103,22 @@ pub(crate) fn to_instance_design_location(
     Ok(result)
 }
 
+/// Whether `loc` lies within every axis' user-space range (inclusive).
+///
+/// fontmake drops named instances located outside the variable font's axis ranges
+/// (`designspaceLib.split._extractSubSpace`); such instances can't be reached by a
+/// variable font and would only clamp to the nearest edge. Axes absent from `loc`
+/// are at their default and therefore in range.
+pub(crate) fn within_axis_ranges(
+    axes: &fontdrasil::types::Axes,
+    loc: &fontdrasil::coords::UserLocation,
+) -> bool {
+    axes.iter().all(|axis| {
+        loc.get(axis.tag)
+            .is_none_or(|coord| axis.min <= coord && coord <= axis.max)
+    })
+}
+
 fn to_ir_contour(
     glyph_name: GlyphName,
     contour: &norad::Contour,
@@ -596,6 +612,22 @@ mod tests {
             matches!(err, Error::InvalidEntry("instance location", _)),
             "{err:?}"
         );
+    }
+
+    #[test]
+    fn detects_instance_outside_axis_range() {
+        let axes = wght_axis_with_map();
+        let wght = Tag::new(b"wght");
+        let at = |v: f64| fontdrasil::coords::UserLocation::from(vec![(wght, UserCoord::new(v))]);
+        assert!(within_axis_ranges(&axes, &at(300.0)));
+        assert!(within_axis_ranges(&axes, &at(700.0)));
+        assert!(!within_axis_ranges(&axes, &at(2000.0)));
+        assert!(!within_axis_ranges(&axes, &at(100.0)));
+        // axes missing from the location are at their default
+        assert!(within_axis_ranges(
+            &axes,
+            &fontdrasil::coords::UserLocation::new()
+        ));
     }
 
     /// Test parsing component anchors from glyphsLib's ComponentInfo in glyph lib.


### PR DESCRIPTION
While trying to fix https://github.com/googlefonts/fontc/issues/1649, I noticed that MutatorSans.designspace has some 'extrapolated' instances located outside the axis ranges, which fontc was writing into fvar as-is. But nothing can reach such an instance in a variable font; consumers just clamp it to the nearest edge, so it would render as a duplicate of an existing instance under a different name.

Most importantly for us, fontmake drops these when it extracts each variable font's subspace ([`designspaceLib.split`](https://github.com/fonttools/fonttools/blob/8e5c1bf7/Lib/fontTools/designspaceLib/split.py#L324-L326)), silently, since in DSv5 an instance outside one `<variable-font>`'s region simply belongs to another.

I do the same in here: filter named instances whose full user location falls outside any axis range, inclusive of the bounds, with axes omitted from the location at their default. No warning, matching the reference.

The MutatorSans fvar named-instance set now matches fontmake's.
