### PR TITLE
fea-merge part 4: singlepos

### DIFF
--- a/fea-rs/src/compile/compile_ctx.rs
+++ b/fea-rs/src/compile/compile_ctx.rs
@@ -2268,7 +2268,7 @@ fn get_reasonable_length_span(node: &NodeOrToken) -> Range<usize> {
 ///
 /// Matches feaLib's `VariableScalar.does_vary`:
 /// <https://github.com/fonttools/fonttools/blob/34be2443a/Lib/fontTools/feaLib/variableScalar.py#L58-L61>
-fn metric_from_deltas(default: i16, deltas: Vec<(VariationRegion, i16)>) -> Metric {
+pub(crate) fn metric_from_deltas(default: i16, deltas: Vec<(VariationRegion, i16)>) -> Metric {
     let device_or_deltas = if deltas.iter().all(|(_, delta)| *delta == 0) {
         DeviceOrDeltas::None
     } else {

--- a/fea-rs/src/compile/merge.rs
+++ b/fea-rs/src/compile/merge.rs
@@ -15,6 +15,8 @@ use super::{PendingCompilation, VariationInfo};
 
 mod error;
 mod lookups;
+mod metric;
+mod single;
 #[cfg(test)]
 mod test_helpers;
 
@@ -56,16 +58,19 @@ pub fn merge<V: VariationInfo>(
 /// The state of a merge in progress.
 ///
 /// `merged` starts as the default master and is updated in place; `others`
-/// are the remaining masters, so master `i + 1` is `others[i]`.
-struct MergeCtx {
+/// are the remaining masters, so master `i + 1` is `others[i]`. `locations`
+/// has one entry per master in that same order, the default first.
+struct MergeCtx<'a, V> {
     merged: PendingCompilation,
     others: Vec<PendingCompilation>,
+    locations: Vec<NormalizedLocation>,
+    var_info: &'a V,
 }
 
-impl MergeCtx {
-    fn new<V: VariationInfo>(
+impl<'a, V: VariationInfo> MergeCtx<'a, V> {
+    fn new(
         masters: Vec<(NormalizedLocation, PendingCompilation)>,
-        var_info: &V,
+        var_info: &'a V,
     ) -> Result<Self, MergeError> {
         let mut seen = HashMap::new();
         for (i, (location, _)) in masters.iter().enumerate() {
@@ -73,15 +78,18 @@ impl MergeCtx {
                 return Err(MergeError::DuplicateLocation { first, second: i });
             }
         }
-        let mut masters = masters.into_iter().map(|(_, master)| master);
-        let Some(mut merged) = masters.next() else {
+        let (locations, compilations): (Vec<_>, Vec<_>) = masters.into_iter().unzip();
+        let mut compilations = compilations.into_iter();
+        let Some(mut merged) = compilations.next() else {
             return Err(MergeError::NoMasters);
         };
         assert!(merged.lig_carets_from_feature_writer.is_empty());
         merged.axis_count = var_info.axis_count();
         Ok(MergeCtx {
             merged,
-            others: masters.collect(),
+            others: compilations.collect(),
+            locations,
+            var_info,
         })
     }
 

--- a/fea-rs/src/compile/merge/error.rs
+++ b/fea-rs/src/compile/merge/error.rs
@@ -90,6 +90,18 @@ pub enum MergeError {
         "master {master}: {lookup} is a contextual lookup that differs from the default master"
     )]
     ContextualDiffers { master: usize, lookup: LookupRef },
+    #[error("{lookup}: a value is present in some masters but missing at the default master")]
+    MissingAtDefault { lookup: LookupRef },
+    #[error(
+        "{lookup}: an explicit device table differs between masters; device tables cannot be interpolated"
+    )]
+    DeviceDiffers { lookup: LookupRef },
+    #[error(
+        "{lookup}: an anchor with a contour point differs between masters; such anchors cannot vary"
+    )]
+    AnchorPoint { lookup: LookupRef },
+    #[error("{lookup}: failed to compute deltas: {message}")]
+    Deltas { lookup: LookupRef, message: String },
     //TODO: remove once every lookup type can be merged
     #[error("{lookup} differs between masters, and merging {kind} lookups is not supported yet")]
     Unsupported { lookup: LookupRef, kind: Kind },

--- a/fea-rs/src/compile/merge/lookups.rs
+++ b/fea-rs/src/compile/merge/lookups.rs
@@ -6,12 +6,12 @@ use super::{LookupRef, MergeCtx, MergeError};
 use crate::{
     Kind,
     compile::{
-        LookupId,
+        LookupId, VariationInfo,
         lookups::{FilterSetId, PositionLookup},
     },
 };
 
-impl MergeCtx {
+impl<V: VariationInfo> MergeCtx<'_, V> {
     pub(super) fn merge_gpos(&mut self) -> Result<(), MergeError> {
         let expected = self.merged.lookups.gpos().len();
         for (i, other) in self.others.iter().enumerate() {
@@ -37,7 +37,7 @@ impl MergeCtx {
         Ok(())
     }
 
-    fn lookup_ref(&self, index: usize) -> LookupRef {
+    pub(super) fn lookup_ref(&self, index: usize) -> LookupRef {
         let id = LookupId::Gpos(index);
         let name = self
             .merged
@@ -79,10 +79,10 @@ impl MergeCtx {
 /// Merge one lookup across all masters.
 ///
 /// `lookups` has one entry per master, the default first.
-fn merge_lookup(
+fn merge_lookup<V: VariationInfo>(
     lookups: &[&PositionLookup],
     index: usize,
-    ctx: &MergeCtx,
+    ctx: &MergeCtx<'_, V>,
 ) -> Result<PositionLookup, MergeError> {
     if lookups.iter().all(|lookup| *lookup == lookups[0]) {
         return Ok(lookups[0].clone());
@@ -123,8 +123,7 @@ fn merge_lookup(
 
     let merged = match inner[0] {
         PositionLookup::Single(_) => {
-            aligned!(Single)?;
-            return Err(ctx.unsupported(index, kind));
+            PositionLookup::Single(ctx.merge_single_pos(aligned!(Single)?, index)?)
         }
         PositionLookup::Pair(_) => {
             aligned!(Pair)?;
@@ -160,21 +159,21 @@ fn merge_lookup(
 }
 
 /// One lookup viewed across all masters, with the common header pulled out.
-struct AlignedLookup<'a, T> {
+pub(super) struct AlignedLookup<'a, T> {
     flags: LookupFlag,
     mark_set: Option<FilterSetId>,
     /// The subtables of each master, the default first.
-    per_master: Vec<&'a [T]>,
+    pub(super) per_master: Vec<&'a [T]>,
 }
 
 /// View every master's lookup as one lookup type, checking that the headers agree.
 ///
 /// `extract` pulls the builder for that type out of a `PositionLookup`; the
 /// caller guarantees every lookup is of that type.
-fn align<'a, T>(
+fn align<'a, T, V: VariationInfo>(
     lookups: &[&'a PositionLookup],
     index: usize,
-    ctx: &MergeCtx,
+    ctx: &MergeCtx<'_, V>,
     extract: impl Fn(&'a PositionLookup) -> &'a LookupBuilder<T>,
 ) -> Result<AlignedLookup<'a, T>, MergeError> {
     let builders: Vec<_> = lookups.iter().map(|lookup| extract(lookup)).collect();
@@ -202,10 +201,10 @@ impl<T> AlignedLookup<'_, T> {
     ///
     /// For lookup types where matching is per subtable this is the only
     /// correct alignment, so differing subtable counts are an error.
-    fn indexwise(
+    fn indexwise<V: VariationInfo>(
         &self,
         index: usize,
-        ctx: &MergeCtx,
+        ctx: &MergeCtx<'_, V>,
         merge_one: impl Fn(&[&T]) -> Result<T, MergeError>,
     ) -> Result<Vec<T>, MergeError> {
         let expected = self.per_master[0].len();
@@ -227,7 +226,7 @@ impl<T> AlignedLookup<'_, T> {
             .collect()
     }
 
-    fn build(self, subtables: Vec<T>) -> LookupBuilder<T> {
+    pub(super) fn build(self, subtables: Vec<T>) -> LookupBuilder<T> {
         LookupBuilder {
             flags: self.flags,
             mark_set: self.mark_set,
@@ -237,11 +236,11 @@ impl<T> AlignedLookup<'_, T> {
 }
 
 //TODO: replace with real per-type merging; for now identical subtables pass through
-fn merge_indexwise<T: PartialEq + Clone>(
+fn merge_indexwise<T: PartialEq + Clone, V: VariationInfo>(
     aligned: AlignedLookup<'_, T>,
     index: usize,
     kind: Kind,
-    ctx: &MergeCtx,
+    ctx: &MergeCtx<'_, V>,
 ) -> Result<LookupBuilder<T>, MergeError> {
     let subtables = aligned.indexwise(index, ctx, |row| {
         if row.iter().all(|subtable| *subtable == row[0]) {

--- a/fea-rs/src/compile/merge/metric.rs
+++ b/fea-rs/src/compile/merge/metric.rs
@@ -1,0 +1,167 @@
+//! Merging per-master values into variable ones.
+
+use std::collections::HashMap;
+
+use fontdrasil::coords::NormalizedLocation;
+use write_fonts::tables::{
+    gpos::builders::ValueRecordBuilder,
+    layout::builders::{DeviceOrDeltas, Metric},
+};
+
+use super::{MergeCtx, MergeError};
+use crate::compile::{VariationInfo, compile_ctx::metric_from_deltas};
+
+impl<V: VariationInfo> MergeCtx<'_, V> {
+    /// Merge one metric across masters.
+    ///
+    /// `values[i]` is master `i`'s value, or `None` if that master has none,
+    /// in which case it contributes zero: a positioning rule a master does not
+    /// have applies no adjustment there. At least one value must be present.
+    /// A value that is the same in every master stays a plain scalar.
+    ///
+    /// <https://github.com/fonttools/fonttools/blob/34be2443a/Lib/fontTools/varLib/merger.py#L1254-L1258>
+    pub(super) fn merge_metric(
+        &self,
+        values: &[Option<&Metric>],
+        index: usize,
+    ) -> Result<Metric, MergeError> {
+        let present: Vec<&Metric> = values.iter().flatten().copied().collect();
+        let first = *present.first().expect("caller passes at least one value");
+        assert!(
+            present
+                .iter()
+                .all(|metric| !matches!(metric.device_or_deltas, DeviceOrDeltas::Deltas(_))),
+            "compile_for_merge has no variation info, so it cannot produce deltas"
+        );
+
+        if present
+            .iter()
+            .any(|metric| matches!(metric.device_or_deltas, DeviceOrDeltas::Device(_)))
+        {
+            return if values.iter().all(|value| *value == Some(first)) {
+                Ok(first.clone())
+            } else {
+                Err(MergeError::DeviceDiffers {
+                    lookup: self.lookup_ref(index),
+                })
+            };
+        }
+
+        let per_master: Vec<i16> = values
+            .iter()
+            .map(|value| value.map(|metric| metric.default).unwrap_or(0))
+            .collect();
+        let default = per_master[0];
+        if per_master.iter().all(|value| *value == default) {
+            return Ok(default.into());
+        }
+
+        let locations: HashMap<NormalizedLocation, i16> =
+            self.locations.iter().cloned().zip(per_master).collect();
+        let (default, deltas) = self
+            .var_info
+            .resolve_variable_metric(&locations)
+            .map_err(|e| MergeError::Deltas {
+                lookup: self.lookup_ref(index),
+                message: e.to_string(),
+            })?;
+        Ok(metric_from_deltas(default, deltas))
+    }
+
+    /// Merge one value record across masters.
+    ///
+    /// A field that is set in any master is merged across all of them; masters
+    /// that do not set it, or have no record at all, contribute zero.
+    ///
+    /// <https://github.com/fonttools/fonttools/blob/34be2443a/Lib/fontTools/varLib/merger.py#L1301-L1315>
+    pub(super) fn merge_value_record(
+        &self,
+        records: &[Option<&ValueRecordBuilder>],
+        index: usize,
+    ) -> Result<ValueRecordBuilder, MergeError> {
+        let field = |get: fn(&ValueRecordBuilder) -> Option<&Metric>| {
+            let values: Vec<_> = records.iter().map(|r| r.and_then(get)).collect();
+            if values.iter().all(Option::is_none) {
+                return Ok(None);
+            }
+            self.merge_metric(&values, index).map(Some)
+        };
+        Ok(ValueRecordBuilder {
+            x_advance: field(|r| r.x_advance.as_ref())?,
+            y_advance: field(|r| r.y_advance.as_ref())?,
+            x_placement: field(|r| r.x_placement.as_ref())?,
+            y_placement: field(|r| r.y_placement.as_ref())?,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use write_fonts::tables::layout::Device;
+
+    use super::{super::test_helpers::*, *};
+    use crate::compile::MockVariationInfo;
+
+    fn ctx<'a>(var_info: &'a MockVariationInfo, wghts: &[f64]) -> MergeCtx<'a, MockVariationInfo> {
+        let masters = wghts
+            .iter()
+            .map(|wght| (location(*wght), pending("languagesystem DFLT dflt;")))
+            .collect();
+        MergeCtx::new(masters, var_info).unwrap()
+    }
+
+    fn deltas(metric: &Metric) -> Vec<i16> {
+        match &metric.device_or_deltas {
+            DeviceOrDeltas::Deltas(deltas) => deltas.iter().map(|(_, delta)| *delta).collect(),
+            DeviceOrDeltas::None => Vec::new(),
+            DeviceOrDeltas::Device(_) => panic!("unexpected device table"),
+        }
+    }
+
+    #[test]
+    fn equal_values_stay_scalar() {
+        let var_info = var_info();
+        let ctx = ctx(&var_info, &[0.0, 1.0]);
+        let ten = Metric::from(10);
+        let merged = ctx.merge_metric(&[Some(&ten), Some(&ten)], 0).unwrap();
+        assert_eq!(merged, ten);
+    }
+
+    #[test]
+    fn differing_values_get_deltas() {
+        let var_info = var_info();
+        let ctx = ctx(&var_info, &[0.0, 1.0]);
+        let merged = ctx
+            .merge_metric(&[Some(&10.into()), Some(&30.into())], 0)
+            .unwrap();
+        assert_eq!(merged.default, 10);
+        assert_eq!(deltas(&merged), vec![20]);
+    }
+
+    #[test]
+    fn missing_is_zero() {
+        let var_info = var_info();
+        let ctx = ctx(&var_info, &[0.0, 1.0]);
+        let merged = ctx.merge_metric(&[Some(&10.into()), None], 0).unwrap();
+        assert_eq!(merged.default, 10);
+        assert_eq!(deltas(&merged), vec![-10]);
+    }
+
+    #[test]
+    fn device_tables_must_agree() {
+        let var_info = var_info();
+        let ctx = ctx(&var_info, &[0.0, 1.0]);
+        let device = Metric {
+            default: 10,
+            device_or_deltas: Device::new(11, 12, &[1, 1]).into(),
+        };
+        let merged = ctx
+            .merge_metric(&[Some(&device), Some(&device)], 0)
+            .unwrap();
+        assert_eq!(merged, device);
+        assert!(matches!(
+            ctx.merge_metric(&[Some(&device), Some(&10.into())], 0),
+            Err(MergeError::DeviceDiffers { .. })
+        ));
+    }
+}

--- a/fea-rs/src/compile/merge/single.rs
+++ b/fea-rs/src/compile/merge/single.rs
@@ -1,0 +1,106 @@
+//! Merging single positioning lookups.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use write_fonts::tables::{
+    gpos::builders::{SinglePosBuilder, ValueRecordBuilder},
+    layout::builders::LookupBuilder,
+};
+
+use super::{MergeCtx, MergeError, lookups::AlignedLookup};
+use crate::{common::GlyphId16, compile::VariationInfo};
+
+impl<V: VariationInfo> MergeCtx<'_, V> {
+    /// Merge a single positioning lookup across masters.
+    ///
+    /// A lookup applies at most one subtable to a glyph, the first that
+    /// covers it, so each master's subtables flatten to one map without
+    /// changing behaviour; the builder splits the merged map back into
+    /// subtables when the lookup is built.
+    ///
+    /// <https://github.com/fonttools/fonttools/blob/34be2443a/Lib/fontTools/varLib/merger.py#L263-L278>
+    pub(super) fn merge_single_pos(
+        &self,
+        aligned: AlignedLookup<'_, SinglePosBuilder>,
+        index: usize,
+    ) -> Result<LookupBuilder<SinglePosBuilder>, MergeError> {
+        let per_master: Vec<BTreeMap<GlyphId16, &ValueRecordBuilder>> = aligned
+            .per_master
+            .iter()
+            .map(|subtables| {
+                let mut map = BTreeMap::new();
+                for subtable in *subtables {
+                    for (glyph, record) in subtable.iter() {
+                        map.entry(glyph).or_insert(record);
+                    }
+                }
+                map
+            })
+            .collect();
+        let glyphs: BTreeSet<GlyphId16> = per_master
+            .iter()
+            .flat_map(|map| map.keys().copied())
+            .collect();
+
+        let mut builder = SinglePosBuilder::default();
+        for glyph in glyphs {
+            let records: Vec<_> = per_master
+                .iter()
+                .map(|map| map.get(&glyph).copied())
+                .collect();
+            builder.insert(glyph, self.merge_value_record(&records, index)?);
+        }
+        Ok(aligned.build(vec![builder]))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::test_helpers::*;
+
+    #[test]
+    fn values_vary() {
+        assert_eq!(
+            merged_binary(&[
+                "feature kern { pos a 10; pos b 5; } kern;",
+                "feature kern { pos a 30; pos b 5; } kern;",
+            ]),
+            one_shot_binary("feature kern { pos a (wght=400:10 wght=900:30); pos b 5; } kern;")
+        );
+    }
+
+    #[test]
+    fn rule_missing_in_a_master_is_zero_there() {
+        assert_eq!(
+            merged_binary(&[
+                "feature kern { pos a 10; } kern;",
+                "feature kern { pos a 10; pos b 20; } kern;",
+            ]),
+            one_shot_binary("feature kern { pos a 10; pos b (wght=400:0 wght=900:20); } kern;")
+        );
+    }
+
+    #[test]
+    fn subtables_flatten_first_wins() {
+        assert_eq!(
+            merged_binary(&[
+                "feature kern { pos a 10; subtable; pos a 99; pos b 20; } kern;",
+                "feature kern { pos a 10; pos b 25; } kern;",
+            ]),
+            one_shot_binary("feature kern { pos a 10; pos b (wght=400:20 wght=900:25); } kern;")
+        );
+    }
+
+    #[test]
+    fn fields_set_in_different_masters_are_unioned() {
+        assert_eq!(
+            merged_binary(&[
+                "feature kern { pos a 10; } kern;",
+                "feature kern { pos a <10 0 0 0>; } kern;",
+            ]),
+            one_shot_binary(
+                "feature kern { pos a <(wght=400:0 wght=900:10) 0 (wght=400:10 wght=900:0) 0>; } kern;"
+            )
+        );
+    }
+}

--- a/fea-rs/src/compile/merge/test_helpers.rs
+++ b/fea-rs/src/compile/merge/test_helpers.rs
@@ -51,7 +51,14 @@ pub(super) fn merge_masters(feas: &[&str]) -> Result<PendingCompilation, MergeEr
     let masters = feas
         .iter()
         .enumerate()
-        .map(|(i, fea)| (location(i as f64 / feas.len() as f64), pending(fea)))
+        .map(|(i, fea)| {
+            let wght = if feas.len() == 1 {
+                0.0
+            } else {
+                i as f64 / (feas.len() - 1) as f64
+            };
+            (location(wght), pending(fea))
+        })
         .collect();
     merge(masters, &var_info())
 }


### PR DESCRIPTION
[fea-rs] Merge values, starting with SinglePos

This adds merge_metric, the core logic for merging values across masters. merge_value_record applies that per field, so the value format of the result is the union of the masters' formats.

Uses this new logic to merge SinglePos lookups. A lookup applies at most one subtable to a glyph, the first that covers it, so each master's subtables flatten to one map (first wins) without changing behaviour. The merged map is rebuilt as one subtable and the builder re-splits it.