### PR TITLE
fea-merge part 3: GPOS scaffolding

### DIFF
--- a/fea-rs/src/compile/lookups.rs
+++ b/fea-rs/src/compile/lookups.rs
@@ -259,7 +259,7 @@ impl PositionLookup {
         }
     }
 
-    fn kind(&self) -> Kind {
+    pub(crate) fn kind(&self) -> Kind {
         match self {
             PositionLookup::Single(_) => Kind::GposType1,
             PositionLookup::Pair(_) => Kind::GposType2,
@@ -616,6 +616,12 @@ impl AllLookups {
 
     pub(crate) fn named(&self) -> &HashMap<SmolStr, LookupId> {
         &self.named
+    }
+
+    /// Replace the GPOS lookups with a merged set; the count must not change.
+    pub(crate) fn set_gpos(&mut self, gpos: Vec<PositionLookup>) {
+        assert_eq!(gpos.len(), self.gpos.len());
+        self.gpos = gpos;
     }
 
     pub(crate) fn debug_info(&self) -> (&[Option<LookupDebugInfo>], &[Option<LookupDebugInfo>]) {

--- a/fea-rs/src/compile/merge.rs
+++ b/fea-rs/src/compile/merge.rs
@@ -14,10 +14,11 @@ use write_fonts::types::GlyphId16;
 use super::{PendingCompilation, VariationInfo};
 
 mod error;
+mod lookups;
 #[cfg(test)]
 mod test_helpers;
 
-pub use error::MergeError;
+pub use error::{LookupRef, MergeError};
 
 /// Merge per-master compilations of non-variable FEA into one variable compilation.
 ///
@@ -48,12 +49,7 @@ pub fn merge<V: VariationInfo>(
     ctx.check_structure()?;
     ctx.merge_mark_classes()?;
     ctx.merge_gdef()?;
-    //TODO: merge these instead of requiring equality
-    for (i, other) in ctx.others.iter().enumerate() {
-        if ctx.merged.lookups.gpos() != other.lookups.gpos() {
-            return Err(MergeError::Gpos { master: i + 1 });
-        }
-    }
+    ctx.merge_gpos()?;
     ctx.finish()
 }
 
@@ -222,10 +218,10 @@ impl MergeCtx {
 
 #[cfg(test)]
 mod tests {
-    use write_fonts::tables::gdef::GlyphClassDef;
+    use write_fonts::{tables::gdef::GlyphClassDef, types::Tag};
 
     use super::{test_helpers::*, *};
-    use crate::compile::NopFeatureProvider;
+    use crate::{Kind, compile::NopFeatureProvider};
 
     #[test]
     fn identical_masters_round_trip() {
@@ -312,16 +308,6 @@ mod tests {
     }
 
     #[test]
-    fn gpos_must_match_for_now() {
-        let a = "feature kern { pos a b -20; } kern;";
-        let b = "feature kern { pos a b -40; } kern;";
-        assert_eq!(
-            merge_masters(&[a, b]).err(),
-            Some(MergeError::Gpos { master: 1 })
-        );
-    }
-
-    #[test]
     fn gdef_glyph_classes_are_unioned() {
         let a = "table GDEF { GlyphClassDef [a], , [acute], ; } GDEF;";
         let b = "table GDEF { GlyphClassDef [b], , [acute], ; } GDEF;";
@@ -372,11 +358,14 @@ mod tests {
     fn mark_classes_are_unioned() {
         let a = "markClass acute <anchor 0 0> @TOP; feature mark { pos base a <anchor 0 0> mark @TOP; } mark;";
         let b = "markClass [acute grave] <anchor 0 0> @TOP; feature mark { pos base a <anchor 0 0> mark @TOP; } mark;";
-        // the mark lookups differ, so this stops at the (later) GPOS check;
+        // the mark lookups differ, so this stops at the lookup merge;
         // what matters is that the mark class union itself is accepted.
         assert_eq!(
             merge_masters(&[a, b]).err(),
-            Some(MergeError::Gpos { master: 1 })
+            Some(MergeError::Unsupported {
+                lookup: lookup_ref(0, None, Some(Tag::new(b"mark"))),
+                kind: Kind::GposType4,
+            })
         );
     }
 }

--- a/fea-rs/src/compile/merge/error.rs
+++ b/fea-rs/src/compile/merge/error.rs
@@ -1,7 +1,12 @@
 //! Errors from merging per-master compilations.
 
+use std::fmt;
+
 use smol_str::SmolStr;
 use write_fonts::{tables::gdef::GlyphClassDef, types::GlyphId16};
+
+use super::super::FeatureKey;
+use crate::Kind;
 
 /// An error encountered while merging per-master compilations.
 ///
@@ -54,12 +59,67 @@ pub enum MergeError {
         expected: SmolStr,
         found: SmolStr,
     },
-    //TODO: remove once GPOS lookups are merged
-    #[error("master {master}: GPOS lookups differ from the default master (not yet supported)")]
-    Gpos { master: usize },
+    #[error(
+        "master {master}: {found} GPOS lookups, but the default master has {expected}. \
+         Inline values in contextual rules create anonymous lookups, so this can be \
+         caused by values that differ between masters"
+    )]
+    LookupCount {
+        master: usize,
+        expected: usize,
+        found: usize,
+    },
+    #[error("master {master}: {lookup} is a different kind of lookup than in the default master")]
+    LookupType { master: usize, lookup: LookupRef },
+    #[error("master {master}: {lookup} has different lookupflags than in the default master")]
+    LookupFlags { master: usize, lookup: LookupRef },
+    #[error(
+        "master {master}: {lookup} does not use extension lookups the way the default master does"
+    )]
+    Extension { master: usize, lookup: LookupRef },
+    #[error(
+        "master {master}: {lookup} has {found} subtables, but the default master has {expected}"
+    )]
+    SubtableCount {
+        master: usize,
+        lookup: LookupRef,
+        expected: usize,
+        found: usize,
+    },
+    #[error(
+        "master {master}: {lookup} is a contextual lookup that differs from the default master"
+    )]
+    ContextualDiffers { master: usize, lookup: LookupRef },
+    //TODO: remove once every lookup type can be merged
+    #[error("{lookup} differs between masters, and merging {kind} lookups is not supported yet")]
+    Unsupported { lookup: LookupRef, kind: Kind },
     //TODO: remove once ligature carets are merged
     #[error(
         "master {master}: GDEF ligature carets differ from the default master (not yet supported)"
     )]
     LigatureCarets { master: usize },
