### PR TITLE
[ci] Update GoogleSans designspace paths after upstream repo reorg

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -259,10 +259,10 @@ jobs:
           path: oswald
 
       - name: Compile GS Roman twice
-        run: ./resources/scripts/repeatable-builds.sh googlesans/source/GoogleSans/GoogleSans.designspace
+        run: ./resources/scripts/repeatable-builds.sh googlesans/sources/GoogleSans.designspace
 
       - name: Compile GS Italic twice
-        run: ./resources/scripts/repeatable-builds.sh googlesans/source/GoogleSans/GoogleSans-Italic.designspace
+        run: ./resources/scripts/repeatable-builds.sh googlesans/sources/GoogleSans-Italic.designspace
 
       - name: Compile Oswald twice
         run: ./resources/scripts/repeatable-builds.sh oswald/sources/Oswald.glyphs


### PR DESCRIPTION
googlefonts/googlesans#768 moved the sources from source/GoogleSans/ to sources/, so the repeatable-builds job now fails on every PR with a missing file error before fontc runs (see e.g. the Build GS job on #2127).

JMM