### PR TITLE
fea-merge part 8: GDEF ligature carets

### DIFF
--- a/fea-rs/src/compile/merge.rs
+++ b/fea-rs/src/compile/merge.rs
@@ -13,6 +13,7 @@ use write_fonts::types::GlyphId16;
 
 use super::{PendingCompilation, VariationInfo};
 
+mod carets;
 mod cursive;
 mod error;
 mod lookups;
@@ -54,6 +55,7 @@ pub fn merge<V: VariationInfo>(
     ctx.check_structure()?;
     ctx.merge_mark_classes()?;
     ctx.merge_gdef()?;
+    ctx.merge_ligature_carets()?;
     ctx.merge_gpos()?;
     ctx.finish()
 }
@@ -201,10 +203,6 @@ impl<'a, V: VariationInfo> MergeCtx<'a, V> {
             let merged = self.merged.tables.gdef.get_or_insert_with(Default::default);
             if merged.attach != other.attach {
                 return Err(MergeError::GdefAttach { master });
-            }
-            //TODO: merge these instead of requiring equality
-            if merged.ligature_pos != other.ligature_pos {
-                return Err(MergeError::LigatureCarets { master });
             }
             // sorted so that the reported conflict is deterministic
             let mut classes: Vec<_> = other.glyph_classes.iter().collect();

--- a/fea-rs/src/compile/merge/carets.rs
+++ b/fea-rs/src/compile/merge/carets.rs
@@ -1,0 +1,200 @@
+//! Merging GDEF ligature carets.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use write_fonts::tables::layout::builders::{CaretValueBuilder, DeviceOrDeltas, Metric};
+
+use super::{MergeCtx, MergeError};
+use crate::{common::GlyphId16, compile::VariationInfo};
+
+impl<V: VariationInfo> MergeCtx<'_, V> {
+    /// Merge the `LigatureCaretByPos`/`ByIndex` statements across masters.
+    ///
+    /// Ligature glyphs are unioned; the masters that have one must agree on
+    /// its number of carets and on which are points. Positions are merged
+    /// over the masters that have the glyph, and so must be present at the
+    /// default master. varLib requires the caret list itself to be identical
+    /// and merges only the positions; this is a superset of that.
+    ///
+    /// <https://github.com/fonttools/fonttools/blob/34be2443a/Lib/fontTools/varLib/merger.py#L1273-L1282>
+    pub(super) fn merge_ligature_carets(&mut self) -> Result<(), MergeError> {
+        let per_master: Vec<Option<&BTreeMap<GlyphId16, Vec<CaretValueBuilder>>>> =
+            std::iter::once(&self.merged)
+                .chain(&self.others)
+                .map(|master| master.tables.gdef.as_ref().map(|gdef| &gdef.ligature_pos))
+                .collect();
+        let glyphs: BTreeSet<GlyphId16> = per_master
+            .iter()
+            .flatten()
+            .flat_map(|carets| carets.keys().copied())
+            .collect();
+        if glyphs.is_empty() {
+            return Ok(());
+        }
+
+        let mut merged = BTreeMap::new();
+        for glyph in glyphs {
+            let carets: Vec<Option<&[CaretValueBuilder]>> = per_master
+                .iter()
+                .map(|master| master.and_then(|c| c.get(&glyph)).map(Vec::as_slice))
+                .collect();
+            let Some(default) = carets[0] else {
+                return Err(MergeError::LigatureCaretsMissingAtDefault { glyph });
+            };
+            let mismatch = |caret: &CaretValueBuilder, other: &CaretValueBuilder| {
+                matches!(
+                    (caret, other),
+                    (
+                        CaretValueBuilder::Coordinate { .. },
+                        CaretValueBuilder::PointIndex(_)
+                    ) | (
+                        CaretValueBuilder::PointIndex(_),
+                        CaretValueBuilder::Coordinate { .. }
+                    )
+                )
+            };
+            if let Some(master) = carets.iter().position(|master| {
+                master.is_some_and(|other| {
+                    other.len() != default.len()
+                        || default.iter().zip(other).any(|(a, b)| mismatch(a, b))
+                })
+            }) {
+                return Err(MergeError::LigatureCarets { master, glyph });
+            }
+
+            let mut values = Vec::with_capacity(default.len());
+            for (i, caret) in default.iter().enumerate() {
+                let CaretValueBuilder::Coordinate { .. } = caret else {
+                    // a point index is not a position; the masters that have
+                    // the glyph must agree on it
+                    if carets.iter().flatten().any(|other| other[i] != *caret) {
+                        return Err(MergeError::LigatureCarets { master: 0, glyph });
+                    }
+                    values.push(caret.clone());
+                    continue;
+                };
+                let per_master: Vec<Option<i16>> = carets
+                    .iter()
+                    .map(|master| {
+                        master.map(|carets| match &carets[i] {
+                            CaretValueBuilder::Coordinate { default, deltas } => {
+                                assert!(
+                                    matches!(deltas, DeviceOrDeltas::None),
+                                    "compile_for_merge cannot produce varying carets"
+                                );
+                                *default
+                            }
+                            CaretValueBuilder::PointIndex(_) => unreachable!("checked above"),
+                        })
+                    })
+                    .collect();
+                let Metric {
+                    default,
+                    device_or_deltas,
+                } = self
+                    .merge_scalars(&per_master)
+                    .map_err(|message| MergeError::LigatureCaretDeltas { glyph, message })?;
+                values.push(CaretValueBuilder::Coordinate {
+                    default,
+                    deltas: device_or_deltas,
+                });
+            }
+            merged.insert(glyph, values);
+        }
+        self.merged
+            .tables
+            .gdef
+            .get_or_insert_with(Default::default)
+            .ligature_pos = merged;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use write_fonts::tables::layout::builders::{CaretValueBuilder, DeviceOrDeltas};
+
+    use super::super::{MergeError, test_helpers::*};
+
+    fn carets(fea_carets: &str) -> String {
+        format!("table GDEF {{ {fea_carets} }} GDEF;")
+    }
+
+    #[test]
+    fn caret_positions_vary() {
+        let merged = merge_masters(&[
+            &carets("LigatureCaretByPos f_i 300;"),
+            &carets("LigatureCaretByPos f_i 320;"),
+        ])
+        .unwrap();
+        let gdef = merged.tables.gdef.as_ref().unwrap();
+        let f_i = glyph_map().get("f_i").unwrap();
+        let [CaretValueBuilder::Coordinate { default, deltas }] =
+            gdef.ligature_pos[&f_i].as_slice()
+        else {
+            panic!("expected one coordinate caret");
+        };
+        assert_eq!(*default, 300);
+        let DeviceOrDeltas::Deltas(deltas) = deltas else {
+            panic!("expected deltas");
+        };
+        assert_eq!(deltas.iter().map(|(_, d)| *d).collect::<Vec<_>>(), vec![20]);
+    }
+
+    #[test]
+    fn equal_carets_stay_static_and_glyphs_are_unioned() {
+        let merged = merge_masters(&[
+            &carets("LigatureCaretByPos f_i 300 600; LigatureCaretByIndex c 4;"),
+            &carets("LigatureCaretByPos f_i 300 600;"),
+        ])
+        .unwrap();
+        let gdef = merged.tables.gdef.as_ref().unwrap();
+        let map = glyph_map();
+        assert_eq!(
+            gdef.ligature_pos[&map.get("f_i").unwrap()],
+            vec![
+                CaretValueBuilder::Coordinate {
+                    default: 300,
+                    deltas: DeviceOrDeltas::None
+                },
+                CaretValueBuilder::Coordinate {
+                    default: 600,
+                    deltas: DeviceOrDeltas::None
+                },
+            ]
+        );
+        assert_eq!(
+            gdef.ligature_pos[&map.get("c").unwrap()],
+            vec![CaretValueBuilder::PointIndex(4)]
+        );
+    }
+
+    #[test]
+    fn caret_count_and_kind_must_agree() {
+        assert!(matches!(
+            merge_masters(&[
+                &carets("LigatureCaretByPos f_i 300 600;"),
+                &carets("LigatureCaretByPos f_i 300;"),
+            ]),
+            Err(MergeError::LigatureCarets { master: 1, .. })
+        ));
+        assert!(matches!(
+            merge_masters(&[
+                &carets("LigatureCaretByPos f_i 300;"),
+                &carets("LigatureCaretByIndex f_i 3;"),
+            ]),
+            Err(MergeError::LigatureCarets { master: 1, .. })
+        ));
+    }
+
+    #[test]
+    fn carets_missing_at_the_default_are_an_error() {
+        assert!(matches!(
+            merge_masters(&[
+                &carets("GlyphClassDef [a], , , ;"),
+                &carets("LigatureCaretByPos f_i 300;")
+            ]),
+            Err(MergeError::LigatureCaretsMissingAtDefault { .. })
+        ));
+    }
+}

--- a/fea-rs/src/compile/merge/carets.rs
+++ b/fea-rs/src/compile/merge/carets.rs
@@ -67,8 +67,11 @@ impl<V: VariationInfo> MergeCtx<'_, V> {
                 let CaretValueBuilder::Coordinate { .. } = caret else {
                     // a point index is not a position; the masters that have
                     // the glyph must agree on it
-                    if carets.iter().flatten().any(|other| other[i] != *caret) {
-                        return Err(MergeError::LigatureCarets { master: 0, glyph });
+                    if let Some(master) = carets
+                        .iter()
+                        .position(|other| other.is_some_and(|other| other[i] != *caret))
+                    {
+                        return Err(MergeError::LigatureCarets { master, glyph });
                     }
                     values.push(caret.clone());
                     continue;
@@ -184,6 +187,18 @@ mod tests {
                 &carets("LigatureCaretByIndex f_i 3;"),
             ]),
             Err(MergeError::LigatureCarets { master: 1, .. })
+        ));
+    }
+
+    #[test]
+    fn caret_point_indices_must_agree() {
+        assert!(matches!(
+            merge_masters(&[
+                &carets("LigatureCaretByIndex f_i 3;"),
+                &carets("LigatureCaretByIndex f_i 3;"),
+                &carets("LigatureCaretByIndex f_i 4;"),
+            ]),
+            Err(MergeError::LigatureCarets { master: 2, .. })
         ));
     }
 

