### PR TITLE
[fea-rs] Match mark classes by their marks, not their names

### DIFF
--- a/fea-rs/src/compile/merge.rs
+++ b/fea-rs/src/compile/merge.rs
@@ -8,8 +8,6 @@
 use std::collections::HashMap;
 
 use fontdrasil::coords::NormalizedLocation;
-use smol_str::SmolStr;
-use write_fonts::types::GlyphId16;
 
 use super::{PendingCompilation, VariationInfo};
 
@@ -40,11 +38,11 @@ pub use error::{LookupRef, MergeError};
 ///
 /// Everything that cannot vary must be identical across masters: language
 /// systems, features and the lookups they reference, GSUB, conditionsets,
-/// mark filtering sets, and so on. GDEF glyph classes and mark class
-/// membership are unioned, with an error if a glyph is classified
-/// differently in two masters. Tables other than GPOS and GDEF are taken
-/// from the default master; each master's own diagnostics are returned by
-/// [`compile_for_merge`], and it is up to the caller to report them.
+/// mark filtering sets, and so on. GDEF glyph classes are unioned, with an
+/// error if a glyph is classified differently in two masters. Mark classes
+/// are matched by the marks they contain, not by name. Tables other than GPOS
+/// and GDEF are taken from the default master; each master's own diagnostics
+/// are returned by [`compile_for_merge`], and it is up to the caller to report them.
 ///
 /// [`compile_for_merge`]: super::compile_for_merge
 pub fn merge<V: VariationInfo>(
@@ -53,7 +51,7 @@ pub fn merge<V: VariationInfo>(
 ) -> Result<PendingCompilation, MergeError> {
     let mut ctx = MergeCtx::new(masters, var_info)?;
     ctx.check_structure()?;
-    ctx.merge_mark_classes()?;
+    ctx.merge_mark_classes();
     ctx.merge_gdef()?;
     ctx.merge_ligature_carets()?;
     ctx.merge_gpos()?;
@@ -146,52 +144,20 @@ impl<'a, V: VariationInfo> MergeCtx<'a, V> {
     ///
     /// Only membership matters here: the anchors are merged where they are
     /// used, in the mark lookups, and this map only feeds GDEF glyph class
-    /// inference.
-    fn merge_mark_classes(&mut self) -> Result<(), MergeError> {
+    /// inference. Names are not compared, since a glyph can be in several
+    /// classes and masters can name the same class differently.
+    fn merge_mark_classes(&mut self) {
         let merged = &mut self.merged.mark_classes;
-        let mut membership: HashMap<GlyphId16, SmolStr> = merged
-            .iter()
-            .flat_map(|(name, class)| {
-                class
-                    .members
-                    .iter()
-                    .flat_map(|(glyphs, _)| glyphs.iter())
-                    .map(move |glyph| (glyph, name.clone()))
-            })
-            .collect();
-
-        for (i, other) in self.others.iter().enumerate() {
+        for other in &self.others {
             for (name, class) in &other.mark_classes {
-                for (glyphs, anchor) in &class.members {
-                    let mut is_new = false;
-                    for glyph in glyphs.iter() {
-                        match membership.get(&glyph) {
-                            Some(existing) if existing != name => {
-                                return Err(MergeError::MarkClassConflict {
-                                    master: i + 1,
-                                    glyph,
-                                    expected: existing.clone(),
-                                    found: name.clone(),
-                                });
-                            }
-                            Some(_) => (),
-                            None => {
-                                membership.insert(glyph, name.clone());
-                                is_new = true;
-                            }
-                        }
-                    }
-                    if is_new {
-                        merged
-                            .entry(name.clone())
-                            .or_default()
-                            .members
-                            .push((glyphs.clone(), anchor.clone()));
+                let members = &mut merged.entry(name.clone()).or_default().members;
+                for member in &class.members {
+                    if !members.contains(member) {
+                        members.push(member.clone());
                     }
                 }
             }
         }
-        Ok(())
     }
 
     fn merge_gdef(&mut self) -> Result<(), MergeError> {
@@ -349,17 +315,16 @@ mod tests {
     }
 
     #[test]
-    fn mark_class_conflict() {
+    fn mark_class_names_are_not_compared() {
         let a = "markClass acute <anchor 0 0> @TOP; feature mark { pos base a <anchor 0 0> mark @TOP; } mark;";
         let b = "markClass acute <anchor 0 0> @BOTTOM; feature mark { pos base a <anchor 0 0> mark @BOTTOM; } mark;";
-        assert_eq!(
-            merge_masters(&[a, b]).err(),
-            Some(MergeError::MarkClassConflict {
-                master: 1,
-                glyph: glyph_map().get("acute").unwrap(),
-                expected: "@TOP".into(),
-                found: "@BOTTOM".into(),
-            })
+        let merged = merge_masters(&[a, b]).unwrap();
+        assert_eq!(merged.mark_classes.len(), 2);
+        assert!(
+            merged
+                .mark_classes
+                .values()
+                .all(|class| class.members.len() == 1)
         );
     }
 

--- a/fea-rs/src/compile/merge/error.rs
+++ b/fea-rs/src/compile/merge/error.rs
@@ -50,13 +50,14 @@ pub enum MergeError {
         found: GlyphClassDef,
     },
     #[error(
-        "master {master}: glyph {glyph} is in mark class '{found}', but '{expected}' in another master"
+        "master {master}: {lookup}: marks {glyph} and {other} are in the same mark class in one \
+         master but in different classes in another"
     )]
-    MarkClassConflict {
+    MarkClassMismatch {
         master: usize,
+        lookup: LookupRef,
         glyph: GlyphId16,
-        expected: SmolStr,
-        found: SmolStr,
+        other: GlyphId16,
     },
     #[error(
         "master {master}: {found} GPOS lookups, but the default master has {expected}. \

--- a/fea-rs/src/compile/merge/marks.rs
+++ b/fea-rs/src/compile/merge/marks.rs
@@ -10,37 +10,50 @@ use write_fonts::tables::{
 use super::{MergeCtx, MergeError, lookups::AlignedLookup};
 use crate::{common::GlyphId16, compile::VariationInfo};
 
-/// One master's mark attachment subtable: marks with their class and anchor,
-/// and bases (or the marks attached to) with an anchor per class.
-#[derive(Default)]
-struct MarkAttach<'a> {
-    marks: Marks<'a>,
-    bases: BTreeMap<GlyphId16, BTreeMap<&'a str, &'a AnchorBuilder>>,
-}
-
+/// One master's marks in a subtable, each with its class (as that master
+/// names it) and anchor.
 type Marks<'a> = BTreeMap<GlyphId16, (&'a str, &'a AnchorBuilder)>;
 
-impl<'a> MarkAttach<'a> {
-    fn new(
-        marks: impl Iterator<Item = (GlyphId16, &'a str, &'a AnchorBuilder)>,
-        bases: impl Iterator<Item = (GlyphId16, &'a str, &'a AnchorBuilder)>,
-    ) -> Self {
-        let mut result = Self::default();
-        for (glyph, class, anchor) in marks {
-            result.marks.insert(glyph, (class, anchor));
-        }
-        for (glyph, class, anchor) in bases {
-            result.bases.entry(glyph).or_default().insert(class, anchor);
-        }
-        result
-    }
-}
+/// One master's bases (or the marks attached to) in a subtable: an anchor
+/// per shared class name.
+type Bases<'a> = BTreeMap<GlyphId16, BTreeMap<String, &'a AnchorBuilder>>;
+
+/// For each master, its own mark class names mapped to the shared ones.
+///
+/// See [`MergeCtx::align_mark_classes`].
+type ClassMaps<'a> = Vec<BTreeMap<&'a str, String>>;
 
 /// The merged marks and bases, in the order to insert them.
 #[derive(Default)]
-struct MarkAttachMerged<'a> {
-    marks: Vec<(GlyphId16, &'a str, AnchorBuilder)>,
-    bases: Vec<(GlyphId16, &'a str, AnchorBuilder)>,
+struct MarkAttachMerged {
+    marks: Vec<(GlyphId16, String, AnchorBuilder)>,
+    bases: Vec<(GlyphId16, String, AnchorBuilder)>,
+}
+
+fn marks<'a>(iter: impl Iterator<Item = (GlyphId16, &'a str, &'a AnchorBuilder)>) -> Marks<'a> {
+    iter.map(|(glyph, class, anchor)| (glyph, (class, anchor)))
+        .collect()
+}
+
+fn bases<'a>(
+    iter: impl Iterator<Item = (GlyphId16, &'a str, &'a AnchorBuilder)>,
+    classes: &BTreeMap<&str, String>,
+) -> Bases<'a> {
+    let mut result = Bases::default();
+    for (glyph, class, anchor) in iter {
+        result
+            .entry(glyph)
+            .or_default()
+            .insert(shared_name(classes, class), anchor);
+    }
+    result
+}
+
+fn shared_name(classes: &BTreeMap<&str, String>, class: &str) -> String {
+    classes
+        .get(class)
+        .cloned()
+        .unwrap_or_else(|| class.to_owned())
 }
 
 impl<V: VariationInfo> MergeCtx<'_, V> {
@@ -53,19 +66,25 @@ impl<V: VariationInfo> MergeCtx<'_, V> {
         index: usize,
     ) -> Result<LookupBuilder<MarkToBaseBuilder>, MergeError> {
         let subtables = aligned.indexwise(index, self, |row| {
-            let per_master: Vec<_> = row
+            let marks: Vec<_> = row
                 .iter()
-                .map(|subtable| MarkAttach::new(subtable.iter_marks(), subtable.iter_bases()))
+                .map(|subtable| marks(subtable.iter_marks()))
                 .collect();
-            let merged = self.merge_mark_attach(&per_master, index)?;
+            let classes = self.align_mark_classes(&marks, index)?;
+            let bases: Vec<_> = row
+                .iter()
+                .zip(&classes)
+                .map(|(subtable, classes)| bases(subtable.iter_bases(), classes))
+                .collect();
+            let merged = self.merge_mark_attach(&marks, &classes, &bases, index)?;
             let mut builder = MarkToBaseBuilder::default();
             for (glyph, class, anchor) in merged.marks {
                 builder
-                    .insert_mark(glyph, class, anchor)
+                    .insert_mark(glyph, &class, anchor)
                     .expect("each mark is inserted once");
             }
             for (glyph, class, anchor) in merged.bases {
-                builder.insert_base(glyph, class, anchor);
+                builder.insert_base(glyph, &class, anchor);
             }
             Ok(builder)
         })?;
@@ -81,23 +100,103 @@ impl<V: VariationInfo> MergeCtx<'_, V> {
         index: usize,
     ) -> Result<LookupBuilder<MarkToMarkBuilder>, MergeError> {
         let subtables = aligned.indexwise(index, self, |row| {
-            let per_master: Vec<_> = row
+            let marks: Vec<_> = row
                 .iter()
-                .map(|subtable| MarkAttach::new(subtable.iter_mark1s(), subtable.iter_mark2s()))
+                .map(|subtable| marks(subtable.iter_mark1s()))
                 .collect();
-            let merged = self.merge_mark_attach(&per_master, index)?;
+            let classes = self.align_mark_classes(&marks, index)?;
+            let bases: Vec<_> = row
+                .iter()
+                .zip(&classes)
+                .map(|(subtable, classes)| bases(subtable.iter_mark2s(), classes))
+                .collect();
+            let merged = self.merge_mark_attach(&marks, &classes, &bases, index)?;
             let mut builder = MarkToMarkBuilder::default();
             for (glyph, class, anchor) in merged.marks {
                 builder
-                    .insert_mark1(glyph, class, anchor)
+                    .insert_mark1(glyph, &class, anchor)
                     .expect("each mark is inserted once");
             }
             for (glyph, class, anchor) in merged.bases {
-                builder.insert_mark2(glyph, class, anchor);
+                builder.insert_mark2(glyph, &class, anchor);
             }
             Ok(builder)
         })?;
         Ok(aligned.build(subtables))
+    }
+
+    /// Match up the mark classes of one subtable across masters.
+    ///
+    /// Class names are a source-level convenience: the binary has class
+    /// indices, and two masters can name the same class differently, or use
+    /// one name for different classes. What must agree is how the marks are
+    /// partitioned into classes: marks that share a class in one master
+    /// share it in every master that has them both. Each class gets one
+    /// shared name, the default master's where it has the class, and the
+    /// result maps each master's own names to those.
+    ///
+    /// varLib compares class indices instead, which amounts to the same
+    /// check when the masters number their classes alike:
+    /// <https://github.com/fonttools/fonttools/blob/34be2443a/Lib/fontTools/varLib/merger.py#L693-L730>
+    fn align_mark_classes<'a>(
+        &self,
+        per_master: &[Marks<'a>],
+        index: usize,
+    ) -> Result<ClassMaps<'a>, MergeError> {
+        // the shared class of every mark seen in an earlier master
+        let mut shared_of: BTreeMap<GlyphId16, String> = BTreeMap::new();
+        let mut used: BTreeSet<String> = BTreeSet::new();
+        let mut maps = Vec::with_capacity(per_master.len());
+        for (master, marks) in per_master.iter().enumerate() {
+            let mut map: BTreeMap<&'a str, String> = BTreeMap::new();
+            // the mark that put each own or shared class in the map
+            let mut by_own: BTreeMap<&'a str, GlyphId16> = BTreeMap::new();
+            let mut by_shared: BTreeMap<String, GlyphId16> = BTreeMap::new();
+            for (&glyph, &(class, _)) in marks {
+                let Some(shared) = shared_of.get(&glyph) else {
+                    continue;
+                };
+                let other = match map.get(class) {
+                    Some(existing) if existing != shared => Some(by_own[class]),
+                    Some(_) => None,
+                    None => match by_shared.get(shared) {
+                        Some(other) => Some(*other),
+                        None => {
+                            map.insert(class, shared.clone());
+                            by_own.insert(class, glyph);
+                            by_shared.insert(shared.clone(), glyph);
+                            None
+                        }
+                    },
+                };
+                if let Some(other) = other {
+                    return Err(MergeError::MarkClassMismatch {
+                        master,
+                        lookup: self.lookup_ref(index),
+                        glyph,
+                        other,
+                    });
+                }
+            }
+            for (class, _) in marks.values() {
+                if map.contains_key(class) {
+                    continue;
+                }
+                let mut name = (*class).to_owned();
+                for i in 1.. {
+                    if used.insert(name.clone()) {
+                        break;
+                    }
+                    name = format!("{class}.{i}");
+                }
+                map.insert(class, name);
+            }
+            for (&glyph, &(class, _)) in marks {
+                shared_of.entry(glyph).or_insert_with(|| map[class].clone());
+            }
+            maps.push(map);
+        }
+        Ok(maps)
     }
 
     /// Merge one mark attachment subtable across masters.
@@ -106,33 +205,33 @@ impl<V: VariationInfo> MergeCtx<'_, V> {
     /// that have them.
     ///
     /// <https://github.com/fonttools/fonttools/blob/34be2443a/Lib/fontTools/varLib/merger.py#L675-L758>
-    fn merge_mark_attach<'a>(
+    fn merge_mark_attach(
         &self,
-        per_master: &[MarkAttach<'a>],
+        marks: &[Marks],
+        classes: &ClassMaps,
+        bases: &[Bases],
         index: usize,
-    ) -> Result<MarkAttachMerged<'a>, MergeError> {
-        let marks: Vec<_> = per_master.iter().map(|master| &master.marks).collect();
+    ) -> Result<MarkAttachMerged, MergeError> {
         let mut merged = MarkAttachMerged {
-            marks: self.merge_marks(&marks, index)?,
+            marks: self.merge_marks(marks, classes, index)?,
             bases: Vec::new(),
         };
 
-        let base_glyphs: BTreeSet<GlyphId16> = per_master
+        let base_glyphs: BTreeSet<GlyphId16> = bases
             .iter()
-            .flat_map(|master| master.bases.keys().copied())
+            .flat_map(|master| master.keys().copied())
             .collect();
         for glyph in base_glyphs {
-            let classes: BTreeSet<&str> = per_master
+            let class_names: BTreeSet<&str> = bases
                 .iter()
-                .filter_map(|master| master.bases.get(&glyph))
-                .flat_map(|anchors| anchors.keys().copied())
+                .filter_map(|master| master.get(&glyph))
+                .flat_map(|anchors| anchors.keys().map(String::as_str))
                 .collect();
-            for class in classes {
-                let anchors: Vec<_> = per_master
+            for class in class_names {
+                let anchors: Vec<_> = bases
                     .iter()
                     .map(|master| {
                         master
-                            .bases
                             .get(&glyph)
                             .and_then(|anchors| anchors.get(class))
                             .copied()
@@ -141,7 +240,7 @@ impl<V: VariationInfo> MergeCtx<'_, V> {
                 let anchor = self
                     .merge_anchor(&anchors, index)?
                     .expect("some master has this anchor");
-                merged.bases.push((glyph, class, anchor));
+                merged.bases.push((glyph, class.to_owned(), anchor));
             }
         }
         Ok(merged)
@@ -149,18 +248,14 @@ impl<V: VariationInfo> MergeCtx<'_, V> {
 
     /// Merge the marks of one subtable across masters.
     ///
-    /// Marks are matched by class *name*, since the builder numbers classes
-    /// in insertion order and two masters can number the same classes
-    /// differently; a mark in different classes in different masters is an
-    /// error, as in varLib. The result is in glyph order, so the merged
-    /// class numbering depends only on the input.
-    ///
-    /// <https://github.com/fonttools/fonttools/blob/34be2443a/Lib/fontTools/varLib/merger.py#L693-L730>
-    fn merge_marks<'a>(
+    /// The result is in glyph order, so the merged class numbering depends
+    /// only on the input.
+    fn merge_marks(
         &self,
-        per_master: &[&Marks<'a>],
+        per_master: &[Marks],
+        classes: &ClassMaps,
         index: usize,
-    ) -> Result<Vec<(GlyphId16, &'a str, AnchorBuilder)>, MergeError> {
+    ) -> Result<Vec<(GlyphId16, String, AnchorBuilder)>, MergeError> {
         let glyphs: BTreeSet<GlyphId16> = per_master
             .iter()
             .flat_map(|marks| marks.keys().copied())
@@ -169,23 +264,12 @@ impl<V: VariationInfo> MergeCtx<'_, V> {
         for glyph in glyphs {
             let mut class = None;
             let mut anchors = Vec::with_capacity(per_master.len());
-            for (i, marks) in per_master.iter().enumerate() {
-                let Some((master_class, anchor)) = marks.get(&glyph) else {
+            for (marks, classes) in per_master.iter().zip(classes) {
+                let Some((own, anchor)) = marks.get(&glyph) else {
                     anchors.push(None);
                     continue;
                 };
-                match class {
-                    None => class = Some(*master_class),
-                    Some(expected) if expected != *master_class => {
-                        return Err(MergeError::MarkClassConflict {
-                            master: i,
-                            glyph,
-                            expected: expected.into(),
-                            found: (*master_class).into(),
-                        });
-                    }
-                    Some(_) => (),
-                }
+                class.get_or_insert_with(|| classes[*own].clone());
                 anchors.push(Some(*anchor));
             }
             let anchor = self
@@ -211,26 +295,39 @@ impl<V: VariationInfo> MergeCtx<'_, V> {
         index: usize,
     ) -> Result<LookupBuilder<MarkToLigBuilder>, MergeError> {
         let subtables = aligned.indexwise(index, self, |row| {
-            let marks: Vec<Marks> = row
+            let marks: Vec<_> = row
                 .iter()
-                .map(|subtable| {
+                .map(|subtable| marks(subtable.iter_marks()))
+                .collect();
+            let classes = self.align_mark_classes(&marks, index)?;
+            let ligatures: Vec<BTreeMap<GlyphId16, Vec<BTreeMap<String, &AnchorBuilder>>>> = row
+                .iter()
+                .zip(&classes)
+                .map(|(subtable, classes)| {
                     subtable
-                        .iter_marks()
-                        .map(|(glyph, class, anchor)| (glyph, (class, anchor)))
+                        .iter_ligatures()
+                        .map(|(glyph, components)| {
+                            let components = components
+                                .iter()
+                                .map(|anchors| {
+                                    anchors
+                                        .iter()
+                                        .map(|(class, anchor)| {
+                                            (shared_name(classes, class), anchor)
+                                        })
+                                        .collect()
+                                })
+                                .collect();
+                            (glyph, components)
+                        })
                         .collect()
                 })
                 .collect();
-            let ligatures: Vec<BTreeMap<GlyphId16, &[BTreeMap<String, AnchorBuilder>]>> = row
-                .iter()
-                .map(|subtable| subtable.iter_ligatures().collect())
-                .collect();
 
             let mut builder = MarkToLigBuilder::default();
-            for (glyph, class, anchor) in
-                self.merge_marks(&marks.iter().collect::<Vec<_>>(), index)?
-            {
+            for (glyph, class, anchor) in self.merge_marks(&marks, &classes, index)? {
                 builder
-                    .insert_mark(glyph, class, anchor)
+                    .insert_mark(glyph, &class, anchor)
                     .expect("each mark is inserted once");
             }
 
@@ -239,10 +336,8 @@ impl<V: VariationInfo> MergeCtx<'_, V> {
                 .flat_map(|master| master.keys().copied())
                 .collect();
             for glyph in glyphs {
-                let per_master: Vec<Option<&[BTreeMap<String, AnchorBuilder>]>> = ligatures
-                    .iter()
-                    .map(|master| master.get(&glyph).copied())
-                    .collect();
+                let per_master: Vec<Option<&Vec<BTreeMap<String, &AnchorBuilder>>>> =
+                    ligatures.iter().map(|master| master.get(&glyph)).collect();
                 let component_count = per_master
                     .iter()
                     .flatten()
@@ -270,7 +365,7 @@ impl<V: VariationInfo> MergeCtx<'_, V> {
                     for class in classes {
                         let anchors: Vec<_> = per_master
                             .iter()
-                            .map(|master| master.and_then(|m| m[i].get(class)))
+                            .map(|master| master.and_then(|m| m[i].get(class)).copied())
                             .collect();
                         if let Some(anchor) = self.merge_anchor(&anchors, index)? {
                             merged.insert(class.to_owned(), anchor);
@@ -361,6 +456,69 @@ mod tests {
     }
 
     #[test]
+    fn mark_class_names_need_not_match() {
+        // ufo2ft names mark classes after the lookup they were generated
+        // for, so two masters can call the same class different things
+        assert_eq!(
+            merged_binary(&[
+                "markClass acute <anchor 100 200> @A; feature mark { pos base a <anchor 150 500> mark @A; } mark;",
+                "markClass acute <anchor 100 200> @B; feature mark { pos base a <anchor 150 520> mark @B; } mark;",
+            ]),
+            one_shot_binary(
+                "markClass acute <anchor 100 200> @A; feature mark { pos base a <anchor 150 (wght=400:500 wght=900:520)> mark @A; } mark;"
+            )
+        );
+    }
+
+    #[test]
+    fn mark_class_names_swapped_between_masters() {
+        assert_eq!(
+            merged_binary(&[
+                "markClass acute <anchor 100 200> @A; markClass grave <anchor 100 -10> @B; \
+                 feature mark { pos base a <anchor 150 500> mark @A <anchor 150 -20> mark @B; } mark;",
+                "markClass acute <anchor 100 200> @B; markClass grave <anchor 100 -10> @A; \
+                 feature mark { pos base a <anchor 150 520> mark @B <anchor 150 -30> mark @A; } mark;",
+            ]),
+            one_shot_binary(
+                "markClass acute <anchor 100 200> @A; markClass grave <anchor 100 -10> @B; \
+                 feature mark { pos base a <anchor 150 (wght=400:500 wght=900:520)> mark @A \
+                 <anchor 150 (wght=400:-20 wght=900:-30)> mark @B; } mark;"
+            )
+        );
+    }
+
+    #[test]
+    fn a_mark_in_a_different_class_per_lookup() {
+        let fea = |y: &str| {
+            format!(
+                "markClass acute <anchor 100 200> @TOP; markClass acute <anchor 100 0> @BOTTOM; \
+                 feature mark {{ lookup L1 {{ pos base a <anchor 150 {y}> mark @TOP; }} L1; \
+                 lookup L2 {{ pos base b <anchor 150 -20> mark @BOTTOM; }} L2; }} mark;"
+            )
+        };
+        assert_eq!(
+            merged_binary(&[&fea("500"), &fea("520")]),
+            one_shot_binary(&fea("(wght=400:500 wght=900:520)"))
+        );
+    }
+
+    #[test]
+    fn marks_partitioned_differently_is_an_error() {
+        let one_class = "markClass [acute grave] <anchor 100 200> @TOP; \
+            feature mark { pos base a <anchor 150 500> mark @TOP; } mark;";
+        let two_classes = "markClass acute <anchor 100 200> @TOP; markClass grave <anchor 100 200> @BOTTOM; \
+            feature mark { pos base a <anchor 150 500> mark @TOP <anchor 150 0> mark @BOTTOM; } mark;";
+        assert!(matches!(
+            merge_masters(&[one_class, two_classes]),
+            Err(MergeError::MarkClassMismatch { master: 1, .. })
+        ));
+        assert!(matches!(
+            merge_masters(&[two_classes, one_class]),
+            Err(MergeError::MarkClassMismatch { master: 1, .. })
+        ));
+    }
+
+    #[test]
     fn ligature_anchors_vary() {
         assert_eq!(
             merged_binary(&[
@@ -369,6 +527,19 @@ mod tests {
             ]),
             one_shot_binary(
                 "markClass acute <anchor 100 200> @TOP; feature mark { pos ligature f_i <anchor 100 500> mark @TOP ligComponent <anchor (wght=400:300 wght=900:320) 500> mark @TOP; } mark;"
+            )
+        );
+    }
+
+    #[test]
+    fn ligature_mark_class_names_need_not_match() {
+        assert_eq!(
+            merged_binary(&[
+                "markClass acute <anchor 100 200> @A; feature mark { pos ligature f_i <anchor 100 500> mark @A ligComponent <anchor 300 500> mark @A; } mark;",
+                "markClass acute <anchor 100 200> @B; feature mark { pos ligature f_i <anchor 100 500> mark @B ligComponent <anchor 320 500> mark @B; } mark;",
+            ]),
+            one_shot_binary(
+                "markClass acute <anchor 100 200> @A; feature mark { pos ligature f_i <anchor 100 500> mark @A ligComponent <anchor (wght=400:300 wght=900:320) 500> mark @A; } mark;"
             )
         );
     }


### PR DESCRIPTION
A crater run revealed an issue in our initial handling of mark classes, which this commit resolves.

The first pass at the merge logic compared mark classes by name in two places, and both were wrong for real fonts:

- The per-glyph membership check assumed a glyph is in one mark class, but a mark is routinely in several, one per lookup (Tektur's ogonek is in @ogonek and @bottom in every master). Which class the check saw first came out of a HashMap, so the "conflict" it reported was random.

- Within a subtable, marks were matched by class name. ufo2ft names its generated classes after the lookup index, so Arimo's masters call the same class @_MARKCLASS_0_lookup_6 and @_MARKCLASS_0_lookup_7. The binary has no class names, only a partition of the marks into classes, and that is what varLib effectively compares.

The global map now just unions membership; it only feeds GDEF class inference, where names are irrelevant. Within a subtable, each master's class names are aligned to shared ones by the marks they contain: two marks that share a class in one master must share it in every master that has both, and that is the only error left (MarkClassMismatch, replacing MarkClassConflict). Bases and ligature components are keyed by the shared names so their anchors merge per class as before.