### PR TITLE
fea-merge part 6: anchors + cursive pos

### DIFF
--- a/fea-rs/src/compile/merge.rs
+++ b/fea-rs/src/compile/merge.rs
@@ -13,6 +13,7 @@ use write_fonts::types::GlyphId16;
 
 use super::{PendingCompilation, VariationInfo};
 
+mod cursive;
 mod error;
 mod lookups;
 mod metric;

--- a/fea-rs/src/compile/merge/cursive.rs
+++ b/fea-rs/src/compile/merge/cursive.rs
@@ -1,0 +1,96 @@
+//! Merging cursive attachment lookups.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use write_fonts::tables::{gpos::builders::CursivePosBuilder, layout::builders::LookupBuilder};
+
+use super::{MergeCtx, MergeError, lookups::AlignedLookup};
+use crate::{common::GlyphId16, compile::VariationInfo};
+
+impl<V: VariationInfo> MergeCtx<'_, V> {
+    /// Merge a cursive attachment lookup across masters, subtable by subtable.
+    ///
+    /// Coverage is the union of the masters'; a glyph's entry and exit anchors
+    /// are each merged over the masters that have them.
+    ///
+    /// <https://github.com/fonttools/fonttools/blob/34be2443a/Lib/fontTools/varLib/merger.py#L916-L946>
+    pub(super) fn merge_cursive(
+        &self,
+        aligned: AlignedLookup<'_, CursivePosBuilder>,
+        index: usize,
+    ) -> Result<LookupBuilder<CursivePosBuilder>, MergeError> {
+        let subtables = aligned.indexwise(index, self, |row| {
+            let per_master: Vec<BTreeMap<_, _>> = row
+                .iter()
+                .map(|subtable| {
+                    subtable
+                        .iter()
+                        .map(|(glyph, entry, exit)| (glyph, (entry, exit)))
+                        .collect()
+                })
+                .collect();
+            let glyphs: BTreeSet<GlyphId16> = per_master
+                .iter()
+                .flat_map(|map| map.keys().copied())
+                .collect();
+
+            let mut builder = CursivePosBuilder::default();
+            for glyph in glyphs {
+                let anchors = |pick: fn(&(Option<_>, Option<_>)) -> Option<_>| -> Vec<_> {
+                    per_master
+                        .iter()
+                        .map(|map| map.get(&glyph).and_then(pick))
+                        .collect()
+                };
+                let entry = self.merge_anchor(&anchors(|(entry, _)| *entry), index)?;
+                let exit = self.merge_anchor(&anchors(|(_, exit)| *exit), index)?;
+                builder.insert(glyph, entry, exit);
+            }
+            Ok(builder)
+        })?;
+        Ok(aligned.build(subtables))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::{MergeError, test_helpers::*};
+
+    #[test]
+    fn anchors_vary() {
+        assert_eq!(
+            merged_binary(&[
+                "feature curs { pos cursive a <anchor 100 200> <anchor NULL>; } curs;",
+                "feature curs { pos cursive a <anchor 100 250> <anchor NULL>; } curs;",
+            ]),
+            one_shot_binary(
+                "feature curs { pos cursive a <anchor 100 (wght=400:200 wght=900:250)> <anchor NULL>; } curs;"
+            )
+        );
+    }
+
+    #[test]
+    fn glyph_missing_in_a_middle_master_is_sparse() {
+        assert_eq!(
+            merged_binary(&[
+                "feature curs { pos cursive a <anchor 1 2> <anchor NULL>; pos cursive b <anchor NULL> <anchor 10 10>; } curs;",
+                "feature curs { pos cursive a <anchor 1 2> <anchor NULL>; } curs;",
+                "feature curs { pos cursive a <anchor 1 2> <anchor NULL>; pos cursive b <anchor NULL> <anchor 10 20>; } curs;",
+            ]),
+            one_shot_binary(
+                "feature curs { pos cursive a <anchor 1 2> <anchor NULL>; pos cursive b <anchor NULL> <anchor 10 (wght=400:10 wght=900:20)>; } curs;"
+            )
+        );
+    }
+
+    #[test]
+    fn glyph_missing_at_the_default_is_an_error() {
+        assert!(matches!(
+            merge_masters(&[
+                "feature curs { pos cursive a <anchor 1 2> <anchor NULL>; } curs;",
+                "feature curs { pos cursive a <anchor 1 2> <anchor NULL>; pos cursive b <anchor NULL> <anchor 10 20>; } curs;",
+            ]),
+            Err(MergeError::MissingAtDefault { .. })
+        ));
+    }
+}

