### PR TITLE
bump fonttools to 4.65.0, pin glyphsLib<6.14

### DIFF
--- a/resources/scripts/requirements.in
+++ b/resources/scripts/requirements.in
@@ -12,3 +12,8 @@ gftools==0.9.93
 # of gftools builder, which is run as a post-process step, see:
 # https://github.com/googlefonts/gftools/issues/1159
 paintcompiler
+# glyphsLib 6.14.0 started generating STAT axis labels from named instances
+# (and a STAT-only 'ital' axis, googlefonts/glyphsLib#1158); fontc does not
+# implement that yet, so keep glyphsLib below 6.14 until it does, see
+# https://github.com/googlefonts/fontc/issues/2078
+glyphsLib<6.14

--- a/resources/scripts/requirements.txt
+++ b/resources/scripts/requirements.txt
@@ -38,26 +38,26 @@ bump2version==1.0.1
     # via bumpfontversion
 bumpfontversion==0.4.1
     # via gftools
-cattrs==26.1.0
+cattrs==26.2.0
     # via
     #   statmake
     #   ufolib2
 cdifflib==1.2.9
     # via ttx-diff
-certifi==2026.6.17
+certifi==2026.7.22
     # via requests
-cffi==2.1.0
+cffi==2.1.1
     # via
     #   cryptography
     #   pygit2
     #   pynacl
 cffsubr==0.4.0
     # via ufo2ft
-charset-normalizer==3.4.9
+charset-normalizer==3.5.1
     # via requests
 compreffor==0.6.0
     # via ufo2ft
-cryptography==49.0.0
+cryptography==50.0.1
     # via pyjwt
 defcon[lxml,pens]==0.12.2
     # via
@@ -68,7 +68,7 @@ defcon[lxml,pens]==0.12.2
     #   ufoprocessor
 ffmpeg-python==0.2.0
     # via gftools
-filelock==3.29.7
+filelock==3.32.6
     # via youseedee
 font-v==2.1.0
     # via gftools
@@ -91,7 +91,7 @@ fontparts==1.1.1
     # via ufoprocessor
 fontpens==0.4.0
     # via defcon
-fonttools[lxml,repacker,ufo,unicode,woff]==4.63.0
+fonttools[lxml,repacker,ufo,unicode,woff]==4.65.0
     # via
     #   afdko
     #   axisregistry
@@ -135,24 +135,25 @@ gftools==0.9.93
     #   ttx-diff
 gitdb==4.0.12
     # via gitpython
-gitpython==3.1.51
+gitpython==3.1.62
     # via font-v
 glyphsets==1.1.0
     # via gftools
 glyphslib==6.13.1
     # via
+    #   -r resources/scripts/requirements.in
     #   bumpfontversion
     #   fontmake
     #   gftools
     #   glyphsets
     #   ttx-diff
-idna==3.18
+idna==3.19
     # via requests
 importlib-resources==7.1.0
     # via gfsubsets
 jinja2==3.1.6
     # via gftools
-lxml==6.1.1
+lxml==6.1.3
     # via
     #   afdko
     #   fontfeatures
@@ -168,11 +169,11 @@ mdurl==0.1.2
     # via markdown-it-py
 mutatormath==3.0.1
     # via ufoprocessor
-nanoemoji==0.15.9
+nanoemoji==0.16.0
     # via gftools
 networkx==3.6.1
     # via gftools
-ninja==1.13.0
+ninja==1.13.2
     # via
     #   gftools
     #   nanoemoji
@@ -183,21 +184,21 @@ openstep-plist==0.5.2
     #   glyphslib
 opentype-sanitizer==9.2.0
     # via gftools
-orjson==3.11.9
+orjson==3.12.0
     # via
     #   babelfont
     #   ufolib2
-packaging==26.2
+packaging==26.3
     # via gftools
 paintcompiler==0.3.4
     # via -r resources/scripts/requirements.in
-picosvg==0.22.3
+picosvg==0.23.0
     # via nanoemoji
 pillow==12.3.0
     # via
     #   gftools
     #   nanoemoji
-platformdirs==4.10.0
+platformdirs==4.11.8
     # via youseedee
 pngquant-cli==3.0.3
     # via nanoemoji
@@ -212,9 +213,9 @@ pycparser==3.0
     # via cffi
 pygit2==1.16.0
     # via gftools
-pygithub==2.9.1
+pygithub==2.10.0
     # via gftools
-pygments==2.20.0
+pygments==2.21.0
     # via rich
 pyjwt[crypto]==2.13.0
     # via pygithub
@@ -229,7 +230,7 @@ pyyaml==6.0.3
     #   gftools
     #   glyphsets
     #   ttx-diff
-regex==2026.7.10
+regex==2026.9.10
     # via nanoemoji
 requests==2.34.2
     # via
@@ -251,7 +252,7 @@ skia-pathops==0.9.2
     #   picosvg
 smmap==5.0.3
     # via gitdb
-soupsieve==2.8.4
+soupsieve==2.9.2
     # via beautifulsoup4
 statmake==2.0.1
     # via gftools
@@ -263,9 +264,9 @@ tabulate==0.10.0
     #   glyphsets
 toml==0.10.2
     # via nanoemoji
-tqdm==4.68.4
+tqdm==4.70.0
     # via afdko
-ttfautohint-py==0.6.0
+ttfautohint-py==0.6.1
     # via gftools
 typing-extensions==4.16.0
     # via
@@ -285,7 +286,7 @@ ufolib2[json]==0.18.1
     #   nanoemoji
     #   ufomerge
     #   vttlib
-ufomerge==1.9.6
+ufomerge==1.9.8
     # via
     #   babelfont
     #   gftools
@@ -293,7 +294,7 @@ ufonormalizer==0.6.3
     # via afdko
 ufoprocessor==1.14.1
     # via afdko
-uharfbuzz==0.55.0
+uharfbuzz==0.56.1
     # via
     #   fonttools
     #   vharfbuzz


### PR DESCRIPTION
4.65.0 includes fonttools/fonttools#4169, the feaLib side of #2127.

I also pinned glyphsLib<6.14: 6.14.0 started generating STAT axis values from the named instances, which fontc doesn't implement yet, so we stay on 6.13.1 for now. The pin can go once #2078 is done.