--- a/fea-rs/src/compile/merge/error.rs
+++ b/fea-rs/src/compile/merge/error.rs
@@ -114,11 +114,14 @@ pub enum MergeError {
         lookup: LookupRef,
         glyph: GlyphId16,
     },
-    //TODO: remove once ligature carets are merged
     #[error(
-        "master {master}: GDEF ligature carets differ from the default master (not yet supported)"
+        "master {master}: ligature glyph {glyph} has a different number or kind of carets than in another master"
     )]
-    LigatureCarets { master: usize },
+    LigatureCarets { master: usize, glyph: GlyphId16 },
+    #[error("ligature glyph {glyph} has carets in some masters but not in the default master")]
+    LigatureCaretsMissingAtDefault { glyph: GlyphId16 },
+    #[error("ligature glyph {glyph}: failed to compute caret deltas: {message}")]
+    LigatureCaretDeltas { glyph: GlyphId16, message: String },
 }
 
 /// Identifies a lookup in a [`MergeError`].

--- a/fea-rs/src/compile/merge/error.rs
+++ b/fea-rs/src/compile/merge/error.rs
@@ -114,9 +114,7 @@ pub enum MergeError {
         lookup: LookupRef,
         glyph: GlyphId16,
     },
-    #[error(
-        "master {master}: ligature glyph {glyph} has a different number or kind of carets than in another master"
-    )]
+    #[error("master {master}: carets differ between masters for glyph {glyph}")]
     LigatureCarets { master: usize, glyph: GlyphId16 },
     #[error("ligature glyph {glyph} has carets in some masters but not in the default master")]
     LigatureCaretsMissingAtDefault { glyph: GlyphId16 },

