### PR TITLE
[fea-rs] Preserve lookupflag across a redundant script statement

### DIFF
--- a/fea-rs/src/compile/compile_ctx.rs
+++ b/fea-rs/src/compile/compile_ctx.rs
@@ -91,7 +91,6 @@ pub struct CompilationCtx<'a, F: FeatureProvider, V: VariationInfo> {
     lookup_flags: LookupFlagInfo,
     active_feature: Option<ActiveFeature>,
     vertical_feature: SpecialVerticalFeatureState,
-    script: Option<Tag>,
     glyph_class_defs: HashMap<SmolStr, GlyphClass>,
     mark_classes: HashMap<SmolStr, MarkClass>,
     anchor_defs: HashMap<SmolStr, (Anchor, usize)>,
@@ -134,7 +133,6 @@ impl<'a, F: FeatureProvider, V: VariationInfo> CompilationCtx<'a, F, V> {
             lookup_flags: Default::default(),
             active_feature: Default::default(),
             vertical_feature: Default::default(),
-            script: Default::default(),
             mark_attach_class_id: Default::default(),
             mark_filter_sets: Default::default(),
             opts,
@@ -254,7 +252,6 @@ impl<'a, F: FeatureProvider, V: VariationInfo> CompilationCtx<'a, F, V> {
 
         self.vertical_feature.end_feature();
         self.lookup_flags.clear();
-        self.script = None;
     }
 
     fn start_lookup_block(&mut self, name: &Token, use_extension: bool) {
@@ -289,7 +286,12 @@ impl<'a, F: FeatureProvider, V: VariationInfo> CompilationCtx<'a, F, V> {
 
     fn set_language(&mut self, stmt: typed::Language) {
         let language = stmt.tag().to_raw();
-        let script = self.script.unwrap_or(tags::SCRIPT_DFLT);
+        let script = self
+            .active_feature
+            .as_ref()
+            .unwrap() // language statement only allowed in feature block
+            .current_lang_sys()
+            .script;
         self.set_script_language(
             script,
             language,
@@ -298,24 +300,24 @@ impl<'a, F: FeatureProvider, V: VariationInfo> CompilationCtx<'a, F, V> {
         );
     }
 
+    /// The logic in this fn is surprisingly treacherous.
+    ///
+    /// See <https://github.com/fonttools/fonttools/pull/4169> for the most
+    /// comprehensive explanation.
     fn set_script(&mut self, stmt: typed::Script) {
         let script = stmt.tag().to_raw();
+        let system = LanguageSystem {
+            script,
+            language: tags::LANG_DFLT,
+        };
 
-        // fonttools logic here is kind of particular, so let's match it literally
-        //https://github.com/fonttools/fonttools/blob/5ae2943a43/Lib/fontTools/feaLib/builder.py#L1239
-        if self
-            .active_feature
-            .as_ref()
-            .unwrap()
-            .current_system()
-            .map(|langsys| (langsys.script, langsys.language))
-            == Some((script, tags::LANG_DFLT))
-        {
-            return;
+        let system_is_current = self.active_feature.as_ref().unwrap().current_lang_sys() == system;
+
+        // a script statement naming the already-current system does not reset
+        // the lookupflag.
+        if !system_is_current {
+            self.lookup_flags.clear();
         }
-
-        self.script = Some(script);
-        self.lookup_flags.clear();
 
         self.set_script_language(script, tags::LANG_DFLT, false, false);
     }

--- a/fea-rs/src/compile/features.rs
+++ b/fea-rs/src/compile/features.rs
@@ -44,7 +44,9 @@ pub(crate) struct ActiveFeature {
     pub(crate) tag: Tag,
     condition_set: Option<ConditionSet>,
     default_systems: DefaultLanguageSystems,
-    current_lang_sys: Option<LanguageSystem>,
+    current_lang_sys: LanguageSystem,
+    /// Whether a script or language statement has been seen
+    seen_script_lang: bool,
     lookups: HashMap<LanguageSystem, Vec<LookupId>>,
     script_default_lookups: HashMap<Tag, Vec<LookupId>>,
 }
@@ -349,12 +351,13 @@ impl ActiveFeature {
             condition_set,
             script_default_lookups: Default::default(),
             lookups: Default::default(),
-            current_lang_sys: Default::default(),
+            current_lang_sys: default_systems.first(),
+            seen_script_lang: false,
             default_systems,
         }
     }
 
-    pub(crate) fn current_system(&self) -> Option<LanguageSystem> {
+    pub(crate) fn current_lang_sys(&self) -> LanguageSystem {
         self.current_lang_sys
     }
 
@@ -406,26 +409,27 @@ impl ActiveFeature {
             self.lookups.entry(system).or_insert_with(|| lookups);
         }
 
-        self.current_lang_sys = Some(system);
+        self.current_lang_sys = system;
+        self.seen_script_lang = true;
         system.to_feature_key(self.tag)
     }
 
     pub(crate) fn add_lookup(&mut self, lookup: LookupId) {
         // there is a distinction between "implicit DFLT/dflt" and having
         // an explicit 'DFLT' script in the lookup block.
-        let is_script_default = match self.current_lang_sys {
-            None => false,
-            Some(sys) => sys.language == tags::LANG_DFLT,
-        };
-
-        if is_script_default {
+        if !self.seen_script_lang {
+            self.lookups
+                .entry(LanguageSystem::default())
+                .or_default()
+                .push(lookup);
+        } else if self.current_lang_sys.language == tags::LANG_DFLT {
             self.script_default_lookups
-                .entry(self.current_lang_sys.unwrap().script)
+                .entry(self.current_lang_sys.script)
                 .or_default()
                 .push(lookup);
         } else {
             self.lookups
-                .entry(self.current_lang_sys.unwrap_or_default())
+                .entry(self.current_lang_sys)
                 .or_default()
                 .push(lookup);
         }

--- a/fea-rs/src/compile/language_system.rs
+++ b/fea-rs/src/compile/language_system.rs
@@ -40,6 +40,18 @@ impl DefaultLanguageSystems {
     pub fn iter(&self) -> impl Iterator<Item = LanguageSystem> + '_ {
         self.items.iter().copied()
     }
+
+    /// The first declared language system, ordered by (script, language).
+    ///
+    /// This matches the ordering of makeotf's `langSysMap`, and that behaviour
+    /// is in turn adopted by feaLib.
+    pub(crate) fn first(&self) -> LanguageSystem {
+        self.items
+            .iter()
+            .copied()
+            .min_by_key(|sys| (sys.script, sys.language))
+            .unwrap_or_default()
+    }
 }
 
 impl LanguageSystem {

--- a/fea-rs/test-data/compile-tests/mini-latin/good/lookupflag_redundant_script.fea
+++ b/fea-rs/test-data/compile-tests/mini-latin/good/lookupflag_redundant_script.fea
@@ -1,0 +1,10 @@
+languagesystem latn dflt;
+
+feature test {
+    lookupflag IgnoreMarks;
+    # this script statement does not change the current system (which is seeded
+    # from the languagesystem statement above) and so is a no-op: it does not
+    # clear the preceding lookupflag.
+    script latn;
+    pos a -10;
+} test;

--- a/fea-rs/test-data/compile-tests/mini-latin/good/lookupflag_redundant_script.ttx
+++ b/fea-rs/test-data/compile-tests/mini-latin/good/lookupflag_redundant_script.ttx
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont>
+
+  <GPOS>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="latn"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=1 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="test"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=1 -->
+      <Lookup index="0">
+        <LookupType value="1"/>
+        <LookupFlag value="8"/><!-- ignoreMarks -->
+        <!-- SubTableCount=1 -->
+        <SinglePos index="0" Format="1">
+          <Coverage>
+            <Glyph value="a"/>
+          </Coverage>
+          <ValueFormat value="4"/>
+          <Value XAdvance="-10"/>
+        </SinglePos>
+      </Lookup>
+    </LookupList>
+  </GPOS>
+
+</ttFont>

--- a/fea-rs/test-data/compile-tests/mini-latin/good/redundant_script_explicit_lang_sys.fea
+++ b/fea-rs/test-data/compile-tests/mini-latin/good/redundant_script_explicit_lang_sys.fea
@@ -1,0 +1,8 @@
+languagesystem latn dflt;
+
+feature test {
+    # we had a bug where this reset script to DFLT; see
+    # https://github.com/googlefonts/fontc/pull/2127#discussion_r3949359281
+    language dflt;
+    sub a by b;
+} test;

--- a/fea-rs/test-data/compile-tests/mini-latin/good/redundant_script_explicit_lang_sys.ttx
+++ b/fea-rs/test-data/compile-tests/mini-latin/good/redundant_script_explicit_lang_sys.ttx
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont>
+
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="latn"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=1 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="test"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=1 -->
+      <Lookup index="0">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0">
+          <Substitution in="a" out="b"/>
+        </SingleSubst>
+      </Lookup>
+    </LookupList>
+  </GSUB>
+
+</ttFont>

--- a/fea-rs/test-data/compile-tests/mini-latin/good/repeated_script_stmt.fea
+++ b/fea-rs/test-data/compile-tests/mini-latin/good/repeated_script_stmt.fea
@@ -1,0 +1,12 @@
+languagesystem DFLT dflt;
+languagesystem dev2 dflt;
+languagesystem deva dflt;
+
+feature test {
+    script dev2;
+    sub a by b;
+    # a script statement always closes the open lookup, so the two rules end up
+    # in separate lookups even though this statement changes nothing else.
+    script dev2;
+    sub c by d;
+} test;

--- a/fea-rs/test-data/compile-tests/mini-latin/good/repeated_script_stmt.ttx
+++ b/fea-rs/test-data/compile-tests/mini-latin/good/repeated_script_stmt.ttx
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont>
+
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=1 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="dev2"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=1 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="test"/>
+        <Feature>
+          <!-- LookupCount=2 -->
+          <LookupListIndex index="0" value="0"/>
+          <LookupListIndex index="1" value="1"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=2 -->
+      <Lookup index="0">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0">
+          <Substitution in="a" out="b"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="1">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0">
+          <Substitution in="c" out="d"/>
+        </SingleSubst>
+      </Lookup>
+    </LookupList>
+  </GSUB>
+
+</ttFont>

--- a/fea-rs/test-data/compile-tests/mini-latin/good/script_stmt_seeded_system.fea
+++ b/fea-rs/test-data/compile-tests/mini-latin/good/script_stmt_seeded_system.fea
@@ -1,0 +1,12 @@
+languagesystem cyrl dflt;
+languagesystem latn dflt;
+
+feature test {
+    # 'cyrl' sorts first, and so is the system we start out in; this statement
+    # is a no-op, but rules still only get registered under cyrl.
+    script cyrl;
+    sub a by b;
+
+    script latn;
+    sub c by d;
+} test;

--- a/fea-rs/test-data/compile-tests/mini-latin/good/script_stmt_seeded_system.ttx
+++ b/fea-rs/test-data/compile-tests/mini-latin/good/script_stmt_seeded_system.ttx
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ttFont>
+
+  <GSUB>
+    <Version value="0x00010000"/>
+    <ScriptList>
+      <!-- ScriptCount=2 -->
+      <ScriptRecord index="0">
+        <ScriptTag value="cyrl"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="0"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+      <ScriptRecord index="1">
+        <ScriptTag value="latn"/>
+        <Script>
+          <DefaultLangSys>
+            <ReqFeatureIndex value="65535"/>
+            <!-- FeatureCount=1 -->
+            <FeatureIndex index="0" value="1"/>
+          </DefaultLangSys>
+          <!-- LangSysCount=0 -->
+        </Script>
+      </ScriptRecord>
+    </ScriptList>
+    <FeatureList>
+      <!-- FeatureCount=2 -->
+      <FeatureRecord index="0">
+        <FeatureTag value="test"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="0"/>
+        </Feature>
+      </FeatureRecord>
+      <FeatureRecord index="1">
+        <FeatureTag value="test"/>
+        <Feature>
+          <!-- LookupCount=1 -->
+          <LookupListIndex index="0" value="1"/>
+        </Feature>
+      </FeatureRecord>
+    </FeatureList>
+    <LookupList>
+      <!-- LookupCount=2 -->
+      <Lookup index="0">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0">
+          <Substitution in="a" out="b"/>
+        </SingleSubst>
+      </Lookup>
+      <Lookup index="1">
+        <LookupType value="1"/>
+        <LookupFlag value="0"/>
+        <!-- SubTableCount=1 -->
+        <SingleSubst index="0">
+          <Substitution in="c" out="d"/>
+        </SingleSubst>
+      </Lookup>
+    </LookupList>
+  </GSUB>
+
+</ttFont>


### PR DESCRIPTION
See https://github.com/fonttools/fonttools/pull/4169 for more detail on this issue.

In fea-rs, the issue was straightforward: we hardcoded self.script_ to "DFLT" instead of seeding it from the declared languagesystem statements.

This caused our guard in set_script to be incorrect, which could cause lookups to be registered under DFLT instead of the declared script.


Alongside the fonttools patch above, this produces at least a +20 identical on crater.