### PR TITLE
fea-merge finale: fontbe integration

### DIFF
--- a/fontbe/src/error.rs
+++ b/fontbe/src/error.rs
@@ -28,8 +28,20 @@ pub enum Error {
     IoError(#[from] io::Error),
     #[error(transparent)]
     FeaCompileError(#[from] CompilerError),
-    #[error("masters have non-identical features, which is not yet supported: {0:?}")]
-    VariableFeaUnsupported(Vec<String>),
+    #[error("failed to merge the masters' features: {0}")]
+    FeaMergeError(#[from] fea_rs::compile::MergeError),
+    #[error(
+        "the masters have {0} distinct feature files but none belongs to the default master; \
+         merging needs the default master's features"
+    )]
+    VariableFeaNoDefaultMaster(usize),
+    #[error("feature source '{0}' is not associated with any master")]
+    VariableFeaSourceWithoutMaster(String),
+    #[error("could not normalize the location of feature source '{fea}': {error}")]
+    VariableFeaBadLocation {
+        fea: String,
+        error: fontdrasil::error::Error,
+    },
     #[error(transparent)]
     GlyphOrderError(#[from] GlyphOrderError),
     #[error("'{0}' {1}")]

--- a/fontbe/src/error.rs
+++ b/fontbe/src/error.rs
@@ -28,6 +28,8 @@ pub enum Error {
     IoError(#[from] io::Error),
     #[error(transparent)]
     FeaCompileError(#[from] CompilerError),
+    #[error("masters have non-identical features, which is not yet supported: {0:?}")]
+    VariableFeaUnsupported(Vec<String>),
     #[error(transparent)]
     GlyphOrderError(#[from] GlyphOrderError),
     #[error("'{0}' {1}")]

--- a/fontbe/src/features.rs
+++ b/fontbe/src/features.rs
@@ -48,7 +48,7 @@ use crate::{
     error::Error,
     orchestration::{
         AnyWorkId, BeWork, Context, ExtraFeaTables, FeaFirstPassOutput, FeaRsKerns, FeaRsMarks,
-        WorkId,
+        FeaSourceIdx, WorkId,
     },
 };
 
@@ -74,8 +74,16 @@ const MKMK: Tag = Tag::new(b"mkmk");
 const ABVM: Tag = Tag::new(b"abvm");
 const BLWM: Tag = Tag::new(b"blwm");
 
+/// Parse, validate, and first-pass compile one of the font's FEA sources.
+///
+/// A designspace can have a features.fea per master; each distinct source is
+/// compiled by its own instance of this work. Only the default master's output
+/// ([`WorkId::DEFAULT_FEATURES_AST`]) is consumed today, see
+/// [`FeatureCompilationWork`].
 #[derive(Debug)]
-pub struct FeatureFirstPassWork {}
+pub struct FeatureFirstPassWork {
+    idx: FeaSourceIdx,
+}
 
 #[derive(Debug)]
 pub struct FeatureCompilationWork {}
@@ -414,14 +422,24 @@ fn write_debug_glyph_order(debug_dir: &Path, glyphs: &GlyphOrder) {
     }
 }
 
-fn write_debug_fea(context: &Context, is_error: bool, why: &str, fea_content: &str) {
+fn write_debug_fea(
+    context: &Context,
+    is_error: bool,
+    why: &str,
+    fea_content: &str,
+    idx: FeaSourceIdx,
+) {
     let Some(debug_dir) = context.debug_dir.as_ref() else {
         if is_error {
             warn!("Debug fea not written for '{why}' because --emit-debug is off");
         }
         return;
     };
-    let debug_file = debug_dir.join("features.fea");
+    // one file per source; the default master keeps the historical name
+    let debug_file = match idx {
+        0 => debug_dir.join("features.fea"),
+        idx => debug_dir.join(format!("features_{idx}.fea")),
+    };
     match fs::write(&debug_file, fea_content) {
         Ok(_) if is_error => warn!("{why}; fea written to {debug_file:?}"),
         Ok(_) => debug!("fea written to {debug_file:?}"),
@@ -431,7 +449,7 @@ fn write_debug_fea(context: &Context, is_error: bool, why: &str, fea_content: &s
 
 impl Work<Context, AnyWorkId, Error> for FeatureFirstPassWork {
     fn id(&self) -> AnyWorkId {
-        WorkId::FeaturesAst.into()
+        WorkId::FeaturesAst(self.idx).into()
     }
 
     fn read_access(&self) -> Access<AnyWorkId> {
@@ -444,18 +462,30 @@ impl Work<Context, AnyWorkId, Error> for FeatureFirstPassWork {
 
     #[tracing::instrument(name = "fontbe::FeatureFirstPassWork::exec", skip_all)]
     fn exec(&self, context: &Context) -> Result<(), Error> {
-        let features = context.ir.features.get();
+        let all_features = context.ir.features.get();
+        let features = &all_features
+            .get(self.idx)
+            .unwrap_or_else(|| panic!("no fea source {}", self.idx))
+            .source;
         let glyph_order = context.ir.glyph_order.get();
         let static_metadata = context.ir.static_metadata.get();
         let glyph_map = GlyphMap::new(glyph_order.names().cloned())?;
 
-        let result = self.parse(&features, &glyph_map);
+        let result = self.parse(features, &glyph_map);
 
-        if let Some(debug_dir) = context.debug_dir.as_ref() {
+        if self.is_default()
+            && let Some(debug_dir) = context.debug_dir.as_ref()
+        {
             write_debug_glyph_order(debug_dir, &glyph_order);
         }
-        if let FeaturesSource::Memory { fea_content, .. } = features.as_ref() {
-            write_debug_fea(context, result.is_err(), "compile failed", fea_content);
+        if let FeaturesSource::Memory { fea_content, .. } = features {
+            write_debug_fea(
+                context,
+                result.is_err(),
+                "compile failed",
+                fea_content,
+                self.idx,
+            );
         }
 
         let ast = result?;
@@ -475,15 +505,20 @@ impl Work<Context, AnyWorkId, Error> for FeatureFirstPassWork {
             Error::FeaCompileError(fea_rs::compile::error::CompilerError::CompilationFail(err))
         })?;
         context
-            .fea_ast
-            .set(FeaFirstPassOutput::new(ast, compilation)?);
+            .fea_asts
+            .set(FeaFirstPassOutput::new(self.idx, ast, compilation)?);
         Ok(())
     }
 }
 
 impl FeatureFirstPassWork {
-    pub fn create() -> Box<BeWork> {
-        Box::new(Self {})
+    pub fn create(idx: FeaSourceIdx) -> Box<BeWork> {
+        Box::new(Self { idx })
+    }
+
+    /// True if this is the default master's source
+    fn is_default(&self) -> bool {
+        WorkId::FeaturesAst(self.idx) == WorkId::DEFAULT_FEATURES_AST
     }
 
     fn parse(&self, features: &FeaturesSource, glyph_map: &GlyphMap) -> Result<ParseTree, Error> {
@@ -551,7 +586,10 @@ impl Work<Context, AnyWorkId, Error> for FeatureCompilationWork {
     fn read_access(&self) -> Access<AnyWorkId> {
         AccessBuilder::new()
             .variant(FeWorkId::GlyphOrder)
-            .variant(WorkId::FeaturesAst)
+            .variant(FeWorkId::Features)
+            // every master's fea, not just the default's: they must all
+            // compile, and we need to know if they disagree
+            .variant(WorkId::ALL_FEATURE_ASTS)
             .variant(WorkId::GatherBeKerning)
             .variant(WorkId::Marks)
             .build()
@@ -570,7 +608,16 @@ impl Work<Context, AnyWorkId, Error> for FeatureCompilationWork {
     fn exec(&self, context: &Context) -> Result<(), Error> {
         let static_metadata = context.ir.static_metadata.get();
         let gdef_categories = context.ir.gdef_categories.get();
-        let ast = context.fea_ast.get();
+        let features = context.ir.features.get();
+        // Every master's fea has been compiled by now, but we have nothing to
+        // do with any but the default's: merging them is not yet implemented.
+        // https://github.com/googlefonts/fontc/issues/1204
+        if features.n_sources() > 1 {
+            return Err(Error::VariableFeaUnsupported(
+                features.iter().map(|s| s.source.to_string()).collect(),
+            ));
+        }
+        let ast = context.default_fea_ast();
         let glyph_order = context.ir.glyph_order.get();
         let kerns = context.fea_rs_kerns.get();
         let marks = context.fea_rs_marks.get();

--- a/fontbe/src/features.rs
+++ b/fontbe/src/features.rs
@@ -510,9 +510,12 @@ fn master_compilations(
         }
     }
 
+    let default_location = static_metadata
+        .default_location()
+        .subset_axes(&static_metadata.axes);
     let Some(default) = masters
         .iter()
-        .position(|(location, _)| location == static_metadata.default_location())
+        .position(|(location, _)| *location == default_location)
     else {
         return Err(Error::VariableFeaNoDefaultMaster(features.n_sources()));
     };

--- a/fontbe/src/features.rs
+++ b/fontbe/src/features.rs
@@ -16,8 +16,8 @@ use ordered_float::OrderedFloat;
 use fea_rs::{
     DiagnosticSet, GlyphMap, Opts, ParseTree,
     compile::{
-        Compilation, FeatureBuilder, FeatureProvider, NopFeatureProvider, PendingLookup,
-        VariationInfo, error::CompilerError,
+        Compilation, FeatureBuilder, FeatureProvider, NopFeatureProvider, PendingCompilation,
+        PendingLookup, VariationInfo, error::CompilerError,
     },
     parse::{FileSystemResolver, SourceLoadError, SourceResolver},
     typed::{AstNode, LanguageSystem},
@@ -25,8 +25,8 @@ use fea_rs::{
 
 use fontir::{
     ir::{
-        self, FeatureGenerationPlan, FeatureGenerationSettings, FeatureWriterMode, FeaturesSource,
-        GdefCategories, GlyphOrder, StaticMetadata,
+        self, FeatureGenerationPlan, FeatureGenerationSettings, FeatureSources, FeatureWriterMode,
+        FeaturesSource, GdefCategories, GlyphOrder, StaticMetadata,
     },
     orchestration::WorkId as FeWorkId,
 };
@@ -77,9 +77,8 @@ const BLWM: Tag = Tag::new(b"blwm");
 /// Parse, validate, and first-pass compile one of the font's FEA sources.
 ///
 /// A designspace can have a features.fea per master; each distinct source is
-/// compiled by its own instance of this work. Only the default master's output
-/// ([`WorkId::DEFAULT_FEATURES_AST`]) is consumed today, see
-/// [`FeatureCompilationWork`].
+/// compiled by its own instance of this work, and [`FeatureCompilationWork`]
+/// merges the results when they differ.
 #[derive(Debug)]
 pub struct FeatureFirstPassWork {
     idx: FeaSourceIdx,
@@ -380,20 +379,9 @@ impl FeatureCompilationWork {
         plan: &FeatureGenerationPlan,
         compile_debg: bool,
     ) -> Result<Compilation, Error> {
-        let feature_variations = static_metadata
-            .variations
-            .as_ref()
-            .map(|ir_variations| {
-                feature_variations::FeatureVariationsProvider::new(
-                    ir_variations,
-                    static_metadata,
-                    glyph_order,
-                )
-            })
-            .transpose()?;
         let var_info = FeaVariationInfo::new(static_metadata);
         let feature_writer =
-            FeatureWriter::new(kerns, marks, feature_variations, append_forced_tags(plan));
+            self.feature_writer(static_metadata, glyph_order, kerns, marks, plan)?;
         // we've already validated the AST, so we only need to compile
         match fea_rs::compile::compile(
             &ast.ast,
@@ -411,6 +399,125 @@ impl FeatureCompilationWork {
             ))),
         }
     }
+
+    /// Compile each master's FEA on its own and merge the results.
+    ///
+    /// Used when the masters of a designspace do not all share a features.fea.
+    /// Every master is compiled to pre-build state, those are merged into one
+    /// variable compilation, and only then does the feature writer run: the
+    /// generated kerning and marks, the `ItemVariationStore`, and everything
+    /// else that exists once per font are produced a single time.
+    #[allow(clippy::too_many_arguments)]
+    fn compile_merged(
+        &self,
+        static_metadata: &StaticMetadata,
+        glyph_order: &GlyphOrder,
+        features: &FeatureSources,
+        asts: &HashMap<FeaSourceIdx, Arc<FeaFirstPassOutput>>,
+        kerns: &FeaRsKerns,
+        marks: &FeaRsMarks,
+        plan: &FeatureGenerationPlan,
+        compile_debg: bool,
+    ) -> Result<Compilation, Error> {
+        let opts = Opts::new().compile_debg(compile_debg);
+        let masters = master_compilations(features, asts, static_metadata, &marks.glyphmap, &opts)?;
+        let var_info = FeaVariationInfo::new(static_metadata);
+        let merged = fea_rs::compile::merge(masters, &var_info)?;
+
+        let feature_writer =
+            self.feature_writer(static_metadata, glyph_order, kerns, marks, plan)?;
+        match merged.finish(Some(&feature_writer)) {
+            Ok((result, warnings)) => {
+                log_fea_warnings("compilation", &warnings);
+                Ok(result)
+            }
+            Err(errors) => Err(Error::FeaCompileError(CompilerError::CompilationFail(
+                errors,
+            ))),
+        }
+    }
+
+    fn feature_writer<'a>(
+        &self,
+        static_metadata: &StaticMetadata,
+        glyph_order: &GlyphOrder,
+        kerns: &'a FeaRsKerns,
+        marks: &'a FeaRsMarks,
+        plan: &FeatureGenerationPlan,
+    ) -> Result<FeatureWriter<'a>, Error> {
+        let feature_variations = static_metadata
+            .variations
+            .as_ref()
+            .map(|ir_variations| {
+                feature_variations::FeatureVariationsProvider::new(
+                    ir_variations,
+                    static_metadata,
+                    glyph_order,
+                )
+            })
+            .transpose()?;
+        Ok(FeatureWriter::new(
+            kerns,
+            marks,
+            feature_variations,
+            append_forced_tags(plan),
+        ))
+    }
+}
+
+/// Compile each master's FEA into the pre-build state that [`merge`] consumes.
+///
+/// The masters that share a source each get their own compilation of it: the
+/// values in a master's feature file are that master's contribution to the
+/// variation model, not something to interpolate through. The default master
+/// comes first, as `merge` requires.
+///
+/// [`merge`]: fea_rs::compile::merge
+fn master_compilations(
+    features: &FeatureSources,
+    asts: &HashMap<FeaSourceIdx, Arc<FeaFirstPassOutput>>,
+    static_metadata: &StaticMetadata,
+    glyph_map: &GlyphMap,
+    opts: &Opts,
+) -> Result<Vec<(NormalizedLocation, PendingCompilation)>, Error> {
+    let mut masters = Vec::new();
+    for (idx, master) in features.iter().enumerate() {
+        // a source with no master is font-wide (a .glyphs file); we only get
+        // here when the sources are per-master, so this would be a bug
+        if master.locations.is_empty() {
+            return Err(Error::VariableFeaSourceWithoutMaster(
+                master.source.to_string(),
+            ));
+        }
+        let ast = asts
+            .get(&idx)
+            .unwrap_or_else(|| panic!("no first pass output for fea source {idx}"));
+        for design_location in &master.locations {
+            let location = design_location
+                .to_normalized(&static_metadata.all_source_axes)
+                .map_err(|error| Error::VariableFeaBadLocation {
+                    fea: master.source.to_string(),
+                    error,
+                })?
+                // point axes are not in the variation model
+                .subset_axes(&static_metadata.axes);
+            let (pending, warnings) =
+                fea_rs::compile::compile_for_merge(&ast.ast, glyph_map, opts.clone()).map_err(
+                    |errors| Error::FeaCompileError(CompilerError::CompilationFail(errors)),
+                )?;
+            log_fea_warnings("compilation", &warnings);
+            masters.push((location, pending));
+        }
+    }
+
+    let Some(default) = masters
+        .iter()
+        .position(|(location, _)| location == static_metadata.default_location())
+    else {
+        return Err(Error::VariableFeaNoDefaultMaster(features.n_sources()));
+    };
+    masters.swap(0, default);
+    Ok(masters)
 }
 
 fn write_debug_glyph_order(debug_dir: &Path, glyphs: &GlyphOrder) {
@@ -609,15 +716,6 @@ impl Work<Context, AnyWorkId, Error> for FeatureCompilationWork {
         let static_metadata = context.ir.static_metadata.get();
         let gdef_categories = context.ir.gdef_categories.get();
         let features = context.ir.features.get();
-        // Every master's fea has been compiled by now, but we have nothing to
-        // do with any but the default's: merging them is not yet implemented.
-        // https://github.com/googlefonts/fontc/issues/1204
-        if features.n_sources() > 1 {
-            return Err(Error::VariableFeaUnsupported(
-                features.iter().map(|s| s.source.to_string()).collect(),
-            ));
-        }
-        let ast = context.default_fea_ast();
         let glyph_order = context.ir.glyph_order.get();
         let kerns = context.fea_rs_kerns.get();
         let marks = context.fea_rs_marks.get();
@@ -625,15 +723,34 @@ impl Work<Context, AnyWorkId, Error> for FeatureCompilationWork {
         // Resolve the plan once for this work unit; separate work units (kern,
         // marks) resolve their own, since the work graph precludes threading one.
         let plan = ir::resolve_feature_generation(&static_metadata.misc.feature_generation);
-        let mut result = self.compile(
-            &static_metadata,
-            &glyph_order,
-            &ast,
-            kerns.as_ref(),
-            marks.as_ref(),
-            &plan,
-            context.compile_debg,
-        )?;
+        let mut result = if features.n_sources() > 1 {
+            let asts = context
+                .fea_asts
+                .all()
+                .into_iter()
+                .map(|(_, ast)| (ast.idx, ast))
+                .collect();
+            self.compile_merged(
+                &static_metadata,
+                &glyph_order,
+                &features,
+                &asts,
+                kerns.as_ref(),
+                marks.as_ref(),
+                &plan,
+                context.compile_debg,
+            )?
+        } else {
+            self.compile(
+                &static_metadata,
+                &glyph_order,
+                &context.default_fea_ast(),
+                kerns.as_ref(),
+                marks.as_ref(),
+                &plan,
+                context.compile_debg,
+            )?
+        };
         if plan.gdef && result.gdef_classes.is_none() && !gdef_categories.categories.is_empty() {
             // the FEA did not contain an explicit GDEF block with glyph categories,
             // so let's use the ones from the source, if present (i.e. from

--- a/fontbe/src/features/kern.rs
+++ b/fontbe/src/features/kern.rs
@@ -832,7 +832,7 @@ impl Work<Context, AnyWorkId, Error> for KerningGatherWork {
     fn exec(&self, context: &Context) -> Result<(), Error> {
         debug!("Gather be kerning");
         let arc_fragments = context.kern_fragments.all();
-        let ast = context.fea_ast.get();
+        let ast = context.default_fea_ast();
         let glyph_order = context.ir.glyph_order.get();
         let gdef_categories = context.ir.gdef_categories.get();
         let static_metadata = context.ir.static_metadata.get();

--- a/fontbe/src/features/marks.rs
+++ b/fontbe/src/features/marks.rs
@@ -795,7 +795,7 @@ impl Work<Context, AnyWorkId, Error> for MarkWork {
             .variant(FeWorkId::StaticMetadata)
             .variant(FeWorkId::GlyphOrder)
             .variant(FeWorkId::GdefCategories)
-            .variant(WorkId::FeaturesAst)
+            .specific_instance(WorkId::DEFAULT_FEATURES_AST)
             .variant(FeWorkId::ALL_ANCHORS)
             .build()
     }
@@ -807,7 +807,7 @@ impl Work<Context, AnyWorkId, Error> for MarkWork {
         let glyph_order = context.ir.glyph_order.get();
         let gdef_categories = context.ir.gdef_categories.get();
         let raw_anchors = context.ir.anchors.all();
-        let fea_first_pass = context.fea_ast.get();
+        let fea_first_pass = context.default_fea_ast();
 
         let anchors = raw_anchors
             .iter()

--- a/fontbe/src/orchestration.rs
+++ b/fontbe/src/orchestration.rs
@@ -71,6 +71,13 @@ use crate::error::Error;
 
 type KernBlock = usize;
 
+/// Identifies one of the (possibly several) FEA sources of a font.
+///
+/// Index 0 is always the default master's source; see [`FeatureSources`].
+///
+/// [`FeatureSources`]: fontir::ir::FeatureSources
+pub type FeaSourceIdx = usize;
+
 /// Unique identifier of work.
 ///
 /// If there are no fields work is unique.
@@ -78,7 +85,7 @@ type KernBlock = usize;
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum WorkId {
     Features,
-    FeaturesAst,
+    FeaturesAst(FeaSourceIdx),
     Avar,
     Cmap,
     Colr,
@@ -122,6 +129,14 @@ impl WorkId {
 
     /// An id representing access to all gvar fragments
     pub const ALL_GVAR_FRAGMENTS: WorkId = WorkId::GvarFragment(GlyphName::NOTDEF);
+
+    /// An id representing access to every master's fea ast
+    pub const ALL_FEATURE_ASTS: WorkId = WorkId::FeaturesAst(0);
+
+    /// The ast of the default master's fea; see [`FeatureSources`]
+    ///
+    /// [`FeatureSources`]: fontir::ir::FeatureSources
+    pub const DEFAULT_FEATURES_AST: WorkId = WorkId::FeaturesAst(0);
 }
 
 impl Identifier for WorkId {
@@ -129,7 +144,7 @@ impl Identifier for WorkId {
         match self {
             WorkId::Features => "BeFeatures",
             WorkId::Meta => "BeMeta",
-            WorkId::FeaturesAst => "BeFeaturesAst",
+            WorkId::FeaturesAst(..) => "BeFeaturesAst",
             WorkId::Avar => "BeAvar",
             WorkId::Cmap => "BeCmap",
             WorkId::Colr => "BeColr",
@@ -358,6 +373,8 @@ pub struct FeaRsKerns {
 /// This does not include features that are generated, such as for kerning or marks.
 #[derive(Clone, Debug, PartialEq)]
 pub struct FeaFirstPassOutput {
+    /// Which of the font's FEA sources this is the output for.
+    pub idx: FeaSourceIdx,
     /// A validated abstract syntax tree.
     pub ast: ParseTree,
     // bytes of the compiled gsub table
@@ -367,7 +384,7 @@ pub struct FeaFirstPassOutput {
 }
 
 impl FeaFirstPassOutput {
-    pub fn new(ast: ParseTree, compilation: Compilation) -> Result<Self, Error> {
+    pub fn new(idx: FeaSourceIdx, ast: ParseTree, compilation: Compilation) -> Result<Self, Error> {
         let gsub_bytes = compilation
             .gsub
             .as_ref()
@@ -378,6 +395,7 @@ impl FeaFirstPassOutput {
                 context: "GSUB".into(),
             })?;
         Ok(Self {
+            idx,
             ast,
             gsub_bytes,
             gdef_classes: compilation.gdef_classes,
@@ -398,7 +416,7 @@ impl FeaFirstPassOutput {
             None,
             Opts::new().compile_gpos(false),
         ) {
-            Ok((compilation, _)) => Self::new(ast, compilation),
+            Ok((compilation, _)) => Self::new(0, ast, compilation),
             Err(err) => panic!("{}", err.display()),
         }
     }
@@ -427,6 +445,12 @@ impl FeaRsKerns {
             .flatten()
             .map(|id| &self.lookups[*id])
             .collect()
+    }
+}
+
+impl IdAware<AnyWorkId> for FeaFirstPassOutput {
+    fn id(&self) -> AnyWorkId {
+        AnyWorkId::Be(WorkId::FeaturesAst(self.idx))
     }
 }
 
@@ -683,7 +707,7 @@ pub struct Context {
     pub vvar: BeContextItem<Vvar>,
     pub all_kerning_pairs: BeContextItem<AllKerningPairs>,
     pub kern_fragments: BeContextMap<KernFragment>,
-    pub fea_ast: BeContextItem<FeaFirstPassOutput>,
+    pub fea_asts: BeContextMap<FeaFirstPassOutput>,
     pub fea_rs_kerns: BeContextItem<FeaRsKerns>,
     pub fea_rs_marks: BeContextItem<FeaRsMarks>,
     pub extra_fea_tables: BeContextItem<ExtraFeaTables>,
@@ -733,7 +757,7 @@ impl Context {
             fea_rs_kerns: self.fea_rs_kerns.clone_with_acl(acl.clone()),
             fea_rs_marks: self.fea_rs_marks.clone_with_acl(acl.clone()),
             stat: self.stat.clone_with_acl(acl.clone()),
-            fea_ast: self.fea_ast.clone_with_acl(acl.clone()),
+            fea_asts: self.fea_asts.clone_with_acl(acl.clone()),
             extra_fea_tables: self.extra_fea_tables.clone_with_acl(acl.clone()),
             font: self.font.clone_with_acl(acl),
         }
@@ -785,7 +809,7 @@ impl Context {
             kern_fragments: ContextMap::new(acl.clone()),
             fea_rs_kerns: ContextItem::new(WorkId::GatherBeKerning.into(), acl.clone()),
             fea_rs_marks: ContextItem::new(WorkId::Marks.into(), acl.clone()),
-            fea_ast: ContextItem::new(WorkId::FeaturesAst.into(), acl.clone()),
+            fea_asts: ContextMap::new(acl.clone()),
             stat: ContextItem::new(WorkId::Stat.into(), acl.clone()),
             extra_fea_tables: ContextItem::new(WorkId::ExtraFeaTables.into(), acl.clone()),
             font: ContextItem::new(WorkId::Font.into(), acl),
@@ -802,6 +826,13 @@ impl Context {
 
     pub fn copy_read_only(&self) -> Context {
         self.copy(AccessControlList::read_only())
+    }
+
+    /// The first pass output for the default master's FEA.
+    ///
+    /// Anything that isn't compiled per-master works from this one.
+    pub fn default_fea_ast(&self) -> Arc<FeaFirstPassOutput> {
+        self.fea_asts.get(&WorkId::DEFAULT_FEATURES_AST.into())
     }
 }
 

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -627,6 +627,25 @@ mod tests {
         assert_compiles_with_gpos_and_gsub("fea_include_resolve.designspace", |o| o);
     }
 
+    // The strongest check we have on the merge: two masters with their own
+    // features.fea must produce exactly what one features.fea written in
+    // variable syntax produces.
+    #[test]
+    fn merged_fea_matches_variable_syntax_fea() {
+        let merged = TestCompile::compile_source("variable_fea/VarFea.designspace");
+        let one_shot = TestCompile::compile_source("variable_fea/VarFeaOneShot.designspace");
+
+        for tag in [Tag::new(b"GPOS"), Tag::new(b"GDEF")] {
+            let merged = merged.font().table_data(tag).map(|d| d.as_bytes().to_vec());
+            let one_shot = one_shot
+                .font()
+                .table_data(tag)
+                .map(|d| d.as_bytes().to_vec());
+            assert!(merged.is_some(), "{tag} should be present");
+            assert_eq!(merged, one_shot, "{tag} differs from the one-shot compile");
+        }
+    }
+
     #[test]
     fn masters_with_unmergeable_fea_are_rejected() {
         // GSUB cannot vary: only the GsubBold master has a liga feature, so

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -646,6 +646,30 @@ mod tests {
         }
     }
 
+    // A point axis is not in the variation model, so it must not stop us from
+    // recognizing the default master's FEA.
+    #[test]
+    fn merged_fea_with_point_axis() {
+        let point_axis = TestCompile::compile_source("variable_fea/VarFeaPointAxis.designspace");
+        let no_point_axis = TestCompile::compile_source("variable_fea/VarFea.designspace");
+
+        for tag in [Tag::new(b"GPOS"), Tag::new(b"GDEF")] {
+            let point_axis = point_axis
+                .font()
+                .table_data(tag)
+                .map(|d| d.as_bytes().to_vec());
+            let no_point_axis = no_point_axis
+                .font()
+                .table_data(tag)
+                .map(|d| d.as_bytes().to_vec());
+            assert!(point_axis.is_some(), "{tag} should be present");
+            assert_eq!(
+                point_axis, no_point_axis,
+                "{tag} differs from the compile without a point axis"
+            );
+        }
+    }
+
     #[test]
     fn masters_with_unmergeable_fea_are_rejected() {
         // GSUB cannot vary: only the GsubBold master has a liga feature, so

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -390,7 +390,8 @@ mod tests {
         fn run(&mut self) {
             let completed = self
                 .workload
-                .run_for_test(&self.fe_context, &self.be_context);
+                .run_for_test(&self.fe_context, &self.be_context)
+                .expect("compile failed");
 
             self.work_executed = completed;
 
@@ -401,6 +402,16 @@ mod tests {
 
         fn compile_source(source: &str) -> TestCompile {
             TestCompile::compile(source, |options| options)
+        }
+
+        /// Run a compile we expect to fail, and return the error
+        ///
+        /// Unlike [`TestCompile::run`] this leaves the contexts intact, so the
+        /// state we got to before failing can be inspected.
+        fn run_expect_err(&mut self) -> Error {
+            self.workload
+                .run_for_test(&self.fe_context, &self.be_context)
+                .expect_err("compile should have failed")
         }
 
         fn compile(source: &str, adjust_options: impl Fn(Options) -> Options) -> TestCompile {
@@ -495,7 +506,7 @@ mod tests {
             FeWorkIdentifier::KernInstance(NormalizedLocation::for_pos(&[("wght", 0.0)])).into(),
             FeWorkIdentifier::KernInstance(NormalizedLocation::for_pos(&[("wght", 1.0)])).into(),
             BeWorkIdentifier::Features.into(),
-            BeWorkIdentifier::FeaturesAst.into(),
+            BeWorkIdentifier::DEFAULT_FEATURES_AST.into(),
             BeWorkIdentifier::Avar.into(),
             BeWorkIdentifier::Cmap.into(),
             BeWorkIdentifier::Colr.into(),
@@ -614,6 +625,32 @@ mod tests {
     #[test]
     fn compile_fea_with_includes_resolved() {
         assert_compiles_with_gpos_and_gsub("fea_include_resolve.designspace", |o| o);
+    }
+
+    #[test]
+    fn masters_with_differing_fea_are_compiled_then_rejected() {
+        // each master's fea is compiled by its own job; we just can't merge
+        // them yet. The error must come from the BE, after both compiled.
+        let mut result = TestCompile::new("variable_fea/VarFea.designspace", |options| options);
+        let error = result.run_expect_err();
+        let Error::Backend(fontbe::error::Error::VariableFeaUnsupported(sources)) = &error else {
+            panic!("expected VariableFeaUnsupported, got {error:?}");
+        };
+        assert_eq!(sources.len(), 2);
+
+        // both masters' fea got compiled, in their own jobs, before we gave up
+        let mut compiled = result
+            .be_context
+            .fea_asts
+            .all()
+            .iter()
+            .map(|(id, ast)| {
+                assert_eq!(*id, BeWorkIdentifier::FeaturesAst(ast.idx).into());
+                ast.idx
+            })
+            .collect::<Vec<_>>();
+        compiled.sort();
+        assert_eq!(compiled, vec![0, 1]);
     }
 
     #[test]

--- a/fontc/src/lib.rs
+++ b/fontc/src/lib.rs
@@ -305,7 +305,7 @@ mod tests {
                 cpal::ColorRecord,
                 gasp::GaspRangeBehavior,
                 glyf::{self, CompositeGlyph, CurvePoint, Glyf},
-                gpos::{AnchorTable, Gpos, MarkBasePosFormat1, PositionLookup},
+                gpos::{AnchorTable, Gpos, MarkBasePosFormat1, PositionLookup, SinglePos},
                 gsub::{SingleSubst, SubstitutionLookup},
                 hmtx::Hmtx,
                 layout::FeatureParams,
@@ -628,17 +628,31 @@ mod tests {
     }
 
     #[test]
-    fn masters_with_differing_fea_are_compiled_then_rejected() {
-        // each master's fea is compiled by its own job; we just can't merge
-        // them yet. The error must come from the BE, after both compiled.
-        let mut result = TestCompile::new("variable_fea/VarFea.designspace", |options| options);
+    fn masters_with_unmergeable_fea_are_rejected() {
+        // GSUB cannot vary: only the GsubBold master has a liga feature, so
+        // there is nothing sensible to merge and the BE must say so.
+        let mut result =
+            TestCompile::new("variable_fea/VarFeaGsubMismatch.designspace", |options| {
+                options
+            });
         let error = result.run_expect_err();
-        let Error::Backend(fontbe::error::Error::VariableFeaUnsupported(sources)) = &error else {
-            panic!("expected VariableFeaUnsupported, got {error:?}");
+        let Error::Backend(fontbe::error::Error::FeaMergeError(merge_error)) = &error else {
+            panic!("expected a merge error, got {error:?}");
         };
-        assert_eq!(sources.len(), 2);
+        assert_eq!(
+            merge_error.to_string(),
+            "master 1: GSUB lookups differ from the default master"
+        );
+    }
 
-        // both masters' fea got compiled, in their own jobs, before we gave up
+    #[test]
+    fn masters_with_differing_fea_are_merged() {
+        // Regular has `pos A <10 0 20 0>`, Bold `pos A <30 0 40 0>`; each is
+        // compiled by its own job and the two are merged into one variable
+        // single positioning lookup.
+        let result = TestCompile::compile_source("variable_fea/VarFea.designspace");
+
+        // both masters' fea got compiled, in their own jobs
         let mut compiled = result
             .be_context
             .fea_asts
@@ -651,6 +665,39 @@ mod tests {
             .collect::<Vec<_>>();
         compiled.sort();
         assert_eq!(compiled, vec![0, 1]);
+
+        let font = result.font();
+        let gpos = font.gpos().unwrap();
+        let lookup = gpos.lookup_list().unwrap().lookups().get(0).unwrap();
+        let PositionLookup::Single(lookup) = lookup else {
+            panic!("expected a single positioning lookup");
+        };
+        let SinglePos::Format1(single) = lookup.subtables().get(0).unwrap() else {
+            panic!("expected SinglePosFormat1");
+        };
+        let value = single.value_record();
+
+        // the default master's values, with a device table pointing at deltas
+        assert_eq!(value.x_placement(), Some(10));
+        assert_eq!(value.x_advance(), Some(20));
+        assert!(
+            value.x_placement_device().is_some() && value.x_advance_device().is_some(),
+            "both varying fields should carry a VariationIndex"
+        );
+
+        // Bold is +20 on both fields, so one shared delta set of 20
+        let ivs = font
+            .gdef()
+            .unwrap()
+            .item_var_store()
+            .expect("merged GPOS needs an ItemVariationStore")
+            .unwrap();
+        let deltas = ivs
+            .item_variation_data()
+            .iter()
+            .flat_map(|data| delta_sets(&data.unwrap().unwrap()))
+            .collect::<Vec<_>>();
+        assert_eq!(deltas, vec![vec![20]]);
     }
 
     #[test]

--- a/fontc/src/workload.rs
+++ b/fontc/src/workload.rs
@@ -110,6 +110,8 @@ fn priority(id: &AnyWorkId) -> u32 {
         AnyWorkId::Fe(FeWorkIdentifier::StaticMetadata) => 99,
         AnyWorkId::Fe(FeWorkIdentifier::GlobalMetrics) => 99,
         AnyWorkId::Be(BeWorkIdentifier::GatherIrKerning) => 99,
+        // the default master's fea gates marks and kerning; other masters don't
+        AnyWorkId::Be(BeWorkIdentifier::DEFAULT_FEATURES_AST) => 99,
         AnyWorkId::Be(BeWorkIdentifier::Features) => 99,
         AnyWorkId::Be(BeWorkIdentifier::GlyfFragment(..)) => 0,
         AnyWorkId::Be(BeWorkIdentifier::GvarFragment(..)) => 0,
@@ -151,7 +153,8 @@ impl Workload {
         workload.add(workload.source.create_color_glyphs_work()?);
 
         // BE: f(IR, maybe other BE work) => binary
-        workload.add_skippable_feature_work(FeatureFirstPassWork::create());
+        // the default master's fea; any others are added when IR features complete
+        workload.add_skippable_feature_work(FeatureFirstPassWork::create(0));
         workload.add_skippable_feature_work(FeatureCompilationWork::create());
         workload.add(create_gasp_work());
         let ir_glyphs = workload
@@ -407,6 +410,20 @@ impl Workload {
             gvar_job.read_access = gvar_deps.build().into();
         }
 
+        // A designspace can have a features.fea per master; we only know how
+        // many there are once the IR for features exists. The default master's
+        // job is added when we build the graph, so the FeaturesAst variant is
+        // never empty before we get here: anything that depends on it cannot
+        // have run yet.
+        if let AnyWorkId::Fe(FeWorkIdentifier::Features) = success
+            && let Some(features) = fe_root.features.try_get()
+        {
+            for idx in 1..features.n_sources() {
+                debug!("Generating a BE job for fea source {idx}");
+                self.add_skippable_feature_work(FeatureFirstPassWork::create(idx));
+            }
+        }
+
         if let AnyWorkId::Fe(FeWorkIdentifier::KerningLocations) = success {
             if let Some(groups) = fe_root.kerning_locations.try_get() {
                 for location in groups.locations.iter() {
@@ -442,7 +459,7 @@ impl Workload {
                 .expect("Gather BE Kerning has to be pending")
                 .read_access = AccessBuilder::<AnyWorkId>::new()
                 .variant(BeWorkIdentifier::KernFragment(0))
-                .variant(BeWorkIdentifier::FeaturesAst)
+                .specific_instance(BeWorkIdentifier::DEFAULT_FEATURES_AST)
                 .variant(FeWorkIdentifier::Glyph(GlyphName::NOTDEF))
                 .variant(FeWorkIdentifier::StaticMetadata)
                 .build()
@@ -829,7 +846,11 @@ impl Workload {
     ///
     /// Returns the set of ids for tasks that executed as a result of this run.
     #[cfg(test)]
-    pub fn run_for_test(&mut self, fe_root: &FeContext, be_root: &BeContext) -> HashSet<AnyWorkId> {
+    pub fn run_for_test(
+        &mut self,
+        fe_root: &FeContext,
+        be_root: &BeContext,
+    ) -> Result<HashSet<AnyWorkId>, Error> {
         let pre_success = self.success.clone();
         let mut sorted_pre_success = pre_success.iter().collect::<Vec<_>>();
         sorted_pre_success.sort();
@@ -881,9 +902,10 @@ impl Workload {
                 job.write_access.clone(),
             );
             log::debug!("Exec {id:?}");
-            job.work
-                .exec(context)
-                .unwrap_or_else(|e| panic!("{id:?} failed: {e:?}"));
+            job.work.exec(context).map_err(|e| {
+                log::error!("{id:?} failed: {e:?}");
+                e
+            })?;
 
             for counter in self.counters(id) {
                 counter.fetch_sub(1, Ordering::AcqRel);
@@ -892,7 +914,7 @@ impl Workload {
             self.handle_success(fe_root, be_root, id.clone())
                 .unwrap_or_else(|e| panic!("Failed to handle success for {id:?}: {e}"));
         }
-        self.success.difference(&pre_success).cloned().collect()
+        Ok(self.success.difference(&pre_success).cloned().collect())
     }
 }
 

--- a/fontir/src/error.rs
+++ b/fontir/src/error.rs
@@ -40,8 +40,6 @@ pub enum Error {
         #[source]
         VariationModelError,
     ),
-    #[error("feature files are non-identical: {0}, {1}")]
-    NonIdenticalFea(PathBuf, PathBuf),
     #[error("axis '{0}' missing at least one of default/min/max mapping")]
     MissingAxisMapping(Tag),
     #[error("no glyph for name '{0}'")]

--- a/fontir/src/ir.rs
+++ b/fontir/src/ir.rs
@@ -18,7 +18,7 @@ use write_fonts::{
 };
 
 use fontdrasil::{
-    coords::NormalizedLocation,
+    coords::{DesignLocation, NormalizedLocation},
     types::{Axes, GlyphName},
     variations::{ModelDeltas, VariationModel},
 };
@@ -1120,6 +1120,91 @@ impl FeaturesSource {
             fea_content,
             include_dir: None,
         }
+    }
+}
+
+impl Display for FeaturesSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FeaturesSource::Empty => f.write_str("<no features>"),
+            FeaturesSource::File { fea_file, .. } => write!(f, "{}", fea_file.display()),
+            FeaturesSource::Memory { .. } => f.write_str("<memory>"),
+        }
+    }
+}
+
+/// One FEA source, and the masters that use it.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct MasterFeaSource {
+    /// Where the FEA for these masters comes from.
+    pub source: FeaturesSource,
+    /// The design locations of every master that shares this exact source.
+    ///
+    /// Empty if the source isn't associated with any particular master, e.g.
+    /// the features of a .glyphs file, which are font-wide.
+    pub locations: Vec<DesignLocation>,
+}
+
+/// Every distinct FEA source for a font.
+///
+/// The masters of a designspace can each have their own features.fea. Sources
+/// that are equivalent - the overwhelmingly common case, where every master
+/// has the same features - are collapsed into a single entry that records all
+/// the masters sharing it.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct FeatureSources {
+    /// Never empty; `sources[0]` is the source we treat as the default master's.
+    sources: Vec<MasterFeaSource>,
+}
+
+impl FeatureSources {
+    /// One source, used by the entire font
+    pub fn single(source: FeaturesSource) -> Self {
+        FeatureSources {
+            sources: vec![MasterFeaSource {
+                source,
+                locations: Vec::new(),
+            }],
+        }
+    }
+
+    /// Distinct sources, one entry per set of masters that share a source.
+    ///
+    /// The first entry is the one we treat as the default master's; see
+    /// [`FeatureSources::default_source`].
+    ///
+    /// Panics if `sources` is empty; a font always has at least one (possibly
+    /// [`FeaturesSource::Empty`]) source.
+    pub fn new(sources: Vec<MasterFeaSource>) -> Self {
+        assert!(!sources.is_empty(), "a font always has a default source");
+        FeatureSources { sources }
+    }
+
+    /// The source used to compile everything that is not per-master.
+    ///
+    /// This is the default master's FEA, if it has any; a designspace where
+    /// only non-default masters have a features.fea uses the first one found.
+    pub fn default_source(&self) -> &FeaturesSource {
+        &self.sources[0].source
+    }
+
+    /// The number of distinct sources; always at least one.
+    pub fn n_sources(&self) -> usize {
+        self.sources.len()
+    }
+
+    pub fn get(&self, idx: usize) -> Option<&MasterFeaSource> {
+        self.sources.get(idx)
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &MasterFeaSource> {
+        self.sources.iter()
+    }
+}
+
+impl Default for FeatureSources {
+    fn default() -> Self {
+        FeatureSources::single(FeaturesSource::Empty)
     }
 }
 

--- a/fontir/src/ir/static_metadata.rs
+++ b/fontir/src/ir/static_metadata.rs
@@ -593,7 +593,10 @@ impl StaticMetadata {
         self.misc.elided_fallback_name = elided_fallback_name;
     }
 
-    /// The default on all variable axes.
+    /// The default on every source axis, point axes included.
+    ///
+    /// Subset to [`Self::axes`] before comparing with a location in the
+    /// variation model.
     pub fn default_location(&self) -> &NormalizedLocation {
         &self.default_location
     }

--- a/fontir/src/orchestration.rs
+++ b/fontir/src/orchestration.rs
@@ -297,7 +297,7 @@ pub struct Context {
     pub gdef_categories: FeContextItem<ir::GdefCategories>,
     pub global_metrics: FeContextItem<ir::GlobalMetrics>,
     pub glyphs: FeContextMap<ir::Glyph>,
-    pub features: FeContextItem<ir::FeaturesSource>,
+    pub features: FeContextItem<ir::FeatureSources>,
     pub kerning_locations: FeContextItem<ir::KerningLocations>,
     pub kerning_at: FeContextMap<ir::KerningInstance>,
     pub anchors: FeContextMap<ir::GlyphAnchors>,

--- a/fontir/src/source.rs
+++ b/fontir/src/source.rs
@@ -40,7 +40,7 @@ pub trait Source {
 
     /// Create a function that could be called to generate or identify fea file(s).
     ///
-    /// When run work should update [crate::orchestration::Context] with [crate::ir::FeaturesSource].
+    /// When run work should update [crate::orchestration::Context] with [crate::ir::FeatureSources].
     fn create_feature_ir_work(&self) -> Result<Box<IrWork>, Error>;
 
     /// Create a function that could be called to produce the kerning locations.

--- a/glyphs2fontir/src/toir.rs
+++ b/glyphs2fontir/src/toir.rs
@@ -141,15 +141,16 @@ fn to_ir_path(
 pub(crate) fn to_ir_features(
     features: &[FeatureSnippet],
     include_dir: Option<PathBuf>,
-) -> Result<ir::FeaturesSource, Error> {
+) -> Result<ir::FeatureSources, Error> {
     // Based on https://github.com/googlefonts/glyphsLib/blob/24b4d340e4c82948ba121dcfe563c1450a8e69c9/Lib/glyphsLib/builder/features.py#L74
     // TODO: token expansion
     // TODO: implement notes
     let fea_snippets: Vec<_> = features.iter().filter_map(|f| f.str_if_enabled()).collect();
-    Ok(ir::FeaturesSource::Memory {
+    // a .glyphs file has one set of features, shared by every master
+    Ok(ir::FeatureSources::single(ir::FeaturesSource::Memory {
         fea_content: fea_snippets.join("\n\n"),
         include_dir,
-    })
+    }))
 }
 
 pub(crate) fn design_location(

--- a/resources/testdata/variable_fea/VarFea-Bold.ufo/features.fea
+++ b/resources/testdata/variable_fea/VarFea-Bold.ufo/features.fea
@@ -1,0 +1,3 @@
+feature ss01 {
+    pos A <30 0 40 0>;
+} ss01;

--- a/resources/testdata/variable_fea/VarFea-Bold.ufo/fontinfo.plist
+++ b/resources/testdata/variable_fea/VarFea-Bold.ufo/fontinfo.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>unitsPerEm</key>
+    <integer>1000</integer>
+    <key>familyName</key>
+    <string>VarFea</string>
+  </dict>
+</plist>

--- a/resources/testdata/variable_fea/VarFea-Bold.ufo/glyphs/A_.glif
+++ b/resources/testdata/variable_fea/VarFea-Bold.ufo/glyphs/A_.glif
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="A" format="2">
+  <advance width="700"/>
+  <unicode hex="0041"/>
+  <outline>
+    <contour>
+      <point x="0" y="0" type="line"/>
+      <point x="350" y="700" type="line"/>
+      <point x="700" y="0" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/resources/testdata/variable_fea/VarFea-Bold.ufo/glyphs/contents.plist
+++ b/resources/testdata/variable_fea/VarFea-Bold.ufo/glyphs/contents.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>space</key>
+    <string>space.glif</string>
+    <key>A</key>
+    <string>A_.glif</string>
+  </dict>
+</plist>

--- a/resources/testdata/variable_fea/VarFea-Bold.ufo/glyphs/space.glif
+++ b/resources/testdata/variable_fea/VarFea-Bold.ufo/glyphs/space.glif
@@ -1,0 +1,7 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="space" format="2">
+  <advance width="300"/>
+  <unicode hex="0020"/>
+  <outline>
+  </outline>
+</glyph>

--- a/resources/testdata/variable_fea/VarFea-Bold.ufo/layercontents.plist
+++ b/resources/testdata/variable_fea/VarFea-Bold.ufo/layercontents.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <array>
+    <array>
+      <string>public.default</string>
+      <string>glyphs</string>
+    </array>
+  </array>
+</plist>

--- a/resources/testdata/variable_fea/VarFea-Bold.ufo/lib.plist
+++ b/resources/testdata/variable_fea/VarFea-Bold.ufo/lib.plist
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>public.glyphOrder</key>
+    <array>
+      <string>space</string>
+      <string>A</string>
+    </array>
+  </dict>
+</plist>

--- a/resources/testdata/variable_fea/VarFea-Bold.ufo/metainfo.plist
+++ b/resources/testdata/variable_fea/VarFea-Bold.ufo/metainfo.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>creator</key>
+    <string>org.robofab.ufoLib</string>
+    <key>formatVersion</key>
+    <integer>3</integer>
+  </dict>
+</plist>

--- a/resources/testdata/variable_fea/VarFea-GsubBold.ufo/features.fea
+++ b/resources/testdata/variable_fea/VarFea-GsubBold.ufo/features.fea
@@ -1,0 +1,7 @@
+feature ss01 {
+    pos A <30 0 40 0>;
+} ss01;
+
+feature liga {
+    sub A by space;
+} liga;

--- a/resources/testdata/variable_fea/VarFea-GsubBold.ufo/fontinfo.plist
+++ b/resources/testdata/variable_fea/VarFea-GsubBold.ufo/fontinfo.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>unitsPerEm</key>
+    <integer>1000</integer>
+    <key>familyName</key>
+    <string>VarFea</string>
+  </dict>
+</plist>

--- a/resources/testdata/variable_fea/VarFea-GsubBold.ufo/glyphs/A_.glif
+++ b/resources/testdata/variable_fea/VarFea-GsubBold.ufo/glyphs/A_.glif
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="A" format="2">
+  <advance width="700"/>
+  <unicode hex="0041"/>
+  <outline>
+    <contour>
+      <point x="0" y="0" type="line"/>
+      <point x="350" y="700" type="line"/>
+      <point x="700" y="0" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/resources/testdata/variable_fea/VarFea-GsubBold.ufo/glyphs/contents.plist
+++ b/resources/testdata/variable_fea/VarFea-GsubBold.ufo/glyphs/contents.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>space</key>
+    <string>space.glif</string>
+    <key>A</key>
+    <string>A_.glif</string>
+  </dict>
+</plist>

--- a/resources/testdata/variable_fea/VarFea-GsubBold.ufo/glyphs/space.glif
+++ b/resources/testdata/variable_fea/VarFea-GsubBold.ufo/glyphs/space.glif
@@ -1,0 +1,7 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="space" format="2">
+  <advance width="300"/>
+  <unicode hex="0020"/>
+  <outline>
+  </outline>
+</glyph>

--- a/resources/testdata/variable_fea/VarFea-GsubBold.ufo/layercontents.plist
+++ b/resources/testdata/variable_fea/VarFea-GsubBold.ufo/layercontents.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <array>
+    <array>
+      <string>public.default</string>
+      <string>glyphs</string>
+    </array>
+  </array>
+</plist>

--- a/resources/testdata/variable_fea/VarFea-GsubBold.ufo/lib.plist
+++ b/resources/testdata/variable_fea/VarFea-GsubBold.ufo/lib.plist
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>public.glyphOrder</key>
+    <array>
+      <string>space</string>
+      <string>A</string>
+    </array>
+  </dict>
+</plist>

--- a/resources/testdata/variable_fea/VarFea-GsubBold.ufo/metainfo.plist
+++ b/resources/testdata/variable_fea/VarFea-GsubBold.ufo/metainfo.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>creator</key>
+    <string>org.robofab.ufoLib</string>
+    <key>formatVersion</key>
+    <integer>3</integer>
+  </dict>
+</plist>

--- a/resources/testdata/variable_fea/VarFea-Regular.ufo/features.fea
+++ b/resources/testdata/variable_fea/VarFea-Regular.ufo/features.fea
@@ -1,0 +1,3 @@
+feature ss01 {
+    pos A <10 0 20 0>;
+} ss01;

--- a/resources/testdata/variable_fea/VarFea-Regular.ufo/fontinfo.plist
+++ b/resources/testdata/variable_fea/VarFea-Regular.ufo/fontinfo.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>unitsPerEm</key>
+    <integer>1000</integer>
+    <key>familyName</key>
+    <string>VarFea</string>
+  </dict>
+</plist>

--- a/resources/testdata/variable_fea/VarFea-Regular.ufo/glyphs/A_.glif
+++ b/resources/testdata/variable_fea/VarFea-Regular.ufo/glyphs/A_.glif
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="A" format="2">
+  <advance width="600"/>
+  <unicode hex="0041"/>
+  <outline>
+    <contour>
+      <point x="0" y="0" type="line"/>
+      <point x="300" y="700" type="line"/>
+      <point x="600" y="0" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/resources/testdata/variable_fea/VarFea-Regular.ufo/glyphs/contents.plist
+++ b/resources/testdata/variable_fea/VarFea-Regular.ufo/glyphs/contents.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>space</key>
+    <string>space.glif</string>
+    <key>A</key>
+    <string>A_.glif</string>
+  </dict>
+</plist>

--- a/resources/testdata/variable_fea/VarFea-Regular.ufo/glyphs/space.glif
+++ b/resources/testdata/variable_fea/VarFea-Regular.ufo/glyphs/space.glif
@@ -1,0 +1,7 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="space" format="2">
+  <advance width="250"/>
+  <unicode hex="0020"/>
+  <outline>
+  </outline>
+</glyph>

--- a/resources/testdata/variable_fea/VarFea-Regular.ufo/layercontents.plist
+++ b/resources/testdata/variable_fea/VarFea-Regular.ufo/layercontents.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <array>
+    <array>
+      <string>public.default</string>
+      <string>glyphs</string>
+    </array>
+  </array>
+</plist>

--- a/resources/testdata/variable_fea/VarFea-Regular.ufo/lib.plist
+++ b/resources/testdata/variable_fea/VarFea-Regular.ufo/lib.plist
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>public.glyphOrder</key>
+    <array>
+      <string>space</string>
+      <string>A</string>
+    </array>
+  </dict>
+</plist>

--- a/resources/testdata/variable_fea/VarFea-Regular.ufo/metainfo.plist
+++ b/resources/testdata/variable_fea/VarFea-Regular.ufo/metainfo.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>creator</key>
+    <string>org.robofab.ufoLib</string>
+    <key>formatVersion</key>
+    <integer>3</integer>
+  </dict>
+</plist>

--- a/resources/testdata/variable_fea/VarFea.designspace
+++ b/resources/testdata/variable_fea/VarFea.designspace
@@ -1,0 +1,21 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<designspace format="4.1">
+  <axes>
+    <axis tag="wght" name="Weight" minimum="400" maximum="700" default="400"/>
+  </axes>
+  <sources>
+    <source filename="VarFea-Regular.ufo" name="Regular" familyname="VarFea" stylename="Regular">
+      <lib copy="1"/>
+      <groups copy="1"/>
+      <info copy="1"/>
+      <location>
+        <dimension name="Weight" xvalue="400"/>
+      </location>
+    </source>
+    <source filename="VarFea-Bold.ufo" name="Bold" familyname="VarFea" stylename="Bold">
+      <location>
+        <dimension name="Weight" xvalue="700"/>
+      </location>
+    </source>
+  </sources>
+</designspace>

--- a/resources/testdata/variable_fea/VarFeaGsubMismatch.designspace
+++ b/resources/testdata/variable_fea/VarFeaGsubMismatch.designspace
@@ -1,0 +1,21 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<designspace format="4.1">
+  <axes>
+    <axis tag="wght" name="Weight" minimum="400" maximum="700" default="400"/>
+  </axes>
+  <sources>
+    <source filename="VarFea-Regular.ufo" name="Regular" familyname="VarFea" stylename="Regular">
+      <lib copy="1"/>
+      <groups copy="1"/>
+      <info copy="1"/>
+      <location>
+        <dimension name="Weight" xvalue="400"/>
+      </location>
+    </source>
+    <source filename="VarFea-GsubBold.ufo" name="GsubBold" familyname="VarFea" stylename="GsubBold">
+      <location>
+        <dimension name="Weight" xvalue="700"/>
+      </location>
+    </source>
+  </sources>
+</designspace>

--- a/resources/testdata/variable_fea/VarFeaOneShot-Bold.ufo/features.fea
+++ b/resources/testdata/variable_fea/VarFeaOneShot-Bold.ufo/features.fea
@@ -1,0 +1,3 @@
+feature ss01 {
+    pos A <(wght=400:10 wght=700:30) 0 (wght=400:20 wght=700:40) 0>;
+} ss01;

--- a/resources/testdata/variable_fea/VarFeaOneShot-Bold.ufo/fontinfo.plist
+++ b/resources/testdata/variable_fea/VarFeaOneShot-Bold.ufo/fontinfo.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>unitsPerEm</key>
+    <integer>1000</integer>
+    <key>familyName</key>
+    <string>VarFea</string>
+  </dict>
+</plist>

--- a/resources/testdata/variable_fea/VarFeaOneShot-Bold.ufo/glyphs/A_.glif
+++ b/resources/testdata/variable_fea/VarFeaOneShot-Bold.ufo/glyphs/A_.glif
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="A" format="2">
+  <advance width="700"/>
+  <unicode hex="0041"/>
+  <outline>
+    <contour>
+      <point x="0" y="0" type="line"/>
+      <point x="350" y="700" type="line"/>
+      <point x="700" y="0" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/resources/testdata/variable_fea/VarFeaOneShot-Bold.ufo/glyphs/contents.plist
+++ b/resources/testdata/variable_fea/VarFeaOneShot-Bold.ufo/glyphs/contents.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>space</key>
+    <string>space.glif</string>
+    <key>A</key>
+    <string>A_.glif</string>
+  </dict>
+</plist>

--- a/resources/testdata/variable_fea/VarFeaOneShot-Bold.ufo/glyphs/space.glif
+++ b/resources/testdata/variable_fea/VarFeaOneShot-Bold.ufo/glyphs/space.glif
@@ -1,0 +1,7 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="space" format="2">
+  <advance width="300"/>
+  <unicode hex="0020"/>
+  <outline>
+  </outline>
+</glyph>

--- a/resources/testdata/variable_fea/VarFeaOneShot-Bold.ufo/layercontents.plist
+++ b/resources/testdata/variable_fea/VarFeaOneShot-Bold.ufo/layercontents.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <array>
+    <array>
+      <string>public.default</string>
+      <string>glyphs</string>
+    </array>
+  </array>
+</plist>

--- a/resources/testdata/variable_fea/VarFeaOneShot-Bold.ufo/lib.plist
+++ b/resources/testdata/variable_fea/VarFeaOneShot-Bold.ufo/lib.plist
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>public.glyphOrder</key>
+    <array>
+      <string>space</string>
+      <string>A</string>
+    </array>
+  </dict>
+</plist>

--- a/resources/testdata/variable_fea/VarFeaOneShot-Bold.ufo/metainfo.plist
+++ b/resources/testdata/variable_fea/VarFeaOneShot-Bold.ufo/metainfo.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>creator</key>
+    <string>org.robofab.ufoLib</string>
+    <key>formatVersion</key>
+    <integer>3</integer>
+  </dict>
+</plist>

--- a/resources/testdata/variable_fea/VarFeaOneShot-Regular.ufo/features.fea
+++ b/resources/testdata/variable_fea/VarFeaOneShot-Regular.ufo/features.fea
@@ -1,0 +1,3 @@
+feature ss01 {
+    pos A <(wght=400:10 wght=700:30) 0 (wght=400:20 wght=700:40) 0>;
+} ss01;

--- a/resources/testdata/variable_fea/VarFeaOneShot-Regular.ufo/fontinfo.plist
+++ b/resources/testdata/variable_fea/VarFeaOneShot-Regular.ufo/fontinfo.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>unitsPerEm</key>
+    <integer>1000</integer>
+    <key>familyName</key>
+    <string>VarFea</string>
+  </dict>
+</plist>

--- a/resources/testdata/variable_fea/VarFeaOneShot-Regular.ufo/glyphs/A_.glif
+++ b/resources/testdata/variable_fea/VarFeaOneShot-Regular.ufo/glyphs/A_.glif
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="A" format="2">
+  <advance width="600"/>
+  <unicode hex="0041"/>
+  <outline>
+    <contour>
+      <point x="0" y="0" type="line"/>
+      <point x="300" y="700" type="line"/>
+      <point x="600" y="0" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/resources/testdata/variable_fea/VarFeaOneShot-Regular.ufo/glyphs/contents.plist
+++ b/resources/testdata/variable_fea/VarFeaOneShot-Regular.ufo/glyphs/contents.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>space</key>
+    <string>space.glif</string>
+    <key>A</key>
+    <string>A_.glif</string>
+  </dict>
+</plist>

--- a/resources/testdata/variable_fea/VarFeaOneShot-Regular.ufo/glyphs/space.glif
+++ b/resources/testdata/variable_fea/VarFeaOneShot-Regular.ufo/glyphs/space.glif
@@ -1,0 +1,7 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="space" format="2">
+  <advance width="250"/>
+  <unicode hex="0020"/>
+  <outline>
+  </outline>
+</glyph>

--- a/resources/testdata/variable_fea/VarFeaOneShot-Regular.ufo/layercontents.plist
+++ b/resources/testdata/variable_fea/VarFeaOneShot-Regular.ufo/layercontents.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <array>
+    <array>
+      <string>public.default</string>
+      <string>glyphs</string>
+    </array>
+  </array>
+</plist>

--- a/resources/testdata/variable_fea/VarFeaOneShot-Regular.ufo/lib.plist
+++ b/resources/testdata/variable_fea/VarFeaOneShot-Regular.ufo/lib.plist
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>public.glyphOrder</key>
+    <array>
+      <string>space</string>
+      <string>A</string>
+    </array>
+  </dict>
+</plist>

--- a/resources/testdata/variable_fea/VarFeaOneShot-Regular.ufo/metainfo.plist
+++ b/resources/testdata/variable_fea/VarFeaOneShot-Regular.ufo/metainfo.plist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>creator</key>
+    <string>org.robofab.ufoLib</string>
+    <key>formatVersion</key>
+    <integer>3</integer>
+  </dict>
+</plist>

--- a/resources/testdata/variable_fea/VarFeaOneShot.designspace
+++ b/resources/testdata/variable_fea/VarFeaOneShot.designspace
@@ -1,0 +1,21 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<designspace format="4.1">
+  <axes>
+    <axis tag="wght" name="Weight" minimum="400" maximum="700" default="400"/>
+  </axes>
+  <sources>
+    <source filename="VarFeaOneShot-Regular.ufo" name="Regular" familyname="VarFea" stylename="Regular">
+      <lib copy="1"/>
+      <groups copy="1"/>
+      <info copy="1"/>
+      <location>
+        <dimension name="Weight" xvalue="400"/>
+      </location>
+    </source>
+    <source filename="VarFeaOneShot-Bold.ufo" name="Bold" familyname="VarFea" stylename="Bold">
+      <location>
+        <dimension name="Weight" xvalue="700"/>
+      </location>
+    </source>
+  </sources>
+</designspace>

--- a/resources/testdata/variable_fea/VarFeaPointAxis.designspace
+++ b/resources/testdata/variable_fea/VarFeaPointAxis.designspace
@@ -1,0 +1,24 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<designspace format="4.1">
+  <axes>
+    <axis tag="wght" name="Weight" minimum="400" maximum="700" default="400"/>
+    <axis tag="wdth" name="Width" minimum="100" maximum="100" default="100"/>
+  </axes>
+  <sources>
+    <source filename="VarFea-Regular.ufo" name="Regular" familyname="VarFea" stylename="Regular">
+      <lib copy="1"/>
+      <groups copy="1"/>
+      <info copy="1"/>
+      <location>
+        <dimension name="Weight" xvalue="400"/>
+        <dimension name="Width" xvalue="100"/>
+      </location>
+    </source>
+    <source filename="VarFea-Bold.ufo" name="Bold" familyname="VarFea" stylename="Bold">
+      <location>
+        <dimension name="Weight" xvalue="700"/>
+        <dimension name="Width" xvalue="100"/>
+      </location>
+    </source>
+  </sources>
+</designspace>

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -1769,8 +1769,8 @@ fn group_fea_files(fea_files: &[(DesignLocation, PathBuf)]) -> Result<FeatureSou
     }
 
     if sources.len() > 1 {
-        warn!(
-            "{} distinct feature files; compiling variable features is not yet supported",
+        debug!(
+            "{} distinct feature files; they will be merged",
             sources.len()
         );
     }

--- a/ufo2fontir/src/source.rs
+++ b/ufo2fontir/src/source.rs
@@ -21,12 +21,12 @@ use fontir::{
     error::{BadSource, BadSourceKind, Error},
     ir::{
         AnchorBuilder, Color, ColorGlyphs, ColorPalettes, Condition, ConditionSet,
-        DEFAULT_VENDOR_ID, FEATURE_WRITERS_LIB_KEY, FeatureWriterOptionValue, FeatureWriterSpec,
-        FeaturesSource, GlobalMetric, GlobalMetricsBuilder, GlyphOrder, KernGroup, KernSide,
-        KerningInstance, KerningLocations, MetaTableValues, NameBuilder, NameKey, NamedInstance,
-        Paint, PaintGlyph, PaintSolid, Panose, PostscriptNames, PreliminaryGdefCategories, Rule,
-        StaticMetadata, Substitution, VariableFeature, reject_duplicate_writers,
-        validate_feature_writer,
+        DEFAULT_VENDOR_ID, FEATURE_WRITERS_LIB_KEY, FeatureSources, FeatureWriterOptionValue,
+        FeatureWriterSpec, FeaturesSource, GlobalMetric, GlobalMetricsBuilder, GlyphOrder,
+        KernGroup, KernSide, KerningInstance, KerningLocations, MasterFeaSource, MetaTableValues,
+        NameBuilder, NameKey, NamedInstance, Paint, PaintGlyph, PaintSolid, Panose,
+        PostscriptNames, PreliminaryGdefCategories, Rule, StaticMetadata, Substitution,
+        VariableFeature, reject_duplicate_writers, validate_feature_writer,
     },
     orchestration::{Context, Flags, IrWork, WorkId},
     source::Source,
@@ -66,7 +66,8 @@ pub struct DesignSpaceIrSource {
     designspace: Arc<DesignSpaceDocument>,
     designspace_dir: Arc<PathBuf>,
     glyphs: Arc<HashMap<GlyphName, HashMap<PathBuf, Vec<DesignLocation>>>>,
-    fea_files: Arc<Vec<PathBuf>>,
+    /// The features.fea of each master that has one, default master first
+    fea_files: Arc<Vec<(DesignLocation, PathBuf)>>,
 }
 
 fn glif_files(
@@ -277,15 +278,20 @@ impl Source for DesignSpaceIrSource {
             debug!("{} glyphs identified", glyphs.len());
         }
 
-        // For compilation purposes we start from ufo dir / features.fea
-        let fea_files: Vec<_> = designspace
-            .sources
-            .iter()
-            .filter_map(|s| {
-                let fea_file = designspace_dir.join(&s.filename).join("features.fea");
-                fea_file.is_file().then_some(fea_file)
-            })
-            .collect();
+        // For compilation purposes we start from ufo dir / features.fea.
+        // The default master comes first; it is the source of anything we
+        // don't (yet) compile per-master.
+        let mut fea_source_indices = (0..designspace.sources.len()).collect::<Vec<_>>();
+        fea_source_indices.swap(0, default_master_idx);
+        let mut fea_files: Vec<(DesignLocation, PathBuf)> = Vec::new();
+        for idx in fea_source_indices {
+            let source = &designspace.sources[idx];
+            let fea_file = designspace_dir.join(&source.filename).join("features.fea");
+            if fea_file.is_file() {
+                let location = to_design_location(&axis_tags_by_name, &source.location)?;
+                fea_files.push((location, fea_file));
+            }
+        }
 
         // if source was a designspace we don't want to copy over keys like
         // public.skipExportGlyphs, but we do if it was a UFO. (we assume that
@@ -480,7 +486,7 @@ struct GlobalMetricsWork {
 #[derive(Debug)]
 struct FeatureWork {
     designspace_or_ufo: Arc<PathBuf>,
-    fea_files: Arc<Vec<PathBuf>>,
+    fea_files: Arc<Vec<(DesignLocation, PathBuf)>>,
 }
 
 #[derive(Debug)]
@@ -1716,37 +1722,60 @@ impl Work<Context, WorkId, Error> for FeatureWork {
     fn exec(&self, context: &Context) -> Result<(), Error> {
         debug!("Features for {:#?}", self.designspace_or_ufo);
 
-        let fea_files = self.fea_files.as_ref();
-        for fea_file in fea_files.iter().skip(1) {
-            if !fea_files_identical(&fea_files[0], fea_file)? {
-                warn!(
-                    "Bailing out due to non-identical feature files. This is an unnecessary limitation."
-                );
-                return Err(Error::NonIdenticalFea(
-                    fea_files[0].to_path_buf(),
-                    fea_file.to_path_buf(),
-                ));
-            }
-        }
-
-        if !fea_files.is_empty() {
-            // Fea file is required to be ufo_dir/features.fea. Includes resolve as siblings
-            // of ufo_dir.
-            let fea_file = fea_files[0].clone();
-            let include_dir = fea_file
-                .parent()
-                .and_then(|f| f.parent())
-                .map(|v| v.to_path_buf())
-                .ok_or_else(|| BadSource::new(&fea_file, BadSourceKind::ExpectedParent))?;
-            context
-                .features
-                .set(FeaturesSource::from_file(fea_file, Some(include_dir)));
-        } else {
-            context.features.set(FeaturesSource::empty());
-        }
+        context.features.set(group_fea_files(&self.fea_files)?);
 
         Ok(())
     }
+}
+
+/// Collapse the masters' fea files into one entry per distinct source.
+///
+/// Masters whose features are equivalent (see [`fea_files_identical`]) share an
+/// entry, so the usual case - every master has the same features.fea - yields a
+/// single source. `fea_files` must have the default master first.
+fn group_fea_files(fea_files: &[(DesignLocation, PathBuf)]) -> Result<FeatureSources, Error> {
+    if fea_files.is_empty() {
+        return Ok(FeatureSources::single(FeaturesSource::empty()));
+    }
+
+    let mut sources: Vec<MasterFeaSource> = Vec::new();
+    // representative path of each group, parallel to sources
+    let mut representatives: Vec<&PathBuf> = Vec::new();
+    for (location, fea_file) in fea_files {
+        let mut group = None;
+        for (i, other) in representatives.iter().enumerate() {
+            if fea_files_identical(other, fea_file)? {
+                group = Some(i);
+                break;
+            }
+        }
+        match group {
+            Some(i) => sources[i].locations.push(location.clone()),
+            None => {
+                // Fea file is required to be ufo_dir/features.fea. Includes resolve as siblings
+                // of ufo_dir.
+                let include_dir = fea_file
+                    .parent()
+                    .and_then(|f| f.parent())
+                    .map(|v| v.to_path_buf())
+                    .ok_or_else(|| BadSource::new(fea_file, BadSourceKind::ExpectedParent))?;
+                sources.push(MasterFeaSource {
+                    source: FeaturesSource::from_file(fea_file.clone(), Some(include_dir)),
+                    locations: vec![location.clone()],
+                });
+                representatives.push(fea_file);
+            }
+        }
+    }
+
+    if sources.len() > 1 {
+        warn!(
+            "{} distinct feature files; compiling variable features is not yet supported",
+            sources.len()
+        );
+    }
+
+    Ok(FeatureSources::new(sources))
 }
 
 /// Build the kern-group partition for a single source.
@@ -2352,6 +2381,75 @@ mod tests {
         let a = write_master("A.ufo", "include(../shared.fea)");
         let b = write_master("B.ufo", "include (../shared.fea)\n");
         assert!(fea_files_identical(&a, &b).unwrap());
+    }
+
+    fn fea_sources(designspace: &str) -> FeatureSources {
+        let source = DesignSpaceIrSource::new(&testdata_dir().join(designspace)).unwrap();
+        group_fea_files(&source.fea_files).unwrap()
+    }
+
+    fn fea_file(source: &MasterFeaSource) -> &Path {
+        match &source.source {
+            FeaturesSource::File { fea_file, .. } => fea_file,
+            other => panic!("expected a file, got {other}"),
+        }
+    }
+
+    #[test]
+    fn no_fea_is_one_empty_source() {
+        let sources = group_fea_files(&[]).unwrap();
+        assert_eq!(sources.n_sources(), 1);
+        assert_eq!(sources.default_source(), &FeaturesSource::Empty);
+    }
+
+    #[test]
+    fn masters_sharing_fea_are_one_source() {
+        // both masters have the same features.fea; we compile it once
+        let sources = fea_sources("fea_include.designspace");
+        assert_eq!(sources.n_sources(), 1);
+        assert_eq!(
+            sources.get(0).unwrap().locations,
+            vec![
+                DesignLocation::for_pos(&[("wght", 400.0)]),
+                DesignLocation::for_pos(&[("wght", 700.0)]),
+            ]
+        );
+    }
+
+    #[test]
+    fn equivalent_includes_at_different_depths_are_one_source() {
+        // the masters sit at different depths so their include paths differ,
+        // but they resolve to the same file: still one source
+        let sources = fea_sources("fea_include_resolve.designspace");
+        assert_eq!(sources.n_sources(), 1);
+        assert_eq!(sources.get(0).unwrap().locations.len(), 2);
+    }
+
+    #[test]
+    fn differing_master_fea_are_separate_sources_default_first() {
+        let sources = fea_sources("variable_fea/VarFea.designspace");
+        assert_eq!(sources.n_sources(), 2);
+        let names = sources
+            .iter()
+            .map(|s| {
+                fea_file(s)
+                    .parent()
+                    .and_then(|p| p.file_name())
+                    .unwrap()
+                    .to_str()
+                    .unwrap()
+                    .to_string()
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(names, vec!["VarFea-Regular.ufo", "VarFea-Bold.ufo"]);
+        assert_eq!(
+            sources.get(0).unwrap().locations,
+            vec![DesignLocation::for_pos(&[("wght", 400.0)])]
+        );
+        assert_eq!(
+            sources.get(1).unwrap().locations,
+            vec![DesignLocation::for_pos(&[("wght", 700.0)])]
+        );
     }
 
     macro_rules! plist_dict {


### PR DESCRIPTION
This is the final bit of the fea-merge work, wiring the merge logic into fontbe.

When FEA is identical, we will still take the fast path and just build it once; when it differs across masters we will compile each master's FEA in parallel and then attempt to merge them.

This gets us compiling a bunch of new fonts, and has us matching fontmake on many of them.