--- a/fea-rs/src/compile/merge/lookups.rs
+++ b/fea-rs/src/compile/merge/lookups.rs
@@ -129,7 +129,7 @@ fn merge_lookup<V: VariationInfo>(
             PositionLookup::Pair(ctx.merge_pair_pos(aligned!(Pair)?, index)?)
         }
         PositionLookup::Cursive(_) => {
-            PositionLookup::Cursive(merge_indexwise(aligned!(Cursive)?, index, kind, ctx)?)
+            PositionLookup::Cursive(ctx.merge_cursive(aligned!(Cursive)?, index)?)
         }
         PositionLookup::MarkToBase(_) => {
             PositionLookup::MarkToBase(merge_indexwise(aligned!(MarkToBase)?, index, kind, ctx)?)
@@ -200,7 +200,7 @@ impl<T> AlignedLookup<'_, T> {
     ///
     /// For lookup types where matching is per subtable this is the only
     /// correct alignment, so differing subtable counts are an error.
-    fn indexwise<V: VariationInfo>(
+    pub(super) fn indexwise<V: VariationInfo>(
         &self,
         index: usize,
         ctx: &MergeCtx<'_, V>,

--- a/fea-rs/src/compile/merge/metric.rs
+++ b/fea-rs/src/compile/merge/metric.rs
@@ -4,25 +4,38 @@ use std::collections::HashMap;
 
 use fontdrasil::coords::NormalizedLocation;
 use write_fonts::tables::{
-    gpos::builders::ValueRecordBuilder,
+    gpos::builders::{AnchorBuilder, ValueRecordBuilder},
     layout::builders::{DeviceOrDeltas, Metric},
 };
 
 use super::{MergeCtx, MergeError};
 use crate::compile::{VariationInfo, compile_ctx::metric_from_deltas};
 
+/// What a master without a value contributes.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum Missing {
+    /// Zero: a positioning rule that a master does not have applies no
+    /// adjustment there.
+    Zero,
+    /// Nothing: the master is left out of the variation model, as varLib does
+    /// for anchors.
+    ///
+    /// <https://github.com/fonttools/fonttools/blob/34be2443a/Lib/fontTools/varLib/merger.py#L1227-L1251>
+    Sparse,
+}
+
 impl<V: VariationInfo> MergeCtx<'_, V> {
     /// Merge one metric across masters.
     ///
-    /// `values[i]` is master `i`'s value, or `None` if that master has none,
-    /// in which case it contributes zero: a positioning rule a master does not
-    /// have applies no adjustment there. At least one value must be present.
-    /// A value that is the same in every master stays a plain scalar.
+    /// `values[i]` is master `i`'s value, or `None` if that master has none;
+    /// at least one must be present. A value that is the same wherever it is
+    /// present stays a plain scalar.
     ///
     /// <https://github.com/fonttools/fonttools/blob/34be2443a/Lib/fontTools/varLib/merger.py#L1254-L1258>
     pub(super) fn merge_metric(
         &self,
         values: &[Option<&Metric>],
+        missing: Missing,
         index: usize,
     ) -> Result<Metric, MergeError> {
         let present: Vec<&Metric> = values.iter().flatten().copied().collect();
@@ -47,17 +60,29 @@ impl<V: VariationInfo> MergeCtx<'_, V> {
             };
         }
 
-        let per_master: Vec<i16> = values
+        let per_master: Vec<Option<i16>> = values
             .iter()
-            .map(|value| value.map(|metric| metric.default).unwrap_or(0))
+            .map(|value| match (value, missing) {
+                (Some(metric), _) => Some(metric.default),
+                (None, Missing::Zero) => Some(0),
+                (None, Missing::Sparse) => None,
+            })
             .collect();
-        let default = per_master[0];
-        if per_master.iter().all(|value| *value == default) {
+        let Some(default) = per_master[0] else {
+            return Err(MergeError::MissingAtDefault {
+                lookup: self.lookup_ref(index),
+            });
+        };
+        if per_master.iter().flatten().all(|value| *value == default) {
             return Ok(default.into());
         }
 
-        let locations: HashMap<NormalizedLocation, i16> =
-            self.locations.iter().cloned().zip(per_master).collect();
+        let locations: HashMap<NormalizedLocation, i16> = self
+            .locations
+            .iter()
+            .zip(&per_master)
+            .filter_map(|(location, value)| value.map(|value| (location.clone(), value)))
+            .collect();
         let (default, deltas) = self
             .var_info
             .resolve_variable_metric(&locations)
@@ -70,8 +95,8 @@ impl<V: VariationInfo> MergeCtx<'_, V> {
 
     /// Merge one value record across masters.
     ///
-    /// A field that is set in any master is merged across all of them; masters
-    /// that do not set it, or have no record at all, contribute zero.
+    /// A field that is set in any master is merged with [`Missing::Zero`]:
+    /// masters that do not set it, or have no record at all, contribute zero.
     ///
     /// <https://github.com/fonttools/fonttools/blob/34be2443a/Lib/fontTools/varLib/merger.py#L1301-L1315>
     pub(super) fn merge_value_record(
@@ -84,7 +109,7 @@ impl<V: VariationInfo> MergeCtx<'_, V> {
             if values.iter().all(Option::is_none) {
                 return Ok(None);
             }
-            self.merge_metric(&values, index).map(Some)
+            self.merge_metric(&values, Missing::Zero, index).map(Some)
         };
         Ok(ValueRecordBuilder {
             x_advance: field(|r| r.x_advance.as_ref())?,
@@ -92,6 +117,43 @@ impl<V: VariationInfo> MergeCtx<'_, V> {
             x_placement: field(|r| r.x_placement.as_ref())?,
             y_placement: field(|r| r.y_placement.as_ref())?,
         })
+    }
+
+    /// Merge one anchor across masters; masters without it are left out, and
+    /// an anchor that no master has stays absent.
+    ///
+    /// varLib only merges format 1 anchors. A format 2 anchor's contour point
+    /// has no home in the format 3 anchor a varying position needs, so an
+    /// anchor with a contour point may not vary at all.
+    ///
+    /// <https://github.com/fonttools/fonttools/blob/34be2443a/Lib/fontTools/varLib/merger.py#L1285-L1298>
+    pub(super) fn merge_anchor(
+        &self,
+        anchors: &[Option<&AnchorBuilder>],
+        index: usize,
+    ) -> Result<Option<AnchorBuilder>, MergeError> {
+        let present: Vec<&AnchorBuilder> = anchors.iter().flatten().copied().collect();
+        let Some(first) = present.first() else {
+            return Ok(None);
+        };
+        let contourpoint = first.contourpoint;
+        let anchor_point_error = || MergeError::AnchorPoint {
+            lookup: self.lookup_ref(index),
+        };
+        if present
+            .iter()
+            .any(|anchor| anchor.contourpoint != contourpoint)
+        {
+            return Err(anchor_point_error());
+        }
+        let x: Vec<_> = anchors.iter().map(|a| a.map(|a| &a.x)).collect();
+        let y: Vec<_> = anchors.iter().map(|a| a.map(|a| &a.y)).collect();
+        let x = self.merge_metric(&x, Missing::Sparse, index)?;
+        let y = self.merge_metric(&y, Missing::Sparse, index)?;
+        if contourpoint.is_some() && (x.has_device_or_deltas() || y.has_device_or_deltas()) {
+            return Err(anchor_point_error());
+        }
+        Ok(Some(AnchorBuilder { x, y, contourpoint }))
     }
 }
 