--- a/fea-rs/src/compile/merge/metric.rs
+++ b/fea-rs/src/compile/merge/metric.rs
@@ -72,25 +72,37 @@ impl<V: VariationInfo> MergeCtx<'_, V> {
                 })
             };
         }
-        if present.iter().all(|metric| metric.default == first.default) {
-            return Ok(first.default.into());
-        }
 
+        let per_master: Vec<Option<i16>> = per_master
+            .iter()
+            .map(|metric| metric.map(|metric| metric.default))
+            .collect();
+        self.merge_scalars(&per_master)
+            .map_err(|message| MergeError::Deltas {
+                lookup: self.lookup_ref(index),
+                message,
+            })
+    }
+
+    /// Merge plain values; `per_master[0]` must be present.
+    ///
+    /// The error is the message from computing deltas, for the caller to
+    /// wrap with context.
+    pub(super) fn merge_scalars(&self, per_master: &[Option<i16>]) -> Result<Metric, String> {
+        let default = per_master[0].expect("caller checks the default is present");
+        if per_master.iter().flatten().all(|value| *value == default) {
+            return Ok(default.into());
+        }
         let locations: HashMap<NormalizedLocation, i16> = self
             .locations
             .iter()
-            .zip(&per_master)
-            .filter_map(|(location, metric)| {
-                metric.map(|metric| (location.clone(), metric.default))
-            })
+            .zip(per_master)
+            .filter_map(|(location, value)| value.map(|value| (location.clone(), value)))
             .collect();
         let (default, deltas) = self
             .var_info
             .resolve_variable_metric(&locations)
-            .map_err(|e| MergeError::Deltas {
-                lookup: self.lookup_ref(index),
-                message: e.to_string(),
-            })?;
+            .map_err(|e| e.to_string())?;
         Ok(metric_from_deltas(default, deltas))
     }
 


### PR DESCRIPTION
Ligature glyphs are unioned; the masters that have one must agree on its number of carets and on which are contour points, and positions are merged over the masters that have the glyph, so they must be present at the default master. varLib's LigCaretList goes through the generic merger, so it requires the caret lists themselves to be identical and interpolates only the positions; this is a superset of that. This is what Anek and Public Sans need, whose masters differ only in LigatureCaretByPos.