### PR TITLE
fea-merge part 2: basic API and structure

### DIFF
--- a/fea-rs/src/common.rs
+++ b/fea-rs/src/common.rs
@@ -37,7 +37,7 @@ pub enum GlyphIdent {
     Cid(u16),
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub(crate) struct MarkClass {
     pub(crate) members: Vec<(GlyphClass, Option<AnchorBuilder>)>,
 }

--- a/fea-rs/src/compile.rs
+++ b/fea-rs/src/compile.rs
@@ -18,6 +18,7 @@ pub use feature_writer::{
 };
 pub use language_system::LanguageSystem;
 pub use lookups::{FeatureKey, LookupId};
+pub use merge::{MergeError, merge};
 pub use opts::Opts;
 pub use output::{Compilation, PendingCompilation};
 pub use tables::Os2Builder;
@@ -35,6 +36,7 @@ mod glyph_range;
 pub(crate) mod glyphsapp_syntax_ext;
 mod language_system;
 mod lookups;
+mod merge;
 mod opts;
 mod output;
 mod tables;
@@ -80,7 +82,7 @@ pub fn compile<V: VariationInfo, T: FeatureProvider>(
 /// Compile one master's (non-variable) FEA into the intermediate state used for merging.
 ///
 /// A designspace may have a different `features.fea` per master. To combine
-/// them, compile each one with this function, [`merge`] the results into a
+/// them, compile each one with this function, [`merge()`] the results into a
 /// single variable [`PendingCompilation`], and call [`PendingCompilation::finish`]
 /// once; the feature writer therefore runs once, on the merged result.
 ///

--- a/fea-rs/src/compile.rs
+++ b/fea-rs/src/compile.rs
@@ -19,7 +19,7 @@ pub use feature_writer::{
 pub use language_system::LanguageSystem;
 pub use lookups::{FeatureKey, LookupId};
 pub use opts::Opts;
-pub use output::Compilation;
+pub use output::{Compilation, PendingCompilation};
 pub use tables::Os2Builder;
 pub use variations::{AxisLocation, NopVariationInfo, VariationInfo};
 
@@ -75,6 +75,32 @@ pub fn compile<V: VariationInfo, T: FeatureProvider>(
             Err(errors)
         }
     }
+}
+
+/// Compile one master's (non-variable) FEA into the intermediate state used for merging.
+///
+/// A designspace may have a different `features.fea` per master. To combine
+/// them, compile each one with this function, [`merge`] the results into a
+/// single variable [`PendingCompilation`], and call [`PendingCompilation::finish`]
+/// once; the feature writer therefore runs once, on the merged result.
+///
+/// Unlike [`compile`] this takes no [`VariationInfo`]: a master's FEA is by
+/// definition not variable, so variable metrics, conditionsets and glyphsapp
+/// number values are rejected, as they would be when compiling a static font.
+pub fn compile_for_merge(
+    tree: &ParseTree,
+    glyph_map: &GlyphMap,
+    opts: Opts,
+) -> Result<PendingCompilation, DiagnosticSet> {
+    let mut ctx = CompilationCtx::<NopFeatureProvider, NopVariationInfo>::new(
+        glyph_map, tree, None, None, opts,
+    );
+    ctx.compile(&tree.typed_root());
+    let pending = ctx.get_pending_compilation();
+    if pending.has_errors() {
+        return Err(DiagnosticSet::new(pending.errors, tree, usize::MAX));
+    }
+    Ok(pending)
 }
 
 /// A helper function for extracting the glyph order from a UFO

--- a/fea-rs/src/compile.rs
+++ b/fea-rs/src/compile.rs
@@ -89,20 +89,25 @@ pub fn compile<V: VariationInfo, T: FeatureProvider>(
 /// Unlike [`compile`] this takes no [`VariationInfo`]: a master's FEA is by
 /// definition not variable, so variable metrics, conditionsets and glyphsapp
 /// number values are rejected, as they would be when compiling a static font.
+///
+/// If successful, returns the [`PendingCompilation`], and any warnings. The
+/// warnings are removed from the returned state, so they are not reported
+/// again by [`PendingCompilation::finish`].
 pub fn compile_for_merge(
     tree: &ParseTree,
     glyph_map: &GlyphMap,
     opts: Opts,
-) -> Result<PendingCompilation, DiagnosticSet> {
+) -> Result<(PendingCompilation, DiagnosticSet), DiagnosticSet> {
     let mut ctx = CompilationCtx::<NopFeatureProvider, NopVariationInfo>::new(
         glyph_map, tree, None, None, opts,
     );
     ctx.compile(&tree.typed_root());
-    let pending = ctx.get_pending_compilation();
+    let mut pending = ctx.get_pending_compilation();
     if pending.has_errors() {
         return Err(DiagnosticSet::new(pending.errors, tree, usize::MAX));
     }
-    Ok(pending)
+    let warnings = std::mem::take(&mut pending.errors);
+    Ok((pending, DiagnosticSet::new(warnings, tree, usize::MAX)))
 }
 
 /// A helper function for extracting the glyph order from a UFO

--- a/fea-rs/src/compile/features.rs
+++ b/fea-rs/src/compile/features.rs
@@ -15,7 +15,7 @@ use super::{
     tags,
 };
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub(crate) struct FeatureLookups {
     /// the base (not variation specific) lookups
     pub(crate) base: Vec<LookupId>,
@@ -25,7 +25,7 @@ pub(crate) struct FeatureLookups {
 /// A type to store accumulated features during compilation
 ///
 /// We update this type as we encounter feature blocks in the source FEA.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub(crate) struct AllFeatures {
     pub(crate) features: BTreeMap<FeatureKey, FeatureLookups>,
     required_features: HashSet<FeatureKey>,
@@ -56,7 +56,7 @@ pub(crate) struct ActiveFeature {
 /// This is a special and annoying case. We create this object when we encounter
 /// the aalt feature block, and then we use this to generate the aalt lookups
 /// once we've finished processing the input.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub(crate) struct AaltFeature {
     aalt_features: Vec<Tag>,
     pub(crate) all_alts: HashMap<GlyphId16, Vec<GlyphId16>>,
@@ -66,7 +66,7 @@ pub(crate) struct AaltFeature {
 }
 
 /// Helper for compiling the `size` feature
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub(crate) struct SizeFeature {
     pub design_size: u16,
     pub identifier: u16,
@@ -75,7 +75,7 @@ pub(crate) struct SizeFeature {
     pub names: Vec<NameSpec>,
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub(crate) struct CvParams {
     pub feat_ui_label_name: Vec<NameSpec>,
     pub feat_ui_tooltip_text_name: Vec<NameSpec>,
@@ -99,7 +99,7 @@ pub(crate) enum SpecialVerticalFeatureState {
 
 /// maps names to conditionsets, also tracking declaration order (which
 /// is maintained in the final output table)
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub(crate) struct ConditionSetMap {
     named_conditionsets: HashMap<SmolStr, ConditionSet>,
     // used for sorting

--- a/fea-rs/src/compile/language_system.rs
+++ b/fea-rs/src/compile/language_system.rs
@@ -17,7 +17,7 @@ pub struct LanguageSystem {
 /// Track languagesystem statements
 ///
 /// Seeing no statements is the same as seeing 'DFLT dflt'.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub(crate) struct DefaultLanguageSystems {
     has_explicit_entry: bool,
     // this is me being fancy, because we clone this everytime we start a lookup.

--- a/fea-rs/src/compile/language_system.rs
+++ b/fea-rs/src/compile/language_system.rs
@@ -17,11 +17,19 @@ pub struct LanguageSystem {
 /// Track languagesystem statements
 ///
 /// Seeing no statements is the same as seeing 'DFLT dflt'.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug)]
 pub(crate) struct DefaultLanguageSystems {
     has_explicit_entry: bool,
     // this is me being fancy, because we clone this everytime we start a lookup.
     items: Rc<HashSet<LanguageSystem>>,
+}
+
+/// Only the resulting set matters: an implicit and an explicit 'DFLT dflt'
+/// are the same language system.
+impl PartialEq for DefaultLanguageSystems {
+    fn eq(&self, other: &Self) -> bool {
+        self.items == other.items
+    }
 }
 
 impl DefaultLanguageSystems {

--- a/fea-rs/src/compile/lookups.rs
+++ b/fea-rs/src/compile/lookups.rs
@@ -606,6 +606,18 @@ impl AllLookups {
         }
     }
 
+    pub(crate) fn gpos(&self) -> &[PositionLookup] {
+        &self.gpos
+    }
+
+    pub(crate) fn gsub(&self) -> &[SubstitutionLookup] {
+        &self.gsub
+    }
+
+    pub(crate) fn named(&self) -> &HashMap<SmolStr, LookupId> {
+        &self.named
+    }
+
     pub(crate) fn debug_info(&self) -> (&[Option<LookupDebugInfo>], &[Option<LookupDebugInfo>]) {
         (&self.gsub_debug_info, &self.gpos_debug_info)
     }

--- a/fea-rs/src/compile/lookups.rs
+++ b/fea-rs/src/compile/lookups.rs
@@ -69,7 +69,7 @@ pub(crate) struct AllLookups {
     gsub_debug_info: Vec<Option<LookupDebugInfo>>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub(crate) enum PositionLookup {
     Single(LookupBuilder<SinglePosBuilder>),
     Pair(LookupBuilder<PairPosBuilder>),
@@ -108,7 +108,7 @@ impl_into_lookup!(MarkToLigBuilder, PositionLookup, MarkToLig);
 impl_into_lookup!(CursivePosBuilder, PositionLookup, Cursive);
 impl_into_lookup!(SingleSubBuilder, SubstitutionLookup, Single);
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub(crate) enum SubstitutionLookup {
     Single(LookupBuilder<SingleSubBuilder>),
     Multiple(LookupBuilder<MultipleSubBuilder>),

--- a/fea-rs/src/compile/lookups/contextual.rs
+++ b/fea-rs/src/compile/lookups/contextual.rs
@@ -257,40 +257,40 @@ impl ContextualLookupBuilder<SubstitutionLookup> {
     }
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub(crate) struct ContextBuilder {
     rules: Vec<ContextRule>,
 }
 
 // we use separate types here to ensure we don't mix lookups
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub(crate) struct PosContextBuilder(ContextBuilder);
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub(crate) struct SubContextBuilder(ContextBuilder);
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub(crate) struct ReverseChainBuilder {
     rules: Vec<ReverseSubRule>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 struct ReverseSubRule {
     backtrack: Vec<GlyphOrClass>,
     context: BTreeMap<GlyphId16, GlyphId16>,
     lookahead: Vec<GlyphOrClass>,
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub(crate) struct ChainContextBuilder(ContextBuilder);
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub(crate) struct PosChainContextBuilder(ChainContextBuilder);
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub(crate) struct SubChainContextBuilder(ChainContextBuilder);
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 struct ContextRule {
     backtrack: Vec<GlyphOrClass>,
     context: Vec<(GlyphOrClass, Vec<LookupId>)>,

--- a/fea-rs/src/compile/merge.rs
+++ b/fea-rs/src/compile/merge.rs
@@ -1,0 +1,375 @@
+//! Merging per-master compilations into a single variable compilation.
+//!
+//! This is the fea-rs counterpart of fontTools' `varLib.merger`, applied one
+//! stage earlier: instead of merging built GPOS/GDEF tables we merge the
+//! compiler's intermediate state, before the feature writer has run and before
+//! any `ItemVariationStore` exists.
+
+use std::collections::HashMap;
+
+use fontdrasil::coords::NormalizedLocation;
+use smol_str::SmolStr;
+use write_fonts::types::GlyphId16;
+
+use super::{PendingCompilation, VariationInfo};
+
+mod error;
+#[cfg(test)]
+mod test_helpers;
+
+pub use error::MergeError;
+
+/// Merge per-master compilations of non-variable FEA into one variable compilation.
+///
+/// Each input is the output of [`compile_for_merge`] for one master, paired
+/// with that master's location. The caller must ensure that:
+///
+/// - the master at index 0 is the default master, i.e. its location is the
+///   default location of `var_info`'s variation model;
+/// - locations are normalized, and every master's location is one the
+///   variation model knows about;
+/// - only masters that actually have FEA are included. A master without a
+///   feature file is not "an empty feature file"; leave it out.
+///
+/// Everything that cannot vary must be identical across masters: language
+/// systems, features and the lookups they reference, GSUB, conditionsets,
+/// mark filtering sets, and so on. GDEF glyph classes and mark class
+/// membership are unioned, with an error if a glyph is classified
+/// differently in two masters. Tables other than GPOS and GDEF, and any
+/// warnings, are taken from the default master; the caller should report
+/// each master's own diagnostics before merging.
+///
+/// [`compile_for_merge`]: super::compile_for_merge
+pub fn merge<V: VariationInfo>(
+    masters: Vec<(NormalizedLocation, PendingCompilation)>,
+    var_info: &V,
+) -> Result<PendingCompilation, MergeError> {
+    let mut ctx = MergeCtx::new(masters, var_info)?;
+    ctx.check_structure()?;
+    ctx.merge_mark_classes()?;
+    ctx.merge_gdef()?;
+    //TODO: merge these instead of requiring equality
+    for (i, other) in ctx.others.iter().enumerate() {
+        if ctx.merged.lookups.gpos() != other.lookups.gpos() {
+            return Err(MergeError::Gpos { master: i + 1 });
+        }
+    }
+    ctx.finish()
+}
+
+/// The state of a merge in progress.
+///
+/// `merged` starts as the default master and is updated in place; `others`
+/// are the remaining masters, so master `i + 1` is `others[i]`.
+struct MergeCtx {
+    merged: PendingCompilation,
+    others: Vec<PendingCompilation>,
+}
+
+impl MergeCtx {
+    fn new<V: VariationInfo>(
+        masters: Vec<(NormalizedLocation, PendingCompilation)>,
+        var_info: &V,
+    ) -> Result<Self, MergeError> {
+        let mut seen = HashMap::new();
+        for (i, (location, _)) in masters.iter().enumerate() {
+            if let Some(first) = seen.insert(location.clone(), i) {
+                return Err(MergeError::DuplicateLocation { first, second: i });
+            }
+        }
+        let mut masters = masters.into_iter().map(|(_, master)| master);
+        let Some(mut merged) = masters.next() else {
+            return Err(MergeError::NoMasters);
+        };
+        assert!(merged.lig_carets_from_feature_writer.is_empty());
+        merged.axis_count = var_info.axis_count();
+        Ok(MergeCtx {
+            merged,
+            others: masters.collect(),
+        })
+    }
+
+    /// Run any checks that need the fully merged result, and return it.
+    fn finish(self) -> Result<PendingCompilation, MergeError> {
+        Ok(self.merged)
+    }
+
+    /// Check that everything which cannot vary is the same in every master.
+    fn check_structure(&self) -> Result<(), MergeError> {
+        let default = &self.merged;
+        for (i, other) in self.others.iter().enumerate() {
+            let master = i + 1;
+            if default.default_lang_systems != other.default_lang_systems {
+                return Err(MergeError::LanguageSystems { master });
+            }
+            if default.insert_markers != other.insert_markers {
+                return Err(MergeError::InsertMarkers { master });
+            }
+            if default.conditionset_defs != other.conditionset_defs {
+                return Err(MergeError::ConditionSets { master });
+            }
+            if default.opts.compile_gsub != other.opts.compile_gsub
+                || default.opts.compile_gpos != other.opts.compile_gpos
+                || default.opts.compile_debg != other.opts.compile_debg
+            {
+                return Err(MergeError::Options { master });
+            }
+            if default.mark_filter_sets != other.mark_filter_sets {
+                return Err(MergeError::MarkFilterSets { master });
+            }
+            if default.mark_attach_class_id != other.mark_attach_class_id {
+                return Err(MergeError::MarkAttachClasses { master });
+            }
+            if default.lookups.named() != other.lookups.named() {
+                return Err(MergeError::NamedLookups { master });
+            }
+            if default.lookups.gsub() != other.lookups.gsub() {
+                return Err(MergeError::Gsub { master });
+            }
+            if default.features != other.features {
+                return Err(MergeError::Features { master });
+            }
+        }
+        Ok(())
+    }
+
+    /// Union mark class membership.
+    ///
+    /// Only membership matters here: the anchors are merged where they are
+    /// used, in the mark lookups, and this map only feeds GDEF glyph class
+    /// inference.
+    fn merge_mark_classes(&mut self) -> Result<(), MergeError> {
+        let merged = &mut self.merged.mark_classes;
+        let mut membership: HashMap<GlyphId16, SmolStr> = merged
+            .iter()
+            .flat_map(|(name, class)| {
+                class
+                    .members
+                    .iter()
+                    .flat_map(|(glyphs, _)| glyphs.iter())
+                    .map(move |glyph| (glyph, name.clone()))
+            })
+            .collect();
+
+        for (i, other) in self.others.iter().enumerate() {
+            for (name, class) in &other.mark_classes {
+                for (glyphs, anchor) in &class.members {
+                    let mut is_new = false;
+                    for glyph in glyphs.iter() {
+                        match membership.get(&glyph) {
+                            Some(existing) if existing != name => {
+                                return Err(MergeError::MarkClassConflict {
+                                    master: i + 1,
+                                    glyph,
+                                    expected: existing.clone(),
+                                    found: name.clone(),
+                                });
+                            }
+                            Some(_) => (),
+                            None => {
+                                membership.insert(glyph, name.clone());
+                                is_new = true;
+                            }
+                        }
+                    }
+                    if is_new {
+                        merged
+                            .entry(name.clone())
+                            .or_default()
+                            .members
+                            .push((glyphs.clone(), anchor.clone()));
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn merge_gdef(&mut self) -> Result<(), MergeError> {
+        for (i, other) in self.others.iter().enumerate() {
+            let master = i + 1;
+            let Some(other) = other.tables.gdef.as_ref() else {
+                continue;
+            };
+            let merged = self.merged.tables.gdef.get_or_insert_with(Default::default);
+            if merged.attach != other.attach {
+                return Err(MergeError::GdefAttach { master });
+            }
+            //TODO: merge these instead of requiring equality
+            if merged.ligature_pos != other.ligature_pos {
+                return Err(MergeError::LigatureCarets { master });
+            }
+            // sorted so that the reported conflict is deterministic
+            let mut classes: Vec<_> = other.glyph_classes.iter().collect();
+            classes.sort();
+            for (glyph, class) in classes {
+                match merged.glyph_classes.insert(*glyph, *class) {
+                    Some(expected) if expected != *class => {
+                        return Err(MergeError::GlyphClassConflict {
+                            master,
+                            glyph: *glyph,
+                            expected,
+                            found: *class,
+                        });
+                    }
+                    _ => (),
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use write_fonts::tables::gdef::GlyphClassDef;
+
+    use super::{test_helpers::*, *};
+    use crate::compile::NopFeatureProvider;
+
+    #[test]
+    fn identical_masters_round_trip() {
+        assert_eq!(
+            merged_binary(&[KITCHEN_SINK, KITCHEN_SINK, KITCHEN_SINK]),
+            one_shot_binary(KITCHEN_SINK)
+        );
+    }
+
+    #[test]
+    fn single_master_is_identity() {
+        assert_eq!(
+            merged_binary(&[KITCHEN_SINK]),
+            one_shot_binary(KITCHEN_SINK)
+        );
+    }
+
+    #[test]
+    fn no_masters() {
+        assert_eq!(merge_masters(&[]).err(), Some(MergeError::NoMasters));
+    }
+
+    #[test]
+    fn duplicate_locations() {
+        let masters = vec![
+            (location(0.0), pending(KITCHEN_SINK)),
+            (location(1.0), pending(KITCHEN_SINK)),
+            (location(0.0), pending(KITCHEN_SINK)),
+        ];
+        assert_eq!(
+            merge(masters, &var_info()).err(),
+            Some(MergeError::DuplicateLocation {
+                first: 0,
+                second: 2
+            })
+        );
+    }
+
+    #[test]
+    fn gsub_must_match() {
+        let a = "feature liga { sub a b by f_i; } liga;";
+        let b = "feature liga { sub a c by f_i; } liga;";
+        assert_eq!(
+            merge_masters(&[a, a, b]).err(),
+            Some(MergeError::Gsub { master: 2 })
+        );
+    }
+
+    #[test]
+    fn language_systems_must_match() {
+        let a = "languagesystem DFLT dflt; feature kern { pos a b -20; } kern;";
+        let b = "languagesystem latn dflt; feature kern { pos a b -20; } kern;";
+        assert_eq!(
+            merge_masters(&[a, b]).err(),
+            Some(MergeError::LanguageSystems { master: 1 })
+        );
+    }
+
+    #[test]
+    fn features_must_match() {
+        let a = "lookup K { pos a b -20; } K; feature kern { lookup K; } kern;";
+        let b = "lookup K { pos a b -20; } K; feature kern { lookup K; } kern; feature dist { lookup K; } dist;";
+        assert_eq!(
+            merge_masters(&[a, b]).err(),
+            Some(MergeError::Features { master: 1 })
+        );
+    }
+
+    #[test]
+    fn insert_markers_must_match() {
+        let a = "feature kern { pos a b -20; } kern;";
+        let b = "feature kern { # Automatic Code\n pos a b -20; } kern;";
+        assert_eq!(
+            merge_masters(&[a, b]).err(),
+            Some(MergeError::InsertMarkers { master: 1 })
+        );
+    }
+
+    #[test]
+    fn gpos_must_match_for_now() {
+        let a = "feature kern { pos a b -20; } kern;";
+        let b = "feature kern { pos a b -40; } kern;";
+        assert_eq!(
+            merge_masters(&[a, b]).err(),
+            Some(MergeError::Gpos { master: 1 })
+        );
+    }
+
+    #[test]
+    fn gdef_glyph_classes_are_unioned() {
+        let a = "table GDEF { GlyphClassDef [a], , [acute], ; } GDEF;";
+        let b = "table GDEF { GlyphClassDef [b], , [acute], ; } GDEF;";
+        let (compilation, _) = merge_masters(&[a, b])
+            .unwrap()
+            .finish::<NopFeatureProvider>(None)
+            .unwrap();
+        let classes = compilation.gdef_classes.unwrap();
+        let map = glyph_map();
+        let class_of = |name: &str| classes.get(&map.get(name).unwrap()).copied();
+        assert_eq!(class_of("a"), Some(GlyphClassDef::Base));
+        assert_eq!(class_of("b"), Some(GlyphClassDef::Base));
+        assert_eq!(class_of("acute"), Some(GlyphClassDef::Mark));
+        assert_eq!(class_of("c"), None);
+    }
+
+    #[test]
+    fn gdef_glyph_class_conflict() {
+        let a = "table GDEF { GlyphClassDef [a], , [acute], ; } GDEF;";
+        let b = "table GDEF { GlyphClassDef [acute], , [a], ; } GDEF;";
+        assert_eq!(
+            merge_masters(&[a, b]).err(),
+            Some(MergeError::GlyphClassConflict {
+                master: 1,
+                glyph: glyph_map().get("a").unwrap(),
+                expected: GlyphClassDef::Base,
+                found: GlyphClassDef::Mark,
+            })
+        );
+    }
+
+    #[test]
+    fn mark_class_conflict() {
+        let a = "markClass acute <anchor 0 0> @TOP; feature mark { pos base a <anchor 0 0> mark @TOP; } mark;";
+        let b = "markClass acute <anchor 0 0> @BOTTOM; feature mark { pos base a <anchor 0 0> mark @BOTTOM; } mark;";
+        assert_eq!(
+            merge_masters(&[a, b]).err(),
+            Some(MergeError::MarkClassConflict {
+                master: 1,
+                glyph: glyph_map().get("acute").unwrap(),
+                expected: "@TOP".into(),
+                found: "@BOTTOM".into(),
+            })
+        );
+    }
+
+    #[test]
+    fn mark_classes_are_unioned() {
+        let a = "markClass acute <anchor 0 0> @TOP; feature mark { pos base a <anchor 0 0> mark @TOP; } mark;";
+        let b = "markClass [acute grave] <anchor 0 0> @TOP; feature mark { pos base a <anchor 0 0> mark @TOP; } mark;";
+        // the mark lookups differ, so this stops at the (later) GPOS check;
+        // what matters is that the mark class union itself is accepted.
+        assert_eq!(
+            merge_masters(&[a, b]).err(),
+            Some(MergeError::Gpos { master: 1 })
+        );
+    }
+}

--- a/fea-rs/src/compile/merge.rs
+++ b/fea-rs/src/compile/merge.rs
@@ -35,9 +35,9 @@ pub use error::MergeError;
 /// systems, features and the lookups they reference, GSUB, conditionsets,
 /// mark filtering sets, and so on. GDEF glyph classes and mark class
 /// membership are unioned, with an error if a glyph is classified
-/// differently in two masters. Tables other than GPOS and GDEF, and any
-/// warnings, are taken from the default master; the caller should report
-/// each master's own diagnostics before merging.
+/// differently in two masters. Tables other than GPOS and GDEF are taken
+/// from the default master; each master's own diagnostics are returned by
+/// [`compile_for_merge`], and it is up to the caller to report them.
 ///
 /// [`compile_for_merge`]: super::compile_for_merge
 pub fn merge<V: VariationInfo>(
@@ -282,6 +282,13 @@ mod tests {
             merge_masters(&[a, b]).err(),
             Some(MergeError::LanguageSystems { master: 1 })
         );
+    }
+
+    #[test]
+    fn implicit_and_explicit_dflt_are_the_same_language_system() {
+        let a = "feature kern { pos a b -20; } kern;";
+        let b = "languagesystem DFLT dflt; feature kern { pos a b -20; } kern;";
+        assert_eq!(merged_binary(&[a, b]), one_shot_binary(a));
     }
 
     #[test]

--- a/fea-rs/src/compile/merge/error.rs
+++ b/fea-rs/src/compile/merge/error.rs
@@ -1,0 +1,65 @@
+//! Errors from merging per-master compilations.
+
+use smol_str::SmolStr;
+use write_fonts::{tables::gdef::GlyphClassDef, types::GlyphId16};
+
+/// An error encountered while merging per-master compilations.
+///
+/// `master` is the index into the input at which the problem was found; the
+/// master at index 0 is the default, and every other master is compared
+/// against it.
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
+#[non_exhaustive]
+#[allow(missing_docs)]
+pub enum MergeError {
+    #[error("no masters to merge")]
+    NoMasters,
+    #[error("masters {first} and {second} have the same location")]
+    DuplicateLocation { first: usize, second: usize },
+    #[error("master {master}: languagesystem statements differ from the default master")]
+    LanguageSystems { master: usize },
+    #[error("master {master}: '# Automatic Code' markers differ from the default master")]
+    InsertMarkers { master: usize },
+    #[error("master {master}: conditionset definitions differ from the default master")]
+    ConditionSets { master: usize },
+    #[error("master {master}: compilation options differ from the default master")]
+    Options { master: usize },
+    #[error("master {master}: mark filtering sets differ from the default master")]
+    MarkFilterSets { master: usize },
+    #[error("master {master}: mark attachment classes differ from the default master")]
+    MarkAttachClasses { master: usize },
+    #[error("master {master}: named lookups differ from the default master")]
+    NamedLookups { master: usize },
+    #[error("master {master}: GSUB lookups differ from the default master")]
+    Gsub { master: usize },
+    #[error("master {master}: feature definitions differ from the default master")]
+    Features { master: usize },
+    #[error("master {master}: GDEF Attach statements differ from the default master")]
+    GdefAttach { master: usize },
+    #[error(
+        "master {master}: glyph {glyph} has GDEF class {found:?}, but {expected:?} in another master"
+    )]
+    GlyphClassConflict {
+        master: usize,
+        glyph: GlyphId16,
+        expected: GlyphClassDef,
+        found: GlyphClassDef,
+    },
+    #[error(
+        "master {master}: glyph {glyph} is in mark class '{found}', but '{expected}' in another master"
+    )]
+    MarkClassConflict {
+        master: usize,
+        glyph: GlyphId16,
+        expected: SmolStr,
+        found: SmolStr,
+    },
+    //TODO: remove once GPOS lookups are merged
+    #[error("master {master}: GPOS lookups differ from the default master (not yet supported)")]
+    Gpos { master: usize },
+    //TODO: remove once ligature carets are merged
+    #[error(
+        "master {master}: GDEF ligature carets differ from the default master (not yet supported)"
+    )]
+    LigatureCarets { master: usize },
+}

--- a/fea-rs/src/compile/merge/test_helpers.rs
+++ b/fea-rs/src/compile/merge/test_helpers.rs
@@ -1,0 +1,89 @@
+//! Shared helpers for the merge tests.
+
+use fontdrasil::{coords::NormalizedLocation, types::GlyphName};
+
+use super::{MergeError, merge};
+use crate::{
+    GlyphMap,
+    compile::{self, MockVariationInfo, NopFeatureProvider, Opts, PendingCompilation},
+    parse,
+};
+
+pub(super) fn glyph_map() -> GlyphMap {
+    GlyphMap::new(
+        [".notdef", "a", "b", "c", "f_i", "acute", "grave"]
+            .iter()
+            .map(|name| GlyphName::new(*name)),
+    )
+    .unwrap()
+}
+
+pub(super) fn var_info() -> MockVariationInfo {
+    MockVariationInfo::new(&[("wght", 100, 400, 900)])
+}
+
+pub(super) fn location(wght: f64) -> NormalizedLocation {
+    NormalizedLocation::for_pos(&[("wght", wght)])
+}
+
+pub(super) fn pending(fea: &str) -> PendingCompilation {
+    let (tree, diagnostics) = parse::parse_string(fea);
+    assert!(!diagnostics.has_errors(), "{}", diagnostics.display());
+    compile::compile_for_merge(&tree, &glyph_map(), Opts::new()).unwrap()
+}
+
+pub(super) fn merge_masters(feas: &[&str]) -> Result<PendingCompilation, MergeError> {
+    let masters = feas
+        .iter()
+        .enumerate()
+        .map(|(i, fea)| (location(i as f64 / feas.len() as f64), pending(fea)))
+        .collect();
+    merge(masters, &var_info())
+}
+
+pub(super) fn merged_binary(feas: &[&str]) -> Vec<u8> {
+    merge_masters(feas)
+        .unwrap()
+        .finish::<NopFeatureProvider>(None)
+        .unwrap()
+        .0
+        .to_binary(&glyph_map())
+        .unwrap()
+}
+
+pub(super) fn one_shot_binary(fea: &str) -> Vec<u8> {
+    let (tree, _) = parse::parse_string(fea);
+    let (compilation, _) = compile::compile(
+        &tree,
+        &glyph_map(),
+        Some(&var_info()),
+        None::<&NopFeatureProvider>,
+        Opts::new(),
+    )
+    .unwrap();
+    compilation.to_binary(&glyph_map()).unwrap()
+}
+
+pub(super) const KITCHEN_SINK: &str = "\
+languagesystem DFLT dflt;
+languagesystem latn dflt;
+markClass acute <anchor 100 200> @TOP;
+markClass grave <anchor 100 200> @TOP;
+table GDEF {
+GlyphClassDef [a b], [f_i], [acute grave], ;
+LigatureCaretByPos f_i 300;
+} GDEF;
+lookup MARKS {
+pos base [a b] <anchor 150 500> mark @TOP;
+} MARKS;
+feature liga {
+sub a b by f_i;
+} liga;
+feature kern {
+pos a b -20;
+pos a c <-10 0 -10 0>;
+} kern;
+feature mark {
+lookup MARKS;
+} mark;
+";

--- a/fea-rs/src/compile/merge/test_helpers.rs
+++ b/fea-rs/src/compile/merge/test_helpers.rs
@@ -29,7 +29,9 @@ pub(super) fn location(wght: f64) -> NormalizedLocation {
 pub(super) fn pending(fea: &str) -> PendingCompilation {
     let (tree, diagnostics) = parse::parse_string(fea);
     assert!(!diagnostics.has_errors(), "{}", diagnostics.display());
-    compile::compile_for_merge(&tree, &glyph_map(), Opts::new()).unwrap()
+    compile::compile_for_merge(&tree, &glyph_map(), Opts::new())
+        .unwrap()
+        .0
 }
 
 pub(super) fn merge_masters(feas: &[&str]) -> Result<PendingCompilation, MergeError> {

--- a/fea-rs/src/compile/opts.rs
+++ b/fea-rs/src/compile/opts.rs
@@ -8,7 +8,7 @@
 const DEFAULT_N_MESSAGES_TO_PRINT: usize = 100;
 
 /// Options for configuring compilation behaviour.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Opts {
     pub(crate) make_post_table: bool,
     pub(crate) max_n_errors: usize,

--- a/fea-rs/src/compile/output.rs
+++ b/fea-rs/src/compile/output.rs
@@ -24,7 +24,7 @@ use super::feature_writer::InsertionPoint;
 use super::tables::DEBG_TAG;
 
 use crate::{
-    Diagnostic, GlyphMap, GlyphSet, ParseTree,
+    Diagnostic, DiagnosticSet, GlyphMap, GlyphSet, ParseTree,
     common::MarkClass,
     compile::{
         FeatureBuilder, FeatureProvider,
@@ -40,6 +40,7 @@ use crate::{
 ///
 /// This exists to support the case of merging two or more different non-variable
 /// FEA sources into a variable output, in the vein of python's varLib.
+#[derive(Debug)]
 pub struct PendingCompilation {
     pub(super) tree: ParseTree,
     pub(super) features: AllFeatures,
@@ -116,6 +117,32 @@ pub struct Compilation {
 }
 
 impl PendingCompilation {
+    pub(crate) fn has_errors(&self) -> bool {
+        self.errors.iter().any(Diagnostic::is_error)
+    }
+
+    /// Run the feature provider (if any) and build the final tables.
+    ///
+    /// This is the second half of [`compile_for_merge`]; call it once, on the
+    /// merged result, so that generated features are added a single time.
+    ///
+    /// [`compile_for_merge`]: crate::compile::compile_for_merge
+    pub fn finish<F: FeatureProvider>(
+        mut self,
+        writer: Option<&F>,
+    ) -> Result<(Compilation, DiagnosticSet), DiagnosticSet> {
+        let tree = self.tree.clone();
+        if let Some(writer) = writer {
+            self.run_feature_provider(writer);
+        }
+        match self.build() {
+            Ok((compilation, warnings)) => {
+                Ok((compilation, DiagnosticSet::new(warnings, &tree, usize::MAX)))
+            }
+            Err(errors) => Err(DiagnosticSet::new(errors, &tree, usize::MAX)),
+        }
+    }
+
     pub(crate) fn run_feature_provider<T: FeatureProvider>(&mut self, provider: &T) {
         let mut builder = FeatureBuilder::new(
             &self.default_lang_systems,


### PR DESCRIPTION
This adds the basic API/shape of the merging logic, without implementing merging any for of the relevant tables or their values.


This also includes a temporary commit pinning to fontations:HEAD; I'll do a release there and get an update merged here as a separate PR, and then drop that commit.