@@ -123,7 +185,9 @@ mod tests {
         let var_info = var_info();
         let ctx = ctx(&var_info, &[0.0, 1.0]);
         let ten = Metric::from(10);
-        let merged = ctx.merge_metric(&[Some(&ten), Some(&ten)], 0).unwrap();
+        let merged = ctx
+            .merge_metric(&[Some(&ten), Some(&ten)], Missing::Sparse, 0)
+            .unwrap();
         assert_eq!(merged, ten);
     }
 
@@ -132,7 +196,7 @@ mod tests {
         let var_info = var_info();
         let ctx = ctx(&var_info, &[0.0, 1.0]);
         let merged = ctx
-            .merge_metric(&[Some(&10.into()), Some(&30.into())], 0)
+            .merge_metric(&[Some(&10.into()), Some(&30.into())], Missing::Sparse, 0)
             .unwrap();
         assert_eq!(merged.default, 10);
         assert_eq!(deltas(&merged), vec![20]);
@@ -142,9 +206,37 @@ mod tests {
     fn missing_is_zero() {
         let var_info = var_info();
         let ctx = ctx(&var_info, &[0.0, 1.0]);
-        let merged = ctx.merge_metric(&[Some(&10.into()), None], 0).unwrap();
+        let merged = ctx
+            .merge_metric(&[Some(&10.into()), None], Missing::Zero, 0)
+            .unwrap();
         assert_eq!(merged.default, 10);
         assert_eq!(deltas(&merged), vec![-10]);
+    }
+
+    #[test]
+    fn missing_is_sparse() {
+        let var_info = var_info();
+        let ctx = ctx(&var_info, &[0.0, 0.5, 1.0]);
+        let merged = ctx
+            .merge_metric(
+                &[Some(&10.into()), None, Some(&30.into())],
+                Missing::Sparse,
+                0,
+            )
+            .unwrap();
+        assert_eq!(merged.default, 10);
+        // the absent middle master is not a region, only the end
+        assert_eq!(deltas(&merged), vec![20]);
+    }
+
+    #[test]
+    fn sparse_at_default_is_an_error() {
+        let var_info = var_info();
+        let ctx = ctx(&var_info, &[0.0, 1.0]);
+        assert!(matches!(
+            ctx.merge_metric(&[None, Some(&5.into())], Missing::Sparse, 0),
+            Err(MergeError::MissingAtDefault { .. })
+        ));
     }
 
     #[test]
@@ -156,12 +248,55 @@ mod tests {
             device_or_deltas: Device::new(11, 12, &[1, 1]).into(),
         };
         let merged = ctx
-            .merge_metric(&[Some(&device), Some(&device)], 0)
+            .merge_metric(&[Some(&device), Some(&device)], Missing::Zero, 0)
             .unwrap();
         assert_eq!(merged, device);
         assert!(matches!(
-            ctx.merge_metric(&[Some(&device), Some(&10.into())], 0),
+            ctx.merge_metric(&[Some(&device), Some(&10.into())], Missing::Zero, 0),
             Err(MergeError::DeviceDiffers { .. })
+        ));
+    }
+
+    #[test]
+    fn anchors_are_sparse() {
+        let var_info = var_info();
+        let ctx = ctx(&var_info, &[0.0, 0.5, 1.0]);
+        let merged = ctx
+            .merge_anchor(
+                &[
+                    Some(&AnchorBuilder::new(100, 200)),
+                    None,
+                    Some(&AnchorBuilder::new(100, 250)),
+                ],
+                0,
+            )
+            .unwrap()
+            .unwrap();
+        assert_eq!(merged.x, 100.into());
+        assert_eq!(merged.y.default, 200);
+        assert_eq!(deltas(&merged.y), vec![50]);
+    }
+
+    #[test]
+    fn contour_point_anchors_cannot_vary() {
+        let var_info = var_info();
+        let ctx = ctx(&var_info, &[0.0, 1.0]);
+        let point = AnchorBuilder::new(100, 200).with_contourpoint(3);
+        let merged = ctx
+            .merge_anchor(&[Some(&point), Some(&point)], 0)
+            .unwrap()
+            .unwrap();
+        assert_eq!(merged, point);
+
+        let other_point = AnchorBuilder::new(100, 200).with_contourpoint(4);
+        assert!(matches!(
+            ctx.merge_anchor(&[Some(&point), Some(&other_point)], 0),
+            Err(MergeError::AnchorPoint { .. })
+        ));
+        let moved = AnchorBuilder::new(100, 250).with_contourpoint(3);
+        assert!(matches!(
+            ctx.merge_anchor(&[Some(&point), Some(&moved)], 0),
+            Err(MergeError::AnchorPoint { .. })
         ));
     }
 }

