### PR TITLE
[crater] Skip comparison when fontc output unchanged

### DIFF
--- a/fontc_crater/src/ci/results_cache.rs
+++ b/fontc_crater/src/ci/results_cache.rs
@@ -2,7 +2,10 @@
 
 use std::path::{Path, PathBuf};
 
-use crate::Target;
+use crate::{
+    RunResult, Target,
+    ttx_diff_runner::{DiffError, DiffOutput},
+};
 
 static CACHE_DIR_NAME: &str = "crater_cached_results";
 
@@ -10,6 +13,36 @@ static CACHE_DIR_NAME: &str = "crater_cached_results";
 static FONT_FILE: &str = "fontmake.ttf";
 static TTX_FILE: &str = "fontmake.ttx";
 static MARKKERN_FILE: &str = "fontmake.markkern.txt";
+// the previous run's result, keyed by the font fontc produced for this target
+static RESULT_FILE: &str = "result.json";
+
+/// A previous run's result, and the sha256 of the fontc.ttf it describes.
+///
+/// The diff is a function of the two compiled fonts, so if fontc produces the
+/// same font again and fontmake's side still comes from this cache, this result
+/// stands. This is the hash of fontc's *output*, not of the fontc binary; the
+/// binary changes every run, which is the thing we are trying to look past.
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub(crate) struct CachedRun {
+    pub(crate) fontc_ttf_hash: String,
+    result: CachedResult,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum CachedResult {
+    Success(DiffOutput),
+    Failure(DiffError),
+}
+
+impl CachedRun {
+    pub(crate) fn into_result(self) -> RunResult<DiffOutput, DiffError> {
+        match self.result {
+            CachedResult::Success(output) => RunResult::Success(output),
+            CachedResult::Failure(err) => RunResult::Fail(err),
+        }
+    }
+}
 
 /// Manages a cache of files on disk
 pub(crate) struct ResultsCache {
@@ -34,15 +67,66 @@ impl ResultsCache {
     }
 
     /// if we have cached files for this target, copy them into the build directory.
-    pub fn copy_cached_files_to_build_dir(&self, target: &Target, build_dir: &Path) {
+    ///
+    /// Returns `true` if fontmake's output came from the cache, and so will not
+    /// be rebuilt.
+    pub fn copy_cached_files_to_build_dir(&self, target: &Target, build_dir: &Path) -> bool {
         let target_cache_dir = target.cache_dir(&self.base_results_cache_dir);
         if !target_cache_dir.exists() {
             log::trace!("no cached files for {target}");
-            return;
+            return false;
         }
 
-        if copy_cache_files(&target_cache_dir, build_dir).unwrap() {
+        let copied = copy_cache_files(&target_cache_dir, build_dir).unwrap();
+        if copied {
             log::trace!("reused cached files for {target}",);
+        }
+        copied
+    }
+
+    /// The previous run's result for this target, if we have one.
+    pub fn load_result(&self, target: &Target) -> Option<CachedRun> {
+        let path = target
+            .cache_dir(&self.base_results_cache_dir)
+            .join(RESULT_FILE);
+        if !path.exists() {
+            return None;
+        }
+        match crate::try_read_json(&path) {
+            Ok(run) => Some(run),
+            Err(e) => {
+                log::warn!("failed to load cached result for {target}: '{e}'");
+                None
+            }
+        }
+    }
+
+    /// Record this run's result so the next run can skip the comparison if the
+    /// font fontc produces is unchanged.
+    pub fn save_result(
+        &self,
+        target: &Target,
+        fontc_ttf_hash: String,
+        result: &RunResult<DiffOutput, DiffError>,
+    ) {
+        let result = match result {
+            RunResult::Success(output) => CachedResult::Success(output.clone()),
+            RunResult::Fail(DiffError::CompileFailed(err)) => {
+                CachedResult::Failure(DiffError::CompileFailed(err.clone()))
+            }
+            // a runtime error says nothing about these two binaries; retry next time
+            RunResult::Fail(DiffError::Other(_)) => return,
+        };
+        let target_cache_dir = target.cache_dir(&self.base_results_cache_dir);
+        if !target_cache_dir.exists() {
+            std::fs::create_dir_all(&target_cache_dir).unwrap();
+        }
+        let run = CachedRun {
+            fontc_ttf_hash,
+            result,
+        };
+        if let Err(e) = crate::try_write_json(&run, &target_cache_dir.join(RESULT_FILE)) {
+            log::warn!("failed to save cached result for {target}: '{e}'");
         }
     }
 
@@ -80,5 +164,98 @@ fn copy_cache_files(from_dir: &Path, to_dir: &Path) -> std::io::Result<bool> {
         Ok(true)
     } else {
         Ok(false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ttx_diff_runner::{CompileFailed, CompilerFailure, DiffValue};
+
+    fn test_target() -> Target {
+        Target::new(
+            "org/repo_deadbeefc0",
+            "deadbeefc0ffee",
+            "sources/config.yaml",
+            false,
+            "Font.glyphs",
+        )
+    }
+
+    #[test]
+    fn result_round_trip() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let cache = ResultsCache::in_dir(tempdir.path());
+        let target = test_target();
+        assert!(cache.load_result(&target).is_none());
+
+        let diffs = [("GPOS".to_string(), DiffValue::Ratio(0.5))]
+            .into_iter()
+            .collect();
+        cache.save_result(
+            &target,
+            "abc123".into(),
+            &RunResult::Success(DiffOutput::Diffs(diffs)),
+        );
+
+        let loaded = cache.load_result(&target).expect("just saved it");
+        assert_eq!(loaded.fontc_ttf_hash, "abc123");
+        let RunResult::Success(DiffOutput::Diffs(diffs)) = loaded.into_result() else {
+            panic!("expected diffs");
+        };
+        assert_eq!(diffs.get("GPOS"), Some(&DiffValue::Ratio(0.5)));
+    }
+
+    #[test]
+    fn compile_failures_are_cached() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let cache = ResultsCache::in_dir(tempdir.path());
+        let target = test_target();
+        cache.save_result(
+            &target,
+            "abc123".into(),
+            &RunResult::Fail(DiffError::CompileFailed(CompileFailed {
+                fontc: None,
+                fontmake: Some(CompilerFailure {
+                    command: "fontmake -o variable".into(),
+                    stderr: "oh no".into(),
+                }),
+            })),
+        );
+
+        let loaded = cache.load_result(&target).expect("just saved it");
+        let RunResult::Fail(DiffError::CompileFailed(failed)) = loaded.into_result() else {
+            panic!("expected a compile failure");
+        };
+        assert!(failed.fontc.is_none());
+        assert_eq!(failed.fontmake.unwrap().stderr, "oh no");
+    }
+
+    #[test]
+    fn runtime_failures_are_not_cached() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let cache = ResultsCache::in_dir(tempdir.path());
+        let target = test_target();
+        cache.save_result(
+            &target,
+            "abc123".into(),
+            &RunResult::Fail(DiffError::Other("ttx_diff timed out".into())),
+        );
+        assert!(cache.load_result(&target).is_none());
+    }
+
+    #[test]
+    fn delete_all_clears_results() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let cache = ResultsCache::in_dir(tempdir.path());
+        let target = test_target();
+        cache.save_result(
+            &target,
+            "abc123".into(),
+            &RunResult::Success(DiffOutput::Identical),
+        );
+        assert!(cache.load_result(&target).is_some());
+        cache.delete_all();
+        assert!(cache.load_result(&target).is_none());
     }
 }

--- a/fontc_crater/src/ttx_diff_runner.rs
+++ b/fontc_crater/src/ttx_diff_runner.rs
@@ -1,9 +1,18 @@
-use std::{collections::BTreeMap, path::PathBuf, process::Command};
+use std::{
+    collections::BTreeMap,
+    path::{Path, PathBuf},
+    process::Command,
+};
 
 use crate::{BuildType, Results, RunResult, Target, ci::ResultsCache};
 
 // Run ttx-diff via python -m to ensure we use the venv's installed version
 static TTX_DIFF_MODULE: &str = "ttx_diff";
+// holds the sha256 of the font fontc produced; written by ttx_diff into the
+// build dir, keep in sync with core.py
+static FONTC_TTF_HASH_FILE: &str = "fontc.sha256";
+// ttx_diff's exit code for "the font fontc produced matched the hash we passed"
+const UNCHANGED_EXIT_CODE: i32 = 3;
 
 pub(super) struct TtxContext {
     pub fontc_path: PathBuf,
@@ -18,8 +27,14 @@ pub(super) fn run_ttx_diff(ctx: &TtxContext, target: &Target) -> RunResult<DiffO
     let source_path = target.source_path(&ctx.source_cache);
     let compare = target.build.name();
     let build_dir = outdir.join(compare);
-    ctx.results_cache
+    let reusing_fontmake = ctx
+        .results_cache
         .copy_cached_files_to_build_dir(target, &build_dir);
+    // we can only trust a cached result if fontmake's half of the comparison is
+    // the same one that produced it, which is only true if it came from the cache
+    let cached = reusing_fontmake
+        .then(|| ctx.results_cache.load_result(target))
+        .flatten();
     let mut cmd = Command::new("python3");
     cmd.args([
         "-m",
@@ -35,6 +50,10 @@ pub(super) fn run_ttx_diff(ctx: &TtxContext, target: &Target) -> RunResult<DiffO
     .arg("--normalizer_path")
     .arg(&ctx.normalizer_path)
     .args(["--rebuild", "fontc"]);
+    if let Some(cached) = cached.as_ref() {
+        cmd.arg("--expected_fontc_ttf_hash")
+            .arg(&cached.fontc_ttf_hash);
+    }
     if target.build == BuildType::GfTools {
         cmd.arg("--config")
             .arg(target.config_path(&ctx.source_cache));
@@ -67,6 +86,17 @@ pub(super) fn run_ttx_diff(ctx: &TtxContext, target: &Target) -> RunResult<DiffO
             }
             Ok(RawDiffOutput::Error(error)) => RunResult::Fail(DiffError::CompileFailed(error)),
         },
+        // fontc produced the same font as last time, so last time's result stands
+        Some(UNCHANGED_EXIT_CODE) => match cached {
+            Some(cached) => {
+                log::trace!("reused cached result for {target}");
+                return cached.into_result();
+            }
+            // we only pass --expected_fontc_ttf_hash when we have a cached result
+            None => RunResult::Fail(DiffError::Other(
+                "ttx_diff reported no change without a cached result".to_string(),
+            )),
+        },
         Some(124) => RunResult::Fail(DiffError::Other("ttx_diff timed out".to_string())),
         Some(other) => RunResult::Fail(DiffError::Other(format!(
             "unknown error (status {other}): '{stderr}'"
@@ -93,8 +123,21 @@ pub(super) fn run_ttx_diff(ctx: &TtxContext, target: &Target) -> RunResult<DiffO
     if fontmake_finished(&result) {
         ctx.results_cache
             .save_built_files_to_cache(target, &build_dir);
+        if let Some(hash) = read_fontc_ttf_hash(&build_dir) {
+            ctx.results_cache.save_result(target, hash, &result);
+        }
     }
     result
+}
+
+/// The hash ttx_diff recorded for the font fontc just produced.
+///
+/// Absent if fontc did not produce a font.
+fn read_fontc_ttf_hash(build_dir: &Path) -> Option<String> {
+    let path = build_dir.join(FONTC_TTF_HASH_FILE);
+    let hash = std::fs::read_to_string(path).ok()?;
+    let hash = hash.trim();
+    (!hash.is_empty()).then(|| hash.to_owned())
 }
 
 fn fontmake_finished(result: &RunResult<DiffOutput, DiffError>) -> bool {
@@ -239,7 +282,7 @@ pub(crate) enum DiffError {
 }
 
 /// One or both compilers failed to run
-#[derive(Debug, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
 pub(crate) struct CompileFailed {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -249,7 +292,7 @@ pub(crate) struct CompileFailed {
 }
 
 /// Info regarding the failure of a single compiler
-#[derive(Debug, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
 pub(crate) struct CompilerFailure {
     pub(crate) command: String,

--- a/ttx_diff/src/ttx_diff/__main__.py
+++ b/ttx_diff/src/ttx_diff/__main__.py
@@ -43,6 +43,15 @@ flags.DEFINE_float(
     0.1,
     "The percentage of point (glyf) or delta (gvar) values allowed to differ by one without counting as a diff",
 )
+flags.DEFINE_string(
+    "expected_fontc_ttf_hash",
+    default=None,
+    help="sha256 of the font fontc produced last time the caller compared this "
+    "source. If the font fontc produces now hashes to the same value, exit 3 "
+    "immediately instead of comparing; the caller's stored result still applies. "
+    "The hash of the font fontc produces is always written to fontc.sha256 in "
+    "the build directory.",
+)
 flags.DEFINE_bool("json", False, "print results in machine-readable JSON format")
 flags.DEFINE_string("outdir", default=None, help="directory to store generated files")
 flags.DEFINE_bool(

--- a/ttx_diff/src/ttx_diff/core.py
+++ b/ttx_diff/src/ttx_diff/core.py
@@ -35,8 +35,16 @@ JSON:
     where keys are the name of the compiler that failed, and the body is a
     dictionary with "command" and "stderr" fields, where the "command" field
     is the command that was used to run that compiler.
+
+Exit codes:
+    0   the two fonts compare as identical
+    2   the fonts differ, or a compiler failed (see JSON, above)
+    3   --expected_fontc_ttf_hash was passed and the font fontc produced hashed
+        to it, so we stopped without comparing anything. The sha256 of the font
+        fontc produced is always written to fontc.sha256 in the build directory.
 """
 
+import hashlib
 import json
 import os
 import re
@@ -75,6 +83,10 @@ LIG_CARET_NAME = "ligcaret"
 # maximum chars of stderr to include when reporting errors; prevents
 # too much bloat when run in CI
 MAX_ERR_LEN = 1000
+# file in the build dir holding the sha256 of the font fontc produced
+FONTC_TTF_HASH_FILE = "fontc.sha256"
+# exit code used when --expected_fontc_ttf_hash matched and we skipped the diff
+UNCHANGED_EXIT_CODE = 3
 
 # fontc and fontmake's builds may be off by a second or two in the
 # head.created/modified; setting this makes them the same
@@ -467,6 +479,29 @@ def source_is_variable(path: Path) -> bool:
 def copy(old, new):
     shutil.copyfile(old, new)
     return new
+
+
+def hash_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+# Record the hash of the font fontc just produced, and if the caller told us what
+# hash it has already seen, exit without doing any of the comparison work: the
+# same two fonts always produce the same diff, so the caller's result stands.
+def write_hash_and_maybe_exit_early(
+    fontc_ttf: Path, build_dir: Path, expected_hash: Optional[str]
+):
+    if not fontc_ttf.is_file():
+        return
+    fontc_ttf_hash = hash_file(fontc_ttf)
+    (build_dir / FONTC_TTF_HASH_FILE).write_text(fontc_ttf_hash)
+    if expected_hash == fontc_ttf_hash:
+        eprint(f"fontc output unchanged ({fontc_ttf_hash[:12]}), skipping comparison")
+        sys.exit(UNCHANGED_EXIT_CODE)
 
 
 def get_name_to_id_map(ttx: etree.ElementTree):
@@ -1696,6 +1731,10 @@ def main(argv):
                     "command": " ".join(e.command),
                     "stderr": e.msg[-MAX_ERR_LEN:],
                 }
+        if "fontc" not in failures:
+            write_hash_and_maybe_exit_early(
+                fontc_ttf, build_dir, FLAGS.expected_fontc_ttf_hash
+            )
         with timed("build fontmake"):
             try:
                 if compare == "default":

--- a/ttx_diff/tests/test_core.py
+++ b/ttx_diff/tests/test_core.py
@@ -1,8 +1,18 @@
 """Tests for ttx_diff.core."""
 
+import hashlib
+
+import pytest
 from lxml import etree
 
-from ttx_diff.core import strip_fontc_version_tag, unwrap_extension_lookups
+from ttx_diff.core import (
+    FONTC_TTF_HASH_FILE,
+    UNCHANGED_EXIT_CODE,
+    hash_file,
+    strip_fontc_version_tag,
+    unwrap_extension_lookups,
+    write_hash_and_maybe_exit_early,
+)
 
 
 def _make_tree(xml_str):
@@ -144,3 +154,38 @@ def test_strip_keeps_non_stamp_fontc_note():
     want = _name_tree("Version 1.000;fontc is broken")
     strip_fontc_version_tag(got)
     assert etree.tostring(got) == etree.tostring(want)
+
+
+def test_hash_file_matches_hashlib(tmp_path):
+    font = tmp_path / "fontc.ttf"
+    font.write_bytes(b"not really a font" * 1000)
+    assert hash_file(font) == hashlib.sha256(font.read_bytes()).hexdigest()
+
+
+def test_write_hash_records_the_hash(tmp_path):
+    font = tmp_path / "fontc.ttf"
+    font.write_bytes(b"pretend this is a font")
+    write_hash_and_maybe_exit_early(font, tmp_path, None)
+    assert (tmp_path / FONTC_TTF_HASH_FILE).read_text() == hash_file(font)
+
+
+def test_write_hash_exits_when_the_hash_matches(tmp_path):
+    font = tmp_path / "fontc.ttf"
+    font.write_bytes(b"pretend this is a font")
+    with pytest.raises(SystemExit) as exit:
+        write_hash_and_maybe_exit_early(font, tmp_path, hash_file(font))
+    assert exit.value.code == UNCHANGED_EXIT_CODE
+
+
+def test_write_hash_continues_when_the_hash_differs(tmp_path):
+    font = tmp_path / "fontc.ttf"
+    font.write_bytes(b"pretend this is a font")
+    write_hash_and_maybe_exit_early(font, tmp_path, "0" * 64)
+    assert (tmp_path / FONTC_TTF_HASH_FILE).read_text() == hash_file(font)
+
+
+# fontc failing to build is not a result we can cache, so there is nothing to
+# record and nothing to skip
+def test_write_hash_is_a_noop_without_a_font(tmp_path):
+    write_hash_and_maybe_exit_early(tmp_path / "fontc.ttf", tmp_path, "0" * 64)
+    assert not (tmp_path / FONTC_TTF_HASH_FILE).exists()


### PR DESCRIPTION
On average compiling a target with fontc accounts for 8% of the the runtime of crater (with a _cached_ fontmake output), with the majority of the rest of the time spent in the ttx_diff python code itself: dumping the ttx and doing various bits of xml normalization and cleanup.

This points us to an easy and significant win: avoid doing any of that ttx/xml work if fontc's output is unchanged.

ttx_diff now writes the sha256 of the font it built to fontc.sha256, and takes an --expected_fontc_ttf_hash; on a match it exits 3 without comparing anything. Crater records that hash alongside the result and passes it back on the next run. A hit costs a fontc build and a hash instead of the whole comparison.

Only results that describe a specific pair of fonts are cached: a runtime failure could have any cause, and if fontc did not produce a font there is no hash to key on. The cached result is only trusted when fontmake's output came from the cache in the same run, and the existing invalidation still applies (the whole cache is dropped when ttx_diff or the pinned python deps change.)