+}
+
+/// Identifies a lookup in a [`MergeError`].
+#[derive(Debug, Clone, PartialEq)]
+pub struct LookupRef {
+    /// The position in the GPOS lookup list.
+    pub index: usize,
+    /// The lookup's name, if it came from a named lookup block.
+    pub name: Option<SmolStr>,
+    /// A feature that references this lookup, if any does.
+    pub feature: Option<FeatureKey>,
+}
+
+impl fmt::Display for LookupRef {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "GPOS lookup {}", self.index)?;
+        if let Some(name) = &self.name {
+            write!(f, " ('{name}')")?;
+        }
+        if let Some(feature) = &self.feature {
+            write!(f, " in feature {feature:?}")?;
+        }
+        Ok(())
+    }
 }

--- a/fea-rs/src/compile/merge/lookups.rs
+++ b/fea-rs/src/compile/merge/lookups.rs
@@ -1,0 +1,366 @@
+//! Aligning and merging GPOS lookups across masters.
+
+use write_fonts::tables::layout::{LookupFlag, builders::LookupBuilder};
+
+use super::{LookupRef, MergeCtx, MergeError};
+use crate::{
+    Kind,
+    compile::{
+        LookupId,
+        lookups::{FilterSetId, PositionLookup},
+    },
+};
+
+impl MergeCtx {
+    pub(super) fn merge_gpos(&mut self) -> Result<(), MergeError> {
+        let expected = self.merged.lookups.gpos().len();
+        for (i, other) in self.others.iter().enumerate() {
+            let found = other.lookups.gpos().len();
+            if found != expected {
+                return Err(MergeError::LookupCount {
+                    master: i + 1,
+                    expected,
+                    found,
+                });
+            }
+        }
+        let gpos = (0..expected)
+            .map(|index| {
+                let lookups: Vec<_> = std::iter::once(&self.merged)
+                    .chain(&self.others)
+                    .map(|master| &master.lookups.gpos()[index])
+                    .collect();
+                merge_lookup(&lookups, index, self)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        self.merged.lookups.set_gpos(gpos);
+        Ok(())
+    }
+
+    fn lookup_ref(&self, index: usize) -> LookupRef {
+        let id = LookupId::Gpos(index);
+        let name = self
+            .merged
+            .lookups
+            .named()
+            .iter()
+            .find_map(|(name, named_id)| (*named_id == id).then(|| name.clone()));
+        let feature = self
+            .merged
+            .features
+            .iter()
+            .find_map(|(key, lookups)| lookups.base.contains(&id).then_some(*key));
+        LookupRef {
+            index,
+            name,
+            feature,
+        }
+    }
+
+    fn unsupported(&self, index: usize, kind: Kind) -> MergeError {
+        MergeError::Unsupported {
+            lookup: self.lookup_ref(index),
+            kind,
+        }
+    }
+
+    fn contextual_differs(&self, inner: &[&PositionLookup], index: usize) -> MergeError {
+        let master = inner
+            .iter()
+            .position(|lookup| *lookup != inner[0])
+            .unwrap_or_default();
+        MergeError::ContextualDiffers {
+            master,
+            lookup: self.lookup_ref(index),
+        }
+    }
+}
+
+/// Merge one lookup across all masters.
+///
+/// `lookups` has one entry per master, the default first.
+fn merge_lookup(
+    lookups: &[&PositionLookup],
+    index: usize,
+    ctx: &MergeCtx,
+) -> Result<PositionLookup, MergeError> {
+    if lookups.iter().all(|lookup| *lookup == lookups[0]) {
+        return Ok(lookups[0].clone());
+    }
+
+    let use_extension = matches!(lookups[0], PositionLookup::Extension(_));
+    let mut inner = Vec::with_capacity(lookups.len());
+    for (master, lookup) in lookups.iter().enumerate() {
+        match (use_extension, lookup) {
+            (true, PositionLookup::Extension(wrapped)) => inner.push(&**wrapped),
+            (false, PositionLookup::Extension(_)) | (true, _) => {
+                return Err(MergeError::Extension {
+                    master,
+                    lookup: ctx.lookup_ref(index),
+                });
+            }
+            (false, other) => inner.push(*other),
+        }
+    }
+
+    let kind = inner[0].kind();
+    if let Some(master) = inner.iter().position(|lookup| lookup.kind() != kind) {
+        return Err(MergeError::LookupType {
+            master,
+            lookup: ctx.lookup_ref(index),
+        });
+    }
+
+    // view every master's lookup as the given variant, checking the headers agree
+    macro_rules! aligned {
+        ($variant:ident) => {
+            align(&inner, index, ctx, |lookup| match lookup {
+                PositionLookup::$variant(builder) => builder,
+                _ => unreachable!("all lookups have the kind of inner[0], checked above"),
+            })
+        };
+    }
+
+    let merged = match inner[0] {
+        PositionLookup::Single(_) => {
+            aligned!(Single)?;
+            return Err(ctx.unsupported(index, kind));
+        }
+        PositionLookup::Pair(_) => {
+            aligned!(Pair)?;
+            return Err(ctx.unsupported(index, kind));
+        }
+        PositionLookup::Cursive(_) => {
+            PositionLookup::Cursive(merge_indexwise(aligned!(Cursive)?, index, kind, ctx)?)
+        }
+        PositionLookup::MarkToBase(_) => {
+            PositionLookup::MarkToBase(merge_indexwise(aligned!(MarkToBase)?, index, kind, ctx)?)
+        }
+        PositionLookup::MarkToLig(_) => {
+            PositionLookup::MarkToLig(merge_indexwise(aligned!(MarkToLig)?, index, kind, ctx)?)
+        }
+        PositionLookup::MarkToMark(_) => {
+            PositionLookup::MarkToMark(merge_indexwise(aligned!(MarkToMark)?, index, kind, ctx)?)
+        }
+        PositionLookup::Contextual(_) => {
+            aligned!(Contextual)?;
+            return Err(ctx.contextual_differs(&inner, index));
+        }
+        PositionLookup::ChainedContextual(_) => {
+            aligned!(ChainedContextual)?;
+            return Err(ctx.contextual_differs(&inner, index));
+        }
+        PositionLookup::Extension(_) => unreachable!("unwrapped above"),
+    };
+    Ok(if use_extension {
+        PositionLookup::Extension(Box::new(merged))
+    } else {
+        merged
+    })
+}
+
+/// One lookup viewed across all masters, with the common header pulled out.
+struct AlignedLookup<'a, T> {
+    flags: LookupFlag,
+    mark_set: Option<FilterSetId>,
+    /// The subtables of each master, the default first.
+    per_master: Vec<&'a [T]>,
+}
+
+/// View every master's lookup as one lookup type, checking that the headers agree.
+///
+/// `extract` pulls the builder for that type out of a `PositionLookup`; the
+/// caller guarantees every lookup is of that type.
+fn align<'a, T>(
+    lookups: &[&'a PositionLookup],
+    index: usize,
+    ctx: &MergeCtx,
+    extract: impl Fn(&'a PositionLookup) -> &'a LookupBuilder<T>,
+) -> Result<AlignedLookup<'a, T>, MergeError> {
+    let builders: Vec<_> = lookups.iter().map(|lookup| extract(lookup)).collect();
+    let first = builders[0];
+    for (master, builder) in builders.iter().enumerate() {
+        if builder.flags != first.flags || builder.mark_set != first.mark_set {
+            return Err(MergeError::LookupFlags {
+                master,
+                lookup: ctx.lookup_ref(index),
+            });
+        }
+    }
+    Ok(AlignedLookup {
+        flags: first.flags,
+        mark_set: first.mark_set,
+        per_master: builders
+            .iter()
+            .map(|builder| builder.subtables.as_slice())
+            .collect(),
+    })
+}
+
+impl<T> AlignedLookup<'_, T> {
+    /// Merge subtable `i` of every master into subtable `i` of the result.
+    ///
+    /// For lookup types where matching is per subtable this is the only
+    /// correct alignment, so differing subtable counts are an error.
+    fn indexwise(
+        &self,
+        index: usize,
+        ctx: &MergeCtx,
+        merge_one: impl Fn(&[&T]) -> Result<T, MergeError>,
+    ) -> Result<Vec<T>, MergeError> {
+        let expected = self.per_master[0].len();
+        for (master, subtables) in self.per_master.iter().enumerate() {
+            if subtables.len() != expected {
+                return Err(MergeError::SubtableCount {
+                    master,
+                    lookup: ctx.lookup_ref(index),
+                    expected,
+                    found: subtables.len(),
+                });
+            }
+        }
+        (0..expected)
+            .map(|i| {
+                let row: Vec<_> = self.per_master.iter().map(|subs| &subs[i]).collect();
+                merge_one(&row)
+            })
+            .collect()
+    }
+
+    fn build(self, subtables: Vec<T>) -> LookupBuilder<T> {
+        LookupBuilder {
+            flags: self.flags,
+            mark_set: self.mark_set,
+            subtables,
+        }
+    }
+}
+
+//TODO: replace with real per-type merging; for now identical subtables pass through
+fn merge_indexwise<T: PartialEq + Clone>(
+    aligned: AlignedLookup<'_, T>,
+    index: usize,
+    kind: Kind,
+    ctx: &MergeCtx,
+) -> Result<LookupBuilder<T>, MergeError> {
+    let subtables = aligned.indexwise(index, ctx, |row| {
+        if row.iter().all(|subtable| *subtable == row[0]) {
+            Ok(row[0].clone())
+        } else {
+            Err(ctx.unsupported(index, kind))
+        }
+    })?;
+    Ok(aligned.build(subtables))
+}
+
+#[cfg(test)]
+mod tests {
+    use write_fonts::types::Tag;
+
+    use super::super::{MergeError, test_helpers::*};
+    use crate::Kind;
+
+    #[test]
+    fn value_divergence_is_unsupported_for_now() {
+        let a = "feature kern { pos a b -20; } kern;";
+        let b = "feature kern { pos a b -40; } kern;";
+        assert_eq!(
+            merge_masters(&[a, b]).err(),
+            Some(MergeError::Unsupported {
+                lookup: lookup_ref(0, None, Some(Tag::new(b"kern"))),
+                kind: Kind::GposType2,
+            })
+        );
+    }
+
+    #[test]
+    fn lookup_count_differs_via_anonymous_lookups() {
+        // both rules position 'b', so the second value needs its own anonymous lookup
+        let a = "feature kern { pos a b' 10 c; pos a b' 10 f_i; } kern;";
+        let b = "feature kern { pos a b' 10 c; pos a b' 20 f_i; } kern;";
+        assert_eq!(
+            merge_masters(&[a, b]).err(),
+            Some(MergeError::LookupCount {
+                master: 1,
+                expected: 2,
+                found: 3,
+            })
+        );
+    }
+
+    #[test]
+    fn lookup_type_differs() {
+        let a = "feature kern { pos a b -20; } kern;";
+        let b = "feature kern { pos a -20; } kern;";
+        assert_eq!(
+            merge_masters(&[a, b]).err(),
+            Some(MergeError::LookupType {
+                master: 1,
+                lookup: lookup_ref(0, None, Some(Tag::new(b"kern"))),
+            })
+        );
+    }
+
+    #[test]
+    fn lookup_flags_differ() {
+        let a = "feature kern { lookupflag IgnoreMarks; pos a b -20; } kern;";
+        let b = "feature kern { pos a b -20; } kern;";
+        assert_eq!(
+            merge_masters(&[a, b]).err(),
+            Some(MergeError::LookupFlags {
+                master: 1,
+                lookup: lookup_ref(0, None, Some(Tag::new(b"kern"))),
+            })
+        );
+    }
+
+    #[test]
+    fn extension_differs() {
+        let a = "lookup K useExtension { pos a b -20; } K; feature kern { lookup K; } kern;";
+        let b = "lookup K { pos a b -20; } K; feature kern { lookup K; } kern;";
+        assert_eq!(
+            merge_masters(&[a, b]).err(),
+            Some(MergeError::Extension {
+                master: 1,
+                lookup: lookup_ref(0, Some("K"), Some(Tag::new(b"kern"))),
+            })
+        );
+    }
+
+    #[test]
+    fn contextual_differs() {
+        let a = "feature calt { pos a b' 10 c; } calt;";
+        let b = "feature calt { pos a b' 10 f_i; } calt;";
+        assert_eq!(
+            merge_masters(&[a, b]).err(),
+            Some(MergeError::ContextualDiffers {
+                master: 1,
+                lookup: lookup_ref(0, None, Some(Tag::new(b"calt"))),
+            })
+        );
+    }
+
+    #[test]
+    fn subtable_count_differs() {
+        let a = "markClass acute <anchor 0 0> @TOP; feature mark { pos base a <anchor 0 0> mark @TOP; subtable; pos base b <anchor 0 0> mark @TOP; } mark;";
+        let b = "markClass acute <anchor 0 0> @TOP; feature mark { pos base a <anchor 0 0> mark @TOP; pos base b <anchor 0 0> mark @TOP; } mark;";
+        assert_eq!(
+            merge_masters(&[a, b]).err(),
+            Some(MergeError::SubtableCount {
+                master: 1,
+                lookup: lookup_ref(0, None, Some(Tag::new(b"mark"))),
+                expected: 2,
+                found: 1,
+            })
+        );
+    }
+
+    #[test]
+    fn lookup_ref_display() {
+        assert_eq!(
+            lookup_ref(3, Some("K"), Some(Tag::new(b"kern"))).to_string(),
+            "GPOS lookup 3 ('K') in feature kern: DFLT/dflt"
+        );
+        assert_eq!(lookup_ref(1, None, None).to_string(), "GPOS lookup 1");
+    }
+}

