### PR TITLE
[release] push only the tags cargo-release just created

### DIFF
--- a/resources/scripts/release.sh
+++ b/resources/scripts/release.sh
@@ -66,7 +66,7 @@ trap - SIGINT  # Remove trap
 echo "Generate tags"
 cargo release tag -x ${crate_specifier}  # this prompts y/N
 echo "Pushing tag to github"
-git push --tags
+cargo release push -x ${crate_specifier}  # this prompts y/N
 
 echo "NEXT STEPS"
 echo "You probably want to create a release on github"


### PR DESCRIPTION
We got a security report arguing that `git push --tags` is bad because it uploads all local tags to the remote repo rather than just the release tag (insecure untrusted local tag propagation, potential supply chain compromise, plus other scary things).

cargo-release already knows which tags it planned for the selected packages, so I let it do the push too.

`cargo release push` sends exactly those, to the push remote from the config (origin) rather than to whatever remote the current branch happens to track. It also pushes the current branch atomically with the tags if it's ahead of the remote (which after bump-version.sh it isn't).