### PR TITLE
[fontc] drop vergen .idempotent() so the stamped version tracks HEAD

### DIFF
--- a/fontc/build.rs
+++ b/fontc/build.rs
@@ -12,12 +12,17 @@ fn main() -> Result<(), Box<dyn Error>> {
         // `short = false` -> full commit SHA in VERGEN_GIT_SHA, shown by `--vv`.
         .sha(false)
         .build()?;
+    // On a git-less build (e.g. a published crate) the git lookups fail and,
+    // because `fail_on_error` is off by default, vergen emits the
+    // VERGEN_IDEMPOTENT_OUTPUT sentinel instead; fontbe::version detects it and
+    // falls back to the crate version.
+    //
+    // Don't enable `.idempotent()` here: for vergen-gitcl its only effect is to
+    // stop emitting `cargo:rerun-if-changed=.git/HEAD` (and the ref file), so
+    // the build script would not re-run when HEAD moves and the stamped
+    // version would go stale in a warm target dir.
     Emitter::new()
         .quiet()
-        // On a git-less build (e.g. a published crate) the git lookups emit the
-        // VERGEN_IDEMPOTENT_OUTPUT sentinel instead of failing; fontbe::version
-        // detects it and falls back to the crate version.
-        .idempotent()
         .add_instructions(&CargoBuilder::all_cargo()?)? // VERGEN_CARGO_* for `--vv`
         .add_instructions(&gitcl)?
         .add_instructions(&RustcBuilder::all_rustc()?)? // VERGEN_RUSTC_* for `--vv`


### PR DESCRIPTION
Colin noticed in #2138 that the git sha in the version stamp can go stale locally. Turns out that's because of the `.idempotent()` call in build.rs, which this PR removes: vergen-gitcl only emits rerun-if-changed for .git/HEAD and the current ref when idempotent is off, so the build script was only re-running when build.rs itself changed. Easy to repro on main: make an empty commit, `cargo build -p fontc`, and `fontc --version` still prints the previous sha.

The comment I wrote in #2049 got this wrong: the git-less fallback to the crate version comes from fail_on_error being off (the default), while idempotent only affects timestamps and sysinfo, which we don't request. I checked that a build with git unreachable still emits the VERGEN_IDEMPOTENT_OUTPUT sentinel and falls back to the crate version.

The cost is that fontc gets relinked every time HEAD moves, which seems fine to me. This merges cleanly with #2138; the env override there is still needed since vergen doesn't emit rerun-if-env-changed for VERGEN_GIT_DESCRIBE on its own.