--- a/fea-rs/src/compile/merge/test_helpers.rs
+++ b/fea-rs/src/compile/merge/test_helpers.rs
@@ -1,11 +1,16 @@
 //! Shared helpers for the merge tests.
 
 use fontdrasil::{coords::NormalizedLocation, types::GlyphName};
+use smol_str::SmolStr;
+use write_fonts::types::Tag;
 
-use super::{MergeError, merge};
+use super::{LookupRef, MergeError, merge};
 use crate::{
     GlyphMap,
-    compile::{self, MockVariationInfo, NopFeatureProvider, Opts, PendingCompilation},
+    compile::{
+        self, FeatureKey, MockVariationInfo, NopFeatureProvider, Opts, PendingCompilation,
+        tags::{LANG_DFLT, SCRIPT_DFLT},
+    },
     parse,
 };
 
@@ -24,6 +29,14 @@ pub(super) fn var_info() -> MockVariationInfo {
 
 pub(super) fn location(wght: f64) -> NormalizedLocation {
     NormalizedLocation::for_pos(&[("wght", wght)])
+}
+
+pub(super) fn lookup_ref(index: usize, name: Option<&str>, feature: Option<Tag>) -> LookupRef {
+    LookupRef {
+        index,
+        name: name.map(SmolStr::new),
+        feature: feature.map(|tag| FeatureKey::new(tag, LANG_DFLT, SCRIPT_DFLT)),
+    }
 }
 
 pub(super) fn pending(fea: &str) -> PendingCompilation {
@@ -88,4 +101,12 @@ pos a c <-10 0 -10 0>;
 feature mark {
 lookup MARKS;
 } mark;
+lookup SPLIT {
+pos a 10;
+subtable;
+pos b 20;
+} SPLIT;
+feature cpsp {
+lookup SPLIT;
+} cpsp;
 ";


### PR DESCRIPTION
This is the basic structure for merging GPOS, without support for merging the individual lookup types.

----
[fea-rs] Align GPOS lookups across masters when merging

Per lookup index the masters must agree on count, kind, lookupflags, mark filtering set and extension-ness; an anonymous-lookup count difference gets an error message that says where it usually comes from, since a value-only edit to an inline contextual rule can cause it.

Lookups that are identical across masters are passed through untouched, so identical masters still round-trip byte-for-byte. The subtable policy by type follows varLib: cursive and mark lookups merge subtable-by-subtable and require equal counts, because matching there is per (mark, base) pair within one subtable; contextual lookups must be identical. Single and pair lookups are flattened before merging, which lands with their value merging. Until then any lookup whose values differ is reported as unsupported.