--- a/fea-rs/src/compile/merge/metric.rs
+++ b/fea-rs/src/compile/merge/metric.rs
@@ -28,8 +28,8 @@ impl<V: VariationInfo> MergeCtx<'_, V> {
     /// Merge one metric across masters.
     ///
     /// `values[i]` is master `i`'s value, or `None` if that master has none;
-    /// at least one must be present. A value that is the same wherever it is
-    /// present stays a plain scalar.
+    /// with [`Missing::Sparse`] the default master must have one. A value
+    /// that is the same wherever it is present stays a plain scalar.
     ///
     /// <https://github.com/fonttools/fonttools/blob/34be2443a/Lib/fontTools/varLib/merger.py#L1254-L1258>
     pub(super) fn merge_metric(
@@ -38,8 +38,21 @@ impl<V: VariationInfo> MergeCtx<'_, V> {
         missing: Missing,
         index: usize,
     ) -> Result<Metric, MergeError> {
-        let present: Vec<&Metric> = values.iter().flatten().copied().collect();
-        let first = *present.first().expect("caller passes at least one value");
+        let zero = Metric::from(0);
+        let per_master: Vec<Option<&Metric>> = values
+            .iter()
+            .map(|value| match (value, missing) {
+                (Some(metric), _) => Some(*metric),
+                (None, Missing::Zero) => Some(&zero),
+                (None, Missing::Sparse) => None,
+            })
+            .collect();
+        let Some(first) = per_master[0] else {
+            return Err(MergeError::MissingAtDefault {
+                lookup: self.lookup_ref(index),
+            });
+        };
+        let present: Vec<&Metric> = per_master.iter().flatten().copied().collect();
         assert!(
             present
                 .iter()
@@ -51,7 +64,7 @@ impl<V: VariationInfo> MergeCtx<'_, V> {
             .iter()
             .any(|metric| matches!(metric.device_or_deltas, DeviceOrDeltas::Device(_)))
         {
-            return if values.iter().all(|value| *value == Some(first)) {
+            return if present.iter().all(|metric| *metric == first) {
                 Ok(first.clone())
             } else {
                 Err(MergeError::DeviceDiffers {
@@ -59,29 +72,17 @@ impl<V: VariationInfo> MergeCtx<'_, V> {
                 })
             };
         }
-
-        let per_master: Vec<Option<i16>> = values
-            .iter()
-            .map(|value| match (value, missing) {
-                (Some(metric), _) => Some(metric.default),
-                (None, Missing::Zero) => Some(0),
-                (None, Missing::Sparse) => None,
-            })
-            .collect();
-        let Some(default) = per_master[0] else {
-            return Err(MergeError::MissingAtDefault {
-                lookup: self.lookup_ref(index),
-            });
-        };
-        if per_master.iter().flatten().all(|value| *value == default) {
-            return Ok(default.into());
+        if present.iter().all(|metric| metric.default == first.default) {
+            return Ok(first.default.into());
         }
 
         let locations: HashMap<NormalizedLocation, i16> = self
             .locations
             .iter()
             .zip(&per_master)
-            .filter_map(|(location, value)| value.map(|value| (location.clone(), value)))
+            .filter_map(|(location, metric)| {
+                metric.map(|metric| (location.clone(), metric.default))
+            })
             .collect();
         let (default, deltas) = self
             .var_info
@@ -237,6 +238,14 @@ mod tests {
             ctx.merge_metric(&[None, Some(&5.into())], Missing::Sparse, 0),
             Err(MergeError::MissingAtDefault { .. })
         ));
+        let device = Metric {
+            default: 10,
+            device_or_deltas: Device::new(11, 12, &[1, 1]).into(),
+        };
+        assert!(matches!(
+            ctx.merge_metric(&[None, Some(&device)], Missing::Sparse, 0),
+            Err(MergeError::MissingAtDefault { .. })
+        ));
     }
 
     #[test]
@@ -253,6 +262,24 @@ mod tests {
         assert_eq!(merged, device);
         assert!(matches!(
             ctx.merge_metric(&[Some(&device), Some(&10.into())], Missing::Zero, 0),
+            Err(MergeError::DeviceDiffers { .. })
+        ));
+    }
+
+    #[test]
+    fn device_tables_can_be_sparse() {
+        let var_info = var_info();
+        let ctx = ctx(&var_info, &[0.0, 1.0]);
+        let device = Metric {
+            default: 10,
+            device_or_deltas: Device::new(11, 12, &[1, 1]).into(),
+        };
+        let merged = ctx
+            .merge_metric(&[Some(&device), None], Missing::Sparse, 0)
+            .unwrap();
+        assert_eq!(merged, device);
+        assert!(matches!(
+            ctx.merge_metric(&[Some(&device), None], Missing::Zero, 0),
             Err(MergeError::DeviceDiffers { .. })
         ));
     }


### PR DESCRIPTION
[fea-rs] Merge anchors, starting with cursive

Anchors are sparse rather than zero-filled: a master that lacks an anchor is left out of the variation model, as varLib does via getSubModel, so merge_metric grows a Missing::{Zero, Sparse} choice. Since fontdrasil's model needs a value at the default location, an anchor present only in non-default masters is an error, matching varLib's "Base master not found". varLib merges only format 1 anchors; a contour point has no home in the format 3 anchor a varying position needs, so an anchor with one may not vary.

Cursive attachment is the first consumer: subtable by subtable, coverage unioned, entry and exit anchors merged over the masters that have them.